### PR TITLE
Add cgroup2 CI (Fedora on Vagrant on GHA)

### DIFF
--- a/.github/workflows/cgroup2.yaml
+++ b/.github/workflows/cgroup2.yaml
@@ -1,0 +1,60 @@
+name: cgroup2
+on: [push, pull_request]
+jobs:
+  build:
+    name: "Build"
+    runs-on: ubuntu-20.04
+    timeout-minutes: 40
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: "Make"
+      run: DOCKER_BUILDKIT=1 SKIP_VALIDATE=1 make
+    - name: "Upload k3s binary"
+      uses: actions/upload-artifact@v2
+      with:
+        name: k3s
+        path: dist/artifacts/k3s
+  test:
+    name: "Test"
+    needs: build
+    # nested virtualization is only available on macOS hosts
+    runs-on: macos-10.15
+    timeout-minutes: 40
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: "Download k3s binary"
+      uses: actions/download-artifact@v2
+      with:
+        name: k3s
+        path: ./tests/cgroup2
+    - name: "Boot Fedora VM"
+      run: |
+        cp k3s.service ./tests/cgroup2
+        cd ./tests/cgroup2
+        vagrant up
+        vagrant ssh-config >> ~/.ssh/config
+    # Sonobuoy requires CoreDNS to be ready
+    - name: "Waiting fore CoreDNS to be ready"
+      run: |
+        counter=0
+        # `kubectl wait` fails when the pods with the specified label are not created yet
+        until ssh default -- sudo k3s kubectl wait --for=condition=ready pods --namespace=kube-system -l k8s-app=kube-dns; do
+          sleep 10
+          ((counter++))
+          if [[ $counter -eq 10 ]]; then
+            echo "CoreDNS not running?"
+            ssh default -- sudo k3s kubectl get pods -A
+            ssh default -- sudo k3s kubectl get nodes -o wide
+            exit 1
+          fi
+        done
+    # Vagrant is slow, so we set --mode=quick here
+    - name: "Run Sonobuoy (--mode=quick)"
+      run: |
+        ssh default -- sudo KUBECONFIG=/etc/rancher/k3s/k3s.yaml /usr/local/bin/sonobuoy run --mode=quick --wait

--- a/tests/cgroup2/.gitignore
+++ b/tests/cgroup2/.gitignore
@@ -1,0 +1,3 @@
+k3s
+k3s.service
+.vagrant/

--- a/tests/cgroup2/Vagrantfile
+++ b/tests/cgroup2/Vagrantfile
@@ -1,0 +1,34 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrant box for testing k3s with cgroup v2.
+# Invoked via k3s/.github/workflows/cgroup2.yaml .
+#
+# The following files need to be present in this directory:
+# - k3s
+# - k3s.service
+Vagrant.configure("2") do |config|
+  config.vm.box = "fedora/33-cloud-base"
+  memory = 2048
+  cpus = 2
+  config.vm.provider :virtualbox do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+  config.vm.provision "install-k3s", type: "shell", run: "once" do |sh|
+    sh.inline = <<~SHELL
+    set -eux -o pipefail
+    install -m 755  /vagrant/k3s /usr/local/bin
+    cp -f /vagrant/k3s.service /etc/systemd/system/k3s.service
+    touch /etc/systemd/system/k3s.service.env
+    systemctl daemon-reload
+    systemctl enable --now k3s.service || { systemctl status --full --no-pager k3s.service ; exit 1; }
+
+    curl -fsSL https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.20.0/sonobuoy_0.20.0_linux_amd64.tar.gz | tar xzvC /usr/local/bin sonobuoy
+    SHELL
+  end
+end


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Add `.github/workflows/cgroup2.yaml` for running Fedora on Vagrant on GitHub Actions to test cgroup2 environment.

Only very basic smoke tests are executed, as Vagrant is too slow to run the entire sonobuoy.

Relevant:
- kubernetes-sigs/kind#2017
- https://github.com/rootless-containers/usernetes/blob/v20210201.0/.github/workflows/main.yaml



#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
CI

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
CI logs can be observed on https://github.com/AkihiroSuda/k3s/actions?query=workflow%3Acgroup2 until this PR gets merged.


#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

Close https://github.com/k3s-io/k3s/issues/2845 (`Request: cgroup v2 CI`)

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Feel free to close this PR if we can get Drone instances for cgroup2.

