### PR TITLE
Update Dockerfile to use Entrypoint Script to support Cgroupv2

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -10,6 +10,7 @@ RUN cd image/bin && \
 
 FROM scratch
 COPY --from=base /image /
+COPY entrypoint.sh /bin/entrypoint.sh
 RUN mkdir -p /etc && \
     echo 'hosts: files dns' > /etc/nsswitch.conf
 RUN chmod 1777 /tmp
@@ -19,5 +20,5 @@ VOLUME /var/lib/cni
 VOLUME /var/log
 ENV PATH="$PATH:/bin/aux"
 ENV CRI_CONFIG_FILE="/var/lib/rancher/k3s/agent/etc/crictl.yaml"
-ENTRYPOINT ["/bin/k3s"]
+ENTRYPOINT ["/bin/entrypoint.sh"]
 CMD ["agent"]

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -15,7 +15,6 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
   # otherwise writing subtree_control fails with EBUSY.
   mkdir -p /sys/fs/cgroup/init
   echo 1 > /sys/fs/cgroup/init/cgroup.procs
-  sleep 3
   # enable controllers
   sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
 fi

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -14,7 +14,7 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
 	# move the processes from the root group to the /init group,
   # otherwise writing subtree_control fails with EBUSY.
   mkdir -p /sys/fs/cgroup/init
-  xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+  busybox xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
   # enable controllers
   sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
 fi

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -11,10 +11,10 @@ set -o pipefail
 # Moby License Apache 2.0: https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/LICENSE														#
 #########################################################################################################################################
 if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
-	# move the init process (PID 1) from the root group to the /init group,
+	# move the processes from the root group to the /init group,
   # otherwise writing subtree_control fails with EBUSY.
   mkdir -p /sys/fs/cgroup/init
-  echo 1 > /sys/fs/cgroup/init/cgroup.procs
+  xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
   # enable controllers
   sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
 fi

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+#########################################################################################################################################
+# DISCLAIMER																																																														#
+# Copied from https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/hack/dind#L28-L37															#
+# Permission granted by Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> (https://github.com/rancher/k3d/issues/493#issuecomment-827405962)	#
+# Moby License Apache 2.0: https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/LICENSE														#
+#########################################################################################################################################
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+	# move the init process (PID 1) from the root group to the /init group,
+  # otherwise writing subtree_control fails with EBUSY.
+  mkdir -p /sys/fs/cgroup/init
+  echo 1 > /sys/fs/cgroup/init/cgroup.procs
+  sleep 3
+  # enable controllers
+  sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
+fi
+
+exec /bin/k3s "$@"


### PR DESCRIPTION
#### Proposed Changes ####

Fixes usage of containerized k3s on cgroupv2 systems

#### Types of Changes ####

- Entrypoint script for image

#### Verification ####

- build the image
- run it on a system using cgroupv2 (`server`)
- if you don't see an error related to cgroups, then it's working

#### Linked Issues ####

- https://github.com/rancher/k3d/issues/493

#### Further Comments ####

- also used in DinD (Moby): https://github.com/moby/moby/commit/ed89041433a031cafc0a0f19cfe573c31688d377

