### PR TITLE
[release-1.19] Bump golang to 1.15.8

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-alpine3.12
+FROM golang:1.15.8-alpine3.12
 
 ARG http_proxy=$http_proxy
 ARG https_proxy=$https_proxy

--- a/Dockerfile.manifest
+++ b/Dockerfile.manifest
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-alpine3.12
+FROM golang:1.15.8-alpine3.12
 
 COPY --from=plugins/manifest:1.2.3 /bin/* /bin/
 

--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-alpine3.12
+FROM golang:1.15.8-alpine3.12
 
 RUN apk -U --no-cache add bash git gcc musl-dev docker curl jq coreutils python2 openssl
 


### PR DESCRIPTION
#### Proposed Changes ####

Bump golang to 1.15.8

#### Types of Changes ####

go version

#### Verification ####

`k3s --version`

#### Linked Issues ####

kubernetes/release#1895

#### Further Comments ####

