### PR TITLE
Bump k3s-root to v0.8.0

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -4,7 +4,7 @@ cd $(dirname $0)/..
 
 . ./scripts/version.sh
 
-ROOT_VERSION=v0.7.3
+ROOT_VERSION=v0.8.0
 TRAEFIK_VERSION=1.81.0
 CHARTS_DIR=build/static/charts
 


### PR DESCRIPTION
#### Proposed Changes ####

Bump k3s-root to v0.8.0 - buildroot 2020.02.2 → 2020.11.1
https://git.buildroot.net/buildroot/plain/CHANGES?id=2020.11.1

#### Types of Changes ####

* packaged components

#### Verification ####

Check versions in `/var/lib/rancher/k3s/data/current/bin/`

#### Linked Issues ####

Related to #2783

#### Further Comments ####
```
[root@centos01 ~]# k3s --version
k3s version v1.20.2+k3s-1bcaaffe (1bcaaffe)
go version go1.15.5

[root@centos01 ~]# /var/lib/rancher/k3s/data/current/bin/busybox
BusyBox v1.32.0 (2021-01-26 21:37:43 UTC) multi-call binary.
BusyBox is copyrighted by many authors between 1998-2015.
Licensed under GPLv2. See source distribution for detailed
copyright notices.

[root@centos01 ~]# /var/lib/rancher/k3s/data/current/bin/coreutils --version
coreutils (GNU coreutils) 8.32
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```