### PR TITLE
Restore legacy master role for etcd nodes

### DIFF
--- a/pkg/etcd/controller.go
+++ b/pkg/etcd/controller.go
@@ -13,6 +13,7 @@ import (
 const (
 	nodeID       = "etcd.k3s.cattle.io/node-name"
 	nodeAddress  = "etcd.k3s.cattle.io/node-address"
+	master       = "node-role.kubernetes.io/master"
 	controlPlane = "node-role.kubernetes.io/control-plane"
 	etcdRole     = "node-role.kubernetes.io/etcd"
 )
@@ -69,6 +70,7 @@ func (h *handler) handleSelf(node *v1.Node) (*v1.Node, error) {
 	node.Annotations[nodeID] = h.etcd.name
 	node.Annotations[nodeAddress] = h.etcd.address
 	node.Labels[etcdRole] = "true"
+	node.Labels[master] = "true"
 	node.Labels[controlPlane] = "true"
 
 	return h.nodeController.Update(node)


### PR DESCRIPTION
#### Proposed Changes ####

63f2211b314d5e2e8c7b7cef027ffe369b5955f5 replaced the master role with control-plane for etcd nodes, when it should have added it instead. The old role cannot go away until after the transition period.

#### Types of Changes ####

Bugfix

#### Verification ####

* Create multi-node cluster with embedded etcd
* Note correct labels (control-plane, master, etcd) on all nodes

#### Linked Issues ####

k3s-io/k3s#2385

#### Further Comments ####

Thanks @erikwilson!
