### PR TITLE
A new variable to handle failures during installation behind proxy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,6 +83,20 @@ set -e
 #   - INSTALL_K3S_CHANNEL
 #     Channel to use for fetching k3s download URL.
 #     Defaults to 'stable'.
+#
+#   - INSTALL_K3S_CONF_FILE
+#     Configuration file which holds additional configurations which needs to
+#     set before installation starts.
+#     For example below curl aliases can be kept in a configuration file
+#     and passed to this variable, to handle failures during installation
+#     behind proxy.
+#         alias curl='curl --cacert /path/to/extra/cert/xxx.crt'
+#         or
+#         alias curl='curl --insecure'
+
+if [ -n "$INSTALL_K3S_CONF_FILE" ]; then
+    . ${INSTALL_K3S_CONF_FILE}
+fi
 
 GITHUB_URL=https://github.com/rancher/k3s/releases
 STORAGE_URL=https://storage.googleapis.com/k3s-ci-builds


### PR DESCRIPTION
## Problem in installation behind proxy
Triggering `./install.sh` behind HTTPS proxy causes failure in `curl` command's TLS server cert verification, when proxy's CA cert is not installed. One solution for this failure is to add one of the below `alias` on environment.
```
alias curl='curl --cacert /path/to/extra/cert/xxx.crt'
```
or
```
alias curl='curl --insecure'
```

But even after adding these aliases on environment, it does not help as environment aliases are not passed on to the called script.

## Solution
So we can add a new install env variable `INSTALL_K3S_CONF_FILE` to pass a config file, which gets sourced at the beginning of `install.sh`. User can keep aliases and any other configuration in that config file.