### PR TITLE
Add restoration from rke1 snapshot

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -61,6 +61,7 @@ type Server struct {
 	ClusterInit              bool
 	ClusterReset             bool
 	ClusterResetRestorePath  string
+	RKE1Snapshot             bool
 	EncryptSecrets           bool
 	StartupHooks             []func(context.Context, <-chan struct{}, string) error
 	EtcdSnapshotName         string
@@ -417,6 +418,11 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Name:        "cluster-reset-restore-path",
 				Usage:       "(db) Path to snapshot file to be restored",
 				Destination: &ServerConfig.ClusterResetRestorePath,
+			},
+			&cli.BoolFlag{
+				Name:        "rke1-snapshot",
+				Usage:       "(db) Enable rke1 snapshot restore",
+				Destination: &ServerConfig.RKE1Snapshot,
 			},
 			cli.BoolFlag{
 				Name:        "secrets-encryption",

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -155,6 +155,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 
 	serverConfig.ControlConfig.ClusterReset = cfg.ClusterReset
 	serverConfig.ControlConfig.ClusterResetRestorePath = cfg.ClusterResetRestorePath
+	serverConfig.ControlConfig.RKE1Snapshot = cfg.RKE1Snapshot
 
 	if serverConfig.ControlConfig.SupervisorPort == 0 {
 		serverConfig.ControlConfig.SupervisorPort = serverConfig.ControlConfig.HTTPSPort

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -1,0 +1,225 @@
+package cluster
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/k3s/pkg/daemons/config"
+)
+
+const (
+	backupDest                 = "/tmp/rke1"
+	compressedExtension        = "zip"
+	stateExtenstion            = "rkestate"
+	caCertName                 = "kube-ca"
+	requestHeaderCACertName    = "kube-apiserver-requestheader-ca"
+	etcdClientCACertName       = "kube-etcd-client-ca"
+	serviceAccountTokenKeyName = "kube-service-account-token"
+	certPEM                    = "certificatePEM"
+	keyPEM                     = "keyPEM"
+
+	certType = iota
+	keyType
+)
+
+func unzip(src, dest string) error {
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	os.MkdirAll(dest, 0700)
+
+	for _, f := range r.File {
+		err := extract(f, dest)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func extract(f *zip.File, dest string) error {
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := rc.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	path := filepath.Join(dest, f.Name)
+
+	if !strings.HasPrefix(path, filepath.Clean(dest)+string(os.PathSeparator)) {
+		return fmt.Errorf("illegal file path: %s", path)
+	}
+
+	if f.FileInfo().IsDir() {
+		os.MkdirAll(path, f.Mode())
+	} else {
+		os.MkdirAll(filepath.Dir(path), f.Mode())
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := f.Close(); err != nil {
+				panic(err)
+			}
+		}()
+
+		_, err = io.Copy(f, rc)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isCompressed(filename string) bool {
+	return strings.HasSuffix(filename, fmt.Sprintf(".%s", compressedExtension))
+}
+
+func isStateFile(filename string) bool {
+	return strings.HasSuffix(filename, fmt.Sprintf(".%s", stateExtenstion))
+}
+
+func recoverCerts(ctx context.Context, runtime *config.ControlRuntime, stateFile string) error {
+	var state map[string]interface{}
+	stateJSON, err := ioutil.ReadFile(stateFile)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(stateJSON, &state); err != nil {
+		return err
+	}
+	currentState := state["currentState"].(map[string]interface{})
+	certs := currentState["certificatesBundle"].(map[string]interface{})
+
+	return writeCertBundle(runtime, certs)
+}
+
+func writeCertBundle(runtime *config.ControlRuntime, certBundle map[string]interface{}) error {
+	for certName, cert := range certBundle {
+		currentCert := cert.(map[string]interface{})
+		switch certName {
+		case caCertName:
+			if err := writeFile(
+				currentCert, certType, runtime.ControlRuntimeBootstrap.ClientCA,
+				runtime.ControlRuntimeBootstrap.ETCDPeerCA,
+				runtime.ControlRuntimeBootstrap.ServerCA); err != nil {
+				return err
+			}
+			if err := writeFile(
+				currentCert, keyType, runtime.ControlRuntimeBootstrap.ClientCAKey,
+				runtime.ControlRuntimeBootstrap.ETCDPeerCAKey,
+				runtime.ControlRuntimeBootstrap.ServerCAKey); err != nil {
+				return err
+			}
+		case requestHeaderCACertName:
+			if err := writeFile(
+				currentCert, certType, runtime.ControlRuntimeBootstrap.RequestHeaderCA); err != nil {
+				return err
+			}
+			if err := writeFile(
+				currentCert, keyType, runtime.ControlRuntimeBootstrap.RequestHeaderCAKey); err != nil {
+				return err
+			}
+		case etcdClientCACertName:
+			if err := writeFile(
+				currentCert, certType, runtime.ControlRuntimeBootstrap.ETCDServerCA); err != nil {
+				return err
+			}
+			if err := writeFile(
+				currentCert, keyType, runtime.ControlRuntimeBootstrap.RequestHeaderCAKey); err != nil {
+				return err
+			}
+		case serviceAccountTokenKeyName:
+			if err := writeFile(
+				currentCert, keyType, runtime.ControlRuntimeBootstrap.ServiceKey); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeFile(cert map[string]interface{}, fileType int, certPaths ...string) error {
+	for _, path := range certPaths {
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return errors.Wrapf(err, "failed to mkdir %s", filepath.Dir(path))
+		}
+		if fileType == certType {
+			if err := ioutil.WriteFile(path, []byte(cert[certPEM].(string)), 0600); err != nil {
+				return errors.Wrapf(err, "failed to write to %s", path)
+			}
+		} else if fileType == keyType {
+			if err := ioutil.WriteFile(path, []byte(cert[keyPEM].(string)), 0600); err != nil {
+				return errors.Wrapf(err, "failed to write to %s", path)
+			}
+		}
+	}
+	return nil
+}
+
+func findStateFile(destDir string) (string, error) {
+	fileList, err := fileList(destDir)
+	if err != nil {
+		return "", err
+	}
+	for _, file := range fileList {
+		if isStateFile(file) {
+			return file, nil
+		}
+	}
+	return "", fmt.Errorf("file not found")
+}
+
+func findSnapshotFile(destDir string) (string, error) {
+	fileList, err := fileList(destDir)
+	if err != nil {
+		return "", err
+	}
+	for _, file := range fileList {
+		f, err := os.Stat(file)
+		if err != nil {
+			return "", nil
+		}
+		if f.IsDir() {
+			continue
+		}
+		if !isStateFile(file) {
+			return file, nil
+		}
+	}
+	return "", fmt.Errorf("snapshot file not found")
+}
+
+func fileList(destDir string) ([]string, error) {
+	fileList := make([]string, 0)
+	e := filepath.Walk(destDir, func(path string, f os.FileInfo, err error) error {
+		fileList = append(fileList, path)
+		return err
+	})
+
+	if e != nil {
+		return nil, fmt.Errorf("failed to search content of snapshot")
+	}
+	return fileList, nil
+}

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -136,6 +136,7 @@ type Control struct {
 	ClusterInit              bool
 	ClusterReset             bool
 	ClusterResetRestorePath  string
+	RKE1Snapshot             bool
 	EncryptSecrets           bool
 	TLSMinVersion            uint16
 	TLSCipherSuites          []uint16


### PR DESCRIPTION

#### Proposed Changes ####

This PR adds the ability to restore from rke1 snapshot, by populating the runtime.controlBootstrap data from rkestate file

#### Types of Changes ####

feature

#### Verification ####

- take a snapshot from the cluster with rke1
- use k3s restore with --rke1-snapshot flag
