### PR TITLE
Handle cgroup v1/2/hybrid in check-config.sh more explicitly/accurately

### DIFF
--- a/contrib/util/check-config.sh
+++ b/contrib/util/check-config.sh
@@ -301,19 +301,54 @@ echo
 
 echo 'Generally Necessary:'
 
+cgroupV2FsType='63677270'
+cgroupFsType="$(stat --file-system --format=%t /sys/fs/cgroup 2>/dev/null || :)"
+cgroupHybridFsType="$(stat --file-system --format=%t /sys/fs/cgroup/unified 2>/dev/null || :)"
+
 echo -n '- '
-cgroupSubsystemDir="$(awk '/[, ](cpu|cpuacct|cpuset|devices|freezer|memory)[, ]/ && $3 == "cgroup" { print $2 }' /proc/mounts | head -n1)"
-cgroupDir="$(dirname "$cgroupSubsystemDir")"
-if [ -d "$cgroupDir/cpu" ] || [ -d "$cgroupDir/cpuacct" ] || [ -d "$cgroupDir/cpuset" ] || [  -d "$cgroupDir/devices" ] || [ -d "$cgroupDir/freezer" ] || [ -d "$cgroupDir/memory" ]; then
-  wrap_good 'cgroup hierarchy' "properly mounted [$cgroupDir]"
-else
-  if [ "$cgroupSubsystemDir" ]; then
-    wrap_bad 'cgroup hierarchy' "single mountpoint! [$cgroupSubsystemDir]"
-  else
-    wrap_bad 'cgroup hierarchy' 'nonexistent??'
-  fi
-  echo "    $(wrap_color '(see https://github.com/tianon/cgroupfs-mount)' yellow)"
-fi
+case "${cgroupFsType}:${cgroupHybridFsType}" in
+  '':*)
+    cgroupVariant='Nonexistent'
+    ;;
+  ${cgroupV2FsType}:*)
+    cgroupVariant='V2'
+    ;;
+  *:${cgroupV2FsType})
+    cgroupVariant='Hybrid'
+    ;;
+  *)
+    cgroupVariant='V1'
+    ;;
+esac
+
+case "${cgroupVariant}" in
+  Nonexistent)
+    wrap_bad 'cgroup hierarchy' "cgroups ${cgroupVariant}"
+    ;;
+  *)
+    case "${cgroupVariant}" in
+      V2)
+        cgroupMatch='cpu|cpuset|memory'
+        cgroupMatchNum=3
+        cgroupFile='/sys/fs/cgroup/cgroup.controllers'
+        ;;
+      *)
+        cgroupMatch='cpuset|memory'
+        cgroupMatchNum=2
+        cgroupFile='/proc/self/cgroup'
+        ;;
+    esac
+    if [ "$(tr -s ' ' '\n' <"${cgroupFile}" 2>/dev/null | grep -Ec "^(${cgroupMatch})\$")" -eq ${cgroupMatchNum} ]; then
+      cgroupStatus='good'
+    else
+      cgroupStatus='bad'
+    fi
+    wrap_${cgroupStatus} 'cgroup hierarchy' "cgroups ${cgroupVariant} mounted, ${cgroupMatch} controllers status: ${cgroupStatus}"
+    if [ "x${cgroupStatus}" = 'xbad' ]; then
+      warning '    (for cgroups V1/Hybrid on non-Systemd init see https://github.com/tianon/cgroupfs-mount)'
+    fi
+    ;;
+esac
 
 if [ "$(cat /sys/module/apparmor/parameters/enabled 2>/dev/null)" = 'Y' ]; then
   echo -n '- '


### PR DESCRIPTION
Problem:
 In `check-config.sh` assumptions are made about cgroups v1/v2/hybrid,
 causes false-negative on pure V2 system.

Solution:
 In `check-config.sh` implement the same validation as found in
 `./pkg/agent/run.go` -> `validate()`, `validateCgroupsV1()`, `validateCgroupsV2()`
 [ which use `containerd/cgroups:utils.go` -> `Mode()` ]

Signed-off-by: Rowan Thorpe <rowan@rowanthorpe.com>

#### Proposed Changes ####

On a Debian Testing system with cgroups v2 only (not hybrid) `k3s check-config` throws a false-negative. This seems to be just due to the contrib shellscript taking some pragmatic shortcuts to do a quick sanity-check, but on a cgroups v2 only system those shortcuts impact enough to be false. I just replicated in shellscript the validation logic from the core Go files (mentioned in the commit message) to make the `check-config.sh` inline with that.

#### Types of Changes ####

Bugfix

#### Verification ####

Run `k3s check-config` on cgroups v1, v2, hybrid, (and no cgroups!) systems, and at least on the v2 system it should throw a false "invalid" warning even when the adequate controllers are loaded, etc. After this change a correctly configured v2 system should "pass" while (hopefully) not introducing any regressions for the other systems. In fact due to following the validation logic from the core Go files more strictly in general this should have improved the robustness and clarity of diagnostic output for all systems. I assume the change (improvement) in wordings in the diagnostics output shouldn't break anything else because if other code is doing automated parsing of freeform diagnostic output then that is a problem all of its own...

#### Linked Issues ####

#3224 Seems like it might be indirectly relevant, but probably not directly related
#3228 If anything is changed for this issue then the changed logic should probably be mirrored to this script too

#### Further Comments ####

The 63677270 number in the code is the hex "magic number" of the cgroups v2 FS type, explained at https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html and as used (behind a variable) in the equivalent Go code.

BTW: Although I only ever managed to *build* k3s using Docker, I did manage to run rootless k3s on Podman, but it involved using a rather more involved wrapper script than I expected would be needed. If that would be useful to supply (not so much for use, but perhaps to highlight what it had to work around) then let me know. The script involves sniffing/disabling Docker service, sniffing/enabling Podman socket, adding docker->podman command symlink (in the same/earlier directory/path as docker, not just an alias as that was not adequate here), exporting `DOCKER_HOST` pointing to podman unix socket, and *also* symlinking to the socket.