### PR TITLE
Wait for apiserver to become healthy before starting agent controllers

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/controller-manager/app"
 )
 
 var (
@@ -98,6 +99,9 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 	if err != nil {
 		return err
 	}
+
+	app.WaitForAPIServer(coreClient, 30*time.Second)
+
 	if !nodeConfig.NoFlannel {
 		if err := flannel.Run(ctx, nodeConfig, coreClient.CoreV1().Nodes()); err != nil {
 			return err


### PR DESCRIPTION
#### Proposed Changes ####

It is possible that the apiserver may serve read requests but not allow writes yet, in which case flannel will crash on startup when trying to configure the subnet manager. 

The kubelet itself will keep retrying the node registration if the apiserver isn't writable yet, but flannel exits immediately if a write fails so we need to fix this by waiting for the apiserver to become fully ready before starting flannel and the network policy controller.

#### Types of Changes ####

* agent startup

#### Verification ####

Not sure how to reproduce this on demand; seems to happen occasionally on systems with slow IO (such as raspberry pi) where the apiserver serves reads but does not become fully healthy until a few seconds after startup?

#### Linked Issues ####

#2989
Possibly #2509

#### Further Comments ####