### PR TITLE
Sign CSRs for kubelet-serving with the server CA

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -109,8 +109,14 @@ func controllerManager(cfg *config.Control, runtime *config.ControlRuntime) erro
 		"bind-address":                     localhostIP.String(),
 		"secure-port":                      "0",
 		"use-service-account-credentials":  "true",
-		"cluster-signing-cert-file":        runtime.ClientCA,
-		"cluster-signing-key-file":         runtime.ClientCAKey,
+		"cluster-signing-kube-apiserver-client-cert-file": runtime.ClientCA,
+		"cluster-signing-kube-apiserver-client-key-file":  runtime.ClientCAKey,
+		"cluster-signing-kubelet-client-cert-file":        runtime.ClientCA,
+		"cluster-signing-kubelet-client-key-file":         runtime.ClientCAKey,
+		"cluster-signing-kubelet-serving-cert-file":       runtime.ServerCA,
+		"cluster-signing-kubelet-serving-key-file":        runtime.ServerCAKey,
+		"cluster-signing-legacy-unknown-cert-file":        runtime.ClientCA,
+		"cluster-signing-legacy-unknown-key-file":         runtime.ClientCAKey,
 	}
 	if cfg.NoLeaderElect {
 		argsMap["leader-elect"] = "false"


### PR DESCRIPTION
Problem:
Only the client CA is passed to the kube-controller-manager and
therefore CSRs with the signer name "kubernetes.io/kubelet-serving" are
signed with the client CA. Serving certificates must be signed with the
server CA otherwise e.g. "kubectl logs" fails with the error message
"x509: certificate signed by unknown authority".

Solution:
Instead of providing only one CA via the kube-controller-manager
parameter "--cluster-signing-cert-file", the corresponding CA for every
signer is set with the parameters
"--cluster-signing-kube-apiserver-client-cert-file",
"--cluster-signing-kubelet-client-cert-file",
"--cluster-signing-kubelet-serving-cert-file", and
"--cluster-signing-legacy-unknown-cert-file".

Signed-off-by: Siegfried Weber <mail@siegfriedweber.net>


#### Linked Issues ####

#3244