### PR TITLE
systemd unit: make EnvironmentFile optional

### DIFF
--- a/k3s.service
+++ b/k3s.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=notify
-EnvironmentFile=/etc/systemd/system/k3s.service.env
+EnvironmentFile=-/etc/systemd/system/k3s.service.env
 ExecStart=/usr/local/bin/k3s server
 KillMode=process
 Delegate=yes


### PR DESCRIPTION



<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Make `EnvironmentFile` optional.

Previously, `k3s.service` was failing when the `EnvironmentFile` does not exist:
```
Feb 02 17:17:30 suda-ws01 systemd[1]: k3s.service: Failed to load environment files: No such file or directory
Feb 02 17:17:30 suda-ws01 systemd[1]: k3s.service: Failed to run 'start' task: No such file or directory
Feb 02 17:17:30 suda-ws01 systemd[1]: k3s.service: Failed with result 'resources'.
Feb 02 17:17:30 suda-ws01 systemd[1]: Failed to start Lightweight Kubernetes.
```

ref: https://unix.stackexchange.com/questions/404199/documentation-of-equals-minus-in-systemd-unit-files


#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
BugFix

#### Verification ####

`systemctl status k3s.service` without `/etc/systemd/system/k3s.service.env`.