### PR TITLE
Add user-facing change section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,15 @@
 
 <!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
 
+#### User-Facing Change ####
+<!--
+Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
+If the PR requires additional action from users switching to the new release, include the string "action required".
+-->
+```release-note
+
+```
+
 #### Further Comments ####
 
 <!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
-


### PR DESCRIPTION
#### Proposed Changes ####

Add user-facing change section to PR template

#### Types of Changes ####

Github

#### Verification ####

* Open a new PR
* See new template
* Fill out template including user-facing change section
* See contents of PR template show up in release notes

#### Linked Issues ####

N/A

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####
This sets us up to write some automation to scrape release-note sections from PRs for inclusion in release note documents. This is inspired by the upstream PR template and release automation:
https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md. 