### PR TITLE
[ Backport 1.21 ] - etcd subcommands 1.21

### DIFF
--- a/cmd/etcdsnapshot/main.go
+++ b/cmd/etcdsnapshot/main.go
@@ -17,7 +17,8 @@ func main() {
 			cmds.NewEtcdSnapshotSubcommands(
 				etcdsnapshot.Delete,
 				etcdsnapshot.List,
-				etcdsnapshot.Prune),
+				etcdsnapshot.Prune,
+				etcdsnapshot.Run),
 		),
 	}
 

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -48,6 +48,7 @@ func main() {
 			cmds.NewEtcdSnapshotSubcommands(
 				etcdsnapshotCommand,
 				etcdsnapshotCommand,
+				etcdsnapshotCommand,
 				etcdsnapshotCommand),
 		),
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -47,7 +47,8 @@ func main() {
 			cmds.NewEtcdSnapshotSubcommands(
 				etcdsnapshot.Delete,
 				etcdsnapshot.List,
-				etcdsnapshot.Prune),
+				etcdsnapshot.Prune,
+				etcdsnapshot.Run),
 		),
 	}
 

--- a/main.go
+++ b/main.go
@@ -31,7 +31,8 @@ func main() {
 			cmds.NewEtcdSnapshotSubcommands(
 				etcdsnapshot.Delete,
 				etcdsnapshot.List,
-				etcdsnapshot.Prune),
+				etcdsnapshot.Prune,
+				etcdsnapshot.Run),
 		),
 	}
 

--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -122,7 +122,7 @@ func NewEtcdSnapshotSubcommands(delete, list, prune, save func(ctx *cli.Context)
 			Action:          prune,
 			Flags: append(EtcdSnapshotFlags, &cli.IntFlag{
 				Name:        "snapshot-retention",
-				Usage:       "(db) Number of snapshots to retain",
+				Usage:       "(db) Number of snapshots to retain. Default: 5",
 				Destination: &ServerConfig.EtcdSnapshotRetention,
 				Value:       defaultSnapshotRentention,
 			}),

--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -95,7 +95,7 @@ func NewEtcdSnapshotCommand(action func(*cli.Context) error, subcommands []cli.C
 	}
 }
 
-func NewEtcdSnapshotSubcommands(delete, list, prune func(ctx *cli.Context) error) []cli.Command {
+func NewEtcdSnapshotSubcommands(delete, list, prune, save func(ctx *cli.Context) error) []cli.Command {
 	return []cli.Command{
 		{
 			Name:            "delete",
@@ -125,6 +125,18 @@ func NewEtcdSnapshotSubcommands(delete, list, prune func(ctx *cli.Context) error
 				Usage:       "(db) Number of snapshots to retain",
 				Destination: &ServerConfig.EtcdSnapshotRetention,
 				Value:       defaultSnapshotRentention,
+			}),
+		},
+		{
+			Name:            "save",
+			Usage:           "Trigger an immediate etcd snapshot",
+			SkipFlagParsing: false,
+			SkipArgReorder:  true,
+			Action:          save,
+			Flags: append(EtcdSnapshotFlags, &cli.StringFlag{
+				Name:        "dir",
+				Usage:       "(db) Directory to save etcd on-demand snapshot. (default: ${data-dir}/db/snapshots)",
+				Destination: &ServerConfig.EtcdSnapshotDir,
 			}),
 		},
 	}

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -252,7 +252,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 			},
 			&cli.IntFlag{
 				Name:        "etcd-snapshot-retention",
-				Usage:       "(db) Number of snapshots to retain",
+				Usage:       "(db) Number of snapshots to retain Default: 5",
 				Destination: &ServerConfig.EtcdSnapshotRetention,
 				Value:       defaultSnapshotRentention,
 			},

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -1017,12 +1017,13 @@ func (e *ETCD) DeleteSnapshots(ctx context.Context, snapshots []string) error {
 		}
 
 		objectsCh := make(chan minio.ObjectInfo)
-		defer close(objectsCh)
 
 		ctx, cancel := context.WithTimeout(ctx, defaultS3OpTimeout)
 		defer cancel()
 
 		go func() {
+			defer close(objectsCh)
+
 			opts := minio.ListObjectsOptions{
 				Recursive: true,
 			}

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -978,6 +978,14 @@ func (e *ETCD) PruneSnapshots(ctx context.Context) error {
 		return errors.Wrap(err, "failed to get the snapshot dir")
 	}
 
+	if e.config.EtcdS3 {
+		if e.initS3IfNil(ctx); err != nil {
+			return err
+		}
+
+		return e.s3.snapshotRetention(ctx)
+	}
+
 	return snapshotRetention(e.config.EtcdSnapshotRetention, snapshotDir)
 }
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Backports the etcd subcommand functionality found in mastser to the release-1.21 branch.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

