### PR TITLE
Add support for retagging images on load from tarball

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -504,6 +504,7 @@ func get(envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
 	nodeConfig.AgentConfig.NodeTaints = envInfo.Taints
 	nodeConfig.AgentConfig.NodeLabels = envInfo.Labels
 	nodeConfig.AgentConfig.PrivateRegistry = envInfo.PrivateRegistry
+	nodeConfig.AgentConfig.AirgapExtraRegistry = envInfo.AirgapExtraRegistry
 	nodeConfig.AgentConfig.DisableCCM = controlConfig.DisableCCM
 	nodeConfig.AgentConfig.DisableNPC = controlConfig.DisableNPC
 	nodeConfig.AgentConfig.DisableKubeProxy = controlConfig.DisableKubeProxy

--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rancher/k3s/pkg/agent/templates"
 	util2 "github.com/rancher/k3s/pkg/agent/util"
 	"github.com/rancher/k3s/pkg/daemons/config"
+	"github.com/rancher/k3s/pkg/untar"
 	"github.com/rancher/k3s/pkg/version"
 	"github.com/rancher/wrangler/pkg/merr"
 	"github.com/sirupsen/logrus"
@@ -229,7 +230,7 @@ func preloadFile(ctx context.Context, cfg *config.Node, client *containerd.Clien
 		defer zr.Close()
 		imageReader = zr
 	case util2.HasSuffixI(filePath, "tar.zst", ".tzst"):
-		zr, err := zstd.NewReader(file)
+		zr, err := zstd.NewReader(file, zstd.WithDecoderMaxMemory(untar.MaxDecoderMemory))
 		if err != nil {
 			return err
 		}

--- a/pkg/agent/util/strings.go
+++ b/pkg/agent/util/strings.go
@@ -1,0 +1,14 @@
+package util
+
+import "strings"
+
+// HasSuffixI returns true if string s has any of the given suffixes, ignoring case.
+func HasSuffixI(s string, suffixes ...string) bool {
+	s = strings.ToLower(s)
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(s, strings.ToLower(suffix)) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -36,12 +36,13 @@ type Agent struct {
 	WithNodeID               bool
 	EnableSELinux            bool
 	ProtectKernelDefaults    bool
+	PrivateRegistry          string
+	AirgapExtraRegistry      cli.StringSlice
+	ExtraKubeletArgs         cli.StringSlice
+	ExtraKubeProxyArgs       cli.StringSlice
+	Labels                   cli.StringSlice
+	Taints                   cli.StringSlice
 	AgentShared
-	ExtraKubeletArgs   cli.StringSlice
-	ExtraKubeProxyArgs cli.StringSlice
-	Labels             cli.StringSlice
-	Taints             cli.StringSlice
-	PrivateRegistry    string
 }
 
 type AgentShared struct {
@@ -87,6 +88,11 @@ var (
 		Usage:       "(agent/runtime) Private registry configuration file",
 		Destination: &AgentConfig.PrivateRegistry,
 		Value:       "/etc/rancher/" + version.Program + "/registries.yaml",
+	}
+	AirgapExtraRegistryFlag = cli.StringSliceFlag{
+		Name:  "airgap-extra-registry",
+		Usage: "(agent/runtime) Additional registry to tag airgap images as being sourced from",
+		Value: &AgentConfig.AirgapExtraRegistry,
 	}
 	PauseImageFlag = cli.StringFlag{
 		Name:        "pause-image",
@@ -225,6 +231,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			PauseImageFlag,
 			SnapshotterFlag,
 			PrivateRegistryFlag,
+			AirgapExtraRegistryFlag,
 			NodeIPFlag,
 			NodeExternalIPFlag,
 			ResolvConfFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -308,6 +308,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 			PauseImageFlag,
 			SnapshotterFlag,
 			PrivateRegistryFlag,
+			AirgapExtraRegistryFlag,
 			NodeIPFlag,
 			NodeExternalIPFlag,
 			ResolvConfFlag,

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -85,6 +85,7 @@ type Agent struct {
 	IPSECPSK                string
 	StrongSwanDir           string
 	PrivateRegistry         string
+	AirgapExtraRegistry     []string
 	DisableCCM              bool
 	DisableNPC              bool
 	DisableKubeProxy        bool

--- a/pkg/deploy/controller.go
+++ b/pkg/deploy/controller.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	errors2 "github.com/pkg/errors"
+	"github.com/rancher/k3s/pkg/agent/util"
 	v12 "github.com/rancher/k3s/pkg/apis/k3s.cattle.io/v1"
 	v1 "github.com/rancher/k3s/pkg/generated/controllers/k3s.cattle.io/v1"
 	"github.com/rancher/wrangler/pkg/apply"
@@ -309,11 +310,7 @@ func skipFile(fileName string, skips map[string]bool) bool {
 		return true
 	case skips[fileName]:
 		return true
-	case strings.HasSuffix(fileName, ".json"):
-		return false
-	case strings.HasSuffix(fileName, ".yml"):
-		return false
-	case strings.HasSuffix(fileName, ".yaml"):
+	case util.HasSuffixI(fileName, ".yaml", ".yml", ".json"):
 		return false
 	default:
 		return true
@@ -329,11 +326,7 @@ func shouldDisableService(base, fileName string, disables map[string]bool) bool 
 			return true
 		}
 	}
-	switch {
-	case strings.HasSuffix(fileName, ".json"):
-	case strings.HasSuffix(fileName, ".yml"):
-	case strings.HasSuffix(fileName, ".yaml"):
-	default:
+	if !util.HasSuffixI(fileName, ".yaml", ".yml", ".json") {
 		return false
 	}
 	baseFile := filepath.Base(fileName)

--- a/pkg/untar/untar.go
+++ b/pkg/untar/untar.go
@@ -18,6 +18,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// The zstd decoder will attempt to use up to 1GB memory for streaming operations by default,
+	// which is excessive and will OOM low-memory devices.
+	// NOTE: This must be at least as large as the window size used when compressing tarballs, or you
+	// will see a "window size exceeded" error when decompressing. The zstd CLI tool uses 4MB by
+	// default; the --long option defaults to 27 or 128M, which is still too much for a Pi3. 32MB
+	// (--long=25) has been tested to work acceptably while still compressing by an additional 3-6% on
+	// our datasets.
+	MaxDecoderMemory = 1 << 25
+)
+
 // TODO(bradfitz): this was copied from x/build/cmd/buildlet/buildlet.go
 // but there were some buildlet-specific bits in there, so the code is
 // forked for now.  Unfork and add some opts arguments here, so the
@@ -38,9 +49,9 @@ func untar(r io.Reader, dir string) (err error) {
 			logrus.Printf("error extracting tarball into %s after %d files, %d dirs, %v: %v", dir, nFiles, len(madeDir), td, err)
 		}
 	}()
-	zr, err := zstd.NewReader(r)
+	zr, err := zstd.NewReader(r, zstd.WithDecoderMaxMemory(MaxDecoderMemory))
 	if err != nil {
-		return fmt.Errorf("requires zstd-compressed body: %v", err)
+		return fmt.Errorf("error extracting zstd-compressed body: %v", err)
 	}
 	defer zr.Close()
 	tr := tar.NewReader(zr)

--- a/scripts/package-cli
+++ b/scripts/package-cli
@@ -36,7 +36,7 @@ mkdir -p dist/artifacts
 )
 
 tar cvf ./build/out/data.tar --exclude ./bin/hyperkube ./bin ./etc 
-zstd -v -T0 -16 -f --long --rm ./build/out/data.tar -o ./build/out/data.tar.zst
+zstd -v -T0 -16 -f --long=25 --rm ./build/out/data.tar -o ./build/out/data.tar.zst
 HASH=$(sha256sum ./build/out/data.tar.zst | awk '{print $1}')
 
 cp ./build/out/data.tar.zst ./build/data/${HASH}.tar.zst


### PR DESCRIPTION
#### Proposed Changes ####

Adds support for retagging images to appear to have been sourced from one or more additional registries as they are imported from the tarball. This is intended to support RKE2 use cases with system-default-registry where the images need to appear to have been pulled from a registry other than docker.io.

This also extends our use of zstd to support loading airgap images from zstd compressed tarballs, and more reliably ensures that files and decompressors are closed at the end of the image load cycle.

#### Types of Changes ####

- Airgap

#### Verification ####

```
[root@centos01 ~]# k3s --debug server --airgap-extra-registry=registry.lan.khaus:5000

[root@centos01 ~]# k3s crictl image ls
IMAGE                                                    TAG                 IMAGE ID            SIZE
docker.io/rancher/coredns-coredns                        1.8.0               296a6d5035e2d       12.9MB
registry.lan.khaus:5000/rancher/coredns-coredns          1.8.0               296a6d5035e2d       12.9MB
docker.io/rancher/klipper-lb                             v0.1.2              897ce3c5fc8ff       2.71MB
registry.lan.khaus:5000/rancher/klipper-lb               v0.1.2              897ce3c5fc8ff       2.71MB
docker.io/rancher/library-busybox                        1.31.1              1c35c44120825       1.44MB
registry.lan.khaus:5000/rancher/library-busybox          1.31.1              1c35c44120825       1.44MB
docker.io/rancher/local-path-provisioner                 v0.0.14             e422121c9c5f9       42MB
registry.lan.khaus:5000/rancher/local-path-provisioner   v0.0.14             e422121c9c5f9       42MB
docker.io/rancher/metrics-server                         v0.3.6              9dd718864ce61       10.5MB
registry.lan.khaus:5000/rancher/metrics-server           v0.3.6              9dd718864ce61       10.5MB
docker.io/rancher/klipper-helm                           v0.4.3              3b0b04aa3473f       50.7MB
registry.lan.khaus:5000/rancher/klipper-helm             v0.4.3              3b0b04aa3473f       50.7MB
docker.io/rancher/library-traefik                        1.7.19              aa764f7db3051       24MB
registry.lan.khaus:5000/rancher/library-traefik          1.7.19              aa764f7db3051       24MB
docker.io/rancher/pause                                  3.1                 da86e6ba6ca19       325kB
registry.lan.khaus:5000/rancher/pause                    3.1                 da86e6ba6ca19       325kB
```

#### Linked Issues ####
#2941
rancher/rke2#683

#### Further Comments ####

Quick comparison of sizes and load times for various formats:

```
-rw------- 1 brandond brandond 351M Feb 12 16:34 k3s-airgap-images-amd64.tar
-rw------- 1 brandond brandond 109M Feb 12 16:34 k3s-airgap-images-amd64.tar.gz
-rw------- 1 brandond brandond  75M Feb 12 16:34 k3s-airgap-images-amd64.tar.zst

Imported images from /var/lib/rancher/k3s/agent/images/k3s-airgap-images-amd64.tar in 5.021896552s
Imported images from /var/lib/rancher/k3s/agent/images/k3s-airgap-images-amd64.tar.zst in 6.291824836s
Imported images from /var/lib/rancher/k3s/agent/images/k3s-airgap-images-amd64.tar.gz in 7.572577879s
```

