### PR TITLE
rootless: allow kernel.dmesg_restrict=1

### DIFF
--- a/pkg/rootless/mounts.go
+++ b/pkg/rootless/mounts.go
@@ -37,6 +37,18 @@ func setupMounts(stateDir string) error {
 		}
 	}
 
+	if devKmsg, err := os.Open("/dev/kmsg"); err == nil {
+		devKmsg.Close()
+	} else {
+		// kubelet requires /dev/kmsg to be readable
+		// https://github.com/rootless-containers/usernetes/issues/204
+		// https://github.com/rootless-containers/usernetes/pull/214
+		logrus.Debugf("`kernel.dmesg_restrict` seems to be set, bind-mounting /dev/null into /dev/kmsg")
+		if err := unix.Mount("/dev/null", "/dev/kmsg", "none", unix.MS_BIND, ""); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -78,10 +78,6 @@ func validateSysctl() error {
 		// However, the current k3s implementation has a bug that requires net.ipv4.ip_forward=1
 		// https://github.com/rancher/k3s/issues/2420#issuecomment-715051120
 		"net.ipv4.ip_forward": "1",
-
-		// Currently, kernel.dmesg_restrict needs to be 0 to allow OOM-related messages
-		// https://github.com/rootless-containers/usernetes/issues/204
-		"kernel.dmesg_restrict": "0",
 	}
 	for key, expectedValue := range expected {
 		if actualValue, err := readSysctl(key); err == nil {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

When `/dev/kmsg` is unreadable due to sysctl value `kernel.dmesg_restrict=1`, bind-mount `/dev/null` into `/dev/kmsg`


#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

Enhancement

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- Run`sudo sysctl -w kernel.dmesg_restrict=1`
- Run `k3s server --rootless` and make sure kubelet starts up.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

Related to #3011 

