### PR TITLE
[Backport 1.18] Set a cgroup if containerized

### DIFF
--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -172,7 +172,7 @@ func addFeatureGate(current, new string) string {
 	return current + "," + new
 }
 
-func checkCgroups() (kubeletRoot string, runtimeRoot string, hasCFS bool, hasPIDs bool) {
+func checkCgroups() (kubeletRoot, runtimeRoot string, hasCFS, hasPIDs bool) {
 	f, err := os.Open("/proc/self/cgroup")
 	if err != nil {
 		return "", "", false, false

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/rancher/k3s/pkg/daemons/config"
+	"github.com/rancher/k3s/pkg/version"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/component-base/logs"
@@ -21,8 +22,6 @@ import (
 	_ "k8s.io/component-base/metrics/prometheus/restclient" // for client metric registration
 	_ "k8s.io/component-base/metrics/prometheus/version"    // for version metric registration
 )
-
-const k3sCgroupRoot = "/k3s"
 
 func Agent(config *config.Agent) error {
 	rand.Seed(time.Now().UTC().UnixNano())
@@ -206,7 +205,7 @@ func checkCgroups() (kubeletRoot, runtimeRoot string, hasCFS, hasPIDs bool) {
 				last := parts[len(parts)-1]
 				i := strings.LastIndex(last, ".scope")
 				if i > 0 {
-					kubeletRoot = k3sCgroupRoot
+					kubeletRoot = "/" + version.Program
 				}
 			}
 		}
@@ -234,8 +233,8 @@ func checkCgroups() (kubeletRoot, runtimeRoot string, hasCFS, hasPIDs bool) {
 				if system == "name=systemd" {
 					last := parts[len(parts)-1]
 					if last != "/" && last != "/init.scope" {
-						kubeletRoot = k3sCgroupRoot
-						runtimeRoot = k3sCgroupRoot
+						kubeletRoot = "/" + version.Program
+						runtimeRoot = "/" + version.Program
 					}
 				}
 			}

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -190,12 +190,31 @@ func checkCgroups() (root string, hasCFS bool, hasPIDs bool) {
 				if _, err := os.Stat(p); err == nil {
 					hasCFS = true
 				}
-			} else if system == "name=systemd" {
+			}
+		}
+	}
+
+	// Examine process ID 1 to see if there is a cgroup assigned to it.
+	// When we are not in a container, process 1 is likely to be systemd or some other service manager.
+	// When containerized, process 1 will be generally be in a cgroup, otherwise, we may be running in
+	// a host PID scenario but we don't support this.
+	g, err := os.Open("/proc/1/cgroup")
+	if err != nil {
+		return "", false, false
+	}
+	defer g.Close()
+	root = ""
+	scan = bufio.NewScanner(g)
+	for scan.Scan() {
+		parts := strings.Split(scan.Text(), ":")
+		if len(parts) < 3 {
+			continue
+		}
+		systems := strings.Split(parts[1], ",")
+		for _, system := range systems {
+			if system == "name=systemd" {
 				last := parts[len(parts)-1]
-				i := strings.LastIndex(last, ".slice")
-				if i > 0 {
-					root = "/systemd" + last[:i+len(".slice")]
-				} else {
+				if last != "/" {
 					root = "/systemd"
 				}
 			}

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -22,6 +22,8 @@ import (
 	_ "k8s.io/component-base/metrics/prometheus/version"    // for version metric registration
 )
 
+const k3sCgroupRoot = "/k3s"
+
 func Agent(config *config.Agent) error {
 	rand.Seed(time.Now().UTC().UnixNano())
 
@@ -116,7 +118,7 @@ func startKubelet(cfg *config.Agent) {
 	if err != nil || defaultIP.String() != cfg.NodeIP {
 		argsMap["node-ip"] = cfg.NodeIP
 	}
-	root, hasCFS, hasPIDs := checkCgroups()
+	kubeletRoot, runtimeRoot, hasCFS, hasPIDs := checkCgroups()
 	if !hasCFS {
 		logrus.Warn("Disabling CPU quotas due to missing cpu.cfs_period_us")
 		argsMap["cpu-cfs-quota"] = "false"
@@ -127,9 +129,11 @@ func startKubelet(cfg *config.Agent) {
 		argsMap["enforce-node-allocatable"] = ""
 		argsMap["feature-gates"] = addFeatureGate(argsMap["feature-gates"], "SupportPodPidsLimit=false")
 	}
-	if root != "" {
-		argsMap["runtime-cgroups"] = root
-		argsMap["kubelet-cgroups"] = root
+	if kubeletRoot != "" {
+		argsMap["kubelet-cgroups"] = kubeletRoot
+	}
+	if runtimeRoot != "" {
+		argsMap["runtime-cgroups"] = runtimeRoot
 	}
 	if system.RunningInUserNS() {
 		argsMap["feature-gates"] = addFeatureGate(argsMap["feature-gates"], "DevicePlugins=false")
@@ -168,10 +172,10 @@ func addFeatureGate(current, new string) string {
 	return current + "," + new
 }
 
-func checkCgroups() (root string, hasCFS bool, hasPIDs bool) {
+func checkCgroups() (kubeletRoot string, runtimeRoot string, hasCFS bool, hasPIDs bool) {
 	f, err := os.Open("/proc/self/cgroup")
 	if err != nil {
-		return "", false, false
+		return "", "", false, false
 	}
 	defer f.Close()
 
@@ -190,37 +194,52 @@ func checkCgroups() (root string, hasCFS bool, hasPIDs bool) {
 				if _, err := os.Stat(p); err == nil {
 					hasCFS = true
 				}
-			}
-		}
-	}
-
-	// Examine process ID 1 to see if there is a cgroup assigned to it.
-	// When we are not in a container, process 1 is likely to be systemd or some other service manager.
-	// It either lives at `/` or `/init.scope` according to https://man7.org/linux/man-pages/man7/systemd.special.7.html
-	// When containerized, process 1 will be generally be in a cgroup, otherwise, we may be running in
-	// a host PID scenario but we don't support this.
-	g, err := os.Open("/proc/1/cgroup")
-	if err != nil {
-		return "", false, false
-	}
-	defer g.Close()
-	root = ""
-	scan = bufio.NewScanner(g)
-	for scan.Scan() {
-		parts := strings.Split(scan.Text(), ":")
-		if len(parts) < 3 {
-			continue
-		}
-		systems := strings.Split(parts[1], ",")
-		for _, system := range systems {
-			if system == "name=systemd" {
+			} else if system == "name=systemd" {
+				// If we detect that we are running under a `.scope` unit with systemd
+				// we can assume we are being directly invoked from the command line
+				// and thus need to set our kubelet root to something out of the context
+				// of `/user.slice` to ensure that `CPUAccounting` and `MemoryAccounting`
+				// are enabled, as they are generally disabled by default for `user.slice`
+				// Note that we are not setting the `runtimeRoot` as if we are running with
+				// `--docker`, we will inadvertently move the cgroup `dockerd` lives in
+				//  which is not ideal and causes dockerd to become unmanageable by systemd.
 				last := parts[len(parts)-1]
-				if last != "/" && last != "/init.scope" {
-					root = "/systemd"
+				i := strings.LastIndex(last, ".scope")
+				if i > 0 {
+					kubeletRoot = k3sCgroupRoot
 				}
 			}
 		}
 	}
 
-	return root, hasCFS, hasPIDs
+	if kubeletRoot == "" {
+		// Examine process ID 1 to see if there is a cgroup assigned to it.
+		// When we are not in a container, process 1 is likely to be systemd or some other service manager.
+		// It either lives at `/` or `/init.scope` according to https://man7.org/linux/man-pages/man7/systemd.special.7.html
+		// When containerized, process 1 will be generally be in a cgroup, otherwise, we may be running in
+		// a host PID scenario but we don't support this.
+		g, err := os.Open("/proc/1/cgroup")
+		if err != nil {
+			return "", "", false, false
+		}
+		defer g.Close()
+		scan = bufio.NewScanner(g)
+		for scan.Scan() {
+			parts := strings.Split(scan.Text(), ":")
+			if len(parts) < 3 {
+				continue
+			}
+			systems := strings.Split(parts[1], ",")
+			for _, system := range systems {
+				if system == "name=systemd" {
+					last := parts[len(parts)-1]
+					if last != "/" && last != "/init.scope" {
+						kubeletRoot = k3sCgroupRoot
+						runtimeRoot = k3sCgroupRoot
+					}
+				}
+			}
+		}
+	}
+	return kubeletRoot, runtimeRoot, hasCFS, hasPIDs
 }

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -196,6 +196,7 @@ func checkCgroups() (root string, hasCFS bool, hasPIDs bool) {
 
 	// Examine process ID 1 to see if there is a cgroup assigned to it.
 	// When we are not in a container, process 1 is likely to be systemd or some other service manager.
+	// It either lives at `/` or `/init.scope` according to https://man7.org/linux/man-pages/man7/systemd.special.7.html
 	// When containerized, process 1 will be generally be in a cgroup, otherwise, we may be running in
 	// a host PID scenario but we don't support this.
 	g, err := os.Open("/proc/1/cgroup")
@@ -214,7 +215,7 @@ func checkCgroups() (root string, hasCFS bool, hasPIDs bool) {
 		for _, system := range systems {
 			if system == "name=systemd" {
 				last := parts[len(parts)-1]
-				if last != "/" {
+				if last != "/" && last != "/init.scope" {
 					root = "/systemd"
 				}
 			}


### PR DESCRIPTION
Backport of 
https://github.com/k3s-io/k3s/pull/2642
https://github.com/k3s-io/k3s/pull/2654
https://github.com/k3s-io/k3s/pull/2668

#### Proposed Changes ####
Set --kubelet-cgroups and --runtime-cgroups on the kubelet only if we think we are containerized and running with systemd.

#### Types of Changes ####
Bugfix

#### Verification ####
Run K3s from shell, using `K3d`, and as a `systemd` controlled daemon and observe no cgroup complaints.

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/2548
