### PR TITLE
add conf.d args support for k3s

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -227,6 +227,7 @@ setup_env() {
     elif [ "${HAS_OPENRC}" = true ]; then
         $SUDO mkdir -p /etc/rancher/k3s
         FILE_K3S_SERVICE=/etc/init.d/${SYSTEM_NAME}
+        FILE_K3S_CONFD=/etc/conf.d/${SYSTEM_NAME}
         FILE_K3S_ENV=/etc/rancher/k3s/${SYSTEM_NAME}.env
     fi
 
@@ -584,6 +585,7 @@ if which rc-update; then
 fi
 
 rm -f ${FILE_K3S_SERVICE}
+rm -f ${FILE_K3S_CONFD}
 rm -f ${FILE_K3S_ENV}
 
 remove_uninstall() {
@@ -682,6 +684,7 @@ supervisor=supervise-daemon
 name=${SYSTEM_NAME}
 command="${BIN_DIR}/k3s"
 command_args="$(escape_dq "${CMD_K3S_EXEC}")
+    $k3s_server_args \
     >>${LOG_FILE} 2>&1"
 
 output_log=${LOG_FILE}
@@ -696,6 +699,14 @@ if [ -f ${FILE_K3S_ENV} ]; then source ${FILE_K3S_ENV}; fi
 set +o allexport
 EOF
     $SUDO chmod 0755 ${FILE_K3S_SERVICE}
+
+    $SUDO tee ${FILE_K3S_CONFD} >/dev/null << EOF
+# conf.d file for k3s
+
+# use this to set additional k3s server args
+k3s_server_args=""
+EOF
+    $SUDO chmod 0755 ${FILE_K3S_CONFD}
 
     $SUDO tee /etc/logrotate.d/${SYSTEM_NAME} >/dev/null << EOF
 ${LOG_FILE} {


### PR DESCRIPTION
It's handy to use conf.d on openrc systems for configuration. I'm not sure if this PR works (was unable to test) but wanted to share just to give an idea what it'd take. I think this is close, just bash quoting, you know..... 