### PR TITLE
added raspberry installation hint

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -755,6 +755,11 @@ openrc_start() {
 
 # --- startup systemd or openrc service ---
 service_enable_and_start() {
+    if [ -f "/proc/cgroups" ] && [ "$(grep memory /proc/cgroups | while read -r n n n enabled; do echo $enabled; done)" -eq 0 ];
+    then
+        info 'Failed to find memory cgroup, you may need to add "cgroup_memory=1 cgroup_enable=memory" to your linux cmdline (/boot/cmdline.txt on a Raspberry Pi)'
+    fi
+
     [ "${INSTALL_K3S_SKIP_ENABLE}" = true ] && return
 
     [ "${HAS_SYSTEMD}" = true ] && systemd_enable


### PR DESCRIPTION
#### Proposed Changes ####

When installing k3s on a raspberry Pi one of the nuisances is that the installer looks to have worked just fine:

```
root@datalore:~# curl -sfL https://get.k3s.io | sh -
[INFO]  Finding release for channel stable
[INFO]  Using v1.18.9+k3s1 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/v1.18.9+k3s1/sha256sum-arm.txt
[INFO]  Downloading binary https://github.com/rancher/k3s/releases/download/v1.18.9+k3s1/k3s-armhf
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Skipping /usr/local/bin/ctr symlink to k3s, command exists in PATH at /usr/bin/ctr
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.
[INFO]  systemd: Starting k3s
```

But you won't be able to get k3s running because you need to enable memory cgroups, the systemctl status won't help either:

```
root@datalore:~# systemctl status k3s
● k3s.service - Lightweight Kubernetes
   Loaded: loaded (/etc/systemd/system/k3s.service; enabled; vendor preset: enabled)
   Active: activating (auto-restart) (Result: exit-code) since Tue 2020-10-13 16:38:00 BST; 4s ago
     Docs: https://k3s.io
  Process: 2107 ExecStartPre=/sbin/modprobe br_netfilter (code=exited, status=0/SUCCESS)
  Process: 2108 ExecStartPre=/sbin/modprobe overlay (code=exited, status=0/SUCCESS)
  Process: 2109 ExecStart=/usr/local/bin/k3s server (code=exited, status=1/FAILURE)
 Main PID: 2109 (code=exited, status=1/FAILURE)
```

You will have to start k3s manually to be able to get a helpful error message:

```
ERRO[2020-10-13T16:40:58.690824994+01:00] Failed to find memory cgroup, you may need to add "cgroup_memory=1 cgroup_enable=memory" to your linux cmdline (/boot/cmdline.txt on a Raspberry Pi) 
FATA[2020-10-13T16:40:58.691126492+01:00] failed to find memory cgroup, you may need to add "cgroup_memory=1 cgroup_enable=memory" to your linux cmdline (/boot/cmdline.txt on a Raspberry Pi) 
```
What I propose is to add a message warning the user to enable cgroups checking that are actually disabled. To do so we can check that the /proc/cgrups file exists, and if it does, check the 4th column for the "memory": If it is 0 we can warn the user

#### Types of Changes ####

Between a bug and a feature request, it's a way of helping the user to start using k3s

#### Verification ####

You can check that on a system with the memory cgroups disabled it will look like this:

```
pi@datalore:~ $ cat /proc/cgroups 
#subsys_name	hierarchy	num_cgroups	enabled
(...)
memory	0	87	0
(...)
```

Once we add "cgroup_memory=1 cgroup_enable=memory" to the cmdline.txt it will look like this:

```
pi@datalore:~ $ cat /proc/cgroups 
#subsys_name	hierarchy	num_cgroups	enabled
(...)
memory	8	186	1
(...)
```
#### Linked Issues ####

There have been [several issues](https://github.com/rancher/k3s/issues?q=is%3Aissue+is%3Aclosed+cgroup+memory+) related to this


