### PR TITLE
add retention default and wire in s3 prune

### DIFF
--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -122,7 +122,7 @@ func NewEtcdSnapshotSubcommands(delete, list, prune, save func(ctx *cli.Context)
 			Action:          prune,
 			Flags: append(EtcdSnapshotFlags, &cli.IntFlag{
 				Name:        "snapshot-retention",
-				Usage:       "(db) Number of snapshots to retain",
+				Usage:       "(db) Number of snapshots to retain. Default: 5",
 				Destination: &ServerConfig.EtcdSnapshotRetention,
 				Value:       defaultSnapshotRentention,
 			}),

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -252,7 +252,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 			},
 			&cli.IntFlag{
 				Name:        "etcd-snapshot-retention",
-				Usage:       "(db) Number of snapshots to retain",
+				Usage:       "(db) Number of snapshots to retain Default: 5",
 				Destination: &ServerConfig.EtcdSnapshotRetention,
 				Value:       defaultSnapshotRentention,
 			},

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -978,6 +978,14 @@ func (e *ETCD) PruneSnapshots(ctx context.Context) error {
 		return errors.Wrap(err, "failed to get the snapshot dir")
 	}
 
+	if e.config.EtcdS3 {
+		if e.initS3IfNil(ctx); err != nil {
+			return err
+		}
+
+		return e.s3.snapshotRetention(ctx)
+	}
+
 	return snapshotRetention(e.config.EtcdSnapshotRetention, snapshotDir)
 }
 


### PR DESCRIPTION
Signed-off-by: Brian Downs <brian.downs@gmail.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Wire in s3 snapshot purning and adds default value to retention flag help.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

```sh
k3s etcd-snapshot prune --s3 --s3-bucket=k3s-snapshots --s3-access-key=<REDACTED> --s3-secret-key=<REDACTED> --snapshot-retention=3
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#3278 
#3339 

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

