### PR TITLE
Add cluster DNS domain to ServingKubeAPICert

### DIFF
--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -319,7 +319,7 @@ func genServerCerts(config *config.Control, runtime *config.ControlRuntime) erro
 	}
 
 	altNames := &certutil.AltNames{
-		DNSNames: []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"},
+		DNSNames: []string{"localhost", "kubernetes", "kubernetes.default", "kubernetes.default.svc." + config.ClusterDomain},
 		IPs:      []net.IP{apiServerServiceIP},
 	}
 

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -172,8 +172,8 @@ func apiServer(ctx context.Context, cfg *config.Control, runtime *config.Control
 	argsMap["tls-cert-file"] = runtime.ServingKubeAPICert
 	argsMap["tls-private-key-file"] = runtime.ServingKubeAPIKey
 	argsMap["service-account-key-file"] = runtime.ServiceKey
-	argsMap["service-account-issuer"] = "https://kubernetes.default.svc.cluster.local"
-	argsMap["api-audiences"] = "https://kubernetes.default.svc.cluster.local," + version.Program
+	argsMap["service-account-issuer"] = "https://kubernetes.default.svc." + cfg.ClusterDomain
+	argsMap["api-audiences"] = "https://kubernetes.default.svc." + cfg.ClusterDomain + "," + version.Program
 	argsMap["kubelet-certificate-authority"] = runtime.ServerCA
 	argsMap["kubelet-client-certificate"] = runtime.ClientKubeAPICert
 	argsMap["kubelet-client-key"] = runtime.ClientKubeAPIKey


### PR DESCRIPTION
#### Proposed Changes ####

Add cluster DNS domain to ServingKubeAPICert to match SANs on serving cert at
https://github.com/k3s-io/k3s/blob/master/pkg/cluster/https.go#L41

#### Types of Changes ####

* Certificates

#### Verification ####

Pull through in to RKE2; run Kubernetes conformance tests for 1.21.0 - note that it passes

#### Linked Issues ####

rancher/rke2#845

#### Further Comments ####

Fixes error in v1.21.0 conformance tests:
```
[Fail] [sig-auth] ServiceAccounts [It] ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer [Conformance]

[It] ServiceAccountIssuerDiscovery
should support OIDC discovery of service account issuer [Conformance] \ /workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:630
Apr 27 23:16:58.906: INFO: created pod
Apr 27 23:16:58.906: INFO: Waiting up to 5m0s for pod \“oidc-discovery-validator\” in namespace \“svcaccounts-8058\” to be \“Succeeded or Failed\“
Apr 27 23:16:58.909: INFO: Pod \“oidc-discovery-validator\“: Phase=\“Pending\“, Reason=\“\”, readiness=false. Elapsed: 3.207767ms
Apr 27 23:17:00.912: INFO: Pod \“oidc-discovery-validator\“: Phase=\“Failed\“, Reason=\“\”, readiness=false. Elapsed: 2.00608865s
Apr 27 23:17:30.914: INFO: polling logs
Apr 27 23:17:30.917: INFO: Pod logs: 
2021/04/27 23:17:00 OK: Got token
2021/04/27 23:17:00 OK: got issuer https://kubernetes.default.svc.cluster.local
2021/04/27 23:17:00 Full, not-validated claims: openidmetadata.claims{Claims:jwt.Claims{Issuer:\“https://kubernetes.default.svc.cluster.local\“,
Subject:\“system:serviceaccount:svcaccounts-8058:default\“, Audience:jwt.Audience{\“oidc-discovery-test\“},
Expiry:1619566019, NotBefore:1619565419, IssuedAt:1619565419, ID:\“\”},
Kubernetes:openidmetadata.kubeClaims{Namespace:\“svcaccounts-8058\“, ServiceAccount:openidmetadata.kubeName{Name:\“default\“, UID:\“7aaca08b-6cbd-4284-87a9-606dca737009\“}}}
2021/04/27 23:17:00 Get \“https://kubernetes.default.svc.cluster.local/.well-known/openid-configuration\“:
x509: certificate is valid for kubernetes.default.svc, kubernetes.default, kubernetes, localhost, not kubernetes.default.svc.cluster.local
```