### PR TITLE
Add support for multiple env files for systemd unit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -728,7 +728,9 @@ WantedBy=multi-user.target
 
 [Service]
 Type=${SYSTEMD_TYPE}
-EnvironmentFile=${FILE_K3S_ENV}
+EnvironmentFile=-/etc/default/%N
+EnvironmentFile=-/etc/sysconfig/%N
+EnvironmentFile=-${FILE_K3S_ENV}
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/k3s.service
+++ b/k3s.service
@@ -6,6 +6,8 @@ Wants=network-online.target
 
 [Service]
 Type=notify
+EnvironmentFile=-/etc/default/%N
+EnvironmentFile=-/etc/sysconfig/%N
 EnvironmentFile=-/etc/systemd/system/k3s.service.env
 ExecStart=/usr/local/bin/k3s server
 KillMode=process


### PR DESCRIPTION
#### Proposed Changes ####

Add support for multiple env files for systemd unit

#### Types of Changes ####

Install script
systemd unit

#### Verification ####

- Place K3s environment files at /etc/default/k3s and/or /etc/sysconfig/k3s
- Install K3s and note that configuration from these files is honored (note that not all K3s CLI flags support passing via environment variable)
- Reinstall K3s with different K3S_ environment variables; note that the new env files are not clobbered by the install and uninstall scripts.

#### Linked Issues ####

For #3243

#### Further Comments ####
