### PR TITLE
Update helm-controller to v0.8.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/k3s-io/helm-controller v0.8.0
+	github.com/k3s-io/helm-controller v0.8.3
 	github.com/k3s-io/kine v0.6.0
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -520,8 +520,8 @@ github.com/k3s-io/go-powershell v0.0.0-20200701182037-6845e6fcfa79 h1:9naOL3iARE
 github.com/k3s-io/go-powershell v0.0.0-20200701182037-6845e6fcfa79/go.mod h1:lsDHcxq5ugFJff6YHEwpzLh31NDv0B2cIKki1ViQ65o=
 github.com/k3s-io/go-powershell v0.0.0-20201118222746-51f4c451fbd7 h1:C+6IIP6yECS10qkq2EeGQjr2ts0k7UxrutGF+pLPSnU=
 github.com/k3s-io/go-powershell v0.0.0-20201118222746-51f4c451fbd7/go.mod h1:wJnuh+xbDmskSfAM3UikTsGO8kaWLu3iycSgUKAiYjQ=
-github.com/k3s-io/helm-controller v0.8.0 h1:ZxnXRMiVjerBqpTkZeR0soEtsC3Bcv3Sbq2AIZQPlhk=
-github.com/k3s-io/helm-controller v0.8.0/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
+github.com/k3s-io/helm-controller v0.8.3 h1:GWxavyMz7Bw2ClxH5okkeOL8o5U6IBK7uauc44SDCjU=
+github.com/k3s-io/helm-controller v0.8.3/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
 github.com/k3s-io/kine v0.6.0 h1:4l7wjgCxb2oD+7Hyf3xIhkGd/6s1sXpRFdQiyy+7Ki8=
 github.com/k3s-io/kine v0.6.0/go.mod h1:rzCs93+rQHZGOiewMd84PDrER92QeZ6eeHbWkfEy4+w=
 github.com/k3s-io/kubernetes v1.20.0-k3s1 h1:m/p4cZPfNoyMiGTMySXRITuHHlWMi6Ts9NLp6yNP97w=

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,5 +1,5 @@
 docker.io/rancher/coredns-coredns:1.8.0
-docker.io/rancher/klipper-helm:v0.3.2
+docker.io/rancher/klipper-helm:v0.4.3
 docker.io/rancher/klipper-lb:v0.1.2
 docker.io/rancher/library-busybox:1.31.1
 docker.io/rancher/library-traefik:1.7.19

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -674,7 +674,7 @@ github.com/json-iterator/go
 # github.com/k3s-io/go-powershell v0.0.0-20200701182037-6845e6fcfa79
 github.com/k3s-io/go-powershell/backend
 github.com/k3s-io/go-powershell/utils
-# github.com/k3s-io/helm-controller v0.8.0
+# github.com/k3s-io/helm-controller v0.8.3
 ## explicit
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1


### PR DESCRIPTION
#### Proposed Changes ####

Update helm-controller to v0.8.3

#### Types of Changes ####

* helm controller

#### Verification ####

* Taint nodes with "CriticalAddonsOnly=true:NoExecute"; note that helm jobs don't fail to run.
* Install helm v2 chart from stable repo (see example from https://github.com/k3s-io/helm-controller/blob/master/test/suite/helm_test.go#L176); note that chart is installed successfully

#### Linked Issues ####

#2777
rancher/rke2#487
k3s-io/klipper-helm#25

#### Further Comments ####

