### PR TITLE
Fix passthrough of SystemDefaultRegistry from server config

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -552,10 +552,11 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 
 	nodeConfig.AgentConfig.PauseImage = envInfo.PauseImage
 	nodeConfig.AgentConfig.AirgapExtraRegistry = envInfo.AirgapExtraRegistry
+	nodeConfig.AgentConfig.SystemDefaultRegistry = controlConfig.SystemDefaultRegistry
 
 	// Apply SystemDefaultRegistry to PauseImage and AirgapExtraRegistry
 	if controlConfig.SystemDefaultRegistry != "" {
-		if !strings.HasPrefix(nodeConfig.AgentConfig.PauseImage, controlConfig.SystemDefaultRegistry) {
+		if nodeConfig.AgentConfig.PauseImage != "" && !strings.HasPrefix(nodeConfig.AgentConfig.PauseImage, controlConfig.SystemDefaultRegistry) {
 			nodeConfig.AgentConfig.PauseImage = controlConfig.SystemDefaultRegistry + "/" + nodeConfig.AgentConfig.PauseImage
 		}
 		if !slice.ContainsString(nodeConfig.AgentConfig.AirgapExtraRegistry, controlConfig.SystemDefaultRegistry) {


### PR DESCRIPTION
#### Proposed Changes ####

Fix passthrough of SystemDefaultRegistry from server config

#3285 did not properly pass through the --system-default-registry flag to agents. It was used in the  fields that are important to k3s agents but was not available for direct use by downstream projects (RKE2) that depend on it being set.

#### Types of Changes ####

Agent configuration

#### Verification ####

No change to K3s; will be used downstream by RKE2

#### Linked Issues ####

rancher/rke2#958 and rancher/rke2#959

#### Further Comments ####
