### PR TITLE
Add dual stack support to K3S

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -593,7 +593,6 @@ github.com/knative/pkg v0.0.0-20190514205332-5e4512dcb2ca/go.mod h1:7Ijfhw7rfB+H
 github.com/knative/serving v0.6.1/go.mod h1:ljvMfwQy2qanaM/8xnBSK4Mz3Vv2NawC2fo5kFRJS1A=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -720,7 +719,6 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
-github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3 h1:gph6h/qe9GSUw1NhH1gp+qb+h8rXD8Cy60Z32Qw3ELA=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
@@ -832,7 +830,6 @@ github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjM
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -898,7 +895,6 @@ github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVU
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=

--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -118,7 +118,7 @@ func createFlannelConf(nodeConfig *config.Node) error {
 		logrus.Infof("Using custom flannel conf defined at %s", nodeConfig.FlannelConf)
 		return nil
 	}
-	confJSON := strings.Replace(flannelConf, "%CIDR%", nodeConfig.AgentConfig.ClusterCIDR.String(), -1)
+	confJSON := strings.Replace(flannelConf, "%CIDR%", nodeConfig.AgentConfig.ClusterCIDRs[0].String(), -1)
 
 	var backendConf string
 

--- a/pkg/agent/netpol/network_policy_controller_test.go
+++ b/pkg/agent/netpol/network_policy_controller_test.go
@@ -261,7 +261,7 @@ func newMinimalNodeConfig(clusterIPCIDR string, nodePortRange string, hostNameOv
 		if err != nil {
 			panic("failed to get parse --service-cluster-ip-range parameter: " + err.Error())
 		}
-		nodeConfig.AgentConfig.ClusterCIDR = *cidr
+		nodeConfig.AgentConfig.ClusterCIDRs = config.NetIPNets{cidr}
 	}
 	if nodePortRange != "" {
 		portRange, err := utilnet.ParsePortRange(nodePortRange)

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -20,8 +20,8 @@ type Agent struct {
 	LBServerPort             int
 	ResolvConf               string
 	DataDir                  string
-	NodeIP                   string
-	NodeExternalIP           string
+	NodeIPs                  []string
+	NodeExternalIPs          []string
 	NodeName                 string
 	PauseImage               string
 	Snapshotter              string
@@ -52,15 +52,13 @@ type AgentShared struct {
 var (
 	appName     = filepath.Base(os.Args[0])
 	AgentConfig Agent
-	NodeIPFlag  = cli.StringFlag{
-		Name:        "node-ip,i",
-		Usage:       "(agent/networking) IP address to advertise for node",
-		Destination: &AgentConfig.NodeIP,
+	NodeIPFlag  = cli.StringSliceFlag{
+		Name:  "node-ip,i",
+		Usage: "(agent/networking) IP address to advertise for node",
 	}
-	NodeExternalIPFlag = cli.StringFlag{
-		Name:        "node-external-ip",
-		Usage:       "(agent/networking) External IP address to advertise for node",
-		Destination: &AgentConfig.NodeExternalIP,
+	NodeExternalIPFlag = cli.StringSliceFlag{
+		Name:  "node-external-ip",
+		Usage: "(agent/networking) External IP address to advertise for node",
 	}
 	NodeNameFlag = cli.StringFlag{
 		Name:        "node-name",
@@ -190,8 +188,12 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 		Name:      "agent",
 		Usage:     "Run node agent",
 		UsageText: appName + " agent [OPTIONS]",
-		Before:    SetupDebug(CheckSELinuxFlags),
-		Action:    action,
+		Before: func(c *cli.Context) error {
+			AgentConfig.NodeExternalIPs = c.StringSlice("node-external-ip")
+			AgentConfig.NodeIPs = c.StringSlice("node-ip")
+			return SetupDebug(CheckSELinuxFlags)(c)
+		},
+		Action: action,
 		Flags: []cli.Flag{
 			ConfigFlag,
 			DebugFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -87,8 +87,12 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 		Name:      "server",
 		Usage:     "Run management server",
 		UsageText: appName + " server [OPTIONS]",
-		Before:    SetupDebug(CheckSELinuxFlags),
-		Action:    action,
+		Before: func(c *cli.Context) error {
+			AgentConfig.NodeExternalIPs = c.StringSlice("node-external-ip")
+			AgentConfig.NodeIPs = c.StringSlice("node-ip")
+			return SetupDebug(CheckSELinuxFlags)(c)
+		},
+		Action: action,
 		Flags: []cli.Flag{
 			ConfigFlag,
 			DebugFlag,

--- a/pkg/cloudprovider/instances.go
+++ b/pkg/cloudprovider/instances.go
@@ -3,6 +3,7 @@ package cloudprovider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/k3s/pkg/version"
@@ -13,9 +14,9 @@ import (
 )
 
 var (
-	InternalIPLabel = version.Program + ".io/internal-ip"
-	ExternalIPLabel = version.Program + ".io/external-ip"
-	HostnameLabel   = version.Program + ".io/hostname"
+	InternalIPAnnotation = version.Program + ".io/internal-ip"
+	ExternalIPAnnotation = version.Program + ".io/external-ip"
+	HostnameAnnotation   = version.Program + ".io/hostname"
 )
 
 func (k *k3s) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
@@ -69,20 +70,24 @@ func (k *k3s) NodeAddresses(ctx context.Context, name types.NodeName) ([]corev1.
 		return nil, fmt.Errorf("Failed to find node %s: %v", name, err)
 	}
 	// check internal address
-	if node.Labels[InternalIPLabel] != "" {
-		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: node.Labels[InternalIPLabel]})
+	if node.Annotations[InternalIPAnnotation] != "" {
+		for _, address := range strings.Split(node.Annotations[InternalIPAnnotation], ",") {
+			addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: address})
+		}
 	} else {
 		logrus.Infof("Couldn't find node internal ip label on node %s", name)
 	}
 
 	// check external address
-	if node.Labels[ExternalIPLabel] != "" {
-		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: node.Labels[ExternalIPLabel]})
+	if node.Annotations[ExternalIPAnnotation] != "" {
+		for _, address := range strings.Split(node.Annotations[ExternalIPAnnotation], ",") {
+			addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: address})
+		}
 	}
 
 	// check hostname
-	if node.Labels[HostnameLabel] != "" {
-		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeHostName, Address: node.Labels[HostnameLabel]})
+	if node.Annotations[HostnameAnnotation] != "" {
+		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeHostName, Address: node.Annotations[HostnameAnnotation]})
 	} else {
 		logrus.Infof("Couldn't find node hostname label on node %s", name)
 	}

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -46,7 +46,7 @@ func startKubeProxy(cfg *config.Agent) error {
 		"proxy-mode":           "iptables",
 		"healthz-bind-address": "127.0.0.1",
 		"kubeconfig":           cfg.KubeConfigKubeProxy,
-		"cluster-cidr":         cfg.ClusterCIDR.String(),
+		"cluster-cidr":         cfg.ClusterCIDRs.String(),
 	}
 	if cfg.NodeName != "" {
 		argsMap["hostname-override"] = cfg.NodeName
@@ -125,8 +125,8 @@ func startKubelet(cfg *config.Agent) error {
 		argsMap["hostname-override"] = cfg.NodeName
 	}
 	defaultIP, err := net.ChooseHostInterface()
-	if err != nil || defaultIP.String() != cfg.NodeIP {
-		argsMap["node-ip"] = cfg.NodeIP
+	if err != nil || defaultIP.String() != cfg.NodeIPs[0] {
+		argsMap["node-ip"] = cfg.NodeIPs[0]
 	}
 	kubeletRoot, runtimeRoot, hasCFS, hasPIDs := checkCgroups()
 	if !hasCFS {

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -52,15 +52,17 @@ type Containerd struct {
 	SELinux  bool
 }
 
+type NetIPNets []*net.IPNet
+
 type Agent struct {
 	PodManifests            string
 	NodeName                string
 	NodeConfigPath          string
 	ServingKubeletCert      string
 	ServingKubeletKey       string
-	ServiceCIDR             net.IPNet
+	ServiceCIDRs            NetIPNets
 	ServiceNodePortRange    utilnet.PortRange
-	ClusterCIDR             net.IPNet
+	ClusterCIDRs            NetIPNets
 	ClusterDNS              net.IP
 	ClusterDomain           string
 	ResolvConf              string
@@ -68,8 +70,8 @@ type Agent struct {
 	KubeConfigKubelet       string
 	KubeConfigKubeProxy     string
 	KubeConfigK3sController string
-	NodeIP                  string
-	NodeExternalIP          string
+	NodeIPs                 []string
+	NodeExternalIPs         []string
 	RuntimeSocket           string
 	ListenAddress           string
 	ClientCA                string
@@ -101,12 +103,15 @@ type Control struct {
 	// The port which custom k3s API runs on
 	SupervisorPort int
 	// The port which kube-apiserver runs on
-	APIServerPort            int
-	APIServerBindAddress     string
-	AgentToken               string `json:"-"`
-	Token                    string `json:"-"`
+	APIServerPort        int
+	APIServerBindAddress string
+	AgentToken           string `json:"-"`
+	Token                string `json:"-"`
+	// IPRange to enable compatibility with older agents
 	ClusterIPRange           *net.IPNet
 	ServiceIPRange           *net.IPNet
+	ClusterIPRanges          NetIPNets
+	ServiceIPRanges          NetIPNets
 	ServiceNodePortRange     *utilnet.PortRange
 	ClusterDNS               net.IP
 	ClusterDomain            string
@@ -262,4 +267,12 @@ func GetArgsList(argsMap map[string]string, extraArgs []string) []string {
 	}
 	sort.Strings(args)
 	return args
+}
+
+func (ipNets NetIPNets) String() string {
+	ranges := make([]string, len(ipNets))
+	for i, nets := range ipNets {
+		ranges[i] = nets.String()
+	}
+	return strings.Join(ranges, ",")
 }

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -313,7 +313,7 @@ func genServerCerts(config *config.Control, runtime *config.ControlRuntime) erro
 		return err
 	}
 
-	_, apiServerServiceIP, err := controlplane.ServiceIPRange(*config.ServiceIPRange)
+	_, apiServerServiceIP, err := controlplane.ServiceIPRange(*config.ServiceIPRanges[0])
 	if err != nil {
 		return err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -424,8 +424,8 @@ func setNoProxyEnv(config *config.Control) error {
 	envList = append(envList,
 		".svc",
 		"."+config.ClusterDomain,
-		config.ClusterIPRange.String(),
-		config.ServiceIPRange.String(),
+		config.ClusterIPRanges.String(),
+		config.ServiceIPRanges.String(),
 	)
 	os.Unsetenv("no_proxy")
 	return os.Setenv("NO_PROXY", strings.Join(envList, ","))


### PR DESCRIPTION
Problem: Although Kubernetes does support dual stack, K3S does not

Solution: Modify K3S so it can both support parameters for dual stack,
and pass them to the different Kubernetes daemons

Signed-off-by: José Luis Ledesma <jose@netlify.com>

#### Proposed Changes ####

Add dual stack support to K3S

#### Types of Changes ####

New Feature

#### Verification ####
You'll need to start K3S with the `DualStack` feature flag. Also you'll need a different CNI than flannel, because it does not support dual stack (yet). I used Cilium and it worked fine. I start the k3s server like this:
```
/usr/local/bin/k3s server --disable traefik –-flannel-backend=none --disable-network-policy  --disable servicelb --no-flannel --disable-kube-proxy  \
		--node-ip <node IPv4 IP> \
		--node-ip <node IPv6 IP> \
		--kube-apiserver-arg 'feature-gates=IPv6DualStack=true' \
		--kube-controller-manager-arg 'feature-gates=IPv6DualStack=true' \
		--kubelet-arg 'feature-gates=IPv6DualStack=true' \
		--cluster-cidr '<cluster IPv4 cidr>,<cluster IPv6 cidr>' \
		--service-cidr '<service IPv4 cidr>,<cluster IPv6 cidr>' \
```

#### Linked Issues ####
Fixes: https://github.com/k3s-io/k3s/issues/1405

#### Further Comments ####
Had to change some node `labels` to `annotations`, because of the restricted set of characters usable in `labels`
