### PR TITLE
Add kubernetes.default.svc to serving certs

### DIFF
--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -38,7 +38,7 @@ func (c *Cluster) newListener(ctx context.Context) (net.Listener, http.Handler, 
 	return dynamiclistener.NewListener(tcp, storage, cert, key, dynamiclistener.Config{
 		ExpirationDaysCheck: config.CertificateRenewDays,
 		Organization:        []string{version.Program},
-		SANs:                append(c.config.SANs, "localhost", "kubernetes", "kubernetes.default", "kubernetes.default.svc."+c.config.ClusterDomain),
+		SANs:                append(c.config.SANs, "localhost", "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc."+c.config.ClusterDomain),
 		CN:                  version.Program,
 		TLSConfig: &tls.Config{
 			ClientAuth:   tls.RequestClientCert,

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -319,7 +319,7 @@ func genServerCerts(config *config.Control, runtime *config.ControlRuntime) erro
 	}
 
 	altNames := &certutil.AltNames{
-		DNSNames: []string{"localhost", "kubernetes", "kubernetes.default", "kubernetes.default.svc." + config.ClusterDomain},
+		DNSNames: []string{"localhost", "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc." + config.ClusterDomain},
 		IPs:      []net.IP{apiServerServiceIP},
 	}
 


### PR DESCRIPTION
#### Proposed Changes ####

Add kubernetes.default.svc to serving certs

#### Types of Changes ####

Bugfix

#### Verification ####

`echo QUIT | openssl s_client -connect localhost:6444 2>/dev/null | openssl x509 -noout -text | grep DNS`

#### Linked Issues ####

For #3399

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

