### PR TITLE
Fix normal user with --rootless or --disable-agent have no permission to start

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -57,7 +57,11 @@ func findDataDir() string {
 	}
 	dataDir := configfilearg.MustFindString(os.Args, "data-dir")
 	if dataDir == "" {
-		dataDir = datadir.DefaultDataDir
+		if os.Getuid() == 0 {
+			dataDir = datadir.DefaultDataDir
+		} else {
+			dataDir = datadir.DefaultHomeDataDir
+		}
 		logrus.Debug("Using default data dir in self-extracting wrapper")
 	}
 	return dataDir


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

If the user is the root, use default data-dir `/var/lib/rancher/k3s`.
Otherwise, use default home data-dir `$HOME/.rancher/k3s`.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

Use the normal user account (non-root), start the server passing either `--rootless` or `--disable-agent`
```
k3s server --cluster-init --rootless
k3s server --cluster-init --disable-agent
```
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

#2780
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

