### PR TITLE
Update validate message.

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -181,7 +181,7 @@ func validate() error {
 	}
 
 	if !strings.Contains(string(cgroups), "memory") {
-		msg := "ailed to find memory cgroup, you may need to add \"cgroup_memory=1 cgroup_enable=memory\" to your linux cmdline (/boot/cmdline.txt on a Raspberry Pi)"
+		msg := "ailed to find memory cgroup, you may need to add \"cgroup_enable=memory\" to your linux cmdline (/boot/cmdline.txt on a Raspberry Pi)"
 		logrus.Error("F" + msg)
 		return errors.New("f" + msg)
 	}


### PR DESCRIPTION
Remove unnecessary config tips.

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Remove `cgroup_memory` config tips.

#### Types of Changes ####

Refine

#### Verification ####

`cgroup_memory=1` was used in the first commit changes, very soon it refined to `cgroup_enable=memory`.
And `cgroup_memory=1` removed in `v4.14`(which in Raspbian 9 Stretch).

See https://github.com/raspberrypi/linux/commit/a57f17a14ad1a2aceb5a1459d988ed71f5024999 and https://github.com/raspberrypi/linux/commit/90668092721aeb7976c5adb9b72bd35bf1e683c4