### PR TITLE
Only container-runtime-endpoint wants RuntimeSocket path as URI

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -479,7 +479,7 @@ func get(envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
 	}
 
 	if !nodeConfig.Docker && nodeConfig.ContainerRuntimeEndpoint == "" {
-		nodeConfig.AgentConfig.RuntimeSocket = "unix://" + nodeConfig.Containerd.Address
+		nodeConfig.AgentConfig.RuntimeSocket = nodeConfig.Containerd.Address
 	} else {
 		nodeConfig.AgentConfig.RuntimeSocket = nodeConfig.ContainerRuntimeEndpoint
 		nodeConfig.AgentConfig.CNIPlugin = true


### PR DESCRIPTION
#### Proposed Changes ####

Only container-runtime-endpoint wants RuntimeSocket path as URI

The fix in 5b318d0 set it too early; this field is used by multiple flags and only one of them wants a URI.

#### Types of Changes ####

Bugfix

#### Verification ####

See steps in linked issue

#### Linked Issues ####

#2831

#### Further Comments ####