### PR TITLE
rootless: remove rootful /run/{netns,containerd} symlinks

### DIFF
--- a/pkg/rootless/mounts.go
+++ b/pkg/rootless/mounts.go
@@ -14,6 +14,16 @@ import (
 )
 
 func setupMounts(stateDir string) error {
+	// Remove symlinks to the rootful files, so that we can create our own files.
+	removeList := []string{
+		"/var/run/netns",
+		"/run/containerd",
+		"/run/xtables.lock",
+	}
+	for _, f := range removeList {
+		_ = os.RemoveAll(f)
+	}
+
 	mountMap := [][]string{
 		{"/var/log", filepath.Join(stateDir, "logs")},
 		{"/var/lib/cni", filepath.Join(stateDir, "cni")},

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -173,7 +173,7 @@ func createChildOpt() (*child.Opt, error) {
 	opt.PipeFDEnvKey = pipeFD
 	opt.NetworkDriver = slirp4netns.NewChildDriver()
 	opt.PortDriver = portbuiltin.NewChildDriver(&logrusDebugWriter{})
-	opt.CopyUpDirs = []string{"/etc", "/run", "/var/lib"}
+	opt.CopyUpDirs = []string{"/etc", "/var/run", "/run", "/var/lib"}
 	opt.CopyUpDriver = tmpfssymlink.NewChildDriver()
 	opt.MountProcfs = true
 	opt.Reaper = true


### PR DESCRIPTION



<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Since a recent commit, rootless mode was failing with the following errors:

```
E0122 22:59:47.615567      21 kuberuntime_manager.go:755] createPodSandbox for pod "helm-install-traefik-wf8lc_kube-system(9de0a1b2-e2a2-4ea5-8fb6-22c9272a182f)" failed: rpc error: code = Unknown desc = failed to create network namespace for sandbox "285ab835609387f82d304bac1fefa5fb2a6c49a542a9921995d0c35d33c683d5": failed to setup netns: open /var/run/netns/cni-c628a228-651e-e03e-d27d-bb5e87281846: permission denied
...
E0122 23:31:34.027814      21 pod_workers.go:191] Error syncing pod 1a77d21f-ff3d-4475-9749-224229ddc31a ("coredns-854c77959c-w4d7g_kube-system(1a77d21f-ff3d-4475-9749-224229ddc31a)"), skipping: failed to "CreatePodSandbox" for "coredns-854c77959c-w4d7g_kube-system(1a77d21f-ff3d-4475-9749-224229ddc31a)" with CreatePodSandboxError: "CreatePodSandbox for pod \"coredns-854c77959c-w4d7g_kube-system(1a77d21f-ff3d-4475-9749-224229ddc31a)\" failed: rpc error: code = Unknown desc = failed to create containerd task: io.containerd.runc.v2: create new shim socket: listen unix /run/containerd/s/8f0e40e11a69738407f1ebaf31ced3f08c29bb62022058813314fb004f93c422: bind: permission denied\n: exit status 1: unknown"
```

Remove symlinks to `/run/{netns,containerd}` so that rootless mode can create their own `/run/{netns,containerd}`.


#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
BugFix
#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
```console
$ k3s server --rootless
```

```console
$ KUBECONFIG=~/.kube/k3s.yaml kubectl get pods -A
NAMESPACE     NAME                                      READY   STATUS      RESTARTS   AGE
kube-system   local-path-provisioner-7c458769fb-6dtcw   1/1     Running     0          51m
kube-system   metrics-server-86cbb8457f-npk4q           1/1     Running     0          51m
kube-system   helm-install-traefik-wf8lc                0/1     Completed   0          51m
kube-system   coredns-854c77959c-w4d7g                  1/1     Running     0          51m
kube-system   svclb-traefik-f67gz                       2/2     Running     0          2m22s
kube-system   traefik-6f9cbd9bd4-zspxg                  1/1     Running     0          2m22s
```

Tested on Ubuntu 20.10