### PR TITLE
Do not validate snapshotter argument if docker is enabled

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -431,16 +431,18 @@ func get(envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
 	nodeConfig.CACerts = info.CACerts
 	nodeConfig.Containerd.Config = filepath.Join(envInfo.DataDir, "agent", "etc", "containerd", "config.toml")
 	nodeConfig.Containerd.Root = filepath.Join(envInfo.DataDir, "agent", "containerd")
-	switch nodeConfig.AgentConfig.Snapshotter {
-	case "overlayfs":
-		if err := overlay.Supported(nodeConfig.Containerd.Root); err != nil {
-			return nil, errors.Wrapf(err, "\"overlayfs\" snapshotter cannot be enabled for %q, try using \"fuse-overlayfs\" or \"native\"",
-				nodeConfig.Containerd.Root)
-		}
-	case "fuse-overlayfs":
-		if err := fuseoverlayfs.Supported(nodeConfig.Containerd.Root); err != nil {
-			return nil, errors.Wrapf(err, "\"fuse-overlayfs\" snapshotter cannot be enabled for %q, try using \"native\"",
-				nodeConfig.Containerd.Root)
+	if !nodeConfig.Docker && nodeConfig.ContainerRuntimeEndpoint == "" {
+		switch nodeConfig.AgentConfig.Snapshotter {
+		case "overlayfs":
+			if err := overlay.Supported(nodeConfig.Containerd.Root); err != nil {
+				return nil, errors.Wrapf(err, "\"overlayfs\" snapshotter cannot be enabled for %q, try using \"fuse-overlayfs\" or \"native\"",
+					nodeConfig.Containerd.Root)
+			}
+		case "fuse-overlayfs":
+			if err := fuseoverlayfs.Supported(nodeConfig.Containerd.Root); err != nil {
+				return nil, errors.Wrapf(err, "\"fuse-overlayfs\" snapshotter cannot be enabled for %q, try using \"native\"",
+					nodeConfig.Containerd.Root)
+			}
 		}
 	}
 	nodeConfig.Containerd.Opt = filepath.Join(envInfo.DataDir, "agent", "containerd")


### PR DESCRIPTION
Problem:
While using ZFS on debian and K3s with docker, I am unable to get k3s working as the snapshotter value is being validated and the validation fails.

Solution:
We should not validate snapshotter value if we are using docker as it's a no-op in that case.

Signed-off-by: Waqar Ahmed <waqarahmedjoyia@live.com>

#### Types of Changes ####

Bug Fix

