### PR TITLE
Add support for dual-stack Pod/Service CIDRs and node IP addresses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,5 +122,6 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.21.0
 	k8s.io/kubernetes v1.21.0
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rancher/k3s/pkg/clientaccess"
 	"github.com/rancher/k3s/pkg/daemons/config"
 	"github.com/rancher/k3s/pkg/daemons/control/deps"
+	"github.com/rancher/k3s/pkg/util"
 	"github.com/rancher/k3s/pkg/version"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -41,7 +42,7 @@ func Get(ctx context.Context, agent cmds.Agent, proxy proxy.Proxy) *config.Node 
 	for {
 		agentConfig, err := get(ctx, &agent, proxy)
 		if err != nil {
-			logrus.Errorf("Failed to retrieve agent config: %v", err)
+			logrus.Errorf("Failed to configure agent: %v", err)
 			select {
 			case <-time.After(5 * time.Second):
 				continue
@@ -64,7 +65,7 @@ func Request(path string, info *clientaccess.Info, requester HTTPRequester) ([]b
 	return requester(u.String(), clientaccess.GetHTTPClient(info.CACerts), info.Username, info.Password)
 }
 
-func getNodeNamedCrt(nodeName, nodeIP, nodePasswordFile string) HTTPRequester {
+func getNodeNamedCrt(nodeName string, nodeIPs []sysnet.IP, nodePasswordFile string) HTTPRequester {
 	return func(u string, client *http.Client, username, password string) ([]byte, error) {
 		req, err := http.NewRequest(http.MethodGet, u, nil)
 		if err != nil {
@@ -81,7 +82,7 @@ func getNodeNamedCrt(nodeName, nodeIP, nodePasswordFile string) HTTPRequester {
 			return nil, err
 		}
 		req.Header.Set(version.Program+"-Node-Password", nodePassword)
-		req.Header.Set(version.Program+"-Node-IP", nodeIP)
+		req.Header.Set(version.Program+"-Node-IP", util.JoinIPs(nodeIPs))
 
 		resp, err := client.Do(req)
 		if err != nil {
@@ -144,8 +145,8 @@ func upgradeOldNodePasswordPath(oldNodePasswordFile, newNodePasswordFile string)
 	}
 }
 
-func getServingCert(nodeName, nodeIP, servingCertFile, servingKeyFile, nodePasswordFile string, info *clientaccess.Info) (*tls.Certificate, error) {
-	servingCert, err := Request("/v1-"+version.Program+"/serving-kubelet.crt", info, getNodeNamedCrt(nodeName, nodeIP, nodePasswordFile))
+func getServingCert(nodeName string, nodeIPs []sysnet.IP, servingCertFile, servingKeyFile, nodePasswordFile string, info *clientaccess.Info) (*tls.Certificate, error) {
+	servingCert, err := Request("/v1-"+version.Program+"/serving-kubelet.crt", info, getNodeNamedCrt(nodeName, nodeIPs, nodePasswordFile))
 	if err != nil {
 		return nil, err
 	}
@@ -207,9 +208,9 @@ func splitCertKeyPEM(bytes []byte) (certPem []byte, keyPem []byte) {
 	return
 }
 
-func getNodeNamedHostFile(filename, keyFile, nodeName, nodeIP, nodePasswordFile string, info *clientaccess.Info) error {
+func getNodeNamedHostFile(filename, keyFile, nodeName string, nodeIPs []sysnet.IP, nodePasswordFile string, info *clientaccess.Info) error {
 	basename := filepath.Base(filename)
-	fileBytes, err := Request("/v1-"+version.Program+"/"+basename, info, getNodeNamedCrt(nodeName, nodeIP, nodePasswordFile))
+	fileBytes, err := Request("/v1-"+version.Program+"/"+basename, info, getNodeNamedCrt(nodeName, nodeIPs, nodePasswordFile))
 	if err != nil {
 		return err
 	}
@@ -224,21 +225,31 @@ func getNodeNamedHostFile(filename, keyFile, nodeName, nodeIP, nodePasswordFile 
 	return nil
 }
 
-func getHostnameAndIP(info cmds.Agent) (string, string, error) {
-	ip := info.NodeIP
-	if ip == "" {
+func getHostnameAndIPs(info cmds.Agent) (string, []sysnet.IP, error) {
+	ips := []sysnet.IP{}
+	if len(info.NodeIP) == 0 {
 		hostIP, err := net.ChooseHostInterface()
 		if err != nil {
-			return "", "", err
+			return "", nil, err
 		}
-		ip = hostIP.String()
+		ips = append(ips, hostIP)
+	} else {
+		for _, hostIP := range info.NodeIP {
+			for _, v := range strings.Split(hostIP, ",") {
+				ip := sysnet.ParseIP(v)
+				if ip == nil {
+					return "", nil, fmt.Errorf("invalid node-ip %s", v)
+				}
+				ips = append(ips, ip)
+			}
+		}
 	}
 
 	name := info.NodeName
 	if name == "" {
 		hostname, err := os.Hostname()
 		if err != nil {
-			return "", "", err
+			return "", nil, err
 		}
 		name = hostname
 	}
@@ -247,7 +258,7 @@ func getHostnameAndIP(info cmds.Agent) (string, string, error) {
 	// https://github.com/kubernetes/kubernetes/issues/71140
 	name = strings.ToLower(name)
 
-	return name, ip, nil
+	return name, ips, nil
 }
 
 func isValidResolvConf(resolvConfFile string) bool {
@@ -305,7 +316,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 
 	controlConfig, err := getConfig(info)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to retrieve configuration from server")
 	}
 
 	// If the supervisor and externally-facing apiserver are not on the same port, tell the proxy where to find the apiserver.
@@ -349,7 +360,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	newNodePasswordFile := filepath.Join(nodeConfigPath, "password")
 	upgradeOldNodePasswordPath(oldNodePasswordFile, newNodePasswordFile)
 
-	nodeName, nodeIP, err := getHostnameAndIP(*envInfo)
+	nodeName, nodeIPs, err := getHostnameAndIPs(*envInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -364,14 +375,14 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 
 	os.Setenv("NODE_NAME", nodeName)
 
-	servingCert, err := getServingCert(nodeName, nodeIP, servingKubeletCert, servingKubeletKey, newNodePasswordFile, info)
+	servingCert, err := getServingCert(nodeName, nodeIPs, servingKubeletCert, servingKubeletKey, newNodePasswordFile, info)
 	if err != nil {
 		return nil, err
 	}
 
 	clientKubeletCert := filepath.Join(envInfo.DataDir, "agent", "client-kubelet.crt")
 	clientKubeletKey := filepath.Join(envInfo.DataDir, "agent", "client-kubelet.key")
-	if err := getNodeNamedHostFile(clientKubeletCert, clientKubeletKey, nodeName, nodeIP, newNodePasswordFile, info); err != nil {
+	if err := getNodeNamedHostFile(clientKubeletCert, clientKubeletKey, nodeName, nodeIPs, newNodePasswordFile, info); err != nil {
 		return nil, err
 	}
 
@@ -411,10 +422,8 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	}
 	nodeConfig.FlannelIface = flannelIface
 	nodeConfig.Images = filepath.Join(envInfo.DataDir, "agent", "images")
-	nodeConfig.AgentConfig.NodeIP = nodeIP
 	nodeConfig.AgentConfig.NodeName = nodeName
 	nodeConfig.AgentConfig.NodeConfigPath = nodeConfigPath
-	nodeConfig.AgentConfig.NodeExternalIP = envInfo.NodeExternalIP
 	nodeConfig.AgentConfig.ServingKubeletCert = servingKubeletCert
 	nodeConfig.AgentConfig.ServingKubeletKey = servingKubeletKey
 	nodeConfig.AgentConfig.ClusterDNS = controlConfig.ClusterDNS
@@ -458,6 +467,32 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	nodeConfig.Containerd.Template = filepath.Join(envInfo.DataDir, "agent", "etc", "containerd", "config.toml.tmpl")
 	nodeConfig.Certificate = servingCert
 
+	nodeConfig.AgentConfig.NodeIPs = nodeIPs
+	nodeIP, err := util.GetFirst4(nodeIPs)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot configure IPv4 node-ip")
+	}
+	nodeConfig.AgentConfig.NodeIP = nodeIP.String()
+
+	for _, externalIP := range envInfo.NodeExternalIP {
+		for _, v := range strings.Split(externalIP, ",") {
+			ip := sysnet.ParseIP(v)
+			if ip == nil {
+				return nil, fmt.Errorf("invalid node-external-ip %s", v)
+			}
+			nodeConfig.AgentConfig.NodeExternalIPs = append(nodeConfig.AgentConfig.NodeExternalIPs, ip)
+		}
+	}
+
+	// if configured, set NodeExternalIP to the first IPv4 address, for legacy clients
+	if len(nodeConfig.AgentConfig.NodeExternalIPs) > 0 {
+		nodeExternalIP, err := util.GetFirst4(nodeConfig.AgentConfig.NodeExternalIPs)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot configure IPv4 node-external-ip")
+		}
+		nodeConfig.AgentConfig.NodeExternalIP = nodeExternalIP.String()
+	}
+
 	if nodeConfig.FlannelBackend == config.FlannelBackendNone {
 		nodeConfig.NoFlannel = true
 	} else {
@@ -488,27 +523,35 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	}
 
 	if controlConfig.ClusterIPRange != nil {
-		nodeConfig.AgentConfig.ClusterCIDR = *controlConfig.ClusterIPRange
+		nodeConfig.AgentConfig.ClusterCIDR = controlConfig.ClusterIPRange
+		nodeConfig.AgentConfig.ClusterCIDRs = []*sysnet.IPNet{controlConfig.ClusterIPRange}
+	}
+
+	if len(controlConfig.ClusterIPRanges) > 0 {
+		nodeConfig.AgentConfig.ClusterCIDRs = controlConfig.ClusterIPRanges
 	}
 
 	if controlConfig.ServiceIPRange != nil {
-		nodeConfig.AgentConfig.ServiceCIDR = *controlConfig.ServiceIPRange
+		nodeConfig.AgentConfig.ServiceCIDR = controlConfig.ServiceIPRange
+		nodeConfig.AgentConfig.ServiceCIDRs = []*sysnet.IPNet{controlConfig.ServiceIPRange}
+	}
+
+	if len(controlConfig.ServiceIPRanges) > 0 {
+		nodeConfig.AgentConfig.ServiceCIDRs = controlConfig.ServiceIPRanges
 	}
 
 	if controlConfig.ServiceNodePortRange != nil {
 		nodeConfig.AgentConfig.ServiceNodePortRange = *controlConfig.ServiceNodePortRange
 	}
 
-	// Old versions of the server do not send enough information to correctly start the NPC. Users
-	// need to upgrade the server to at least the same version as the agent, or disable the NPC
-	// cluster-wide.
-	if controlConfig.DisableNPC == false && (controlConfig.ServiceIPRange == nil || controlConfig.ServiceNodePortRange == nil) {
-		return nil, fmt.Errorf("incompatible down-level server detected; servers must be upgraded to at least %s, or restarted with --disable-network-policy", version.Version)
+	if len(controlConfig.ClusterDNSs) == 0 {
+		nodeConfig.AgentConfig.ClusterDNSs = []sysnet.IP{controlConfig.ClusterDNS}
+	} else {
+		nodeConfig.AgentConfig.ClusterDNSs = controlConfig.ClusterDNSs
 	}
 
 	nodeConfig.AgentConfig.ExtraKubeletArgs = envInfo.ExtraKubeletArgs
 	nodeConfig.AgentConfig.ExtraKubeProxyArgs = envInfo.ExtraKubeProxyArgs
-
 	nodeConfig.AgentConfig.NodeTaints = envInfo.Taints
 	nodeConfig.AgentConfig.NodeLabels = envInfo.Labels
 	nodeConfig.AgentConfig.PrivateRegistry = envInfo.PrivateRegistry
@@ -519,6 +562,10 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	nodeConfig.AgentConfig.Rootless = envInfo.Rootless
 	nodeConfig.AgentConfig.PodManifests = filepath.Join(envInfo.DataDir, "agent", DefaultPodManifestPath)
 	nodeConfig.AgentConfig.ProtectKernelDefaults = envInfo.ProtectKernelDefaults
+
+	if err := validateNetworkConfig(nodeConfig); err != nil {
+		return nil, err
+	}
 
 	return nodeConfig, nil
 }
@@ -531,4 +578,16 @@ func getConfig(info *clientaccess.Info) (*config.Control, error) {
 
 	controlControl := &config.Control{}
 	return controlControl, json.Unmarshal(data, controlControl)
+}
+
+// validateNetworkConfig ensures that the network configuration values provided by the server make sense.
+func validateNetworkConfig(nodeConfig *config.Node) error {
+	// Old versions of the server do not send enough information to correctly start the NPC. Users
+	// need to upgrade the server to at least the same version as the agent, or disable the NPC
+	// cluster-wide.
+	if nodeConfig.AgentConfig.DisableNPC == false && (nodeConfig.AgentConfig.ServiceCIDR == nil || nodeConfig.AgentConfig.ServiceNodePortRange.Size == 0) {
+		return fmt.Errorf("incompatible down-level server detected; servers must be upgraded to at least %s, or restarted with --disable-network-policy", version.Version)
+	}
+
+	return nil
 }

--- a/pkg/agent/netpol/network_policy_controller.go
+++ b/pkg/agent/netpol/network_policy_controller.go
@@ -592,7 +592,7 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	// be up to date with all of the policy changes from any enqueued request after that
 	npc.fullSyncRequestChan = make(chan struct{}, 1)
 
-	npc.serviceClusterIPRange = config.AgentConfig.ServiceCIDR
+	npc.serviceClusterIPRange = *config.AgentConfig.ServiceCIDR
 	npc.serviceNodePortRange = strings.ReplaceAll(config.AgentConfig.ServiceNodePortRange.String(), "-", ":")
 	npc.syncPeriod = defaultSyncPeriod
 

--- a/pkg/agent/netpol/network_policy_controller_test.go
+++ b/pkg/agent/netpol/network_policy_controller_test.go
@@ -253,15 +253,17 @@ func testForMissingOrUnwanted(t *testing.T, targetMsg string, got []podInfo, wan
 	}
 }
 
-func newMinimalNodeConfig(clusterIPCIDR string, nodePortRange string, hostNameOverride string, externalIPs []string) *config.Node {
+func newMinimalNodeConfig(serviceIPCIDR string, nodePortRange string, hostNameOverride string, externalIPs []string) *config.Node {
 	nodeConfig := &config.Node{AgentConfig: config.Agent{}}
 
-	if clusterIPCIDR != "" {
-		_, cidr, err := net.ParseCIDR(clusterIPCIDR)
+	if serviceIPCIDR != "" {
+		_, cidr, err := net.ParseCIDR(serviceIPCIDR)
 		if err != nil {
 			panic("failed to get parse --service-cluster-ip-range parameter: " + err.Error())
 		}
-		nodeConfig.AgentConfig.ClusterCIDR = *cidr
+		nodeConfig.AgentConfig.ServiceCIDR = cidr
+	} else {
+		nodeConfig.AgentConfig.ServiceCIDR = &net.IPNet{}
 	}
 	if nodePortRange != "" {
 		portRange, err := utilnet.ParsePortRange(nodePortRange)

--- a/pkg/agent/syssetup/setup.go
+++ b/pkg/agent/syssetup/setup.go
@@ -32,6 +32,7 @@ func Configure() {
 	loadKernelModule("nf_conntrack")
 	loadKernelModule("br_netfilter")
 	loadKernelModule("iptable_nat")
+	loadKernelModule("ip6table_nat")
 
 	// Kernel is inconsistent about how devconf is configured for
 	// new network namespaces between ipv4 and ipv6. Make sure to

--- a/pkg/agent/syssetup/setup.go
+++ b/pkg/agent/syssetup/setup.go
@@ -27,20 +27,24 @@ func enableSystemControl(file string) {
 	}
 }
 
-func Configure() {
+func Configure(enableIPv6 bool) {
 	loadKernelModule("overlay")
 	loadKernelModule("nf_conntrack")
 	loadKernelModule("br_netfilter")
 	loadKernelModule("iptable_nat")
-	loadKernelModule("ip6table_nat")
+	if enableIPv6 {
+		loadKernelModule("ip6table_nat")
+	}
 
 	// Kernel is inconsistent about how devconf is configured for
 	// new network namespaces between ipv4 and ipv6. Make sure to
-	// enable forwarding on all and default for both ipv4 and ipv8.
+	// enable forwarding on all and default for both ipv4 and ipv6.
 	enableSystemControl("/proc/sys/net/ipv4/conf/all/forwarding")
 	enableSystemControl("/proc/sys/net/ipv4/conf/default/forwarding")
-	enableSystemControl("/proc/sys/net/ipv6/conf/all/forwarding")
-	enableSystemControl("/proc/sys/net/ipv6/conf/default/forwarding")
 	enableSystemControl("/proc/sys/net/bridge/bridge-nf-call-iptables")
-	enableSystemControl("/proc/sys/net/bridge/bridge-nf-call-ip6tables")
+	if enableIPv6 {
+		enableSystemControl("/proc/sys/net/ipv6/conf/all/forwarding")
+		enableSystemControl("/proc/sys/net/ipv6/conf/default/forwarding")
+		enableSystemControl("/proc/sys/net/bridge/bridge-nf-call-ip6tables")
+	}
 }

--- a/pkg/cli/agent/agent.go
+++ b/pkg/cli/agent/agent.go
@@ -50,8 +50,8 @@ func Run(ctx *cli.Context) error {
 		return fmt.Errorf("--server is required")
 	}
 
-	if cmds.AgentConfig.FlannelIface != "" && cmds.AgentConfig.NodeIP == "" {
-		cmds.AgentConfig.NodeIP = netutil.GetIPFromInterface(cmds.AgentConfig.FlannelIface)
+	if cmds.AgentConfig.FlannelIface != "" && len(cmds.AgentConfig.NodeIP) == 0 {
+		cmds.AgentConfig.NodeIP.Set(netutil.GetIPFromInterface(cmds.AgentConfig.FlannelIface))
 	}
 
 	logrus.Info("Starting " + version.Program + " agent " + ctx.App.Version)

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -20,8 +20,8 @@ type Agent struct {
 	LBServerPort             int
 	ResolvConf               string
 	DataDir                  string
-	NodeIP                   string
-	NodeExternalIP           string
+	NodeIP                   cli.StringSlice
+	NodeExternalIP           cli.StringSlice
 	NodeName                 string
 	PauseImage               string
 	Snapshotter              string
@@ -52,15 +52,15 @@ type AgentShared struct {
 var (
 	appName     = filepath.Base(os.Args[0])
 	AgentConfig Agent
-	NodeIPFlag  = cli.StringFlag{
-		Name:        "node-ip,i",
-		Usage:       "(agent/networking) IP address to advertise for node",
-		Destination: &AgentConfig.NodeIP,
+	NodeIPFlag  = cli.StringSliceFlag{
+		Name:  "node-ip,i",
+		Usage: "(agent/networking) IPv4/IPv6 addresses to advertise for node",
+		Value: &AgentConfig.NodeIP,
 	}
-	NodeExternalIPFlag = cli.StringFlag{
-		Name:        "node-external-ip",
-		Usage:       "(agent/networking) External IP address to advertise for node",
-		Destination: &AgentConfig.NodeExternalIP,
+	NodeExternalIPFlag = cli.StringSliceFlag{
+		Name:  "node-external-ip",
+		Usage: "(agent/networking) IPv4/IPv6 external IP addresses to advertise for node",
+		Value: &AgentConfig.NodeExternalIP,
 	}
 	NodeNameFlag = cli.StringFlag{
 		Name:        "node-name",

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -118,7 +118,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 			},
 			cli.StringSliceFlag{
 				Name:  "tls-san",
-				Usage: "(listener) Add additional hostname or IPv4/IPv6 address as a Subject Alternative Name in the TLS cert",
+				Usage: "(listener) Add additional hostnames or IPv4/IPv6 addresses as Subject Alternative Names on the server TLS cert",
 				Value: &ServerConfig.TLSSan,
 			},
 			cli.StringFlag{
@@ -144,7 +144,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 			},
 			cli.StringSliceFlag{
 				Name:  "cluster-dns",
-				Usage: "(networking) IPv4/IPv6 Cluster IPs for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
+				Usage: "(networking) IPv4 Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
 				Value: &ServerConfig.ClusterDNS,
 			},
 			cli.StringFlag{

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -13,15 +13,15 @@ const (
 )
 
 type Server struct {
-	ClusterCIDR          string
+	ClusterCIDR          cli.StringSlice
 	AgentToken           string
 	AgentTokenFile       string
 	Token                string
 	TokenFile            string
 	ClusterSecret        string
-	ServiceCIDR          string
+	ServiceCIDR          cli.StringSlice
 	ServiceNodePortRange string
-	ClusterDNS           string
+	ClusterDNS           cli.StringSlice
 	ClusterDomain        string
 	// The port which kubectl clients can access k8s
 	HTTPSPort int
@@ -108,7 +108,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 			},
 			cli.StringFlag{
 				Name:        "advertise-address",
-				Usage:       "(listener) IP address that apiserver uses to advertise to members of the cluster (default: node-external-ip/node-ip)",
+				Usage:       "(listener) IPv4 address that apiserver uses to advertise to members of the cluster (default: node-external-ip/node-ip)",
 				Destination: &ServerConfig.AdvertiseIP,
 			},
 			cli.IntFlag{
@@ -118,7 +118,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 			},
 			cli.StringSliceFlag{
 				Name:  "tls-san",
-				Usage: "(listener) Add additional hostname or IP as a Subject Alternative Name in the TLS cert",
+				Usage: "(listener) Add additional hostname or IPv4/IPv6 address as a Subject Alternative Name in the TLS cert",
 				Value: &ServerConfig.TLSSan,
 			},
 			cli.StringFlag{
@@ -126,17 +126,15 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
 				Destination: &ServerConfig.DataDir,
 			},
-			cli.StringFlag{
-				Name:        "cluster-cidr",
-				Usage:       "(networking) Network CIDR to use for pod IPs",
-				Destination: &ServerConfig.ClusterCIDR,
-				Value:       "10.42.0.0/16",
+			cli.StringSliceFlag{
+				Name:  "cluster-cidr",
+				Usage: "(networking) IPv4/IPv6 network CIDRs to use for pod IPs (default: 10.42.0.0/16)",
+				Value: &ServerConfig.ClusterCIDR,
 			},
-			cli.StringFlag{
-				Name:        "service-cidr",
-				Usage:       "(networking) Network CIDR to use for services IPs",
-				Destination: &ServerConfig.ServiceCIDR,
-				Value:       "10.43.0.0/16",
+			cli.StringSliceFlag{
+				Name:  "service-cidr",
+				Usage: "(networking) IPv4/IPv6 network CIDRs to use for service IPs (default: 10.43.0.0/16)",
+				Value: &ServerConfig.ServiceCIDR,
 			},
 			cli.StringFlag{
 				Name:        "service-node-port-range",
@@ -144,11 +142,10 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Destination: &ServerConfig.ServiceNodePortRange,
 				Value:       "30000-32767",
 			},
-			cli.StringFlag{
-				Name:        "cluster-dns",
-				Usage:       "(networking) Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
-				Destination: &ServerConfig.ClusterDNS,
-				Value:       "",
+			cli.StringSliceFlag{
+				Name:  "cluster-dns",
+				Usage: "(networking) IPv4/IPv6 Cluster IPs for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
+				Value: &ServerConfig.ClusterDNS,
 			},
 			cli.StringFlag{
 				Name:        "cluster-domain",

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/rancher/k3s/pkg/daemons/config"
 	"github.com/rancher/k3s/pkg/daemons/executor"
+	"github.com/rancher/k3s/pkg/util"
 	"github.com/rancher/k3s/pkg/version"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -47,7 +48,7 @@ func startKubeProxy(cfg *config.Agent) error {
 		"proxy-mode":           "iptables",
 		"healthz-bind-address": "127.0.0.1",
 		"kubeconfig":           cfg.KubeConfigKubeProxy,
-		"cluster-cidr":         cfg.ClusterCIDR.String(),
+		"cluster-cidr":         util.JoinIPNets(cfg.ClusterCIDRs),
 	}
 	if cfg.NodeName != "" {
 		argsMap["hostname-override"] = cfg.NodeName
@@ -94,7 +95,7 @@ func startKubelet(cfg *config.Agent) error {
 		argsMap["network-plugin"] = "cni"
 	}
 	if len(cfg.ClusterDNS) > 0 {
-		argsMap["cluster-dns"] = cfg.ClusterDNS.String()
+		argsMap["cluster-dns"] = util.JoinIPs(cfg.ClusterDNSs)
 	}
 	if cfg.ResolvConf != "" {
 		argsMap["resolv-conf"] = cfg.ResolvConf

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -58,10 +58,13 @@ type Agent struct {
 	NodeConfigPath          string
 	ServingKubeletCert      string
 	ServingKubeletKey       string
-	ServiceCIDR             net.IPNet
+	ServiceCIDR             *net.IPNet
+	ServiceCIDRs            []*net.IPNet
 	ServiceNodePortRange    utilnet.PortRange
-	ClusterCIDR             net.IPNet
+	ClusterCIDR             *net.IPNet
+	ClusterCIDRs            []*net.IPNet
 	ClusterDNS              net.IP
+	ClusterDNSs             []net.IP
 	ClusterDomain           string
 	ResolvConf              string
 	RootDir                 string
@@ -69,7 +72,9 @@ type Agent struct {
 	KubeConfigKubeProxy     string
 	KubeConfigK3sController string
 	NodeIP                  string
+	NodeIPs                 []net.IP
 	NodeExternalIP          string
+	NodeExternalIPs         []net.IP
 	RuntimeSocket           string
 	ListenAddress           string
 	ClientCA                string
@@ -106,9 +111,12 @@ type Control struct {
 	AgentToken               string `json:"-"`
 	Token                    string `json:"-"`
 	ClusterIPRange           *net.IPNet
+	ClusterIPRanges          []*net.IPNet
 	ServiceIPRange           *net.IPNet
+	ServiceIPRanges          []*net.IPNet
 	ServiceNodePortRange     *utilnet.PortRange
 	ClusterDNS               net.IP
+	ClusterDNSs              []net.IP
 	ClusterDomain            string
 	NoCoreDNS                bool
 	KubeConfigOutput         string

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/k3s/pkg/daemons/config"
 	"github.com/rancher/k3s/pkg/daemons/control/deps"
 	"github.com/rancher/k3s/pkg/daemons/executor"
+	util2 "github.com/rancher/k3s/pkg/util"
 	"github.com/rancher/k3s/pkg/version"
 	"github.com/rancher/wrangler-api/pkg/generated/controllers/rbac"
 	"github.com/sirupsen/logrus"
@@ -100,7 +101,7 @@ func controllerManager(cfg *config.Control, runtime *config.ControlRuntime) erro
 		"kubeconfig":                       runtime.KubeConfigController,
 		"service-account-private-key-file": runtime.ServiceKey,
 		"allocate-node-cidrs":              "true",
-		"cluster-cidr":                     cfg.ClusterIPRange.String(),
+		"cluster-cidr":                     util2.JoinIPNets(cfg.ClusterIPRanges),
 		"root-ca-file":                     runtime.ServerCA,
 		"port":                             "10252",
 		"profiling":                        "false",
@@ -155,7 +156,7 @@ func apiServer(ctx context.Context, cfg *config.Control, runtime *config.Control
 	argsMap["allow-privileged"] = "true"
 	argsMap["authorization-mode"] = strings.Join([]string{modes.ModeNode, modes.ModeRBAC}, ",")
 	argsMap["service-account-signing-key-file"] = runtime.ServiceKey
-	argsMap["service-cluster-ip-range"] = cfg.ServiceIPRange.String()
+	argsMap["service-cluster-ip-range"] = util2.JoinIPNets(cfg.ServiceIPRanges)
 	argsMap["service-node-port-range"] = cfg.ServiceNodePortRange.String()
 	argsMap["advertise-port"] = strconv.Itoa(cfg.AdvertisePort)
 	if cfg.AdvertiseIP != "" {
@@ -360,7 +361,7 @@ func cloudControllerManager(ctx context.Context, cfg *config.Control, runtime *c
 
 	ccmOptions.KubeCloudShared.AllocateNodeCIDRs = true
 	ccmOptions.KubeCloudShared.CloudProvider.Name = version.Program
-	ccmOptions.KubeCloudShared.ClusterCIDR = cfg.ClusterIPRange.String()
+	ccmOptions.KubeCloudShared.ClusterCIDR = util2.JoinIPNets(cfg.ClusterIPRanges)
 	ccmOptions.KubeCloudShared.ConfigureCloudRoutes = false
 	ccmOptions.Kubeconfig = runtime.KubeConfigCloudController
 	ccmOptions.NodeStatusUpdateFrequency = metav1.Duration{Duration: 1 * time.Minute}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -435,8 +435,8 @@ func setNoProxyEnv(config *config.Control) error {
 	envList = append(envList,
 		".svc",
 		"."+config.ClusterDomain,
-		config.ClusterIPRange.String(),
-		config.ServiceIPRange.String(),
+		util.JoinIPNets(config.ClusterIPRanges),
+		util.JoinIPNets(config.ServiceIPRanges),
 	)
 	os.Unsetenv("no_proxy")
 	return os.Setenv("NO_PROXY", strings.Join(envList, ","))

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -1,0 +1,65 @@
+package util
+
+import (
+	"errors"
+	"net"
+	"strings"
+)
+
+// JoinIPs stringifies and joins a list of IP addresses with commas.
+func JoinIPs(elems []net.IP) string {
+	var strs []string
+	for _, elem := range elems {
+		strs = append(strs, elem.String())
+	}
+	return strings.Join(strs, ",")
+}
+
+// JoinIPNets stringifies and joins a list of IP networks with commas.
+func JoinIPNets(elems []*net.IPNet) string {
+	var strs []string
+	for _, elem := range elems {
+		strs = append(strs, elem.String())
+	}
+	return strings.Join(strs, ",")
+}
+
+// GetFirst4Net returns the first IPv4 network from the list of IP networks.
+// If no IPv4 addresses are found, an error is raised.
+func GetFirst4Net(elems []*net.IPNet) (*net.IPNet, error) {
+	for _, elem := range elems {
+		if elem == nil || elem.IP.To4() == nil {
+			continue
+		}
+		return elem, nil
+	}
+	return nil, errors.New("no IPv4 CIDRs found")
+}
+
+// GetFirst4 returns the first IPv4 address from the list of IP addresses.
+// If no IPv4 addresses are found, an error is raised.
+func GetFirst4(elems []net.IP) (net.IP, error) {
+	for _, elem := range elems {
+		if elem == nil || elem.To4() == nil {
+			continue
+		}
+		return elem, nil
+	}
+	return nil, errors.New("no IPv4 address found")
+}
+
+// GetFirst4String returns the first IPv4 address from a list of IP address strings.
+// If no IPv4 addresses are found, an error is raised.
+func GetFirst4String(elems []string) (string, error) {
+	ips := []net.IP{}
+	for _, elem := range elems {
+		for _, v := range strings.Split(elem, ",") {
+			ips = append(ips, net.ParseIP(v))
+		}
+	}
+	ip, err := GetFirst4(ips)
+	if err != nil {
+		return "", err
+	}
+	return ip.String(), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3053,6 +3053,7 @@ k8s.io/metrics/pkg/client/external_metrics
 # k8s.io/mount-utils v0.0.0 => github.com/k3s-io/kubernetes/staging/src/k8s.io/mount-utils v1.21.0-k3s1
 k8s.io/mount-utils
 # k8s.io/utils v0.0.0-20201110183641-67b214c5f920
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/clock
 k8s.io/utils/exec


### PR DESCRIPTION
#### Proposed Changes ####

* Add support for dual-stack cluster/service CIDRs and node addresses
* Begin transitioning the ip/externalip/hostname handoff (used by the K3s cloud provider) from labels to annotations, as labels do not allow the character-set necessary to pass through IPv6 addresses.
    * If a node has labels they will be maintained, but new nodes will use only annotations. The cloud provider will continue to check both, with annotations taking precedence.
* Dual-stack node addresses are not autodetected; if desired a dual-stack address list must be passed to --node-ip (and --node-external-ip as necessary). Kubeadm is taking the same approach: https://github.com/kubernetes/kubeadm/issues/1612#issuecomment-786540060

This opens the door to dual-stack operation, even if flannel and the kube-router NPC don't support it yet.

Note: Cluster-DNS and the Kubernetes apiserver `--advertise-address` themselves do not support dual-stack operation yet: https://github.com/kubernetes/kubeadm/issues/1612#issuecomment-772583989

#### Types of Changes ####

Feature

#### Verification ####

* Confirm that K3s works as usual when specifying only IPv4 CIDRs, or when using defaults
* Confirm that specifying dual-stack CIDRs raises an error if not run with `--disable-network-policy --flannel-backend=none`

Example test:
* Add `"ipv6": true, "fixed-cidr-v6": "fd7c:53a5:aef5:0::/64"` to /etc/docker/daemon.json and restart docker
* Run K3s server with IPv6:
    ```
    docker run --name=k3s-server-1 --rm -it --privileged rancher/k3s:BUILD_TAG --debug server --cluster-cidr=10.42.0.0/16,fd42::/48 --service-cidr=10.43.0.0/16,fd43::/112 --disable-network-policy --flannel-backend=none --node-ip=172.17.0.2,fd7c:53a5:aef5::242:ac11:2
    ```
* Check for dual-stack CIDRs and node addresses:
    ````
    docker exec -it k3s-server-1 kubectl get nodes -o yaml | grep -EA6 'spec:|addresses:'
      spec:
        podCIDR: 10.42.0.0/24
        podCIDRs:
        - 10.42.0.0/24
        - fd42::/64
        providerID: k3s://7a78f12c7fb1
        taints:
    --
          addresses:
        - address: 172.17.0.2
          type: InternalIP
        - address: fd7c:53a5:aef5::242:ac11:2
          type: InternalIP
        - address: 7a78f12c7fb1
          type: Hostname
    ````

#### Linked Issues ####

For #3158

#### Further Comments ####

While the CLI has been directly changed to use StringSlices instead of strings, I have opted to add separate fields to the  the Config types in order to retain backwards/forwards compatibility between builds with and without this change.