### PR TITLE
Collect IPs from all pods before deciding to use internal or external addresses

### DIFF
--- a/pkg/servicelb/controller.go
+++ b/pkg/servicelb/controller.go
@@ -122,6 +122,7 @@ func (h *handler) onResourceChange(name, namespace string, obj runtime.Object) (
 	}, nil
 }
 
+// onChangeService handles changes to Services
 func (h *handler) onChangeService(key string, svc *core.Service) (*core.Service, error) {
 	if svc == nil {
 		return nil, nil
@@ -141,6 +142,8 @@ func (h *handler) onChangeService(key string, svc *core.Service) (*core.Service,
 	return nil, err
 }
 
+// onChangeNode handles changes to Nodes. We need to handle this as we may need to kick the DaemonSet
+// to add or remove pods from nodes if labels have changed.
 func (h *handler) onChangeNode(key string, node *core.Node) (*core.Node, error) {
 	if node == nil {
 		return nil, nil
@@ -156,6 +159,8 @@ func (h *handler) onChangeNode(key string, node *core.Node) (*core.Node, error) 
 	return node, nil
 }
 
+// updateService ensures that the Service ingress IP address list is in sync
+// with the Nodes actually running pods for this service.
 func (h *handler) updateService(svc *core.Service) (runtime.Object, error) {
 	if !h.enabled {
 		return svc, nil
@@ -194,6 +199,7 @@ func (h *handler) updateService(svc *core.Service) (runtime.Object, error) {
 	return h.services.Services(svc.Namespace).UpdateStatus(context.TODO(), svc, meta.UpdateOptions{})
 }
 
+// serviceIPs returns the list of ingress IP addresses from the Service
 func serviceIPs(svc *core.Service) []string {
 	var ips []string
 
@@ -206,7 +212,12 @@ func serviceIPs(svc *core.Service) []string {
 	return ips
 }
 
+// podIPs returns a list of IPs for Nodes hosting ServiceLB Pods.
+// If at least one node has External IPs available, only external IPs are returned.
+// If no nodes have External IPs set, the Internal IPs of all nodes running pods are returned.
 func (h *handler) podIPs(pods []*core.Pod) ([]string, error) {
+	// Go doesn't have sets so we stuff things into a map of bools and then get lists of keys
+	// to determine the unique set of IPs in use by pods.
 	extIPs := map[string]bool{}
 	intIPs := map[string]bool{}
 
@@ -234,27 +245,29 @@ func (h *handler) podIPs(pods []*core.Pod) ([]string, error) {
 		}
 	}
 
-	keys := func(addrMap map[string]bool) (addrs []string) {
-		for k := range addrMap {
-			addrs = append(addrs, k)
+	keys := func(addrs map[string]bool) (ips []string) {
+		for k := range addrs {
+			ips = append(ips, k)
 		}
-		return addrs
+		return ips
 	}
 
-	var ipList []string
+	var ips []string
 	if len(extIPs) > 0 {
-		ipList = keys(extIPs)
+		ips = keys(extIPs)
 	} else {
-		ipList = keys(intIPs)
+		ips = keys(intIPs)
 	}
 
-	if len(ipList) > 0 && h.rootless {
+	if len(ips) > 0 && h.rootless {
 		return []string{"127.0.0.1"}, nil
 	}
 
-	return ipList, nil
+	return ips, nil
 }
 
+// deployPod ensures that there is a DaemonSet for each service.
+// It also ensures that any legacy Deployments from older versions of ServiceLB are deleted.
 func (h *handler) deployPod(svc *core.Service) error {
 	if err := h.deleteOldDeployments(svc); err != nil {
 		return err
@@ -274,6 +287,8 @@ func (h *handler) deployPod(svc *core.Service) error {
 	return h.processor.WithOwner(svc).Apply(objs)
 }
 
+// newDaemonSet creates a DaemonSet to ensure that ServiceLB pods are run on
+// each eligible node.
 func (h *handler) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 	name := fmt.Sprintf("svclb-%s", svc.Name)
 	oneInt := intstr.FromInt(1)
@@ -429,6 +444,8 @@ func (h *handler) updateDaemonSets() error {
 	return nil
 }
 
+// deleteOldDeployments ensures that there are no legacy Deployments for ServiceLB pods.
+// ServiceLB used to use Deployments before switching to DaemonSets in 875ba28
 func (h *handler) deleteOldDeployments(svc *core.Service) error {
 	name := fmt.Sprintf("svclb-%s", svc.Name)
 	if _, err := h.deploymentCache.Get(svc.Namespace, name); err != nil {

--- a/pkg/servicelb/controller.go
+++ b/pkg/servicelb/controller.go
@@ -122,7 +122,7 @@ func (h *handler) onResourceChange(name, namespace string, obj runtime.Object) (
 	}, nil
 }
 
-// onChangeService handles changes to Services
+// onChangeService handles changes to Services.
 func (h *handler) onChangeService(key string, svc *core.Service) (*core.Service, error) {
 	if svc == nil {
 		return nil, nil


### PR DESCRIPTION
#### Proposed Changes ####

@Taloth correctly noted that the code that iterates over ServiceLB pods to collect IP addresses was failing to add internal IPs once  the map contained ANY entry from a previous node. This may date back to when ServiceLB used a Deployment instead of a DaemonSet, so there was only ever a single pod.

The new behavior is to collect all internal and external IPs, and then construct the address list of a single type - external if there are any, otherwise internal.

#### Types of Changes ####

- Bugfix
- ServiceLB

#### Verification ####

* Set up multi-node cluster (1 server, 1 agent is fine) with ServiceLB; do not specify ExternalIP addresses for nodes
* Note that the Traefik service lists the IPs of both nodes

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/1652#issuecomment-774497788

#### Further Comments ####
Before - single ExternalIP for traefik service:
```
[root@centos01 ~]# kubectl get nodes -o wide
NAME                 STATUS   ROLES                  AGE    VERSION        INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                KERNEL-VERSION               CONTAINER-RUNTIME
centos01.lan.khaus   Ready    control-plane,master   5m2s   v1.20.2+k3s1   10.0.1.137    <none>        CentOS Linux 7 (Core)   5.8.10-1.el7.elrepo.x86_64   containerd://1.4.3-k3s1
centos02.lan.khaus   Ready    <none>                 12s    v1.20.2+k3s1   10.0.1.170    <none>        CentOS Linux 7 (Core)   5.8.10-1.el7.elrepo.x86_64   containerd://1.4.3-k3s1
[root@centos01 ~]# kubectl get service -A
NAMESPACE     NAME                 TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)                      AGE
default       kubernetes           ClusterIP      10.43.0.1      <none>        443/TCP                      5m16s
kube-system   kube-dns             ClusterIP      10.43.0.10     <none>        53/UDP,53/TCP,9153/TCP       5m14s
kube-system   metrics-server       ClusterIP      10.43.109.44   <none>        443/TCP                      5m14s
kube-system   traefik-prometheus   ClusterIP      10.43.77.22    <none>        9100/TCP                     4m35s
kube-system   traefik              LoadBalancer   10.43.18.86    10.0.1.137    80:32511/TCP,443:32555/TCP   4m35s
```

After - multiple ExternaIPs for traefik service:
```
[root@centos01 ~]# kubectl get nodes -o wide
NAME                 STATUS   ROLES                  AGE     VERSION                INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                KERNEL-VERSION               CONTAINER-RUNTIME
centos01.lan.khaus   Ready    control-plane,master   7m19s   v1.20.2+k3s-74169bfe   10.0.1.137    <none>        CentOS Linux 7 (Core)   5.8.10-1.el7.elrepo.x86_64   containerd://1.4.3-k3s3
centos02.lan.khaus   Ready    <none>                 2m29s   v1.20.2+k3s-74169bfe   10.0.1.170    <none>        CentOS Linux 7 (Core)   5.8.10-1.el7.elrepo.x86_64   containerd://1.4.3-k3s3
[root@centos01 ~]# kubectl get service -A
NAMESPACE     NAME                 TYPE           CLUSTER-IP     EXTERNAL-IP             PORT(S)                      AGE
default       kubernetes           ClusterIP      10.43.0.1      <none>                  443/TCP                      7m28s
kube-system   kube-dns             ClusterIP      10.43.0.10     <none>                  53/UDP,53/TCP,9153/TCP       7m26s
kube-system   metrics-server       ClusterIP      10.43.109.44   <none>                  443/TCP                      7m26s
kube-system   traefik-prometheus   ClusterIP      10.43.77.22    <none>                  9100/TCP                     6m47s
kube-system   traefik              LoadBalancer   10.43.18.86    10.0.1.137,10.0.1.170   80:32511/TCP,443:32555/TCP   6m47s
```