### PR TITLE
[release-1.20]Add ci step to validate incorerct replacement fork

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -257,6 +257,28 @@ volumes:
 
 ---
 kind: pipeline
+name: validate_go_mods
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: validate_go_mods
+    image: rancher/dapper:v0.5.0
+    commands:
+      - dapper -f Dockerfile.test.mod.dapper
+
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+---
+kind: pipeline
 name: manifest
 
 platform:

--- a/Dockerfile.test.mod.dapper
+++ b/Dockerfile.test.mod.dapper
@@ -1,0 +1,11 @@
+ARG GOLANG=golang:1.16.2-alpine3.12
+FROM ${GOLANG}
+
+RUN apk -U --no-cache add bash jq
+ENV DAPPER_SOURCE /go/src/github.com/rancher/k3s/
+ENV HOME ${DAPPER_SOURCE}
+WORKDIR ${DAPPER_SOURCE}
+
+COPY ./scripts/test-mods /bin/
+
+ENTRYPOINT ["/bin/test-mods"]

--- a/scripts/test-mods
+++ b/scripts/test-mods
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e -x
+
+res=$(go mod edit --json | jq '.Replace[] | select(.Old.Path | contains("k8s.io/")) | .New.Path' | grep -v k3s-io | wc -l)
+if [ $res -gt 0 ];then
+  echo "Incorrect kubernetes replacement fork in go.mod"
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
Signed-off-by: MonzElmasry <menna.elmasry@rancher.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Add CI step to check for proper vendoring 

#### Types of Changes ####

CI
#### Verification ####

CI on pull request should have an extra step `validate_go_mods` that errors out when vendoring from a personal fork
#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/2720

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

