### PR TITLE
[backport 1.19] runc: v1.0.0-rc94

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -11,6 +11,9 @@
 		]
 	},
 	"run": {
+		"skip-dirs": [
+			"build", "/go/src/github.com/rancher/k3s/build"
+		],
 		"skip-files": [
 			"/zz_generated_"
 		],

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -28,7 +28,7 @@ RUN GO111MODULE=on go get golang.org/x/tools/cmd/goimports@aa82965741a9fecd12b02
 RUN rm -rf /go/src /go/pkg
 
 RUN if [ "$(go env GOARCH)" = "amd64" ]; then \
-    curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.30.0; \
+    curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.40.0; \
     fi
 
 ARG SELINUX=true

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ replace (
 	github.com/juju/errors => github.com/k3s-io/nocode v0.0.0-20200630202308-cb097102c09f
 	github.com/kubernetes-sigs/cri-tools => github.com/rancher/cri-tools v1.19.0-k3s1
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009
+	// LOOK TO scripts/download FOR THE VERSION OF runc THAT WE ARE BUILDING/SHIPPING
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc92
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6
 	go.etcd.io/etcd => github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea
@@ -83,6 +84,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.4
 	github.com/minio/minio-go/v7 v7.0.7
 	github.com/natefinch/lumberjack v2.0.0+incompatible
+	// LOOK TO scripts/download FOR THE VERSION OF runc THAT WE ARE BUILDING/SHIPPING
 	github.com/opencontainers/runc v1.0.0-rc92
 	github.com/opencontainers/selinux v1.6.0
 	github.com/pierrec/lz4 v2.5.2+incompatible

--- a/scripts/build
+++ b/scripts/build
@@ -117,9 +117,9 @@ ln -s containerd ./bin/ctr
 # echo Building containerd
 # CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/containerd ./cmd/containerd/
 echo Building runc
-rm -f ./vendor/github.com/opencontainers/runc/runc
-make EXTRA_LDFLAGS="-w -s" BUILDTAGS="$RUNC_TAGS" -C ./vendor/github.com/opencontainers/runc $RUNC_STATIC
-cp -f ./vendor/github.com/opencontainers/runc/runc ./bin/runc
+rm -f ./build/src/github.com/opencontainers/runc/runc
+make GOPATH=$(pwd)/build EXTRA_LDFLAGS="-w -s" BUILDTAGS="$RUNC_TAGS" -C ./build/src/github.com/opencontainers/runc $RUNC_STATIC
+cp -f ./build/src/github.com/opencontainers/runc/runc ./bin/runc
 
 echo Building containerd-shim
 rm -f ./vendor/github.com/containerd/containerd/bin/containerd-shim

--- a/scripts/download
+++ b/scripts/download
@@ -4,6 +4,7 @@ cd $(dirname $0)/..
 
 . ./scripts/version.sh
 
+RUNC_VERSION=v1.0.0-rc94
 ROOT_VERSION=v0.8.1
 TRAEFIK_VERSION=1.81.0
 CHARTS_DIR=build/static/charts
@@ -11,6 +12,12 @@ CHARTS_DIR=build/static/charts
 mkdir -p ${CHARTS_DIR}
 
 curl --compressed -sfL https://github.com/rancher/k3s-root/releases/download/${ROOT_VERSION}/k3s-root-${ARCH}.tar | tar xf -
+
+git clone --depth=1 https://github.com/opencontainers/runc build/src/github.com/opencontainers/runc || true
+pushd build/src/github.com/opencontainers/runc
+git fetch --all --tags
+git checkout ${RUNC_VERSION} -b k3s
+popd
 
 TRAEFIK_FILE=traefik-${TRAEFIK_VERSION}.tgz
 TRAEFIK_URL=https://charts.helm.sh/stable/packages/${TRAEFIK_FILE}


### PR DESCRIPTION
- bump the runc version to v1.0.0-rc94
- build runc from its own source tree instead of from ./vendor/
  - side-steps incompatibility with upstream kubelet container manager

backport of #3305
addresses #3301

Signed-off-by: Jacob Blain Christen <dweomer5@gmail.com>
