### PR TITLE
Change from `Type=notify` for server to `Type=exec` universally

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -213,11 +213,7 @@ setup_env() {
     if [ -n "${INSTALL_K3S_TYPE}" ]; then
         SYSTEMD_TYPE=${INSTALL_K3S_TYPE}
     else
-        if [ "${CMD_K3S}" = server ]; then
-            SYSTEMD_TYPE=notify
-        else
-            SYSTEMD_TYPE=exec
-        fi
+        SYSTEMD_TYPE=exec
     fi
 
     # --- use binary install directory if defined or create default ---


### PR DESCRIPTION
#### Proposed Changes ####
Change the `k3s.service` unit file from `Type=notify` to `Type=exec` universally. 

#### Types of Changes ####
`install.sh`

#### Verification ####
Install `k3s` using the new `install.sh` script on a CentOS/RHEL 7.8+ host with `systemd` > `systemd-219-73` and `--docker`.

#### Linked Issues ####
https://github.com/rancher/k3s/issues/2548

#### Further Comments ####
We should revisit this in https://github.com/rancher/k3s/issues/2577
