### PR TITLE
Add codespell CI test and fix codespell error

### DIFF
--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -1,6 +1,6 @@
 FROM golang:1.15.5-alpine3.12
 
-RUN apk -U --no-cache add bash git gcc musl-dev docker curl jq coreutils python2 openssl
+RUN apk -U --no-cache add bash git gcc musl-dev docker curl jq coreutils python2 openssl py-pip
 
 ENV SONOBUOY_VERSION 0.19.0
 
@@ -12,7 +12,8 @@ RUN OS=linux; \
       tar -xzf - -C /usr/local/bin; \
     fi; \
     curl -fsL https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/${ARCH}/kubectl -o /usr/local/bin/kubectl; \
-    chmod a+x /usr/local/bin/kubectl
+    chmod a+x /usr/local/bin/kubectl; \
+    pip install codespell
 
 ENV TEST_CLEANUP true
 

--- a/install.sh
+++ b/install.sh
@@ -275,7 +275,7 @@ can_skip_download() {
     fi
 }
 
-# --- verify an executabe k3s binary is installed ---
+# --- verify an executable k3s binary is installed ---
 verify_k3s_is_executable() {
     if [ ! -x ${BIN_DIR}/k3s ]; then
         fatal "Executable k3s binary not found at ${BIN_DIR}/k3s"
@@ -323,7 +323,7 @@ verify_downloader() {
     return 0
 }
 
-# --- create tempory directory and cleanup when done ---
+# --- create temporary directory and cleanup when done ---
 setup_tmp() {
     TMP_DIR=$(mktemp -d -t k3s-install.XXXXXXXXXX)
     TMP_HASH=${TMP_DIR}/k3s.hash

--- a/package/rpm/install.sh
+++ b/package/rpm/install.sh
@@ -269,7 +269,7 @@ can_skip_download() {
     fi
 }
 
-# --- verify an executabe k3s binary is installed ---
+# --- verify an executable k3s binary is installed ---
 verify_k3s_is_executable() {
     if [ ! -x ${BIN_DIR}/k3s ]; then
         fatal "Executable k3s binary not found at ${BIN_DIR}/k3s"
@@ -326,7 +326,7 @@ verify_semanage() {
     fi
 }
 
-# --- create tempory directory and cleanup when done ---
+# --- create temporary directory and cleanup when done ---
 setup_tmp() {
     TMP_DIR=$(mktemp -d -t k3s-install.XXXXXXXXXX)
     TMP_HASH=${TMP_DIR}/k3s.hash

--- a/pkg/agent/netpol/network_policy_controller.go
+++ b/pkg/agent/netpol/network_policy_controller.go
@@ -710,7 +710,7 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(version string) (map[s
 	for _, pod := range *ingressNetworkPolicyEnabledPods {
 
 		// below condition occurs when we get trasient update while removing or adding pod
-		// subseqent update will do the correct action
+		// subsequent update will do the correct action
 		if len(pod.ip) == 0 || pod.ip == "" {
 			continue
 		}
@@ -834,7 +834,7 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(version string) (map[s
 	for _, pod := range *egressNetworkPolicyEnabledPods {
 
 		// below condition occurs when we get trasient update while removing or adding pod
-		// subseqent update will do the correct action
+		// subsequent update will do the correct action
 		if len(pod.ip) == 0 || pod.ip == "" {
 			continue
 		}
@@ -1544,7 +1544,7 @@ func (npc *NetworkPolicyController) Cleanup() {
 		return
 	}
 
-	// TODO: need a better way to delte rule with out using number
+	// TODO: need a better way to delete rule with out using number
 	var realRuleNo int
 	for i, rule := range forwardChainRules {
 		if strings.Contains(rule, kubePodFirewallChainPrefix) {
@@ -1560,7 +1560,7 @@ func (npc *NetworkPolicyController) Cleanup() {
 		return
 	}
 
-	// TODO: need a better way to delte rule with out using number
+	// TODO: need a better way to delete rule with out using number
 	realRuleNo = 0
 	for i, rule := range forwardChainRules {
 		if strings.Contains(rule, kubePodFirewallChainPrefix) {

--- a/pkg/agent/netpol/utils.go
+++ b/pkg/agent/netpol/utils.go
@@ -31,7 +31,7 @@ const (
 
 	// DefaultMaxElem Default OptionMaxElem value.
 	DefaultMaxElem = "65536"
-	// DefaultHasSize Defaul OptionHashSize value.
+	// DefaultHasSize Default OptionHashSize value.
 	DefaultHasSize = "1024"
 
 	// TypeHashIP The hash:ip set type uses a hash to store IP host addresses (default) or network addresses. Zero valued IP address cannot be stored in a hash:ip type of set.
@@ -96,7 +96,7 @@ type IPSet struct {
 	isIpv6    bool
 }
 
-// Set reprensent a ipset set entry.
+// Set represent a ipset set entry.
 type Set struct {
 	Parent  *IPSet
 	Name    string
@@ -257,7 +257,7 @@ func (entry *Entry) Del() error {
 	return entry.Set.Parent.Save()
 }
 
-// Test wether an entry is in a set or not. Exit status number is zero if the
+// Test whether an entry is in a set or not. Exit status number is zero if the
 // tested entry is in the set and nonzero if it is missing from the set.
 func (set *Set) Test(testOptions ...string) (bool, error) {
 	_, err := set.Parent.run(append([]string{"test", set.name()}, testOptions...)...)
@@ -388,7 +388,7 @@ func (ipset *IPSet) Save() error {
 // stdin. Please note, existing sets and elements are not erased by restore
 // unless specified so in the restore file. All commands are allowed in restore
 // mode except list, help, version, interactive mode and restore itself.
-// Send formated ipset.sets into stdin of "ipset restore" command.
+// Send formatted ipset.sets into stdin of "ipset restore" command.
 func (ipset *IPSet) Restore() error {
 	stdin := bytes.NewBufferString(buildIPSetRestore(ipset))
 	_, err := ipset.runWithStdin(stdin, "restore", "-exist")

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -213,7 +213,7 @@ func validateCgroupsV2() error {
 	}
 	for _, controller := range []string{"cpu", "cpuset", "memory"} {
 		if _, ok := m[controller]; !ok {
-			return fmt.Errorf("faild to find %s cgroup (v2)", controller)
+			return fmt.Errorf("failed to find %s cgroup (v2)", controller)
 		}
 	}
 	return nil

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Bootstrap attempts to load a managed database driver, if one has been initialized or should be created/joined.
-// It then checks to see if the cluster needs to load boostrap data, and if so, loads data into the
+// It then checks to see if the cluster needs to load bootstrap data, and if so, loads data into the
 // ControlRuntimeBoostrap struct, either via HTTP or from the datastore.
 func (c *Cluster) Bootstrap(ctx context.Context) error {
 	if err := c.assignManagedDriver(ctx); err != nil {

--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// newListener returns a new TCP listener and HTTP reqest handler using dynamiclistener.
+// newListener returns a new TCP listener and HTTP request handler using dynamiclistener.
 // dynamiclistener will use the cluster's Server CA to sign the dynamically generate certificate,
 // and will sync the certs into the Kubernetes datastore, with a local disk cache.
 func (c *Cluster) newListener(ctx context.Context) (net.Listener, http.Handler, error) {

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -66,7 +66,7 @@ func (c *Cluster) start(ctx context.Context) error {
 		}
 		return c.managedDB.Reset(ctx)
 	}
-	// removing the reset file and ignore error if the file doesnt exist
+	// removing the reset file and ignore error if the file doesn't exist
 	os.Remove(resetFile)
 
 	return c.managedDB.Start(ctx, c.clientAccessInfo)

--- a/scripts/codespell.sh
+++ b/scripts/codespell.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Ignore vendor folder and check file names as well
+# Note: ignore "ba" in https://github.com/k3s-io/k3s/blob/4317a91/scripts/provision/vagrant#L54
+codespell --skip=.git,./vendor --check-filenames --ignore-words-list=ba
+
+res=`echo $?`
+if [ "$res" = "0" ]; then
+    echo "Codespell found no problems"
+else
+    echo "Codespell found one or more problems"
+fi
+
+exit $res

--- a/scripts/codespell.sh
+++ b/scripts/codespell.sh
@@ -5,11 +5,8 @@ set -e
 # Note: ignore "ba" in https://github.com/k3s-io/k3s/blob/4317a91/scripts/provision/vagrant#L54
 codespell --skip=.git,./vendor --check-filenames --ignore-words-list=ba
 
-res=`echo $?`
-if [ "$res" = "0" ]; then
-    echo "Codespell found no problems"
-else
-    echo "Codespell found one or more problems"
+code=$?
+if [ $code -ne 0 ]; then
+  echo "Error: codespell found one or moe problems!"
+  exit $code
 fi
-
-exit $res

--- a/scripts/test
+++ b/scripts/test
@@ -2,6 +2,7 @@
 set -e -x
 cd $(dirname $0)/..
 
+. ./scripts/codespell.sh
 . ./scripts/version.sh
 . ./scripts/test-helpers
 


### PR DESCRIPTION
#### Proposed Changes ####

Fix the code spell error reported from https://github.com/codespell-project/codespell.

#### Types of Changes ####

- Add a code spell test in CI `./scripts/codespell.sh`
- Correct code spelling

#### Verification ####

None

#### Linked Issues ####

None

#### Further Comments ####

Not sure what's the `ba` means in https://github.com/k3s-io/k3s/blob/4317a91/scripts/provision/vagrant#L54
So I add ignore `ba` in https://github.com/k3s-io/k3s/blob/d64b687223aeaa8ca91b6b3a38595f12ec45f68b/scripts/codespell.sh#L5-L6