### PR TITLE
Updated iptables version check

### DIFF
--- a/contrib/util/check-config.sh
+++ b/contrib/util/check-config.sh
@@ -197,6 +197,9 @@ echo
   version_ge() {
     [ "$1" = "$2" ] || [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]
   }
+  version_less() {
+    [ "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1" ]
+  }
   which_iptables() {
     (
       localIPtables=$(command -v iptables)
@@ -224,8 +227,8 @@ echo
     wrap_warn "- $iptablesCmd" "unknown version: $iptablesInfo"
   elif version_ge $iptablesVersion v1.8.0; then
     iptablesMode=$(echo $iptablesInfo | awk '{ print $3 }')
-    if [ "$iptablesMode" != "(legacy)" ]; then
-      wrap_bad "- $label" 'should be older than v1.8.0 or in legacy mode'
+    if [ "$iptablesMode" != "(legacy)" ] && version_less $iptablesVersion v1.8.4; then 
+      wrap_bad "- $label" 'should be older than v1.8.0, newer than v1.8.3, or in legacy mode'
     else
       wrap_good "- $label" 'ok'
     fi


### PR DESCRIPTION
#### Proposed Changes ####
Added additional check in check-config.sh (i.e `k3 check-config`) that complains about iptables being in nf_tables mode only if the version is between 1.8.0 and 1.8.3.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Run on centOS8, it has iptables v1.8.4 in nf_tables mode by default. `k3 check-config` will no longer fail.

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/2946

#### Further Comments ####
Currently there is a bug in iptables v1.8.2 and v1.8.3 when in nf_tables mode that causes issues.
https://github.com/k3s-io/k3s/issues/3117
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

