### PR TITLE
Add bash to curl image before running dispatch script

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -303,13 +303,15 @@ platform:
 
 steps:
 - name: dispatch
-  image: curlimages/curl:7.69.1
+  image: curlimages/curl:7.74.0
+  user: root
   environment:
     PAT_USERNAME:
       from_secret: pat_username
     PAT_TOKEN:
       from_secret: github_token
   commands:
+    - apk -U --no-cache add bash
     - scripts/dispatch
 
 trigger:


### PR DESCRIPTION
#### Proposed Changes ####

Same as #2716 - missed another step, this one a direct invocation from Drone.

Fix by updating curl image (clean as you go) and installing bash before running the script.

#### Types of Changes ####

* CI

#### Verification ####

* Tag release
* Note that deploy succeeds

#### Linked Issues ####

k3s-io/k3s#2556

#### Further Comments ####

mea culpa @briandowns, you tried to warn me :/