### PR TITLE
install.sh: support install on Flatcar with no args

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -456,7 +456,7 @@ setup_selinux() {
     yum install -y https://${rpm_site}/k3s/${rpm_channel}/common/centos/7/noarch/k3s-selinux-0.2-1.el7_8.noarch.rpm
 "
     policy_error=fatal
-    if [ "$INSTALL_K3S_SELINUX_WARN" = true ]; then
+    if [ "$INSTALL_K3S_SELINUX_WARN" = true ] || grep -q 'ID=flatcar' /etc/os-release; then
         policy_error=warn
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -226,7 +226,7 @@ setup_env() {
     else
         # --- use /usr/local/bin if we can write to it, otherwise try /opt
         BIN_DIR=/usr/local/bin
-	touch ${BIN_DIR}/k3s-ro-test 2>/dev/null && rm -rf ${BIN_DIR}/k3s-ro-test || BIN_DIR=/opt/bin
+	  touch ${BIN_DIR}/k3s-ro-test 2>/dev/null && rm -rf ${BIN_DIR}/k3s-ro-test || BIN_DIR=/opt/bin
     fi
 
     # --- use systemd directory if defined or create default ---

--- a/install.sh
+++ b/install.sh
@@ -224,7 +224,9 @@ setup_env() {
     if [ -n "${INSTALL_K3S_BIN_DIR}" ]; then
         BIN_DIR=${INSTALL_K3S_BIN_DIR}
     else
+        # --- use /usr/local/bin if we can write to it, otherwise try /opt
         BIN_DIR=/usr/local/bin
+	touch ${BIN_DIR}/k3s-ro-test 2>/dev/null && rm -rf ${BIN_DIR}/k3s-ro-test || BIN_DIR=/opt/bin
     fi
 
     # --- use systemd directory if defined or create default ---


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

a couple of tests for the k3s installer to enable flatcar install with fewer (no) parameters.

#### Types of Changes ####

checks inside the installer

#### Verification ####

on a Flatcar host: `bash ./install.sh`

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

one thing this does not address yet is the `/usr/libexec/kubernetes` path for plugins. 
As an example, a user can make an overlay mount before running the k3s installer: https://gist.github.com/vbatts/705c2542df39495319c8601c01b658e8#file-cloud-config-yaml-L17
But this seems a bit in the weeds for this installer to do, unless the maintainers say so, and then I'll add this. Because it's just a `mkdir` and a systemd unit
