### PR TITLE
Add functionality to bind custom IP address for Etcd metrics endpoint

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -212,7 +212,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:        "etcd-expose-metrics",
-				Usage:       "(dc) Expose etcd metrics to client interface. (Default false)",
+				Usage:       "(db) Expose etcd metrics to client interface. (Default false)",
 				Destination: &ServerConfig.EtcdExposeMetrics,
 			},
 			&cli.BoolFlag{

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -59,6 +59,7 @@ type Server struct {
 	EncryptSecrets           bool
 	StartupHooks             []func(context.Context, <-chan struct{}, string) error
 	EtcdDisableSnapshots     bool
+	EtcdListenAddressMetrics string
 	EtcdSnapshotDir          string
 	EtcdSnapshotCron         string
 	EtcdSnapshotRetention    int
@@ -208,6 +209,11 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Usage:       "(db) TLS key file used to secure datastore backend communication",
 				Destination: &ServerConfig.DatastoreKeyFile,
 				EnvVar:      version.ProgramUpper + "_DATASTORE_KEYFILE",
+			},
+			&cli.StringFlag{
+				Name:        "etcd-listen-address-metrics",
+				Usage:       "(dc) Listen address etcd metrics",
+				Destination: &ServerConfig.EtcdListenAddressMetrics,
 			},
 			&cli.BoolFlag{
 				Name:        "etcd-disable-snapshots",

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -59,7 +59,7 @@ type Server struct {
 	EncryptSecrets           bool
 	StartupHooks             []func(context.Context, <-chan struct{}, string) error
 	EtcdDisableSnapshots     bool
-	EtcdListenAddressMetrics string
+	EtcdExposeMetrics        bool
 	EtcdSnapshotDir          string
 	EtcdSnapshotCron         string
 	EtcdSnapshotRetention    int
@@ -210,10 +210,10 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Destination: &ServerConfig.DatastoreKeyFile,
 				EnvVar:      version.ProgramUpper + "_DATASTORE_KEYFILE",
 			},
-			&cli.StringFlag{
-				Name:        "etcd-listen-address-metrics",
-				Usage:       "(dc) Listen address etcd metrics. (Default address 127.0.0.1)",
-				Destination: &ServerConfig.EtcdListenAddressMetrics,
+			&cli.BoolFlag{
+				Name:        "etcd-expose-metrics",
+				Usage:       "(dc) Expose etcd metrics to client interface. (Default false)",
+				Destination: &ServerConfig.EtcdExposeMetrics,
 			},
 			&cli.BoolFlag{
 				Name:        "etcd-disable-snapshots",

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -212,7 +212,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "etcd-listen-address-metrics",
-				Usage:       "(dc) Listen address etcd metrics. (Default adress 127.0.0.1)",
+				Usage:       "(dc) Listen address etcd metrics. (Default address 127.0.0.1)",
 				Destination: &ServerConfig.EtcdListenAddressMetrics,
 			},
 			&cli.BoolFlag{

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -212,7 +212,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "etcd-listen-address-metrics",
-				Usage:       "(dc) Listen address etcd metrics",
+				Usage:       "(dc) Listen address etcd metrics. (Default adress 127.0.0.1)",
 				Destination: &ServerConfig.EtcdListenAddressMetrics,
 			},
 			&cli.BoolFlag{

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -111,11 +111,11 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	serverConfig.ControlConfig.DisableKubeProxy = cfg.DisableKubeProxy
 	serverConfig.ControlConfig.ClusterInit = cfg.ClusterInit
 	serverConfig.ControlConfig.EncryptSecrets = cfg.EncryptSecrets
-	serverConfig.ControlConfig.EtcdListenAddressMetrics = cfg.EtcdListenAddressMetrics
 	serverConfig.ControlConfig.EtcdSnapshotCron = cfg.EtcdSnapshotCron
 	serverConfig.ControlConfig.EtcdSnapshotDir = cfg.EtcdSnapshotDir
 	serverConfig.ControlConfig.EtcdSnapshotRetention = cfg.EtcdSnapshotRetention
 	serverConfig.ControlConfig.EtcdDisableSnapshots = cfg.EtcdDisableSnapshots
+	serverConfig.ControlConfig.EtcdExposeMetrics = cfg.EtcdExposeMetrics
 
 	if cfg.ClusterResetRestorePath != "" && !cfg.ClusterReset {
 		return errors.New("Invalid flag use. --cluster-reset required with --cluster-reset-restore-path")

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -111,6 +111,7 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	serverConfig.ControlConfig.DisableKubeProxy = cfg.DisableKubeProxy
 	serverConfig.ControlConfig.ClusterInit = cfg.ClusterInit
 	serverConfig.ControlConfig.EncryptSecrets = cfg.EncryptSecrets
+	serverConfig.ControlConfig.EtcdListenAddressMetrics = cfg.EtcdListenAddressMetrics
 	serverConfig.ControlConfig.EtcdSnapshotCron = cfg.EtcdSnapshotCron
 	serverConfig.ControlConfig.EtcdSnapshotDir = cfg.EtcdSnapshotDir
 	serverConfig.ControlConfig.EtcdSnapshotRetention = cfg.EtcdSnapshotRetention

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -131,6 +131,7 @@ type Control struct {
 	TLSMinVersion            uint16
 	TLSCipherSuites          []uint16
 	EtcdDisableSnapshots     bool
+	EtcdListenAdressMetrics  string
 	EtcdSnapshotDir          string
 	EtcdSnapshotCron         string
 	EtcdSnapshotRetention    int

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -131,7 +131,7 @@ type Control struct {
 	TLSMinVersion            uint16
 	TLSCipherSuites          []uint16
 	EtcdDisableSnapshots     bool
-	EtcdListenAddressMetrics string
+	EtcdExposeMetrics        bool
 	EtcdSnapshotDir          string
 	EtcdSnapshotCron         string
 	EtcdSnapshotRetention    int

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -131,7 +131,7 @@ type Control struct {
 	TLSMinVersion            uint16
 	TLSCipherSuites          []uint16
 	EtcdDisableSnapshots     bool
-	EtcdListenAdressMetrics  string
+	EtcdListenAddressMetrics string
 	EtcdSnapshotDir          string
 	EtcdSnapshotCron         string
 	EtcdSnapshotRetention    int

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -475,13 +475,13 @@ func (e *ETCD) clientURL() string {
 
 // metricsURL returns the metrics access address
 func (e *ETCD) metricsURL(config *config.Control) string {
-	if config.EtcdListenAdressMetrics == "" {
+	if config.EtcdListenAddressMetrics == "" {
 		// we have to check if address is not empty
 		// the default listen address set if it doesn't exist
 		return fmt.Sprintf("https://%s:2381", e.address)
 	}
 
-	return fmt.Sprintf("https://%s:2381", config.EtcdListenAdressMetrics)
+	return fmt.Sprintf("https://%s:2381", config.EtcdListenAddressMetrics)
 }
 
 // cluster returns ETCDConfig for a cluster

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -455,10 +455,10 @@ func getAdvertiseAddress(advertiseIP string) (string, error) {
 	return ip, nil
 }
 
-// getEtcdMetricsURL returns the IP address after verification
+// getEtcdMetricsURL returns the URL endpoint address of metrics after verification
 func getEtcdMetricsURL(ip, port string) (string, error) {
 	//
-	ipAddr, err := net.Listen("tcp", fmt.Sprintf("%s:%s", ip, "2381"))
+	ipAddr, err := net.Listen("tcp", fmt.Sprintf("%s:%s", ip, port))
 	if err != nil {
 		// address is not bindable
 		return "", err

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -473,6 +473,17 @@ func (e *ETCD) clientURL() string {
 	return fmt.Sprintf("https://%s:2379", e.address)
 }
 
+// metricsURL returns the metrics access address
+func (e *ETCD) metricsURL(config *config.Control) string {
+	if config.EtcdListenAdressMetrics == "" {
+		// we have to check if address is not empty
+		// the default listen address set if it doesn't exist
+		return fmt.Sprintf("https://%s:2381", e.address)
+	}
+
+	return fmt.Sprintf("https://%s:2381", config.EtcdListenAdressMetrics)
+}
+
 // cluster returns ETCDConfig for a cluster
 func (e *ETCD) cluster(ctx context.Context, forceNew bool, options executor.InitialOptions) error {
 	return executor.ETCD(executor.ETCDConfig{
@@ -480,7 +491,7 @@ func (e *ETCD) cluster(ctx context.Context, forceNew bool, options executor.Init
 		InitialOptions:      options,
 		ForceNewCluster:     forceNew,
 		ListenClientURLs:    fmt.Sprintf(e.clientURL() + ",https://127.0.0.1:2379"),
-		ListenMetricsURLs:   "http://127.0.0.1:2381",
+		ListenMetricsURLs:   fmt.Sprintf(e.metricsURL(e.config)),
 		ListenPeerURLs:      e.peerURL(),
 		AdvertiseClientURLs: e.clientURL(),
 		DataDir:             etcdDBDir(e.config),

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -462,9 +462,8 @@ func getEtcdMetricsURL(ip, port string) (string, error) {
 	if err != nil {
 		// address is not bindable
 		return "", err
-	} else {
-		ipAddr.Close()
 	}
+	ipAddr.Close()
 
 	return fmt.Sprintf("http://%s:%s", ip, port), err
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
k3s doesn't allow users to scrape metrics for etcd because it's bonded to localhost 

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Added to cli flag to change bind address for etcd metrics
#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
```
k3s server --etcd-expose-metrics true
```
#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

