### PR TITLE
Add dashboard to traefik

### DIFF
--- a/manifests/traefik.yaml
+++ b/manifests/traefik.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   chart: https://%{KUBERNETES_API}%/static/charts/traefik-1.77.1.tgz
   set:
+    dashboard.enabled: "true"
     rbac.enabled: "true"
     ssl.enabled: "true"
     metrics.prometheus.enabled: "true"


### PR DESCRIPTION
I would suggest adding the dashboard option to traefik which can then be accessed by creating an ingress such as this:

```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: traefik-web-ui
  namespace: kube-system
  annotations:
    kubernetes.io/ingress.class: traefik
spec:
  rules:
  - host: traefik.lab.local
    http:
      paths:
      - path: /
        backend:
          serviceName: traefik-dashboard
          servicePort: 80
```