### PR TITLE
Resolve local retention issue when S3 in use.

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -844,8 +844,6 @@ func (e *ETCD) Snapshot(ctx context.Context, config *config.Control) error {
 				return errors.Wrap(err, "failed to apply s3 snapshot retention")
 			}
 		}
-
-		return nil
 	}
 
 	// check if we need to perform a retention check


### PR DESCRIPTION
Remove early return preventing local retention policy to be enforced
resulting in N number of snapshots being stored.

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Run the command below and verify that there are only 2 snapshots stored locally.

```sh
k3s server --cluster-init --etcd-s3 --etcd-s3-bucket=<bucket name> --etcd-s3-access-key=<key> --etcd-s3-secret-key=<secret>  --etcd-snapshot-schedule-cron='* * * * *' --etcd-snapshot-retention=2
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#3178 

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

