### PR TITLE
Track addon manifest file modification times across cluster nodes

### DIFF
--- a/pkg/apis/k3s.cattle.io/v1/types.go
+++ b/pkg/apis/k3s.cattle.io/v1/types.go
@@ -22,5 +22,7 @@ type AddonSpec struct {
 }
 
 type AddonStatus struct {
-	GVKs []schema.GroupVersionKind `json:"gvks,omitempty"`
+	GVKs     []schema.GroupVersionKind `json:"gvks,omitempty"`
+	ModTime  metav1.Time               `json:"modTime,omitempty"`
+	NodeName string                    `json:"nodeName,omitempty"`
 }

--- a/pkg/apis/k3s.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/k3s.cattle.io/v1/zz_generated_deepcopy.go
@@ -110,6 +110,7 @@ func (in *AddonStatus) DeepCopyInto(out *AddonStatus) {
 		*out = make([]schema.GroupVersionKind, len(*in))
 		copy(*out, *in)
 	}
+	in.ModTime.DeepCopyInto(&out.ModTime)
 	return
 }
 

--- a/pkg/deploy/controller.go
+++ b/pkg/deploy/controller.go
@@ -16,8 +16,8 @@ import (
 
 	errors2 "github.com/pkg/errors"
 	"github.com/rancher/k3s/pkg/agent/util"
-	v12 "github.com/rancher/k3s/pkg/apis/k3s.cattle.io/v1"
-	v1 "github.com/rancher/k3s/pkg/generated/controllers/k3s.cattle.io/v1"
+	apisv1 "github.com/rancher/k3s/pkg/apis/k3s.cattle.io/v1"
+	controllersv1 "github.com/rancher/k3s/pkg/generated/controllers/k3s.cattle.io/v1"
 	"github.com/rancher/wrangler/pkg/apply"
 	"github.com/rancher/wrangler/pkg/merr"
 	"github.com/rancher/wrangler/pkg/objectset"
@@ -35,7 +35,8 @@ const (
 	startKey = "_start_"
 )
 
-func WatchFiles(ctx context.Context, apply apply.Apply, addons v1.AddonController, disables map[string]bool, bases ...string) error {
+// WatchFiles sets up an OnChange callback to start a periodic goroutine to watch files for changes once the controller has started up.
+func WatchFiles(ctx context.Context, apply apply.Apply, addons controllersv1.AddonController, disables map[string]bool, bases ...string) error {
 	w := &watcher{
 		apply:      apply,
 		addonCache: addons.Cache(),
@@ -45,8 +46,8 @@ func WatchFiles(ctx context.Context, apply apply.Apply, addons v1.AddonControlle
 		modTime:    map[string]time.Time{},
 	}
 
-	addons.Enqueue("", startKey)
-	addons.OnChange(ctx, "addon-start", func(key string, _ *v12.Addon) (*v12.Addon, error) {
+	addons.Enqueue(metav1.NamespaceNone, startKey)
+	addons.OnChange(ctx, "addon-start", func(key string, _ *apisv1.Addon) (*apisv1.Addon, error) {
 		if key == startKey {
 			go w.start(ctx)
 		}
@@ -58,13 +59,14 @@ func WatchFiles(ctx context.Context, apply apply.Apply, addons v1.AddonControlle
 
 type watcher struct {
 	apply      apply.Apply
-	addonCache v1.AddonCache
-	addons     v1.AddonClient
+	addonCache controllersv1.AddonCache
+	addons     controllersv1.AddonClient
 	bases      []string
 	disables   map[string]bool
 	modTime    map[string]time.Time
 }
 
+// start calls listFiles at regular intervals to trigger application of manifests that have changed on disk.
 func (w *watcher) start(ctx context.Context) {
 	force := true
 	for {
@@ -81,6 +83,7 @@ func (w *watcher) start(ctx context.Context) {
 	}
 }
 
+// listFiles calls listFilesIn on a list of paths.
 func (w *watcher) listFiles(force bool) error {
 	var errs []error
 	for _, base := range w.bases {
@@ -91,6 +94,8 @@ func (w *watcher) listFiles(force bool) error {
 	return merr.NewErrors(errs...)
 }
 
+// listFilesIn recursively processes all files within a path, and checks them against the disable and skip lists. Files found that
+// are not on either list are loaded as Addons and applied to the cluster.
 func (w *watcher) listFilesIn(base string, force bool) error {
 	files := map[string]os.FileInfo{}
 	if err := filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
@@ -103,6 +108,9 @@ func (w *watcher) listFilesIn(base string, force bool) error {
 		return err
 	}
 
+	// Make a map of .skip files - these are used later to indicate that a given file should be ignored
+	// For example, 'addon.yaml.skip' will cause 'addon.yaml' to be ignored completely - unless it is also
+	// disabled, since disable processing happens first.
 	skips := map[string]bool{}
 	keys := make([]string, len(files))
 	keyIndex := 0
@@ -117,13 +125,15 @@ func (w *watcher) listFilesIn(base string, force bool) error {
 
 	var errs []error
 	for _, path := range keys {
-		if shouldDisableService(base, path, w.disables) {
+		// Disabled files are not just skipped, but actively deleted from the filesystem
+		if shouldDisableFile(base, path, w.disables) {
 			if err := w.delete(path); err != nil {
 				errs = append(errs, errors2.Wrapf(err, "failed to delete %s", path))
 			}
 			continue
 		}
-		if skipFile(files[path].Name(), skips) {
+		// Skipped files are just ignored
+		if shouldSkipFile(files[path].Name(), skips) {
 			continue
 		}
 		modTime := files[path].ModTime()
@@ -140,14 +150,16 @@ func (w *watcher) listFilesIn(base string, force bool) error {
 	return merr.NewErrors(errs...)
 }
 
+// deploy loads yaml from a manifest on disk, creates an AddOn resource to track its application, and then applies
+// all resources contained within to the cluster.
 func (w *watcher) deploy(path string, compareChecksum bool) error {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
 	}
 
-	name := name(path)
-	addon, err := w.addon(name)
+	name := basename(path)
+	addon, err := w.getOrCreateAddon(name)
 	if err != nil {
 		return err
 	}
@@ -171,6 +183,8 @@ func (w *watcher) deploy(path string, compareChecksum bool) error {
 	addon.Spec.Checksum = checksum
 	addon.Status.GVKs = nil
 
+	// Create the new Addon now so that we can use it to report Events when parsing/applying the manifest
+	// Events need the UID and ObjectRevision set to function properly
 	if addon.UID == "" {
 		_, err := w.addons.Create(&addon)
 		return err
@@ -180,9 +194,11 @@ func (w *watcher) deploy(path string, compareChecksum bool) error {
 	return err
 }
 
+// delete completely removes both a manifest, and any resources that it did or would have created. The manifest is
+// parsed, and any resources it specified are deleted. Finally, the file itself is removed from disk.
 func (w *watcher) delete(path string) error {
-	name := name(path)
-	addon, err := w.addon(name)
+	name := basename(path)
+	addon, err := w.getOrCreateAddon(name)
 	if err != nil {
 		return err
 	}
@@ -213,16 +229,19 @@ func (w *watcher) delete(path string) error {
 	return os.Remove(path)
 }
 
-func (w *watcher) addon(name string) (v12.Addon, error) {
-	addon, err := w.addonCache.Get(ns, name)
+// getOrCreateAddon attempts to get an Addon by name from the addon namespace, and creates a new one
+// if it cannot be found.
+func (w *watcher) getOrCreateAddon(name string) (apisv1.Addon, error) {
+	addon, err := w.addonCache.Get(metav1.NamespaceSystem, name)
 	if errors.IsNotFound(err) {
-		addon = v12.NewAddon(ns, name, v12.Addon{})
+		addon = apisv1.NewAddon(metav1.NamespaceSystem, name, apisv1.Addon{})
 	} else if err != nil {
-		return v12.Addon{}, err
+		return apisv1.Addon{}, err
 	}
 	return *addon, nil
 }
 
+// objectSet returns a new ObjectSet containing all resources from a given yaml chunk
 func objectSet(content []byte) (*objectset.ObjectSet, error) {
 	objs, err := yamlToObjects(bytes.NewBuffer(content))
 	if err != nil {
@@ -234,16 +253,19 @@ func objectSet(content []byte) (*objectset.ObjectSet, error) {
 	return os, nil
 }
 
-func name(path string) string {
+// basename returns a file's basename by returning everything before the first period
+func basename(path string) string {
 	name := filepath.Base(path)
 	return strings.SplitN(name, ".", 2)[0]
 }
 
+// checksum returns the hex-encoded SHA256 sum of a byte slice
 func checksum(bytes []byte) string {
 	d := sha256.Sum256(bytes)
 	return hex.EncodeToString(d[:])
 }
 
+// isEmptyYaml returns true if a chunk of YAML contains nothing but whitespace, comments, or document separators
 func isEmptyYaml(yaml []byte) bool {
 	isEmpty := true
 	lines := bytes.Split(yaml, []byte("\n"))
@@ -256,6 +278,7 @@ func isEmptyYaml(yaml []byte) bool {
 	return isEmpty
 }
 
+// yamlToObjects returns an object slice yielded from documents in a chunk of YAML
 func yamlToObjects(in io.Reader) ([]runtime.Object, error) {
 	var result []runtime.Object
 	reader := yamlDecoder.NewYAMLReader(bufio.NewReaderSize(in, 4096))
@@ -281,6 +304,7 @@ func yamlToObjects(in io.Reader) ([]runtime.Object, error) {
 	return result, nil
 }
 
+// Returns one or more objects from a single YAML document
 func toObjects(bytes []byte) ([]runtime.Object, error) {
 	bytes, err := yamlDecoder.ToJSON(bytes)
 	if err != nil {
@@ -304,7 +328,9 @@ func toObjects(bytes []byte) ([]runtime.Object, error) {
 	return []runtime.Object{obj}, nil
 }
 
-func skipFile(fileName string, skips map[string]bool) bool {
+// Returns true if a file should be skipped. Skips anything from the provided skip map,
+// anything that is a dotfile, and anything that does not have a json/yaml/yml extension.
+func shouldSkipFile(fileName string, skips map[string]bool) bool {
 	switch {
 	case strings.HasPrefix(fileName, "."):
 		return true
@@ -317,7 +343,18 @@ func skipFile(fileName string, skips map[string]bool) bool {
 	}
 }
 
-func shouldDisableService(base, fileName string, disables map[string]bool) bool {
+// Returns true if a file should be disabled, by checking the file basename against a disables map.
+// only json/yaml files are checked.
+func shouldDisableFile(base, fileName string, disables map[string]bool) bool {
+	switch {
+	case strings.HasSuffix(fileName, ".json"):
+	case strings.HasSuffix(fileName, ".yaml"):
+	case strings.HasSuffix(fileName, ".yml"):
+	default:
+		return false
+	}
+	// Check to see if the file is in a subdirectory that is in the disables map.
+	// If a file is nested several levels deep, checks 'parent1', 'parent1/parent2', 'parent1/parent2/parent3', etc.
 	relFile := strings.TrimPrefix(fileName, base)
 	namePath := strings.Split(relFile, string(os.PathSeparator))
 	for i := 1; i < len(namePath); i++ {
@@ -329,6 +366,7 @@ func shouldDisableService(base, fileName string, disables map[string]bool) bool 
 	if !util.HasSuffixI(fileName, ".yaml", ".yml", ".json") {
 		return false
 	}
+	// Check the basename against the disables map
 	baseFile := filepath.Base(fileName)
 	suffix := filepath.Ext(baseFile)
 	baseName := strings.TrimSuffix(baseFile, suffix)

--- a/pkg/deploy/stage.go
+++ b/pkg/deploy/stage.go
@@ -4,6 +4,8 @@ package deploy
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,6 +15,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Stage iterates over the embedded asset list. Assets are checked against the skips map
+// to determine if they should not be processed. If they should not be skipped, string substitutions
+// are performed using the templateVars map. Finally, content is checksummed to see if the file should
+// be rewritten. If the content has changed from the on-disk version, the file is rewritten.
 func Stage(dataDir string, templateVars map[string]string, skips map[string]bool) error {
 staging:
 	for _, name := range AssetNames() {
@@ -35,7 +41,19 @@ staging:
 		for k, v := range templateVars {
 			content = bytes.Replace(content, []byte(k), []byte(v), -1)
 		}
+
 		p := filepath.Join(dataDir, name)
+		contentHash := sha256.Sum256(content)
+		currentHash, err := fileSum256(p)
+		if err != nil {
+			return err
+		}
+
+		if bytes.Equal(contentHash[:], currentHash[:]) {
+			logrus.Info("Unchanged manifest: ", p)
+			continue
+		}
+
 		os.MkdirAll(filepath.Dir(p), 0700)
 		logrus.Info("Writing manifest: ", p)
 		if err := ioutil.WriteFile(p, content, 0600); err != nil {
@@ -44,4 +62,22 @@ staging:
 	}
 
 	return nil
+}
+
+// fileSum256 returns the sha256 digest of a file at a given path.
+func fileSum256(path string) (data []byte, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return data, nil
+		}
+		return data, err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return data, err
+	}
+	return h.Sum(nil), nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -188,7 +188,8 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 		servicelb.DefaultLBImage = config.ControlConfig.SystemDefaultRegistry + "/" + servicelb.DefaultLBImage
 	}
 
-	helm.Register(ctx, sc.Apply,
+	helm.Register(ctx,
+		sc.Apply,
 		sc.Helm.Helm().V1().HelmChart(),
 		sc.Helm.Helm().V1().HelmChartConfig(),
 		sc.Batch.Batch().V1().Job(),
@@ -204,7 +205,8 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 		sc.Core.Core().V1().Pod(),
 		sc.Core.Core().V1().Service(),
 		sc.Core.Core().V1().Endpoints(),
-		!config.DisableServiceLB, config.Rootless); err != nil {
+		!config.DisableServiceLB,
+		config.Rootless); err != nil {
 		return err
 	}
 
@@ -213,7 +215,10 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 	}
 
 	if config.Rootless {
-		return rootlessports.Register(ctx, sc.Core.Core().V1().Service(), !config.DisableServiceLB, config.ControlConfig.HTTPSPort)
+		return rootlessports.Register(ctx,
+			sc.Core.Core().V1().Service(),
+			!config.DisableServiceLB,
+			config.ControlConfig.HTTPSPort)
 	}
 
 	return nil
@@ -242,7 +247,11 @@ func stageFiles(ctx context.Context, sc *Context, controlConfig *config.Control)
 		return err
 	}
 
-	return deploy.WatchFiles(ctx, sc.Apply, sc.K3s.K3s().V1().Addon(), controlConfig.Disables, dataDir)
+	return deploy.WatchFiles(ctx,
+		sc.Apply,
+		sc.K3s.K3s().V1().Addon(),
+		controlConfig.Disables,
+		dataDir)
 }
 
 // registryTemplate behaves like the system_default_registry template in Rancher helm charts,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -248,6 +248,7 @@ func stageFiles(ctx context.Context, sc *Context, controlConfig *config.Control)
 	}
 
 	return deploy.WatchFiles(ctx,
+		sc.K8s,
 		sc.Apply,
 		sc.K3s.K3s().V1().Addon(),
 		controlConfig.Disables,


### PR DESCRIPTION
Proposed changes
======
* Addresses issues with multiple nodes applying their local 'latest' version of manifest content by tracking file modification time in the CRD, and only applying file changes if the local mtime is newer.
* Addresses issues with visibility (which node did the currently-applied manifest come from) by adding Hostname to CRD spec. 
* Addresses issues with visibility (were errors encountered when parsing or applying the manifest) by adding change/failure events viewable via `kubectl get events -n kube-system` or `kubectl describe addon -n kube-system <addon>`. Events are inspired by k/k event behavior for Pods, where Events are created for container pull start, container pull success/failure, etc. They should be meaningful but not spammy.

Types of changes
======
- New feature

Verification
===
note new fields: `kubectl get addon -A -o yaml`

Linked Issues
======
Related to k3s-io/k3s#1357 and k3s-io/k3s#1337
Darren had a WIP PR in k3s-io/k3s#1755 to address #1357. An alternative approach (implemented in this PR) was approved in https://github.com/rancher/k3s/pull/1755#issuecomment-624790507

Example output
===
```
Name:         traefik
Namespace:    kube-system
Labels:       <none>
Annotations:  <none>
API Version:  k3s.cattle.io/v1
Kind:         Addon
Metadata:
  Creation Timestamp:  2020-08-27T06:33:10Z
  Generation:          1
  Managed Fields:
    API Version:  k3s.cattle.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:checksum:
        f:hostname:
        f:modTime:
        f:source:
      f:status:
    Manager:         exe
    Operation:       Update
    Time:            2020-08-27T06:33:10Z
  Resource Version:  234
  Self Link:         /apis/k3s.cattle.io/v1/namespaces/kube-system/addons/traefik
  UID:               9485676f-0e38-481b-8989-b5efe3e43f1a
Spec:
  Checksum:  6d311bade7254b59e7b2bb3838032ab2686cb92d725408092f568960973927a6
  Hostname:  dev01.lan.khaus
  Mod Time:  2020-08-27T06:33:09Z
  Source:    /var/lib/repos/k3s/server/manifests/traefik.yaml
Status:
Events:
  Type    Reason            Age   From                                Message
  ----    ------            ----  ----                                -------
  Normal  ApplyingManifest  30s   deploy-controller, dev01.lan.khaus  Applying manifest at "/var/lib/repos/k3s/server/manifests/traefik.yaml"
  Normal  AppliedManifest   30s   deploy-controller, dev01.lan.khaus  Applied manifest at "/var/lib/repos/k3s/server/manifests/traefik.yaml"
```