### PR TITLE
Bump Golang base image to 1.15 moving tag

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.15.2-alpine3.12
+FROM golang:1.15-alpine3.12
 
 ARG http_proxy=$http_proxy
 ARG https_proxy=$https_proxy

--- a/Dockerfile.manifest
+++ b/Dockerfile.manifest
@@ -1,4 +1,4 @@
-FROM golang:1.15.2-alpine3.12
+FROM golang:1.15-alpine3.12
 
 COPY --from=plugins/manifest:1.2.3 /bin/* /bin/
 

--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.15.2-alpine3.12
+FROM golang:1.15-alpine3.12
 
 RUN apk -U --no-cache add bash git gcc musl-dev docker curl jq coreutils python2 openssl
 


### PR DESCRIPTION
#### Proposed Changes ####

This is being refreshed against the latest alpine based
golang 1.15 release so it allows to transparently include
golang patch level updates (which are typically security and
other critical security bugfixes only).



#### Types of Changes ####

#### Verification ####

this is explained in more detail under "Available Images" on the page https://hub.docker.com/_/golang

#### Linked Issues ####


#### Further Comments ####
