### PR TITLE
mark k3s v1.20.2 as stable

### DIFF
--- a/channel.yaml
+++ b/channel.yaml
@@ -1,7 +1,7 @@
 # Example channels config
 channels:
 - name: stable
-  latest: v1.20.0+k3s2
+  latest: v1.20.2+k3s1
 - name: latest
   latestRegexp: .*
   excludeRegexp: ^[^+]+-


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

mark k3s v1.20.2 as stable
#### Types of Changes ####

channelserver
#### Verification ####

install k3s with no passed channels, should pull v1.20.2 as default from stable channel
#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/2794