### PR TITLE
Add the ability to prune etcd snapshots

### DIFF
--- a/cmd/etcdsnapshot/main.go
+++ b/cmd/etcdsnapshot/main.go
@@ -13,7 +13,12 @@ import (
 func main() {
 	app := cmds.NewApp()
 	app.Commands = []cli.Command{
-		cmds.NewEtcdSnapshotCommand(etcdsnapshot.Run, cmds.NewEtcdSnapshotSubcommands(etcdsnapshot.Delete, etcdsnapshot.List)),
+		cmds.NewEtcdSnapshotCommand(etcdsnapshot.Run,
+			cmds.NewEtcdSnapshotSubcommands(
+				etcdsnapshot.Delete,
+				etcdsnapshot.List,
+				etcdsnapshot.Prune),
+		),
 	}
 
 	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil {

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -44,7 +44,12 @@ func main() {
 		cmds.NewCRICTL(externalCLIAction("crictl", dataDir)),
 		cmds.NewCtrCommand(externalCLIAction("ctr", dataDir)),
 		cmds.NewCheckConfigCommand(externalCLIAction("check-config", dataDir)),
-		cmds.NewEtcdSnapshotCommand(etcdsnapshotCommand, cmds.NewEtcdSnapshotSubcommands(etcdsnapshotCommand, etcdsnapshotCommand)),
+		cmds.NewEtcdSnapshotCommand(etcdsnapshotCommand,
+			cmds.NewEtcdSnapshotSubcommands(
+				etcdsnapshotCommand,
+				etcdsnapshotCommand,
+				etcdsnapshotCommand),
+		),
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,7 +43,12 @@ func main() {
 		cmds.NewKubectlCommand(kubectl.Run),
 		cmds.NewCRICTL(crictl.Run),
 		cmds.NewCtrCommand(ctr.Run),
-		cmds.NewEtcdSnapshotCommand(etcdsnapshot.Run, cmds.NewEtcdSnapshotSubcommands(etcdsnapshot.Delete, etcdsnapshot.List)),
+		cmds.NewEtcdSnapshotCommand(etcdsnapshot.Run,
+			cmds.NewEtcdSnapshotSubcommands(
+				etcdsnapshot.Delete,
+				etcdsnapshot.List,
+				etcdsnapshot.Prune),
+		),
 	}
 
 	err := app.Run(configfilearg.MustParse(os.Args))

--- a/main.go
+++ b/main.go
@@ -27,7 +27,12 @@ func main() {
 		cmds.NewAgentCommand(agent.Run),
 		cmds.NewKubectlCommand(kubectl.Run),
 		cmds.NewCRICTL(crictl.Run),
-		cmds.NewEtcdSnapshotCommand(etcdsnapshot.Run, cmds.NewEtcdSnapshotSubcommands(etcdsnapshot.Delete, etcdsnapshot.List)),
+		cmds.NewEtcdSnapshotCommand(etcdsnapshot.Run,
+			cmds.NewEtcdSnapshotSubcommands(
+				etcdsnapshot.Delete,
+				etcdsnapshot.List,
+				etcdsnapshot.Prune),
+		),
 	}
 
 	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil {

--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -95,7 +95,7 @@ func NewEtcdSnapshotCommand(action func(*cli.Context) error, subcommands []cli.C
 	}
 }
 
-func NewEtcdSnapshotSubcommands(delete, list func(ctx *cli.Context) error) []cli.Command {
+func NewEtcdSnapshotSubcommands(delete, list, prune func(ctx *cli.Context) error) []cli.Command {
 	return []cli.Command{
 		{
 			Name:            "delete",
@@ -108,11 +108,24 @@ func NewEtcdSnapshotSubcommands(delete, list func(ctx *cli.Context) error) []cli
 		{
 			Name:            "ls",
 			Aliases:         []string{"list", "l"},
-			Usage:           "List etcd snapshots",
+			Usage:           "List snapshots",
 			SkipFlagParsing: false,
 			SkipArgReorder:  true,
 			Action:          list,
 			Flags:           EtcdSnapshotFlags,
+		},
+		{
+			Name:            "prune",
+			Usage:           "Run retention policy",
+			SkipFlagParsing: false,
+			SkipArgReorder:  true,
+			Action:          prune,
+			Flags: append(EtcdSnapshotFlags, &cli.IntFlag{
+				Name:        "snapshot-retention",
+				Usage:       "(db) Number of snapshots to retain",
+				Destination: &ServerConfig.EtcdSnapshotRetention,
+				Value:       defaultSnapshotRentention,
+			}),
 		},
 	}
 }

--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -116,7 +116,7 @@ func NewEtcdSnapshotSubcommands(delete, list, prune func(ctx *cli.Context) error
 		},
 		{
 			Name:            "prune",
-			Usage:           "Run retention policy",
+			Usage:           "Remove snapshots that exceed the configured retention count",
 			SkipFlagParsing: false,
 			SkipArgReorder:  true,
 			Action:          prune,

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -970,6 +970,17 @@ func (e *ETCD) initS3IfNil(ctx context.Context) error {
 	return nil
 }
 
+// PruneSnapshots perfrorms a retention run with the given
+// retention duration and removes expired snapshots.
+func (e *ETCD) PruneSnapshots(ctx context.Context) error {
+	snapshotDir, err := snapshotDir(e.config)
+	if err != nil {
+		return errors.Wrap(err, "failed to get the snapshot dir")
+	}
+
+	return snapshotRetention(e.config.EtcdSnapshotRetention, snapshotDir)
+}
+
 // ListSnapshots is an exported wrapper method that wraps an
 // unexported method of the same name.
 func (e *ETCD) ListSnapshots(ctx context.Context) ([]SnapshotFile, error) {


### PR DESCRIPTION
Signed-off-by: Brian Downs <brian.downs@gmail.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This change introduces the ability to perform a prune of etcd snapshots from either local storage or an S3 compatible object store. 

This change will require a documentation update. I will do that when the rest of the etcd snapshot CLI CRUD operations are complete.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Run a prune with the default retention policy of 5.

```sh
k3s etcd-snapshot prune
```

Run a prune with the given retention policy.

```sh
k3s etcd-snapshot prune
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#3278 

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

