### PR TITLE
Merge kubeconfigs to ~/.kube/config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -670,6 +670,12 @@ if (ls ${SYSTEMD_DIR}/k3s*.service || ls /etc/init.d/k3s*) >/dev/null 2>&1; then
     exit
 fi
 
+kubectl config view -o jsonpath='{.users[].name}' --kubeconfig=/etc/rancher/k3s/k3s.yaml | xargs -I{} kubectl config unset users.{}
+kubectl config view -o jsonpath='{.contexts[].name}' --kubeconfig=/etc/rancher/k3s/k3s.yaml | xargs -I{} kubectl config unset contexts.{}
+kubectl config view -o jsonpath='{.clusters[].name}' --kubeconfig=/etc/rancher/k3s/k3s.yaml | xargs -I{} kubectl config unset clusters.{}
+kubectl config unset current-context
+kubectl config view -o jsonpath='{.contexts[].name}' | xargs -I{} kubectl config use-context {}
+
 for cmd in kubectl crictl ctr; do
     if [ -L ${BIN_DIR}/\$cmd ]; then
         rm -f ${BIN_DIR}/\$cmd


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

During install, merge the kubeconfig(s) in ~/.kube/config and /etc/rancher/k3s/k3s.yaml into ~/.kube/config and update the current-context to k3s.

During uninstall, remove the k3s kubeconfig (cluster/context/user) in ~/.kube/config and update the current-context.

#### Types of Changes ####

Nice to have enhancement
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

1. Without existing ~/.kube/config
```
# download official kubectl
curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
install kubectl /usr/local/bin

# create k3s server
./install.sh server --cluster-init

# make sure kubectl loaded from file ~/.kube/config
kubectl config view -v=6
# make sure the k3s context default exists
kubectl config get-contexts
# make sure the current-context named default
kubectl config current-context

# run uninstall
/usr/local/bin/k3s-uninstall.sh

# make sure kubectl loaded from file ~/.kube/config
kubectl config view -v=6
# make sure no context exists
kubectl config get-contexts
# make sure the current-context is not set
kubectl config current-context
```

2. With existing ~/.kube/config
```
# download official kubectl
curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
install kubectl /usr/local/bin

# create k3d cluster
k3d cluster create

# create k3s server
./install.sh server --cluster-init

# make sure kubectl loaded from file ~/.kube/config
kubectl config view -v=6
# make sure both two contexts exists
kubectl config get-contexts
# make sure the current-context named default
kubectl config current-context

# run uninstall
/usr/local/bin/k3s-uninstall.sh

# make sure kubectl loaded from file ~/.kube/config
kubectl config view -v=6
# make sure only k3d context exists
kubectl config get-contexts
# make sure the current-context named k3d
kubectl config current-context
```

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

#1541
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

