### PR TITLE
Improve handling of comounted cpu,cpuacct controllers

### DIFF
--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -200,11 +200,11 @@ func checkCgroups() (kubeletRoot, runtimeRoot string, hasCFS, hasPIDs bool) {
 		if err != nil {
 			return "", "", false, false
 		}
-		for _, c := range controllers {
-			switch c {
-			case "cpu":
+		for _, controller := range controllers {
+			switch {
+			case controller == "cpu":
 				hasCFS = true
-			case "pids":
+			case controller == "pids":
 				hasPIDs = true
 			}
 		}
@@ -216,17 +216,23 @@ func checkCgroups() (kubeletRoot, runtimeRoot string, hasCFS, hasPIDs bool) {
 		if len(parts) < 3 {
 			continue
 		}
-		systems := strings.Split(parts[1], ",")
-		// when v2, systems = {""} (only contains a single empty string)
-		for _, system := range systems {
-			if system == "pids" {
+		controllers := strings.Split(parts[1], ",")
+		// For v1 or hybrid, controller can be a single value {"blkio"}, or a comounted set {"cpu","cpuacct"}
+		// For v2, controllers = {""} (only contains a single empty string)
+		for _, controller := range controllers {
+			switch {
+			case controller == "pids":
 				hasPIDs = true
-			} else if system == "cpu" {
-				p := filepath.Join("/sys/fs/cgroup", parts[1], parts[2], "cpu.cfs_period_us")
+			case controller == "cpu":
+				// It is common for this to show up multiple times in /sys/fs/cgroup if the controllers are comounted:
+				// as "cpu" and "cpuacct", symlinked to the actual hierarchy at "cpu,cpuacct". Unfortunately the order
+				// listed in /proc/self/cgroups may not be the same order used in /sys/fs/cgroup, so this check
+				// can fail if we use the comma-separated name. Instead, we check for the controller using the symlink.
+				p := filepath.Join("/sys/fs/cgroup", controller, parts[2], "cpu.cfs_period_us")
 				if _, err := os.Stat(p); err == nil {
 					hasCFS = true
 				}
-			} else if system == "name=systemd" || v2 {
+			case controller == "name=systemd" || v2:
 				// If we detect that we are running under a `.scope` unit with systemd
 				// we can assume we are being directly invoked from the command line
 				// and thus need to set our kubelet root to something out of the context
@@ -261,10 +267,12 @@ func checkCgroups() (kubeletRoot, runtimeRoot string, hasCFS, hasPIDs bool) {
 			if len(parts) < 3 {
 				continue
 			}
-			systems := strings.Split(parts[1], ",")
-			// when v2, systems = {""} (only contains a single empty string)
-			for _, system := range systems {
-				if system == "name=systemd" || v2 {
+			controllers := strings.Split(parts[1], ",")
+			// For v1 or hybrid, controller can be a single value {"blkio"}, or a comounted set {"cpu","cpuacct"}
+			// For v2, controllers = {""} (only contains a single empty string)
+			for _, controller := range controllers {
+				switch {
+				case controller == "name=systemd" || v2:
 					last := parts[len(parts)-1]
 					if last != "/" && last != "/init.scope" {
 						kubeletRoot = "/" + version.Program


### PR DESCRIPTION
#### Proposed Changes ####

Fix handling of comounted v1 controllers.

As noted at https://github.com/rancher/rke2/issues/689#issuecomment-773751230 the order of the comounted controllers in /proc/self/cgroup doesn't always match the order in /sys/fs/cgroup - but we can count on there being an alias in there for each controller that points to the comounted hierarchy.
 
#### Types of Changes ####

- bugfix
- cgroupv1

#### Verification ####

See linked issue

#### Linked Issues ####

rancher/rke2#689

#### Further Comments ####

Also tidied up the code that iterates across the controller lists to be more unified in variable naming, and added some comments explaining whats going on.