### PR TITLE
[Backport 1.21] Add a path for wireguard's privatekey

### DIFF
--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -61,8 +61,8 @@ const (
 
 	wireguardBackend = `{
 	"Type": "extension",
-	"PreStartupCommand": "wg genkey | tee privatekey | wg pubkey",
-	"PostStartupCommand": "export SUBNET_IP=$(echo $SUBNET | cut -d'/' -f 1); ip link del flannel.1 2>/dev/null; echo $PATH >&2; wg-add.sh flannel.1 && wg set flannel.1 listen-port 51820 private-key privatekey && ip addr add $SUBNET_IP/32 dev flannel.1 && ip link set flannel.1 up && ip route add $NETWORK dev flannel.1",
+	"PreStartupCommand": "wg genkey | tee %flannelConfDir%/privatekey | wg pubkey",
+	"PostStartupCommand": "export SUBNET_IP=$(echo $SUBNET | cut -d'/' -f 1); ip link del flannel.1 2>/dev/null; echo $PATH >&2; wg-add.sh flannel.1 && wg set flannel.1 listen-port 51820 private-key %flannelConfDir%/privatekey && ip addr add $SUBNET_IP/32 dev flannel.1 && ip link set flannel.1 up && ip route add $NETWORK dev flannel.1",
 	"ShutdownCommand": "ip link del flannel.1",
 	"SubnetAddCommand": "read PUBLICKEY; wg set flannel.1 peer $PUBLICKEY endpoint $PUBLIC_IP:51820 allowed-ips $SUBNET persistent-keepalive 25",
 	"SubnetRemoveCommand": "read PUBLICKEY; wg set flannel.1 peer $PUBLICKEY remove"
@@ -133,7 +133,7 @@ func createFlannelConf(nodeConfig *config.Node) error {
 			return err
 		}
 	case config.FlannelBackendWireguard:
-		backendConf = wireguardBackend
+		backendConf = strings.ReplaceAll(wireguardBackend, "%flannelConfDir%", filepath.Dir(nodeConfig.FlannelConf))
 	default:
 		return fmt.Errorf("Cannot configure unknown flannel backend '%s'", nodeConfig.FlannelBackend)
 	}


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

Fixes bug https://github.com/k3s-io/k3s/issues/3031

Tracked by https://github.com/k3s-io/k3s/issues/3400

(cherry picked from commit 1576030d6bb4b35b2064c21f285df706af36dafe)