### PR TITLE
Invoke cluster reset function when only reset flag is passed

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -361,6 +361,11 @@ func setupTunnelAndRunAgent(ctx context.Context, nodeConfig *daemonconfig.Node, 
 		case <-ctx.Done():
 			return ctx.Err()
 		}
+	} else if cfg.ClusterReset && proxy.IsAPIServerLBEnabled() {
+		if err := agent.Agent(&nodeConfig.AgentConfig); err != nil {
+			return err
+		}
+		agentRan = true
 	}
 
 	if err := tunnel.Setup(ctx, nodeConfig, proxy); err != nil {

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -43,6 +43,7 @@ type Agent struct {
 	Labels                   cli.StringSlice
 	Taints                   cli.StringSlice
 	AgentShared
+	ClusterReset bool
 }
 
 type AgentShared struct {

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -404,6 +404,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	agentConfig.Token = token
 	agentConfig.DisableLoadBalancer = !serverConfig.ControlConfig.DisableAPIServer
 	agentConfig.ETCDAgent = serverConfig.ControlConfig.DisableAPIServer
+	agentConfig.ClusterReset = serverConfig.ControlConfig.ClusterReset
 
 	agentConfig.Rootless = cfg.Rootless
 

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -70,9 +70,12 @@ func (c *Cluster) start(ctx context.Context) error {
 			if !os.IsNotExist(err) {
 				return err
 			}
-		} else {
-			return fmt.Errorf("cluster-reset was successfully performed, please remove the cluster-reset flag and start %s normally, if you need to perform another cluster reset, you must first manually delete the %s file", version.Program, resetFile)
+			rebootstrap := func() error {
+				return c.storageBootstrap(ctx)
+			}
+			return c.managedDB.Reset(ctx, rebootstrap)
 		}
+		return fmt.Errorf("cluster-reset was successfully performed, please remove the cluster-reset flag and start %s normally, if you need to perform another cluster reset, you must first manually delete the %s file", version.Program, resetFile)
 	}
 
 	// removing the reset file and ignore error if the file doesn't exist


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
The PR does two things:

- Fixes the calling of Reset() function, which only has been called if cluster-reset-restore-path is passed along with cluster-reset
- Makes sure kubelet starts first in clusterReset situation to be able to start etcd with the ForceNewCluster: true config and reset the cluster membership

#### Types of Changes ####

bug fix

#### Linked Issues ####

https://github.com/rancher/rke2/issues/934



