### PR TITLE
k3s cloud provider: support IPv6 addresses

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -213,12 +213,12 @@ func updateMutableLabels(agentConfig *daemonconfig.Agent, nodeLabels map[string]
 
 func updateAddressLabels(agentConfig *daemonconfig.Agent, nodeLabels map[string]string) (map[string]string, bool) {
 	result := map[string]string{
-		InternalIPLabel: agentConfig.NodeIP,
+		InternalIPLabel: strings.ReplaceAll(agentConfig.NodeIP, ":", "x"),
 		HostnameLabel:   agentConfig.NodeName,
 	}
 
 	if agentConfig.NodeExternalIP != "" {
-		result[ExternalIPLabel] = agentConfig.NodeExternalIP
+		result[ExternalIPLabel] = strings.ReplaceAll(agentConfig.NodeExternalIP, ":", "x")
 	}
 
 	result = labels.Merge(nodeLabels, result)

--- a/pkg/cloudprovider/instances.go
+++ b/pkg/cloudprovider/instances.go
@@ -3,6 +3,7 @@ package cloudprovider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -60,14 +61,14 @@ func (k *k3s) NodeAddresses(ctx context.Context, name types.NodeName) ([]corev1.
 	}
 	// check internal address
 	if node.Labels[InternalIPLabel] != "" {
-		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: node.Labels[InternalIPLabel]})
+		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: strings.ReplaceAll(node.Labels[InternalIPLabel], "x", ":")})
 	} else {
 		logrus.Infof("couldn't find node internal ip label on node %s", name)
 	}
 
 	// check external address
 	if node.Labels[ExternalIPLabel] != "" {
-		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: node.Labels[ExternalIPLabel]})
+		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: strings.ReplaceAll(node.Labels[ExternalIPLabel], "x", ":")})
 	}
 
 	// check hostname


### PR DESCRIPTION
When a agent uses IPv6 internal or external address, we get logs like the
following:
```
time="2019-12-31T07:04:55.525551232Z" level=info msg="Failed to update node 83d1262cbe11: Node \"83d1262cbe11\" is invalid: metadata.labels: Invalid value: \"fca1:7383:a065:aced:f051:242:ac11:2\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')"
```

This is because IPv6 addresses contain colons (`:`) and the k3s cloud provider
implementation stores node's IP addresses as values in the node's
metadata.labels, however Kubernetes doesn't allow colons in label values. In
fact Kubernetes has some strict requirements on label values:
> Valid label values must be 63 characters or less and must be empty or begin and end with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.

This pull request encodes `:` as `x` in the label values.