### PR TITLE
Add executor.Bootstrap hook for pre-execution setup

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -26,6 +26,7 @@ import (
 	cp "github.com/rancher/k3s/pkg/cloudprovider"
 	"github.com/rancher/k3s/pkg/daemons/agent"
 	daemonconfig "github.com/rancher/k3s/pkg/daemons/config"
+	"github.com/rancher/k3s/pkg/daemons/executor"
 	"github.com/rancher/k3s/pkg/nodeconfig"
 	"github.com/rancher/k3s/pkg/rootless"
 	"github.com/rancher/k3s/pkg/util"
@@ -88,6 +89,10 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 	syssetup.Configure(dualCluster || dualService || dualNode)
 
 	if err := setupCriCtlConfig(cfg, nodeConfig); err != nil {
+		return err
+	}
+
+	if err := executor.Bootstrap(ctx, nodeConfig, cfg); err != nil {
 		return err
 	}
 

--- a/pkg/daemons/executor/embed.go
+++ b/pkg/daemons/executor/embed.go
@@ -11,6 +11,8 @@ import (
 	proxy "k8s.io/kubernetes/cmd/kube-proxy/app"
 	kubelet "k8s.io/kubernetes/cmd/kubelet/app"
 
+	"github.com/rancher/k3s/pkg/cli/cmds"
+	daemonconfig "github.com/rancher/k3s/pkg/daemons/config"
 	"github.com/sirupsen/logrus"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	cmapp "k8s.io/kubernetes/cmd/kube-controller-manager/app"
@@ -22,6 +24,10 @@ func init() {
 }
 
 type Embedded struct{}
+
+func (Embedded) Bootstrap(ctx context.Context, nodeConfig *daemonconfig.Node, cfg cmds.Agent) error {
+	return nil
+}
 
 func (Embedded) Kubelet(args []string) error {
 	command := kubelet.NewKubeletCommand(context.Background())

--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -9,6 +9,8 @@ import (
 
 	"sigs.k8s.io/yaml"
 
+	"github.com/rancher/k3s/pkg/cli/cmds"
+	daemonconfig "github.com/rancher/k3s/pkg/daemons/config"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 )
 
@@ -17,6 +19,7 @@ var (
 )
 
 type Executor interface {
+	Bootstrap(ctx context.Context, nodeConfig *daemonconfig.Node, cfg cmds.Agent) error
 	Kubelet(args []string) error
 	KubeProxy(args []string) error
 	APIServer(ctx context.Context, etcdReady <-chan struct{}, args []string) (authenticator.Request, http.Handler, error)
@@ -79,6 +82,10 @@ func (e ETCDConfig) ToConfigFile() (string, error) {
 
 func Set(driver Executor) {
 	executor = driver
+}
+
+func Bootstrap(ctx context.Context, nodeConfig *daemonconfig.Node, cfg cmds.Agent) error {
+	return executor.Bootstrap(ctx, nodeConfig, cfg)
 }
 
 func Kubelet(args []string) error {


### PR DESCRIPTION
#### Proposed Changes ####

Add executor.Bootstrap hook for pre-execution setup.

In RKE2 this will be used as a hook for bootstrapping the runtime image AFTER the configuration has been retrieved from the server. Here in K3s is is a no-op.

#### Types of Changes ####

* executor API

#### Verification ####

* No change to K3s - should work as it currently does

#### Linked Issues ####

rancher/rke2#958 and rancher/rke2#959

#### Further Comments ####


