### PR TITLE
Skip systemctl disable (k3s-io#3035)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -692,11 +692,10 @@ EOF
     $SUDO chown root:root ${UNINSTALL_K3S_SH}
 }
 
-# --- disable current service if loaded --
-systemd_disable() {
+# --- delete current systemd service and environment files --
+delete_systemd_files() {
     $SUDO rm -f /etc/systemd/system/${SERVICE_K3S} || true
     $SUDO rm -f /etc/systemd/system/${SERVICE_K3S}.env || true
-    $SUDO systemctl disable ${SYSTEM_NAME} >/dev/null 2>&1 || true
 }
 
 # --- capture current env and create file containing k3s_ variables ---
@@ -857,7 +856,7 @@ eval set -- $(escape "${INSTALL_K3S_EXEC}") $(quote "$@")
     create_symlinks
     create_killall
     create_uninstall
-    systemd_disable
+    delete_systemd_files
     create_env_file
     create_service_file
     service_enable_and_start


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Don't disable systemd unit file when upgrading/installing k3s, because it causes cAdvisor container stats to go stale if k3s is running.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

Install and upgrade k3s from the install.sh script.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

#3035 
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

