### PR TITLE
Update sonobuoy version for v1.20.0

### DIFF
--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -2,7 +2,7 @@ FROM golang:1.15.5-alpine3.12
 
 RUN apk -U --no-cache add bash git gcc musl-dev docker curl jq coreutils python2 openssl py-pip
 
-ENV SONOBUOY_VERSION 0.19.0
+ENV SONOBUOY_VERSION 0.20.0
 
 RUN OS=linux; \
     ARCH=$(go env GOARCH); \

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -171,12 +171,12 @@ export -f dump-logs
 # ---
 
 retrieve-sonobuoy-logs() {
-    sonobuoy status || true
-
     local status=passed
     local code=0
+    local testStatus=$(sonobuoy status 2>&1)
+    cat <<< $testStatus
 
-    if ! sonobuoy status | grep -q -E ' +e2e +complete +passed +'; then
+    if ! grep -q -E '\s+e2e\s+complete\s+passed\s+' <<< $testStatus; then
         status=failed
         code=1
     fi

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -234,7 +234,6 @@ sonobuoy-test() {
     sonobuoy run \
         --config=scripts/sonobuoy-config.json \
         --plugin-env=e2e.E2E_USE_GO_RUNNER=true \
-        --sonobuoy-image=rancher/sonobuoy-sonobuoy:v${SONOBUOY_VERSION:-0.19.0} \
         --kube-conformance-image-version=${VERSION_K8S} \
         --wait=90 \
         $@ &


### PR DESCRIPTION
#### Proposed Changes ####

Update sonobuoy version for v1.20.0

Also drop the rancher-mirrored sonobuoy image since CI has a pull-through image cache now.

#### Types of Changes ####

CI

#### Verification ####

See CI warnings in linked issue

#### Linked Issues ####

Related to #2840

#### Further Comments ####