### PR TITLE
Add support for both config-file and data-dir at a global level in the self-extracting wrapper for K3s

### DIFF
--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -36,7 +36,6 @@ func NewApp() *cli.App {
 	}
 	app.Flags = []cli.Flag{
 		DebugFlag,
-		ConfigFlag,
 		cli.StringFlag{
 			Name:  "data-dir,d",
 			Usage: "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -36,6 +36,11 @@ func NewApp() *cli.App {
 	}
 	app.Flags = []cli.Flag{
 		DebugFlag,
+		ConfigFlag,
+		cli.StringFlag{
+			Name:  "data-dir,d",
+			Usage: "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
+		},
 	}
 	app.Before = SetupDebug(nil)
 

--- a/pkg/configfilearg/defaultparser.go
+++ b/pkg/configfilearg/defaultparser.go
@@ -18,3 +18,17 @@ func MustParse(args []string) []string {
 	}
 	return result
 }
+
+func MustFindString(args []string, target string) string {
+	parser := &Parser{
+		After:         []string{},
+		FlagNames:     []string{"--config", "-c"},
+		EnvName:       version.ProgramUpper + "_CONFIG_FILE",
+		DefaultConfig: "/etc/rancher/" + version.Program + "/config.yaml",
+	}
+	result, err := parser.FindString(args, target)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	return result
+}

--- a/pkg/configfilearg/defaultparser.go
+++ b/pkg/configfilearg/defaultparser.go
@@ -22,7 +22,7 @@ func MustParse(args []string) []string {
 func MustFindString(args []string, target string) string {
 	parser := &Parser{
 		After:         []string{},
-		FlagNames:     []string{"--config", "-c"},
+		FlagNames:     []string{},
 		EnvName:       version.ProgramUpper + "_CONFIG_FILE",
 		DefaultConfig: "/etc/rancher/" + version.Program + "/config.yaml",
 	}

--- a/pkg/configfilearg/parser.go
+++ b/pkg/configfilearg/parser.go
@@ -46,6 +46,32 @@ func (p *Parser) Parse(args []string) ([]string, error) {
 	return args, nil
 }
 
+func (p *Parser) FindString(args []string, target string) (string, error) {
+	configFile, isSet := p.findConfigFileFlag(args)
+	if configFile != "" {
+		bytes, err := readConfigFileData(configFile)
+		if !isSet && os.IsNotExist(err) {
+			return "", nil
+		} else if err != nil {
+			return "", err
+		}
+
+		data := yaml.MapSlice{}
+		if err := yaml.Unmarshal(bytes, &data); err != nil {
+			return "", err
+		}
+
+		for _, i := range data {
+			k, v := convert.ToString(i.Key), convert.ToString(i.Value)
+			if k == target {
+				return v, nil
+			}
+		}
+	}
+
+	return "", nil
+}
+
 func (p *Parser) findConfigFileFlag(args []string) (string, bool) {
 	if envVal := os.Getenv(p.EnvName); p.EnvName != "" && envVal != "" {
 		return envVal, true


### PR DESCRIPTION
Add support for both config-file and data-dir at a global level in the self-extracting wrapper for K3s

#### Proposed Changes ####
Adds `data-dir` and `config-file` parsing to the K3s self-extracting wrapper to ensure that we always use our desired `data-dir`.

#### Types of Changes ####
Enhancement

#### Verification ####
Run the various `k3s` CLI commands with `--data-dir` or create a config file (`/etc/rancher/k3s/config.yaml`) with `data-dir: ` defined in it and observe `K3s` should always use this.

#### Linked Issues ####
https://github.com/rancher/k3s/issues/2593
https://github.com/rancher/k3s/issues/2563

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

