### PR TITLE
Allow systemctl to mask/unmask units by installing to /usr/local

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ set -e
 #
 #   - INSTALL_K3S_SYSTEMD_DIR
 #     Directory to install systemd service and environment files to, or use
-#     /etc/systemd/system as the default
+#     /usr/local/etc/systemd/system as the default
 #
 #   - INSTALL_K3S_EXEC or script arguments
 #     Command with flags to use for launching k3s in the systemd service, if
@@ -197,7 +197,8 @@ setup_env() {
     if [ -n "${INSTALL_K3S_SYSTEMD_DIR}" ]; then
         SYSTEMD_DIR="${INSTALL_K3S_SYSTEMD_DIR}"
     else
-        SYSTEMD_DIR=/etc/systemd/system
+        mkdir -p /usr/local/etc/systemd/system
+        SYSTEMD_DIR=/usr/local/etc/systemd/system
     fi
 
     # --- set related files from system name ---
@@ -578,8 +579,8 @@ EOF
 
 # --- disable current service if loaded --
 systemd_disable() {
-    $SUDO rm -f /etc/systemd/system/${SERVICE_K3S} || true
-    $SUDO rm -f /etc/systemd/system/${SERVICE_K3S}.env || true
+    $SUDO rm -f ${SYSTEMD_DIR}/${SERVICE_K3S} || true
+    $SUDO rm -f ${SYSTEMD_DIR}/${SERVICE_K3S}.env || true
     $SUDO systemctl disable ${SYSTEM_NAME} >/dev/null 2>&1 || true
 }
 


### PR DESCRIPTION
**Version:**
`k3s version v1.17.4+k3s1 (3eee8ac3)1

**K3s arguments:**
```
export INSTALL_K3S_EXEC="--node-external-ip 10.127.0.1"
export INSTALL_K3S_NAME="master-LOCCH"
k3s-install.sh
```
**Describe the bug**
Unable to mask the systemd service since it is created as a file not a sym-link.
```
root@elloe01:~# ls -l /etc/systemd/system/k3s*
-rw-r--r-- 1 root root 544 Mar 25 22:55 /etc/systemd/system/k3s-master-LOCCH.service
-r-------- 1 root root   0 Mar 25 22:55 /etc/systemd/system/k3s-master-LOCCH.service.env
root@elloe01:~# cat /etc/systemd/system/k3s-master-LOCCH.service.env 
root@elloe01:~# systemctl mask k3s-master-LOCCH
Failed to mask unit: File /etc/systemd/system/k3s-master-LOCCH.service already exists.
```
** Solution **
Problem here is that the k3s install is writing the files into `/etc/systemd/system/` rather than another location so that symbolic links can be managed by systemctl.

What *should* happen at install is:
```
mkdir -p /usr/local/etc/systemd/system
 ````
and use this location to install the files to.