### PR TITLE
Allow agent to start up successfully if server has not yet been upgraded to v1.20.4+k3s1

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -498,6 +498,13 @@ func get(envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
 		nodeConfig.AgentConfig.ServiceNodePortRange = *controlConfig.ServiceNodePortRange
 	}
 
+	// Old versions of the server do not send enough information to correctly start the NPC. Users
+	// need to upgrade the server to at least the same version as the agent, or disable the NPC
+	// cluster-wide.
+	if controlConfig.DisableNPC == false && (controlConfig.ServiceIPRange == nil || controlConfig.ServiceNodePortRange == nil) {
+		return nil, fmt.Errorf("incompatible down-level server detected; servers must be upgraded to at least %s, or restarted with --disable-network-policy", version.Version)
+	}
+
 	nodeConfig.AgentConfig.ExtraKubeletArgs = envInfo.ExtraKubeletArgs
 	nodeConfig.AgentConfig.ExtraKubeProxyArgs = envInfo.ExtraKubeProxyArgs
 

--- a/scripts/test
+++ b/scripts/test
@@ -18,6 +18,9 @@ docker ps
 . ./scripts/test-run-basics
 echo "Did test-run-basics $?"
 
+. ./scripts/test-run-compat
+echo "Did test-run-compat $?"
+
 # ---
 
 [ "$ARCH" != 'amd64' ] && \

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -419,7 +419,7 @@ provision-server() {
         -e K3S_TOKEN=$(cat $TEST_DIR/metadata/secret) \
         -e K3S_DEBUG=true \
         ${REGISTRY_CLUSTER_ARGS:-} \
-        $K3S_IMAGE server $ARGS $SERVER_ARGS ${!SERVER_INSTANCE_ARGS}
+        ${K3S_IMAGE_SERVER:-$K3S_IMAGE} server $ARGS $SERVER_ARGS ${!SERVER_INSTANCE_ARGS}
 
     local ip=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $name | tee $TEST_DIR/servers/$count/metadata/ip)
     local url=$(echo "https://$ip:6443" | tee $TEST_DIR/servers/$count/metadata/url)
