### PR TITLE
[release-1.18] Update k3s-root to v0.8.1

### DIFF
--- a/pkg/agent/syssetup/setup.go
+++ b/pkg/agent/syssetup/setup.go
@@ -31,6 +31,7 @@ func Configure() {
 	loadKernelModule("overlay")
 	loadKernelModule("nf_conntrack")
 	loadKernelModule("br_netfilter")
+	loadKernelModule("iptable_nat")
 
 	// Kernel is inconsistent about how devconf is configured for
 	// new network namespaces between ipv4 and ipv6. Make sure to

--- a/scripts/download
+++ b/scripts/download
@@ -4,7 +4,7 @@ cd $(dirname $0)/..
 
 . ./scripts/version.sh
 
-ROOT_VERSION=v0.8.0
+ROOT_VERSION=v0.8.1
 TRAEFIK_VERSION=1.81.0
 CHARTS_DIR=build/static/charts
 


### PR DESCRIPTION
#### Proposed Changes ####

Bump k3s-root to v0.8.1

#### Types of Changes ####

* packaged components

#### Verification ####

* Confirm that k3s works on EL8 on AWS
* Check for `/var/lib/rancher/k3s/data/*/bin/aux/xtables-nft-multi`

#### Linked Issues ####

Related to #2940

#### Further Comments ####
```
[root@centos8 ~]# /var/lib/rancher/k3s/data/current/bin/aux/iptables-nft --version
iptables v1.8.5 (nf_tables)
```