### PR TITLE
channels: tweak testing channel config(s)

### DIFF
--- a/channel.yaml
+++ b/channel.yaml
@@ -6,27 +6,27 @@ channels:
   latestRegexp: .*
   excludeRegexp: ^[^+]+-
 - name: testing
-  latestRegexp: .*
+  latestRegexp: -(alpha|beta|rc)
 - name: v1.16
   latestRegexp: v1\.16\..*
   excludeRegexp: ^[^+]+-
 - name: v1.16-testing
-  latestRegexp: v1\.16\.*
+  latestRegexp: v1\.16\.[0-9]*-(alpha|beta|rc)
 - name: v1.17
   latestRegexp: v1\.17\..*
   excludeRegexp: ^[^+]+-
 - name: v1.17-testing
-  latestRegexp: v1\.17\..*
+  latestRegexp: v1\.17\.[0-9]*-(alpha|beta|rc)
 - name: v1.18
   latestRegexp: v1\.18\..*
   excludeRegexp: ^[^+]+-
 - name: v1.18-testing
-  latestRegexp: v1\.18\..*
+  latestRegexp: v1\.18\.[0-9]*-(alpha|beta|rc)
 # Starting with 1.19, we aren't going to add a *-testing channel for minor releases
 - name: v1.19
   latestRegexp: v1\.19\..*
   excludeRegexp: ^[^+]+-
 github:
-  owner: rancher
+  owner: k3s-io
   repo: k3s
-redirectBase: https://github.com/rancher/k3s/releases/tag/
+redirectBase: https://github.com/k3s-io/k3s/releases/tag/


### PR DESCRIPTION
Limit the `testing` channel(s) to alpha, beta, and rc pre-releases.

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
