### PR TITLE
Add disable flags for control components

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -406,6 +406,7 @@ func get(envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
 		SELinux:                  envInfo.EnableSELinux,
 		ContainerRuntimeEndpoint: envInfo.ContainerRuntimeEndpoint,
 		FlannelBackend:           controlConfig.FlannelBackend,
+		ServerHTTPSPort:          controlConfig.HTTPSPort,
 	}
 	nodeConfig.FlannelIface = flannelIface
 	nodeConfig.Images = filepath.Join(envInfo.DataDir, "agent", "images")

--- a/pkg/agent/loadbalancer/loadbalancer.go
+++ b/pkg/agent/loadbalancer/loadbalancer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"path/filepath"
+	"strconv"
 	"sync"
 
 	"github.com/google/tcpproxy"
@@ -26,15 +27,17 @@ type LoadBalancer struct {
 	randomServers         []string
 	currentServerAddress  string
 	nextServerIndex       int
+	Listener              net.Listener
 }
 
 var (
 	SupervisorServiceName = version.Program + "-agent-load-balancer"
 	APIServerServiceName  = version.Program + "-api-server-agent-load-balancer"
+	ETCDServerServiceName = version.Program + "-etcd-server-load-balancer"
 )
 
-func New(dataDir, serviceName, serverURL string) (_lb *LoadBalancer, _err error) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+func New(dataDir, serviceName, serverURL string, lbServerPort int) (_lb *LoadBalancer, _err error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(lbServerPort))
 	defer func() {
 		if _err != nil {
 			logrus.Warnf("Error starting load balancer: %s", _err)

--- a/pkg/agent/loadbalancer/loadbalancer.go
+++ b/pkg/agent/loadbalancer/loadbalancer.go
@@ -30,6 +30,8 @@ type LoadBalancer struct {
 	Listener              net.Listener
 }
 
+const RandomPort = 0
+
 var (
 	SupervisorServiceName = version.Program + "-agent-load-balancer"
 	APIServerServiceName  = version.Program + "-api-server-agent-load-balancer"

--- a/pkg/agent/loadbalancer/loadbalancer_test.go
+++ b/pkg/agent/loadbalancer/loadbalancer_test.go
@@ -105,7 +105,7 @@ func TestFailOver(t *testing.T) {
 		DataDir:   tmpDir,
 	}
 
-	lb, err := New(cfg.DataDir, SupervisorServiceName, cfg.ServerURL)
+	lb, err := New(cfg.DataDir, SupervisorServiceName, cfg.ServerURL, 0)
 	if err != nil {
 		assertEqual(t, err, nil)
 	}
@@ -156,7 +156,7 @@ func TestFailFast(t *testing.T) {
 		DataDir:   tmpDir,
 	}
 
-	lb, err := New(cfg.DataDir, SupervisorServiceName, cfg.ServerURL)
+	lb, err := New(cfg.DataDir, SupervisorServiceName, cfg.ServerURL, 0)
 	if err != nil {
 		assertEqual(t, err, nil)
 	}

--- a/pkg/agent/loadbalancer/loadbalancer_test.go
+++ b/pkg/agent/loadbalancer/loadbalancer_test.go
@@ -105,7 +105,7 @@ func TestFailOver(t *testing.T) {
 		DataDir:   tmpDir,
 	}
 
-	lb, err := New(cfg.DataDir, SupervisorServiceName, cfg.ServerURL, 0)
+	lb, err := New(cfg.DataDir, SupervisorServiceName, cfg.ServerURL, RandomPort)
 	if err != nil {
 		assertEqual(t, err, nil)
 	}
@@ -156,7 +156,7 @@ func TestFailFast(t *testing.T) {
 		DataDir:   tmpDir,
 	}
 
-	lb, err := New(cfg.DataDir, SupervisorServiceName, cfg.ServerURL, 0)
+	lb, err := New(cfg.DataDir, SupervisorServiceName, cfg.ServerURL, RandomPort)
 	if err != nil {
 		assertEqual(t, err, nil)
 	}

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -144,7 +144,7 @@ func Run(ctx context.Context, cfg *cmds.Agent) error {
 		return err
 	}
 
-	proxy, err := proxy.NewAPIProxy(!cfg.DisableLoadBalancer, cfg.DataDir, cfg.ServerURL, cfg.LBServerPort)
+	proxy, err := proxy.NewAPIProxy(!cfg.DisableLoadBalancer, agentDir, cfg.ServerURL, cfg.LBServerPort)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/tunnel/tunnel.go
+++ b/pkg/agent/tunnel/tunnel.go
@@ -75,7 +75,10 @@ func Setup(ctx context.Context, config *config.Node, proxy proxy.Proxy) error {
 
 	endpoint, _ := client.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
 	if endpoint != nil {
-		proxy.Update(getAddresses(endpoint))
+		addresses := getAddresses(endpoint)
+		if len(addresses) > 0 {
+			proxy.Update(getAddresses(endpoint))
+		}
 	}
 
 	disconnect := map[string]context.CancelFunc{}

--- a/pkg/apiaddresses/controller.go
+++ b/pkg/apiaddresses/controller.go
@@ -1,0 +1,84 @@
+package apiaddresses
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"strconv"
+
+	"github.com/rancher/k3s/pkg/daemons/config"
+	"github.com/rancher/k3s/pkg/etcd"
+	"github.com/rancher/k3s/pkg/version"
+	controllerv1 "github.com/rancher/wrangler-api/pkg/generated/controllers/core/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+var (
+	addressKey = version.Program + "/etcd/apiaddresses"
+)
+
+type EndpointsControllerGetter func() controllerv1.EndpointsController
+
+func Register(ctx context.Context, runtime *config.ControlRuntime, endpoints controllerv1.EndpointsController) error {
+	h := &handler{
+		endpointsController: endpoints,
+		runtime:             runtime,
+		ctx:                 ctx,
+	}
+	endpoints.OnChange(ctx, "endpoints-controller", h.sync)
+	return nil
+}
+
+type handler struct {
+	endpointsController controllerv1.EndpointsController
+	runtime             *config.ControlRuntime
+	ctx                 context.Context
+}
+
+func (h *handler) sync(key string, endpoint *v1.Endpoints) (*v1.Endpoints, error) {
+	if endpoint == nil {
+		return nil, nil
+	}
+
+	if endpoint.Namespace != "default" && endpoint.Name != "kubernetes" {
+		return nil, nil
+	}
+
+	cl, err := etcd.GetClient(h.ctx, h.runtime, "https://127.0.0.1:2379")
+	if err != nil {
+		return nil, err
+	}
+
+	w := &bytes.Buffer{}
+	if err := json.NewEncoder(w).Encode(getAddresses(endpoint)); err != nil {
+		return nil, err
+	}
+
+	_, err = cl.Put(h.ctx, addressKey, w.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return endpoint, nil
+}
+
+func getAddresses(endpoint *v1.Endpoints) []string {
+	serverAddresses := []string{}
+	if endpoint == nil {
+		return serverAddresses
+	}
+	for _, subset := range endpoint.Subsets {
+		var port string
+		if len(subset.Ports) > 0 {
+			port = strconv.Itoa(int(subset.Ports[0].Port))
+		}
+		if port == "" {
+			port = "443"
+		}
+		for _, address := range subset.Addresses {
+			serverAddresses = append(serverAddresses, net.JoinHostPort(address.IP, port))
+		}
+	}
+	return serverAddresses
+}

--- a/pkg/apiaddresses/controller.go
+++ b/pkg/apiaddresses/controller.go
@@ -42,6 +42,8 @@ type handler struct {
 	etcdClient          *etcdv3.Client
 }
 
+// This controller will update the version.program/apiaddresses etcd key with a list of
+// api addresses endpoints found in the kubernetes service in the default namespace
 func (h *handler) sync(key string, endpoint *v1.Endpoints) (*v1.Endpoints, error) {
 	if endpoint == nil {
 		return nil, nil

--- a/pkg/cli/agent/agent.go
+++ b/pkg/cli/agent/agent.go
@@ -67,5 +67,5 @@ func Run(ctx *cli.Context) error {
 
 	contextCtx := signals.SetupSignalHandler(context.Background())
 
-	return agent.Run(contextCtx, cfg)
+	return agent.Run(contextCtx, &cfg)
 }

--- a/pkg/cli/agent/agent.go
+++ b/pkg/cli/agent/agent.go
@@ -67,5 +67,5 @@ func Run(ctx *cli.Context) error {
 
 	contextCtx := signals.SetupSignalHandler(context.Background())
 
-	return agent.Run(contextCtx, &cfg)
+	return agent.Run(contextCtx, cfg)
 }

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -14,7 +14,7 @@ type Agent struct {
 	TokenFile                string
 	ClusterSecret            string
 	ServerURL                string
-	ServerURLTmp             string
+	APIAddressCh             chan string
 	DisableLoadBalancer      bool
 	ETCDAgent                bool
 	LBServerPort             int

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -14,7 +14,10 @@ type Agent struct {
 	TokenFile                string
 	ClusterSecret            string
 	ServerURL                string
+	ServerURLTmp             string
 	DisableLoadBalancer      bool
+	ETCDAgent                bool
+	LBServerPort             int
 	ResolvConf               string
 	DataDir                  string
 	NodeIP                   string
@@ -154,6 +157,14 @@ var (
 		Hidden:      false,
 		Destination: &AgentConfig.EnableSELinux,
 		EnvVar:      version.ProgramUpper + "_SELINUX",
+	}
+	LBServerPort = cli.IntFlag{
+		Name:        "lb-server-port",
+		Usage:       "(agent/node) Internal Loadbalancer port",
+		Hidden:      false,
+		Destination: &AgentConfig.LBServerPort,
+		EnvVar:      version.ProgramUpper + "_LB_SERVER_PORT",
+		Value:       0,
 	}
 )
 

--- a/pkg/cli/cmds/etcd.go
+++ b/pkg/cli/cmds/etcd.go
@@ -1,7 +1,0 @@
-// +build !no_etcd
-
-package cmds
-
-const (
-	hideClusterFlags = false
-)

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -10,6 +10,7 @@ import (
 const (
 	defaultSnapshotRentention    = 5
 	defaultSnapshotIntervalHours = 12
+	hideClusterFlags             = true
 )
 
 type Server struct {
@@ -54,6 +55,9 @@ type Server struct {
 	DisableCCM               bool
 	DisableNPC               bool
 	DisableKubeProxy         bool
+	DisableAPIServer         bool
+	DisableControllerManager bool
+	DisableETCD              bool
 	ClusterInit              bool
 	ClusterReset             bool
 	ClusterResetRestorePath  string
@@ -279,6 +283,21 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Name:        "disable-network-policy",
 				Usage:       "(components) Disable " + version.Program + " default network policy controller",
 				Destination: &ServerConfig.DisableNPC,
+			},
+			cli.BoolFlag{
+				Name:        "disable-api-server",
+				Usage:       "(components) Disable running api server",
+				Destination: &ServerConfig.DisableAPIServer,
+			},
+			cli.BoolFlag{
+				Name:        "disable-controller-manager",
+				Usage:       "(components) Disable running kube-controller-manager",
+				Destination: &ServerConfig.DisableControllerManager,
+			},
+			cli.BoolFlag{
+				Name:        "disable-etcd",
+				Usage:       "(components) Disable running etcd",
+				Destination: &ServerConfig.DisableETCD,
 			},
 			NodeNameFlag,
 			WithNodeIDFlag,

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -355,7 +355,7 @@ func setAPIAddressChannel(ctx context.Context, serverConfig *server.Config, agen
 
 func getAPIAddressFromEtcd(ctx context.Context, serverConfig *server.Config, agentConfig *cmds.Agent) {
 	for {
-		serverIP, serverPort, err := etcd.GetAPIServerURLFromETCD(ctx, &serverConfig.ControlConfig)
+		serverAddress, err := etcd.GetAPIServerURLFromETCD(ctx, &serverConfig.ControlConfig)
 		if err != nil {
 			logrus.Warn(err)
 			select {
@@ -365,7 +365,7 @@ func getAPIAddressFromEtcd(ctx context.Context, serverConfig *server.Config, age
 			}
 			continue
 		}
-		agentConfig.ServerURL = fmt.Sprintf("https://%s:%d", serverIP, serverPort)
+		agentConfig.ServerURL = fmt.Sprintf("https://%s", serverAddress)
 		agentConfig.APIAddressCh <- agentConfig.ServerURL
 		break
 	}

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -310,7 +310,7 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	if serverConfig.ControlConfig.DisableAPIServer {
 		// setting LBServerPort to a prespecified port to initialize the kubeconfigs with the right address
 		agentConfig.LBServerPort = lbServerPort
-		// initialize the apiAddress Channel for recieving the api address from etcd
+		// initialize the apiAddress Channel for receiving the api address from etcd
 		agentConfig.APIAddressCh = make(chan string, 1)
 		setAPIAddressChannel(ctx, &serverConfig, &agentConfig)
 		defer close(agentConfig.APIAddressCh)

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -312,9 +312,8 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 		agentConfig.LBServerPort = lbServerPort
 		// initialize the apiAddress Channel for recieving the api address from etcd
 		agentConfig.APIAddressCh = make(chan string, 1)
-		defer close(agentConfig.APIAddressCh)
-
 		setAPIAddressChannel(ctx, &serverConfig, &agentConfig)
+		defer close(agentConfig.APIAddressCh)
 	}
 	return agent.Run(ctx, agentConfig)
 }
@@ -352,7 +351,6 @@ func setAPIAddressChannel(ctx context.Context, serverConfig *server.Config, agen
 		return
 	}
 	getAPIAddressFromEtcd(ctx, serverConfig, agentConfig)
-	agentConfig.ServerURL = <-agentConfig.APIAddressCh
 }
 
 func getAPIAddressFromEtcd(ctx context.Context, serverConfig *server.Config, agentConfig *cmds.Agent) {
@@ -367,7 +365,8 @@ func getAPIAddressFromEtcd(ctx context.Context, serverConfig *server.Config, age
 			}
 			continue
 		}
-		agentConfig.APIAddressCh <- fmt.Sprintf("https://%s:%d", serverIP, serverPort)
+		agentConfig.ServerURL = fmt.Sprintf("https://%s:%d", serverIP, serverPort)
+		agentConfig.APIAddressCh <- agentConfig.ServerURL
 		break
 	}
 }

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -34,10 +34,7 @@ import (
 )
 
 const (
-	lbServerPort         = 6444
-	etcdRoleName         = "etcd"
-	controlPlaneRoleName = "controlplane"
-	maxRoleCount         = 2
+	lbServerPort = 6444
 )
 
 func Run(app *cli.Context) error {

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -334,7 +334,7 @@ func getArgValueFromList(searchArg string, argList []string) string {
 }
 
 func getServerURLFromEtcd(ctx context.Context, serverConfig *server.Config, agentConfig *cmds.Agent) {
-	// setting LBServerPort to a prespecified port to initalize the kubeconfigs with the right address
+	// setting LBServerPort to a prespecified port to initialize the kubeconfigs with the right address
 	agentConfig.LBServerPort = lbServerPort
 	// start a thread to check for the server ip if set from etcd
 	if serverConfig.ControlConfig.HTTPSPort != serverConfig.ControlConfig.SupervisorPort {

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -341,6 +341,10 @@ func getArgValueFromList(searchArg string, argList []string) string {
 	return value
 }
 
+// setAPIAddressChannel will try to get the api address key from etcd and when it succeed it will
+// set the APIAddressCh channel with its value, the function works for both k3s and rke2 in case
+// of k3s we block returning back to the agent.Run until we get the api address, however in rke2
+// the code will not block operation and will run the operation in a goroutine
 func setAPIAddressChannel(ctx context.Context, serverConfig *server.Config, agentConfig *cmds.Agent) {
 	// start a goroutine to check for the server ip if set from etcd in case of rke2
 	if serverConfig.ControlConfig.HTTPSPort != serverConfig.ControlConfig.SupervisorPort {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"net/url"
 	"strings"
 
 	"github.com/k3s-io/kine/pkg/client"
@@ -10,6 +11,7 @@ import (
 	"github.com/rancher/k3s/pkg/clientaccess"
 	"github.com/rancher/k3s/pkg/cluster/managed"
 	"github.com/rancher/k3s/pkg/daemons/config"
+	"github.com/rancher/k3s/pkg/etcd"
 )
 
 type Cluster struct {
@@ -32,6 +34,21 @@ func (c *Cluster) Start(ctx context.Context) (<-chan struct{}, error) {
 	// Set up the dynamiclistener and http request handlers
 	if err := c.initClusterAndHTTPS(ctx); err != nil {
 		return nil, errors.Wrap(err, "init cluster datastore and https")
+	}
+
+	if c.config.DisableETCD {
+		ready := make(chan struct{})
+		defer close(ready)
+		etcdAddress, err := url.Parse(c.config.JoinURL)
+		if err != nil {
+			return nil, err
+		}
+		etcdProxy, err := etcd.NewETCDProxy(true, c.config.DataDir, "https://"+etcdAddress.Hostname()+":2379")
+		if err != nil {
+			return nil, err
+		}
+		c.setupEtcdProxy(ctx, etcdProxy)
+		return ready, nil
 	}
 
 	// start managed database (if necessary)

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -138,7 +138,7 @@ func (c *Cluster) setupEtcdProxy(ctx context.Context, etcdProxy etcd.Proxy) {
 		for range t.C {
 			newAddresses, err := c.managedDB.GetMembersClientURLs(ctx)
 			if err != nil {
-				logrus.Warnf("failed to get member urls %v", err)
+				logrus.Warnf("failed to get etcd client URLs: %v", err)
 				continue
 			}
 			etcdProxy.Update(newAddresses)

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -126,3 +126,24 @@ func (c *Cluster) assignManagedDriver(ctx context.Context) error {
 
 	return nil
 }
+
+// setupEtcdProxy
+func (c *Cluster) setupEtcdProxy(ctx context.Context, etcdProxy etcd.Proxy) {
+	if c.managedDB == nil {
+		return
+	}
+	go func() {
+		t := time.NewTicker(30 * time.Second)
+		defer t.Stop()
+		for range t.C {
+			newAddresses, err := c.managedDB.GetMembersClientURLs(ctx)
+			if err != nil {
+				logrus.Warnf("failed to get member urls %v", err)
+				continue
+			}
+			etcdProxy.Update(newAddresses)
+
+		}
+	}()
+	return
+}

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -145,5 +145,4 @@ func (c *Cluster) setupEtcdProxy(ctx context.Context, etcdProxy etcd.Proxy) {
 
 		}
 	}()
-	return
 }

--- a/pkg/cluster/managed/drivers.go
+++ b/pkg/cluster/managed/drivers.go
@@ -22,6 +22,7 @@ type Driver interface {
 	Restore(ctx context.Context) error
 	EndpointName() string
 	Snapshot(ctx context.Context, config *config.Control) error
+	GetMembersClientURLs(ctx context.Context) ([]string, error)
 }
 
 func RegisterDriver(d Driver) {

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -30,7 +30,6 @@ func Agent(config *config.Agent) error {
 
 	logs.InitLogs()
 	defer logs.FlushLogs()
-
 	if err := startKubelet(config); err != nil {
 		return err
 	}

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -38,6 +38,7 @@ type Node struct {
 	AgentConfig              Agent
 	CACerts                  []byte
 	Certificate              *tls.Certificate
+	ServerHTTPSPort          int
 }
 
 type Containerd struct {
@@ -115,7 +116,6 @@ type Control struct {
 	Skips                    map[string]bool
 	Disables                 map[string]bool
 	Datastore                endpoint.Config
-	NoScheduler              bool
 	ExtraAPIArgs             []string
 	ExtraControllerArgs      []string
 	ExtraCloudControllerArgs []string
@@ -128,6 +128,10 @@ type Control struct {
 	DisableCCM               bool
 	DisableNPC               bool
 	DisableKubeProxy         bool
+	DisableAPIServer         bool
+	DisableControllerManager bool
+	DisableScheduler         bool
+	DisableETCD              bool
 	ClusterInit              bool
 	ClusterReset             bool
 	ClusterResetRestorePath  string

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -982,7 +982,7 @@ func cloudControllerManager(ctx context.Context, cfg *config.Control, runtime *c
 				select {
 				case <-ctx.Done():
 					logrus.Fatalf("cloud-controller-manager context canceled: %v", ctx.Err())
-				case <-time.After(time.Second):
+				case <-time.After(5 * time.Second):
 					continue
 				}
 			}

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -95,15 +95,20 @@ func Server(ctx context.Context, cfg *config.Control) error {
 	cfg.Runtime.Tunnel = setupTunnel()
 	util.DisableProxyHostnameCheck = true
 
-	auth, handler, err := apiServer(ctx, cfg, runtime)
-	if err != nil {
-		return err
-	}
+	var auth authenticator.Request
+	var handler http.Handler
+	var err error
 
-	if err := waitForAPIServerInBackground(ctx, runtime); err != nil {
-		return err
-	}
+	if !cfg.DisableAPIServer {
+		auth, handler, err = apiServer(ctx, cfg, runtime)
+		if err != nil {
+			return err
+		}
 
+		if err := waitForAPIServerInBackground(ctx, runtime); err != nil {
+			return err
+		}
+	}
 	basicAuth, err := basicAuthenticator(runtime.PasswdFile)
 	if err != nil {
 		return err
@@ -112,14 +117,15 @@ func Server(ctx context.Context, cfg *config.Control) error {
 	runtime.Authenticator = combineAuthenticators(basicAuth, auth)
 	runtime.Handler = handler
 
-	if !cfg.NoScheduler {
+	if !cfg.DisableScheduler {
 		if err := scheduler(cfg, runtime); err != nil {
 			return err
 		}
 	}
-
-	if err := controllerManager(cfg, runtime); err != nil {
-		return err
+	if !cfg.DisableControllerManager {
+		if err := controllerManager(cfg, runtime); err != nil {
+			return err
+		}
 	}
 
 	if !cfg.DisableCCM {

--- a/pkg/etcd/controller.go
+++ b/pkg/etcd/controller.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	nodeID       = "etcd.k3s.cattle.io/node-name"
-	nodeAddress  = "etcd.k3s.cattle.io/node-address"
+	NodeID       = "etcd.k3s.cattle.io/node-name"
+	NodeAddress  = "etcd.k3s.cattle.io/node-address"
 	master       = "node-role.kubernetes.io/master"
 	controlPlane = "node-role.kubernetes.io/control-plane"
 	etcdRole     = "node-role.kubernetes.io/etcd"
@@ -56,10 +56,11 @@ func (h *handler) sync(key string, node *v1.Node) (*v1.Node, error) {
 }
 
 func (h *handler) handleSelf(node *v1.Node) (*v1.Node, error) {
-	if node.Annotations[nodeID] == h.etcd.name &&
-		node.Annotations[nodeAddress] == h.etcd.address &&
+	if node.Annotations[NodeID] == h.etcd.name &&
+		node.Annotations[NodeAddress] == h.etcd.address &&
 		node.Labels[etcdRole] == "true" &&
-		node.Labels[controlPlane] == "true" {
+		node.Labels[controlPlane] == "true" ||
+		h.etcd.config.DisableETCD {
 		return node, nil
 	}
 
@@ -67,8 +68,8 @@ func (h *handler) handleSelf(node *v1.Node) (*v1.Node, error) {
 	if node.Annotations == nil {
 		node.Annotations = map[string]string{}
 	}
-	node.Annotations[nodeID] = h.etcd.name
-	node.Annotations[nodeAddress] = h.etcd.address
+	node.Annotations[NodeID] = h.etcd.name
+	node.Annotations[NodeAddress] = h.etcd.address
 	node.Labels[etcdRole] = "true"
 	node.Labels[master] = "true"
 	node.Labels[controlPlane] = "true"
@@ -81,11 +82,10 @@ func (h *handler) onRemove(key string, node *v1.Node) (*v1.Node, error) {
 		return node, nil
 	}
 
-	id := node.Annotations[nodeID]
-	address := node.Annotations[nodeAddress]
-	if address == "" {
+	id := node.Annotations[NodeID]
+	address, ok := node.Annotations[NodeAddress]
+	if !ok {
 		return node, nil
 	}
-
 	return node, h.etcd.removePeer(h.ctx, id, address)
 }

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -60,7 +60,8 @@ func NewETCD() *ETCD {
 
 var (
 	learnerProgressKey = version.Program + "/etcd/learnerProgress"
-	AddressKey         = version.Program + "/apiaddresses"
+	// AddressKey will contain the value of api addresses list
+	AddressKey = version.Program + "/apiaddresses"
 )
 
 const (
@@ -895,6 +896,8 @@ func backupDirWithRetention(dir string, maxBackupRetention int) (string, error) 
 	return backupDir, nil
 }
 
+// GetAPIServerURLFromETCD will try to fetch the version.Program/apiaddresses key from etcd
+// when it succeed it will parse the first address in the list and return back an IP and Port
 func GetAPIServerURLFromETCD(ctx context.Context, cfg *config.Control) (string, int, error) {
 	if cfg.Runtime == nil {
 		return "", 0, fmt.Errorf("runtime is not ready yet")
@@ -931,6 +934,8 @@ func GetAPIServerURLFromETCD(ctx context.Context, cfg *config.Control) (string, 
 	return address, port, nil
 }
 
+// GetMembersClientURLs will list through the member lists in etcd and return
+// back a combined list of client urls for each member in the cluster
 func (e *ETCD) GetMembersClientURLs(ctx context.Context) ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, testTimeout)
 	defer cancel()

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -245,7 +245,7 @@ func (e *ETCD) Start(ctx context.Context, clientAccessInfo *clientaccess.Info) e
 
 // join attempts to add a member to an existing cluster
 func (e *ETCD) join(ctx context.Context, clientAccessInfo *clientaccess.Info) error {
-	clientURLs, memberList, err := e.clientURLs(ctx, clientAccessInfo)
+	clientURLs, memberList, err := ClientURLs(ctx, clientAccessInfo)
 	if err != nil {
 		return err
 	}
@@ -687,7 +687,7 @@ func (e *ETCD) setLearnerProgress(ctx context.Context, status *learnerProgress) 
 }
 
 // clientURLs returns a list of all non-learner etcd cluster member client access URLs
-func (e *ETCD) clientURLs(ctx context.Context, clientAccessInfo *clientaccess.Info) ([]string, Members, error) {
+func ClientURLs(ctx context.Context, clientAccessInfo *clientaccess.Info) ([]string, Members, error) {
 	var memberList Members
 	resp, err := clientaccess.Get("/db/info", clientAccessInfo)
 	if err != nil {

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -58,7 +58,10 @@ func NewETCD() *ETCD {
 	}
 }
 
-var learnerProgressKey = version.Program + "/etcd/learnerProgress"
+var (
+	learnerProgressKey = version.Program + "/etcd/learnerProgress"
+	AddressKey         = version.Program + "/apiaddresses"
+)
 
 const (
 	snapshotPrefix      = "etcd-snapshot-"
@@ -892,7 +895,7 @@ func backupDirWithRetention(dir string, maxBackupRetention int) (string, error) 
 	return backupDir, nil
 }
 
-func GetServerURLFromETCD(ctx context.Context, cfg *config.Control) (string, int, error) {
+func GetAPIServerURLFromETCD(ctx context.Context, cfg *config.Control) (string, int, error) {
 	if cfg.Runtime == nil {
 		return "", 0, fmt.Errorf("runtime is not ready yet")
 	}
@@ -900,7 +903,7 @@ func GetServerURLFromETCD(ctx context.Context, cfg *config.Control) (string, int
 	if err != nil {
 		return "", 0, err
 	}
-	etcdResp, err := cl.KV.Get(ctx, version.Program+"/etcd/apiaddresses")
+	etcdResp, err := cl.KV.Get(ctx, AddressKey)
 	if err != nil {
 		return "", 0, err
 	}

--- a/pkg/etcd/etcdproxy.go
+++ b/pkg/etcd/etcdproxy.go
@@ -1,0 +1,74 @@
+package etcd
+
+import (
+	"net/url"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/k3s/pkg/agent/loadbalancer"
+)
+
+type Proxy interface {
+	Update(addresses []string)
+	ETCDURL() string
+	ETCDAddresses() []string
+	ETCDServerURL() string
+}
+
+func NewETCDProxy(enabled bool, dataDir, etcdURL string) (Proxy, error) {
+	e := &etcdproxy{
+		dataDir:        dataDir,
+		initialETCDURL: etcdURL,
+		etcdURL:        etcdURL,
+	}
+
+	if enabled {
+		lb, err := loadbalancer.New(dataDir, loadbalancer.ETCDServerServiceName, etcdURL, 2379)
+		if err != nil {
+			return nil, err
+		}
+		e.etcdLB = lb
+		e.etcdLBURL = lb.LoadBalancerServerURL()
+	}
+
+	u, err := url.Parse(e.initialETCDURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse %s", e.initialETCDURL)
+	}
+	e.fallbackETCDAddress = u.Host
+	e.etcdPort = u.Port()
+
+	return e, nil
+}
+
+type etcdproxy struct {
+	dataDir   string
+	etcdLBURL string
+
+	initialETCDURL      string
+	etcdURL             string
+	etcdPort            string
+	fallbackETCDAddress string
+	etcdAddresses       []string
+	etcdLB              *loadbalancer.LoadBalancer
+}
+
+func (e *etcdproxy) Update(addresses []string) {
+	if e.etcdLB != nil {
+		e.etcdLB.Update(addresses)
+	}
+}
+
+func (e *etcdproxy) ETCDURL() string {
+	return e.etcdURL
+}
+
+func (e *etcdproxy) ETCDAddresses() []string {
+	if len(e.etcdAddresses) > 0 {
+		return e.etcdAddresses
+	}
+	return []string{e.fallbackETCDAddress}
+}
+
+func (e *etcdproxy) ETCDServerURL() string {
+	return e.etcdURL
+}

--- a/pkg/etcd/etcdproxy.go
+++ b/pkg/etcd/etcdproxy.go
@@ -14,6 +14,8 @@ type Proxy interface {
 	ETCDServerURL() string
 }
 
+// NewETCDProxy initializes a new proxy structure that contain a load balancer
+// which listens on port 2379 and proxy between etcd cluster members
 func NewETCDProxy(enabled bool, dataDir, etcdURL string) (Proxy, error) {
 	e := &etcdproxy{
 		dataDir:        dataDir,

--- a/pkg/etcd/etcdproxy.go
+++ b/pkg/etcd/etcdproxy.go
@@ -34,7 +34,7 @@ func NewETCDProxy(enabled bool, dataDir, etcdURL string) (Proxy, error) {
 
 	u, err := url.Parse(e.initialETCDURL)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse %s", e.initialETCDURL)
+		return nil, errors.Wrap(err, "failed to parse etcd client URL")
 	}
 	e.fallbackETCDAddress = u.Host
 	e.etcdPort = u.Port()

--- a/pkg/server/etcd.go
+++ b/pkg/server/etcd.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/rancher/k3s/pkg/etcd"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func setETCDLabelsAndAnnotations(ctx context.Context, config *Config) error {
+	t := time.NewTicker(5 * time.Second)
+	defer t.Stop()
+	for range t.C {
+		controlConfig := &config.ControlConfig
+
+		sc, err := newContext(ctx, controlConfig.Runtime.KubeConfigAdmin)
+		if err != nil {
+			logrus.Infof("Waiting for control-plane node agent startup %v", err)
+			continue
+		}
+
+		if err := stageFiles(ctx, sc, controlConfig); err != nil {
+			logrus.Infof("Waiting for control-plane node agent startup %v", err)
+			continue
+		}
+
+		if err := sc.Start(ctx); err != nil {
+			logrus.Infof("Waiting for control-plane node agent startup %v", err)
+			continue
+		}
+
+		controlConfig.Runtime.Core = sc.Core
+		nodes := sc.Core.Core().V1().Node()
+
+		nodeName := os.Getenv("NODE_NAME")
+		if nodeName == "" {
+			logrus.Info("Waiting for control-plane node agent startup")
+			continue
+		}
+		node, err := nodes.Get(nodeName, metav1.GetOptions{})
+		if err != nil {
+			logrus.Infof("Waiting for control-plane node %s startup: %v", nodeName, err)
+			continue
+		}
+		if v, ok := node.Labels[ETCDRoleLabelKey]; ok && v == "true" {
+			break
+		}
+		if node.Labels == nil {
+			node.Labels = make(map[string]string)
+		}
+		node.Labels[ETCDRoleLabelKey] = "true"
+
+		// this is replacement to the etcd controller handleself function
+		if node.Annotations == nil {
+			node.Annotations = map[string]string{}
+		}
+		fileName := filepath.Join(controlConfig.DataDir, "db", "etcd", "name")
+
+		data, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			logrus.Infof("Waiting for etcd node name file to be available: %v", err)
+			continue
+		}
+		etcdNodeName := string(data)
+		node.Annotations[etcd.NodeID] = etcdNodeName
+
+		address, err := etcd.GetAdvertiseAddress(controlConfig.PrivateIP)
+		if err != nil {
+			logrus.Infof("Waiting for etcd node address to be available: %v", err)
+			continue
+		}
+		node.Annotations[etcd.NodeAddress] = address
+
+		_, err = nodes.Update(node)
+		if err == nil {
+			logrus.Infof("ETCD role label and annotations has been set successfully on node: %s", nodeName)
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+	return nil
+}

--- a/pkg/server/etcd.go
+++ b/pkg/server/etcd.go
@@ -20,17 +20,17 @@ func setETCDLabelsAndAnnotations(ctx context.Context, config *Config) error {
 
 		sc, err := newContext(ctx, controlConfig.Runtime.KubeConfigAdmin)
 		if err != nil {
-			logrus.Infof("Waiting for control-plane node agent startup %v", err)
+			logrus.Infof("Failed to set etcd role label %v", err)
 			continue
 		}
 
 		if err := stageFiles(ctx, sc, controlConfig); err != nil {
-			logrus.Infof("Waiting for control-plane node agent startup %v", err)
+			logrus.Infof("Failed to set etcd role label %v", err)
 			continue
 		}
 
 		if err := sc.Start(ctx); err != nil {
-			logrus.Infof("Waiting for control-plane node agent startup %v", err)
+			logrus.Infof("Failed to set etcd role label %v", err)
 			continue
 		}
 
@@ -39,12 +39,12 @@ func setETCDLabelsAndAnnotations(ctx context.Context, config *Config) error {
 
 		nodeName := os.Getenv("NODE_NAME")
 		if nodeName == "" {
-			logrus.Info("Waiting for control-plane node agent startup")
+			logrus.Info("Failed to set etcd role label")
 			continue
 		}
 		node, err := nodes.Get(nodeName, metav1.GetOptions{})
 		if err != nil {
-			logrus.Infof("Waiting for control-plane node %s startup: %v", nodeName, err)
+			logrus.Infof("Failed to set etcd role label: %v", err)
 			continue
 		}
 		if v, ok := node.Labels[ETCDRoleLabelKey]; ok && v == "true" {

--- a/pkg/server/etcd.go
+++ b/pkg/server/etcd.go
@@ -84,7 +84,6 @@ func setETCDLabelsAndAnnotations(ctx context.Context, config *Config) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(time.Second):
 		}
 	}
 	return nil


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

- Add 3 more disable flags for api server, controller manager, and etcd:
  - `--disable-api-server`
  - `--disable-controller-manager`
  - `--disable-etcd`
- a controller for the server to synchronize the k3s/etcd/apiaddresses etcd key with the default:kubernetes endpoints
- In case of disable api server, etcd will only start and will try to get k3s/etcd/apiaddresses list from etcd to connect to the api, once an api joins a cluster it will set this IP
- also in case of disabling the api, the agent internal load balancer will start and will connect with the apis
- in case of disabling etcd a special load balancer (etcd proxy) will start and proxy requests to all etcd servers

#### Types of Changes ####

New Feature

#### Verification ####

- to disable any of the components in the server process you should just pass the argument:

--disable-<component-name>

- to verify the etcd only node, you can start a server with the following args:
```
k3s --disable-api-server --disable-scheduler --disable-controller-manager --cluster-init
```
and to join a server (without etcd) with the etcd node, you can pass:
```
k3s --disable-etcd --server https://<etcd node ip>:6443 --token <token>
```
you can also join a normal server with all components included:
```
k3s --server https://<etcd node ip>:6443 --token <token>
```

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/2635

