### PR TITLE
Avoid redundant chmod of k3s.yaml on startup

### DIFF
--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -7,7 +7,14 @@ import (
 )
 
 func SetFileModeForPath(name string, mode os.FileMode) error {
-	return os.Chmod(name, mode)
+	fi, err := os.Stat(name)
+	if err != nil {
+		return err
+	}
+	if fi.Mode().Perm() != mode.Perm() {
+		return os.Chmod(name, mode)
+	}
+	return nil
 }
 
 func SetFileModeForFile(file *os.File, mode os.FileMode) error {


### PR DESCRIPTION

#### Proposed Changes ####

Server unconditionally[1] performs chmod(2) on /etc/rancher/k3s/k3s.yaml on every startup.  This has a couple site effects that are analyzed in the commit message.

#### Types of Changes ####

Code change to pkg/util/file.go makes chmod happen only if the new mode is different from the current mode.

#### Verification ####

#### Linked Issues ####

#### Further Comments ####
