### PR TITLE
[backport 1.18] runc: v1.0.0-rc94

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -11,6 +11,9 @@
 		]
 	},
 	"run": {
+		"skip-dirs": [
+			"build", "/go/src/github.com/rancher/k3s/build"
+		],
 		"skip-files": [
 			"/zz_generated_"
 		],

--- a/go.mod
+++ b/go.mod
@@ -95,6 +95,7 @@ require (
 	github.com/lxc/lxd v0.0.0-20191108214106-60ea15630455
 	github.com/mattn/go-sqlite3 v1.14.4
 	github.com/natefinch/lumberjack v2.0.0+incompatible
+	// LOOK TO scripts/download FOR THE VERSION OF runc THAT WE ARE BUILDING/SHIPPING
 	github.com/opencontainers/runc v1.0.0-rc10
 	github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52
 	github.com/pkg/errors v0.9.1

--- a/scripts/build
+++ b/scripts/build
@@ -120,9 +120,9 @@ ln -s containerd ./bin/ctr
 # echo Building containerd
 # CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/containerd ./cmd/containerd/
 echo Building runc
-rm -f ./vendor/github.com/opencontainers/runc/runc
-make EXTRA_LDFLAGS="-w -s" BUILDTAGS="$RUNC_TAGS" -C ./vendor/github.com/opencontainers/runc $RUNC_STATIC
-cp -f ./vendor/github.com/opencontainers/runc/runc ./bin/runc
+rm -f ./build/src/github.com/opencontainers/runc/runc
+make GOPATH=$(pwd)/build EXTRA_LDFLAGS="-w -s" BUILDTAGS="$RUNC_TAGS" -C ./build/src/github.com/opencontainers/runc $RUNC_STATIC
+cp -f ./build/src/github.com/opencontainers/runc/runc ./bin/runc
 
 echo Building containerd-shim
 rm -f ./vendor/github.com/containerd/containerd/bin/containerd-shim

--- a/scripts/download
+++ b/scripts/download
@@ -4,6 +4,7 @@ cd $(dirname $0)/..
 
 . ./scripts/version.sh
 
+RUNC_VERSION=v1.0.0-rc94
 ROOT_VERSION=v0.8.1
 TRAEFIK_VERSION=1.81.0
 CHARTS_DIR=build/static/charts
@@ -11,6 +12,12 @@ CHARTS_DIR=build/static/charts
 mkdir -p ${CHARTS_DIR}
 
 curl --compressed -sfL https://github.com/rancher/k3s-root/releases/download/${ROOT_VERSION}/k3s-root-${ARCH}.tar | tar xf -
+
+git clone --depth=1 https://github.com/opencontainers/runc build/src/github.com/opencontainers/runc || true
+pushd build/src/github.com/opencontainers/runc
+git fetch --all --tags
+git checkout ${RUNC_VERSION} -b k3s
+popd
 
 TRAEFIK_FILE=traefik-${TRAEFIK_VERSION}.tgz
 TRAEFIK_URL=https://charts.helm.sh/stable/packages/${TRAEFIK_FILE}


### PR DESCRIPTION
- bump the runc version to v1.0.0-rc94
- build runc from its own source tree instead of from ./vendor/
  - side-steps incompatibility with upstream kubelet container manager

backport of #3305
addresses #3302

Signed-off-by: Jacob Blain Christen <dweomer5@gmail.com>
