### PR TITLE
fix cgroup2 support

### DIFF
--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/cgroups"
+	cgroupsv2 "github.com/containerd/cgroups/v2"
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/rancher/k3s/pkg/daemons/config"
 	"github.com/rancher/k3s/pkg/daemons/executor"
@@ -182,6 +184,26 @@ func checkCgroups() (kubeletRoot, runtimeRoot string, hasCFS, hasPIDs bool) {
 	}
 	defer f.Close()
 
+	v2 := cgroups.Mode() == cgroups.Unified
+	if v2 {
+		m, err := cgroupsv2.LoadManager("/sys/fs/cgroup", "/")
+		if err != nil {
+			return "", "", false, false
+		}
+		controllers, err := m.Controllers()
+		if err != nil {
+			return "", "", false, false
+		}
+		for _, c := range controllers {
+			switch c {
+			case "cpu":
+				hasCFS = true
+			case "pids":
+				hasPIDs = true
+			}
+		}
+	}
+
 	scan := bufio.NewScanner(f)
 	for scan.Scan() {
 		parts := strings.Split(scan.Text(), ":")
@@ -189,6 +211,7 @@ func checkCgroups() (kubeletRoot, runtimeRoot string, hasCFS, hasPIDs bool) {
 			continue
 		}
 		systems := strings.Split(parts[1], ",")
+		// when v2, systems = {""} (only contains a single empty string)
 		for _, system := range systems {
 			if system == "pids" {
 				hasPIDs = true
@@ -197,7 +220,7 @@ func checkCgroups() (kubeletRoot, runtimeRoot string, hasCFS, hasPIDs bool) {
 				if _, err := os.Stat(p); err == nil {
 					hasCFS = true
 				}
-			} else if system == "name=systemd" {
+			} else if system == "name=systemd" || v2 {
 				// If we detect that we are running under a `.scope` unit with systemd
 				// we can assume we are being directly invoked from the command line
 				// and thus need to set our kubelet root to something out of the context
@@ -233,8 +256,9 @@ func checkCgroups() (kubeletRoot, runtimeRoot string, hasCFS, hasPIDs bool) {
 				continue
 			}
 			systems := strings.Split(parts[1], ",")
+			// when v2, systems = {""} (only contains a single empty string)
 			for _, system := range systems {
-				if system == "name=systemd" {
+				if system == "name=systemd" || v2 {
 					last := parts[len(parts)-1]
 					if last != "/" && last != "/init.scope" {
 						kubeletRoot = "/" + version.Program


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->


cgroup2 support was introduced in #2584, but got broken in f3de60ff3191dc3a0ae7ce8393e388700f48ed88

It was failing with "F1210 19:13:37.305388    4955 server.go:181] cannot set feature gate SupportPodPidsLimit to false, feature is locked to true"



#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

BugFix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

`sudo k3s server` on Ubuntu 20.10 with cgroup2

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->


Fix #900

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

