### PR TITLE
Add containerd command

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -30,6 +30,7 @@ func main() {
 		cmds.NewKubectlCommand(externalCLIAction("kubectl")),
 		cmds.NewCRICTL(externalCLIAction("crictl")),
 		cmds.NewCtrCommand(externalCLIAction("ctr")),
+		cmds.NewContainerd(externalCLIAction("containerd")),
 		cmds.NewCheckConfigCommand(externalCLIAction("check-config")),
 	}
 
@@ -43,7 +44,7 @@ func runCLIs() bool {
 	if os.Getenv("CRI_CONFIG_FILE") == "" {
 		os.Setenv("CRI_CONFIG_FILE", datadir.DefaultDataDir+"/agent/etc/crictl.yaml")
 	}
-	for _, cmd := range []string{"kubectl", "ctr", "crictl"} {
+	for _, cmd := range []string{"kubectl", "ctr", "crictl", "containerd"} {
 		if filepath.Base(os.Args[0]) == cmd {
 			if err := externalCLI(cmd, "", os.Args[1:]); err != nil {
 				logrus.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/rancher/k3s/pkg/cli/agent"
 	"github.com/rancher/k3s/pkg/cli/cmds"
+	"github.com/rancher/k3s/pkg/cli/containerd"
 	"github.com/rancher/k3s/pkg/cli/crictl"
 	"github.com/rancher/k3s/pkg/cli/kubectl"
 	"github.com/rancher/k3s/pkg/cli/server"
-	"github.com/rancher/k3s/pkg/cli/containerd"
 	"github.com/rancher/k3s/pkg/configfilearg"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/k3s/pkg/cli/crictl"
 	"github.com/rancher/k3s/pkg/cli/kubectl"
 	"github.com/rancher/k3s/pkg/cli/server"
+	"github.com/rancher/k3s/pkg/cli/containerd"
 	"github.com/rancher/k3s/pkg/configfilearg"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -26,6 +27,7 @@ func main() {
 		cmds.NewAgentCommand(agent.Run),
 		cmds.NewKubectlCommand(kubectl.Run),
 		cmds.NewCRICTL(crictl.Run),
+		cmds.NewContainerd(containerd.Run),
 	}
 
 	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil {

--- a/pkg/cli/cmds/containerd.go
+++ b/pkg/cli/cmds/containerd.go
@@ -1,0 +1,15 @@
+package cmds
+
+import (
+	"github.com/urfave/cli"
+)
+
+func NewContainerd(action func(*cli.Context) error) cli.Command {
+	return cli.Command{
+		Name:            "containerd",
+		Usage:           "Run containerd",
+		SkipFlagParsing: true,
+		SkipArgReorder:  true,
+		Action:          action,
+	}
+}

--- a/pkg/cli/containerd/containerd.go
+++ b/pkg/cli/containerd/containerd.go
@@ -1,0 +1,11 @@
+package containerd
+
+import (
+	"github.com/rancher/k3s/pkg/containerd"
+	"github.com/urfave/cli"
+)
+
+func Run(ctx *cli.Context) error {
+	containerd.Main()
+	return nil
+}


### PR DESCRIPTION
k3s allows users to connect to an existing container runtime via socket.
This is fine for Docker or CRI-O. However, if you want to use
containerd in this way, you need to install a separate containerd binary
even though k3s already contains it. Therefore I added an option to run
just containerd from k3s binary.

Signed-off-by: Peter Pulik <petopulik@gmail.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