@@ -446,7 +446,7 @@ provision-agent() {
         -e K3S_TOKEN=$(cat $TEST_DIR/metadata/secret) \
         -e K3S_URL=$K3S_URL \
         ${REGISTRY_CLUSTER_ARGS:-} \
-        $K3S_IMAGE agent $ARGS $AGENT_ARGS ${!AGENT_INSTANCE_ARGS}
+        ${K3S_IMAGE_AGENT:-$K3S_IMAGE} agent $ARGS $AGENT_ARGS ${!AGENT_INSTANCE_ARGS}
 
     echo "Started $name"
     run-function agent-post-hook $count

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -134,7 +134,7 @@ dump-logs() {
         mkdir -p $node/logs
         local hostname=$(docker exec $name hostname)
         docker logs $name >$node/logs/system.log 2>&1
-        if [[ $name == k3s-* ]]; then
+        if [[ ! -z "$hostname" && $name == k3s-* ]]; then
             docker exec $server kubectl describe node/$hostname >$node/logs/kubectl-describe-node.txt
             docker cp $name:/var/lib/rancher/k3s/agent/containerd/containerd.log $node/logs/containerd.log 2>/dev/null
             docker exec $name crictl pods >$node/logs/crictl-pods.txt
@@ -263,12 +263,16 @@ test-cleanup() {
         echo "Removing container $container"
         docker rm -f -v $container
     done
+    echo
+    if has-function test-post-hook; then
+      test-post-hook $code
+      code=$?
+    fi
     if [ "$TEST_CLEANUP" = true ]; then
         echo "Removing test directory $TEST_DIR"
         rm -rf $TEST_DIR
     fi
     [ -f "$PROVISION_LOCK" ] && rm $PROVISION_LOCK
-    echo
     echo -n "Test $(basename $TEST_DIR) "
     if [ $code -eq 0 ]; then
         echo "passed."
@@ -392,8 +396,15 @@ export -f inc-count
 
 # ---
 
+has-function() {
+  [[ ! -z "$1" && $(type -t $1) == "function" ]]
+} 2> /dev/null
+export -f has-function
+
+# ---
+
 run-function() {
-    declare -f $1 >/dev/null 2>&1 || return 0
+    has-function $1 || return 0
     $@
 }
 export -f run-function

--- a/scripts/test-run-compat
+++ b/scripts/test-run-compat
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+all_services=(
+    coredns
+    local-path-provisioner
+    metrics-server
+    traefik
+)
+
+export NUM_SERVERS=1
+export NUM_AGENTS=1
+export WAIT_SERVICES="${all_services[@]}"
+export SERVER_ARGS="--node-taint=CriticalAddonsOnly=true:NoExecute"
+
+start-test() {
+  echo "Cluster is up"
+}
+export -f start-test
+
+REPO=${REPO:-rancher}
+IMAGE_NAME=${IMAGE_NAME:-k3s}
+PREVIOUS_CHANNEL=$(curl -s https://update.k3s.io/v1-release/channels/stable -o /dev/null -w '%{redirect_url}' | awk -F. '{print "v1." ($(NF - 1) - 1)}')
+PREVIOUS_VERSION=$(curl -s https://update.k3s.io/v1-release/channels/${PREVIOUS_CHANNEL} -o /dev/null -w '%{redirect_url}' | awk -F/ '{print gensub(/\+/, "-", "g", $NF)}')
+STABLE_VERSION=$(curl -s https://update.k3s.io/v1-release/channels/stable -o /dev/null -w '%{redirect_url}' | awk -F/ '{print gensub(/\+/, "-", "g", $NF)}')
+LATEST_VERSION=$(curl -s https://update.k3s.io/v1-release/channels/latest -o /dev/null -w '%{redirect_url}' | awk -F/ '{print gensub(/\+/, "-", "g", $NF)}')
+
+# --- create a basic cluster to test for compat with the previous minor version of the server and agent
+K3S_IMAGE_SERVER=${REPO}/${IMAGE_NAME}:${PREVIOUS_VERSION} LABEL=PREVIOUS-SERVER run-test
+K3S_IMAGE_AGENT=${REPO}/${IMAGE_NAME}:${PREVIOUS_VERSION} LABEL=PREVIOUS-AGENT run-test
+
+# --- create a basic cluster to test for compat with the stable version of the server and agent
+K3S_IMAGE_SERVER=${REPO}/${IMAGE_NAME}:${STABLE_VERSION} LABEL=STABLE-SERVER run-test
+K3S_IMAGE_AGENT=${REPO}/${IMAGE_NAME}:${STABLE_VERSION} LABEL=STABLE-AGENT run-test
+
+# --- create a basic cluster to test for compat with the latest version of the server and agent
+K3S_IMAGE_SERVER=${REPO}/${IMAGE_NAME}:${LATEST_VERSION} LABEL=LATEST-SERVER run-test
+K3S_IMAGE_AGENT=${REPO}/${IMAGE_NAME}:${LATEST_VERSION} LABEL=LATEST-AGENT run-test

--- a/scripts/test-run-compat
+++ b/scripts/test-run-compat
@@ -17,6 +17,15 @@ start-test() {
 }
 export -f start-test
 
+# --- suppress test failures if the agent is intentionally incompatible with the server version
+test-post-hook() {
+  if [[ $1 -eq 0 ]]; then
+    return
+  fi
+  grep -sqF 'incompatible down-level server detected' $TEST_DIR/agents/*/logs/system.log
+}
+export -f test-post-hook
+
 REPO=${REPO:-rancher}
 IMAGE_NAME=${IMAGE_NAME:-k3s}
 PREVIOUS_CHANNEL=$(curl -s https://update.k3s.io/v1-release/channels/stable -o /dev/null -w '%{redirect_url}' | awk -F. '{print "v1." ($(NF - 1) - 1)}')


### PR DESCRIPTION
#### Proposed Changes ####

* Add CI script to test server/agent version compatibility against the latest, stable, and previous minor release channels.
* Log error on startup and disable NPC if server has not been upgraded.

#### Types of Changes ####

* bugfix
* CI

#### Verification ####

* Start k3s agent with v1.20.2+k3s1 server
 
#### Linked Issues ####

#2996 

#### Further Comments ####

