### PR TITLE
add etcd s3 secret and access key flags to secret data

### DIFF
--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -102,11 +102,15 @@ func isSecret(key string) bool {
 		version.ProgramUpper + "_DATASTORE_ENDPOINT",
 		version.ProgramUpper + "_AGENT_TOKEN",
 		version.ProgramUpper + "_CLUSTER_SECRET",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
 		"--token",
 		"-t",
 		"--agent-token",
 		"--datastore-endpoint",
 		"--cluster-secret",
+		"--etcd-s3-access-key",
+		"--etcd-s3-secret-key",
 	}
 	for _, secret := range secretData {
 		if key == secret {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Adds the etcd S3 access key and secret key flags to the secret data slice to be obfuscated in the node data.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Make sure that if the flags are issued, their values are represented with "*"'s. 

```sh
kubectl describe nodes | grep s3
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/rancherlabs/rancher-security/issues/584

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

