### PR TITLE
[release-1.20] Define a Controllers and LeaderControllers on the server config

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -41,10 +41,17 @@ func Run(app *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	return run(app, &cmds.ServerConfig)
+	return run(app, &cmds.ServerConfig, server.CustomControllers{}, server.CustomControllers{})
 }
 
-func run(app *cli.Context, cfg *cmds.Server) error {
+func RunWithControllers(app *cli.Context, leaderControllers server.CustomControllers, controllers server.CustomControllers) error {
+	if err := cmds.InitLogging(); err != nil {
+		return err
+	}
+	return run(app, &cmds.ServerConfig, leaderControllers, controllers)
+}
+
+func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomControllers, controllers server.CustomControllers) error {
 	var (
 		err error
 	)
@@ -232,6 +239,9 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	}
 
 	serverConfig.StartupHooks = append(serverConfig.StartupHooks, cfg.StartupHooks...)
+
+	serverConfig.LeaderControllers = append(serverConfig.LeaderControllers, leaderControllers...)
+	serverConfig.Controllers = append(serverConfig.Controllers, controllers...)
 
 	// TLS config based on mozilla ssl-config generator
 	// https://ssl-config.mozilla.org/#server=golang&version=1.13.6&config=intermediate&guideline=5.4

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -131,6 +131,12 @@ func runControllers(ctx context.Context, config *Config) error {
 		}
 	}
 
+	for _, controller := range config.Controllers {
+		if err := controller(ctx, sc); err != nil {
+			return errors.Wrap(err, "controller")
+		}
+	}
+
 	if err := sc.Start(ctx); err != nil {
 		return err
 	}
@@ -138,6 +144,11 @@ func runControllers(ctx context.Context, config *Config) error {
 	start := func(ctx context.Context) {
 		if err := coreControllers(ctx, sc, config); err != nil {
 			panic(err)
+		}
+		for _, controller := range config.LeaderControllers {
+			if err := controller(ctx, sc); err != nil {
+				panic(errors.Wrap(err, "leader controller"))
+			}
 		}
 		if err := sc.Start(ctx); err != nil {
 			panic(err)

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -7,10 +7,14 @@ import (
 )
 
 type Config struct {
-	DisableAgent     bool
-	DisableServiceLB bool
-	ControlConfig    config.Control
-	Rootless         bool
-	SupervisorPort   int
-	StartupHooks     []func(context.Context, <-chan struct{}, string) error
+	DisableAgent      bool
+	DisableServiceLB  bool
+	ControlConfig     config.Control
+	Rootless          bool
+	SupervisorPort    int
+	StartupHooks      []func(context.Context, <-chan struct{}, string) error
+	LeaderControllers CustomControllers
+	Controllers       CustomControllers
 }
+
+type CustomControllers []func(ctx context.Context, sc *Context) error


### PR DESCRIPTION
Backport to release 1.20

#### Proposed Changes ####
This adds trickle-down scaffolding to define `Controllers` and `LeaderControllers` from RKE2. This is being set up to allow RKE2 to define its own controllers to run, and is set up in such a manner to allow controllers to be defined that either only run on a leader, or run on all "server" nodes.

#### Types of Changes ####
Scaffolding changes.

#### Verification ####
This should not functionally change K3s.

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/3034
https://github.com/rancher/rke2/issues/745