### PR TITLE
Have Bootstrap Data Stored in etcd at Completed Start

### DIFF
--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -26,7 +26,6 @@ func (c *Cluster) Bootstrap(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
 	c.shouldBootstrap = shouldBootstrap
 
 	if shouldBootstrap {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -93,7 +93,17 @@ func (c *Cluster) Start(ctx context.Context) (<-chan struct{}, error) {
 		}
 	}
 
-	return ready, c.startStorage(ctx)
+	if err := c.startStorage(ctx); err != nil {
+		return nil, err
+	}
+
+	if c.managedDB != nil {
+		if err := c.save(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	return ready, nil
 }
 
 // startStorage starts the kine listener and configures the endpoints, if necessary.

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -49,53 +48,6 @@ func (c *Cluster) testClusterDB(ctx context.Context) (<-chan struct{}, error) {
 	return result, nil
 }
 
-// cleanCerts removes existing certificatates previously
-// generated for use by the cluster.
-func (c *Cluster) cleanCerts() {
-	certs := []string{filepath.Join(c.config.DataDir, "tls", "client-ca.crt"),
-		filepath.Join(c.config.DataDir, "tls", "client-ca.key"),
-		filepath.Join(c.config.DataDir, "tls", "server-ca.crt"),
-		filepath.Join(c.config.DataDir, "tls", "server-ca.key"),
-		filepath.Join(c.config.DataDir, "tls", "request-header-ca.crt"),
-		filepath.Join(c.config.DataDir, "tls", "request-header-ca.key"),
-		filepath.Join(c.config.DataDir, "tls", "service.key"),
-		filepath.Join(c.config.DataDir, "tls", "client-admin.crt"),
-		filepath.Join(c.config.DataDir, "tls", "client-admin.key"),
-		filepath.Join(c.config.DataDir, "tls", "client-controller.crt"),
-		filepath.Join(c.config.DataDir, "tls", "client-controller.key"),
-		filepath.Join(c.config.DataDir, "tls", "client-cloud-controller.crt"),
-		filepath.Join(c.config.DataDir, "tls", "client-cloud-controller.key"),
-		filepath.Join(c.config.DataDir, "tls", "client-scheduler.crt"),
-		filepath.Join(c.config.DataDir, "tls", "client-scheduler.key"),
-		filepath.Join(c.config.DataDir, "tls", "client-kube-apiserver.crt"),
-		filepath.Join(c.config.DataDir, "tls", "client-kube-apiserver.key"),
-		filepath.Join(c.config.DataDir, "tls", "client-kube-proxy.crt"),
-		filepath.Join(c.config.DataDir, "tls", "client-kube-proxy.key"),
-		filepath.Join(c.config.DataDir, "tls", "client-"+version.Program+"-controller.crt"),
-		filepath.Join(c.config.DataDir, "tls", "client-"+version.Program+"-controller.key"),
-		filepath.Join(c.config.DataDir, "tls", "serving-kube-apiserver.crt"),
-		filepath.Join(c.config.DataDir, "tls", "serving-kube-apiserver.key"),
-		filepath.Join(c.config.DataDir, "tls", "client-kubelet.key"),
-		filepath.Join(c.config.DataDir, "tls", "serving-kubelet.key"),
-		filepath.Join(c.config.DataDir, "tls", "serving-kubelet.key"),
-		filepath.Join(c.config.DataDir, "tls", "client-auth-proxy.key"),
-		filepath.Join(c.config.DataDir, "tls", "etcd", "server-ca.crt"),
-		filepath.Join(c.config.DataDir, "tls", "etcd", "server-ca.key"),
-		filepath.Join(c.config.DataDir, "tls", "etcd", "peer-ca.crt"),
-		filepath.Join(c.config.DataDir, "tls", "etcd", "peer-ca.key"),
-		filepath.Join(c.config.DataDir, "tls", "etcd", "server-client.crt"),
-		filepath.Join(c.config.DataDir, "tls", "etcd", "server-client.key"),
-		filepath.Join(c.config.DataDir, "tls", "etcd", "peer-server-client.crt"),
-		filepath.Join(c.config.DataDir, "tls", "etcd", "peer-server-client.key"),
-		filepath.Join(c.config.DataDir, "tls", "etcd", "client.crt"),
-		filepath.Join(c.config.DataDir, "tls", "etcd", "client.key"),
-	}
-
-	for _, cert := range certs {
-		os.Remove(cert)
-	}
-}
-
 // start starts the database, unless a cluster reset has been requested, in which case
 // it does that instead.
 func (c *Cluster) start(ctx context.Context) error {
@@ -104,7 +56,15 @@ func (c *Cluster) start(ctx context.Context) error {
 		return nil
 	}
 
-	if c.config.ClusterReset {
+	switch {
+	case c.config.ClusterReset && c.config.ClusterResetRestorePath != "":
+		rebootstrap := func() error {
+			return c.storageBootstrap(ctx)
+		}
+		if err := c.managedDB.Reset(ctx, rebootstrap); err != nil {
+			return err
+		}
+	case c.config.ClusterReset:
 		if _, err := os.Stat(resetFile); err != nil {
 			if !os.IsNotExist(err) {
 				return err
@@ -112,14 +72,8 @@ func (c *Cluster) start(ctx context.Context) error {
 		} else {
 			return fmt.Errorf("cluster-reset was successfully performed, please remove the cluster-reset flag and start %s normally, if you need to perform another cluster reset, you must first manually delete the %s file", version.Program, resetFile)
 		}
-
-		rebootstrap := func() error {
-			return c.storageBootstrap(ctx)
-		}
-		if err := c.managedDB.Reset(ctx, rebootstrap, c.cleanCerts); err != nil {
-			return err
-		}
 	}
+
 	// removing the reset file and ignore error if the file doesn't exist
 	os.Remove(resetFile)
 

--- a/pkg/cluster/managed/drivers.go
+++ b/pkg/cluster/managed/drivers.go
@@ -16,7 +16,7 @@ var (
 type Driver interface {
 	IsInitialized(ctx context.Context, config *config.Control) (bool, error)
 	Register(ctx context.Context, config *config.Control, handler http.Handler) (http.Handler, error)
-	Reset(ctx context.Context, reboostrap func() error, cleanCerts func()) error
+	Reset(ctx context.Context, reboostrap func() error) error
 	Start(ctx context.Context, clientAccessInfo *clientaccess.Info) error
 	Test(ctx context.Context) error
 	Restore(ctx context.Context) error

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/k3s-io/kine/pkg/client"
 	"github.com/rancher/k3s/pkg/bootstrap"
+	"github.com/sirupsen/logrus"
 )
 
 // save writes the current ControlRuntimeBootstrap data to the datastore. This contains a complete
@@ -22,8 +23,21 @@ func (c *Cluster) save(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	storageClient, err := client.New(c.etcdConfig)
+	if err != nil {
+		return err
+	}
+	c.storageClient = storageClient
 
-	return c.storageClient.Create(ctx, storageKey(c.config.Token), data)
+	if err := c.storageClient.Create(ctx, storageKey(c.config.Token), data); err != nil {
+		if err.Error() == "key exists" {
+			logrus.Warnln("Bootstrap key exists. Please follow documentation to on updating a node after restore.")
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }
 
 // storageBootstrap loads data from the datastore into the ControlRuntimeBootstrap struct.

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -27,9 +27,8 @@ func (c *Cluster) save(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	c.storageClient = storageClient
 
-	if err := c.storageClient.Create(ctx, storageKey(c.config.Token), data); err != nil {
+	if err := storageClient.Create(ctx, storageKey(c.config.Token), data); err != nil {
 		if err.Error() == "key exists" {
 			logrus.Warnln("Bootstrap key exists. Please follow documentation to on updating a node after restore.")
 			return nil
@@ -51,7 +50,6 @@ func (c *Cluster) storageBootstrap(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	c.storageClient = storageClient
 
 	value, err := storageClient.Get(ctx, storageKey(c.config.Token))
 	if err == client.ErrNotFound {

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -30,7 +30,7 @@ func (c *Cluster) save(ctx context.Context) error {
 
 	if err := storageClient.Create(ctx, storageKey(c.config.Token), data); err != nil {
 		if err.Error() == "key exists" {
-			logrus.Warnln("Bootstrap key exists. Please follow documentation to on updating a node after restore.")
+			logrus.Warnln("Bootstrap key exists. Please follow documentation updating a node after restore.")
 			return nil
 		}
 		return err

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -161,7 +161,7 @@ func (e *ETCD) IsInitialized(ctx context.Context, config *config.Control) (bool,
 }
 
 // Reset resets an etcd node
-func (e *ETCD) Reset(ctx context.Context, rebootstrap func() error, cleanCerts func()) error {
+func (e *ETCD) Reset(ctx context.Context, rebootstrap func() error) error {
 	// Wait for etcd to come up as a new single-node cluster, then exit
 	go func() {
 		t := time.NewTicker(5 * time.Second)
@@ -177,8 +177,6 @@ func (e *ETCD) Reset(ctx context.Context, rebootstrap func() error, cleanCerts f
 				if err := rebootstrap(); err != nil {
 					logrus.Fatal(err)
 				}
-
-				cleanCerts()
 
 				// call functions to rewrite them from daemons/control/server.go (prepare())
 				if err := deps.GenServerDeps(e.config, e.runtime); err != nil {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

* Add ability to save bootstrap data to etcd  when using managed etcd.
* Remove unneeded code that cleaned up certificates.

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

```sh
k3s etcd-snapshot
k3s server --cluster-reset --cluster-reset-restore-path=/home/bdowns/on-demand-<TIMESTAMP>
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#3040 

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

