### PR TITLE
Fix manifest CI step

### DIFF
--- a/Dockerfile.manifest
+++ b/Dockerfile.manifest
@@ -2,6 +2,8 @@ FROM golang:1.15.5-alpine3.12
 
 COPY --from=plugins/manifest:1.2.3 /bin/* /bin/
 
+RUN apk -U --no-cache add bash
+
 ARG DOCKER_USERNAME
 ENV DOCKER_USERNAME $DOCKER_USERNAME
 


### PR DESCRIPTION
#### Proposed Changes ####

Fix manifest CI step by installing bash, as we do in other Dockerfiles.

I broke this in 50ea2d816421d371cbbee7094310c0b8d3786113 when I standardized on bash for all the CI scripts. Unfortunately I didn't notice that the manifest step Dockerfile is missing bash.

#### Types of Changes ####

CI

#### Verification ####

* Tag release
* Note that deploy succeeds

#### Linked Issues ####

k3s-io/k3s#2556

#### Further Comments ####