### PR TITLE
Add gz and zst airgap artifacts

### DIFF
--- a/scripts/package-airgap
+++ b/scripts/package-airgap
@@ -9,6 +9,8 @@ airgap_image_file='scripts/airgap/image-list.txt'
 images=$(cat "${airgap_image_file}")
 xargs -n1 docker pull <<< "${images}"
 docker save ${images} -o dist/artifacts/k3s-airgap-images-${ARCH}.tar
+zstd -T0 -16 -f --long=25 dist/artifacts/k3s-airgap-images-${ARCH}.tar -o dist/artifacts/k3s-airgap-images-${ARCH}.tar.zst
+gzip -v -c dist/artifacts/k3s-airgap-images-${ARCH}.tar > dist/artifacts/k3s-airgap-images-${ARCH}.tar.gz
 if [ ${ARCH} = amd64 ]; then
   cp "${airgap_image_file}" dist/artifacts/k3s-images.txt
 fi


### PR DESCRIPTION
#### Proposed Changes ####

Add gz and zst airgap artifacts

#### Types of Changes ####

Add zst for direct import
Add gzip for folks using docker to load images into a private registry
Keep plain tar for folks that still expect that

#### Verification ####

* Download .gz or .zst artifact to agent/images folder; note that k3s loads images on startup

#### Linked Issues ####

Relatd to #2941

#### Further Comments ####