### PR TITLE
Hide the airgap-extra-registry flag

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -90,9 +90,10 @@ var (
 		Value:       "/etc/rancher/" + version.Program + "/registries.yaml",
 	}
 	AirgapExtraRegistryFlag = cli.StringSliceFlag{
-		Name:  "airgap-extra-registry",
-		Usage: "(agent/runtime) Additional registry to tag airgap images as being sourced from",
-		Value: &AgentConfig.AirgapExtraRegistry,
+		Name:   "airgap-extra-registry",
+		Usage:  "(agent/runtime) Additional registry to tag airgap images as being sourced from",
+		Value:  &AgentConfig.AirgapExtraRegistry,
+		Hidden: true,
 	}
 	PauseImageFlag = cli.StringFlag{
 		Name:        "pause-image",


### PR DESCRIPTION
#### Proposed Changes ####

Hide the airgap-extra-registry flag.

As per design review on rancher/rke2#715 it was decided that this is advanced functionality that we don't need to expose directly.

#### Types of Changes ####

*CLI

#### Verification ####

* `k3s agent --help | grep airgap-extra-registry`  # flag not listed
* `k3s agent --airgap-extra-registry=my.local.registry`  # flag is accepted

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

