### PR TITLE
Remove unit files after disabling, instead of before

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -694,9 +694,9 @@ EOF
 
 # --- disable current service if loaded --
 systemd_disable() {
+    $SUDO systemctl disable ${SYSTEM_NAME} >/dev/null 2>&1 || true
     $SUDO rm -f /etc/systemd/system/${SERVICE_K3S} || true
     $SUDO rm -f /etc/systemd/system/${SERVICE_K3S}.env || true
-    $SUDO systemctl disable ${SYSTEM_NAME} >/dev/null 2>&1 || true
 }
 
 # --- capture current env and create file containing k3s_ variables ---


### PR DESCRIPTION
Signed-off-by: Martin Norrsken <martin.norrsken@gmail.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Disable k3s service before removing unit files, otherwise systemd removes some cgroup info. This should be the logical order of doing cleanup (reverse order compared to installing and enabling service).

#### Types of Changes ####

Bugfix

#### Verification ####

Installing k3s by script should not make cAdvisor info go stale anymore nor cause systemd to log warnings.

#### Linked Issues ####

#3035
