### PR TITLE
Set ulimits in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,13 @@ services:
     tmpfs:
     - /run
     - /var/run
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535
     privileged: true
+    restart: always
     environment:
     - K3S_TOKEN=${K3S_TOKEN:?err}
     - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
@@ -20,14 +26,22 @@ services:
     # This is just so that we get the kubeconfig file out
     - .:/output
     ports:
-    - 6443:6443
+    - 6443:6443  # Kubernetes API Server
+    - 80:80      # Ingress controller port 80
+    - 443:443    # Ingress controller port 443
 
   agent:
     image: "rancher/k3s:${K3S_VERSION:-latest}"
     tmpfs:
     - /run
     - /var/run
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535
     privileged: true
+    restart: always
     environment:
     - K3S_URL=https://server:6443
     - K3S_TOKEN=${K3S_TOKEN:?err}


### PR DESCRIPTION
The default values of ulimits were set to 65536 in EKS, which can be configured in [docker-compose.yml](https://docs.docker.com/compose/compose-file/compose-file-v3/#ulimits) as well. And port 80/443 should be forwarded by default for all ingress controllers.