### PR TITLE
Do not set KUBECONFIG env in kubectl CLI

### DIFF
--- a/pkg/kubectl/main.go
+++ b/pkg/kubectl/main.go
@@ -16,12 +16,8 @@ import (
 )
 
 func Main() {
-	kubenv := os.Getenv("KUBECONFIG")
-	if kubenv == "" {
-		config, err := server.HomeKubeConfig(false, false)
-		if _, serr := os.Stat(config); err == nil && serr == nil {
-			os.Setenv("KUBECONFIG", config)
-		}
+	config, err := server.HomeKubeConfig(false, false)
+	if _, serr := os.Stat(config); err == nil && serr == nil {
 		if err := checkReadConfigPermissions(config); err != nil {
 			logrus.Warn(err)
 		}


### PR DESCRIPTION
#### Proposed Changes ####

Do not set KUBECONFIG env in k3s embedded kubectl CLI.

#### Types of Changes ####

k3s embedded _kubectl_ behavior change.

#### Verification ####

Run `kubectl config view -v=6`, the kubectl preferred kubeconfig file should be ~/.kube/config if the user did not pass --kubeconfig flag _or_ did not configure KUBECONFIG env variable.

#### Linked Issues ####

#1541 

#### Further Comments ####

Since we do not set KUBECONFIG env variable in k3s embedded kubectl CLI.
To make the user uses _kubectl_ simply without having to pass --kubeconfig _or_ configures KUBECONFIG env variable by themself, we have to merge the kubeconfigs into ~/.kube/config.
This will be handle in another in #2803.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

