### PR TITLE
Send systemd notifications for both server and agent

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -238,7 +238,7 @@ func Run(ctx context.Context, cfg cmds.Agent) error {
 		cfg.Token = newToken.String()
 		break
 	}
-	//systemd.SdNotify(true, "READY=1\n")
+
 	return run(ctx, cfg, proxy)
 }
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -122,9 +122,6 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 		return err
 	}
 
-	os.Setenv("NOTIFY_SOCKET", notifySocket)
-	systemd.SdNotify(true, "READY=1\n")
-
 	coreClient, err := coreClient(nodeConfig.AgentConfig.KubeConfigKubelet)
 	if err != nil {
 		return err
@@ -147,6 +144,9 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 			return err
 		}
 	}
+
+	os.Setenv("NOTIFY_SOCKET", notifySocket)
+	systemd.SdNotify(true, "READY=1\n")
 
 	<-ctx.Done()
 	return ctx.Err()

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -123,7 +123,6 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 	}
 
 	os.Setenv("NOTIFY_SOCKET", notifySocket)
-	logrus.Warn("XXX - got here")
 	systemd.SdNotify(true, "READY=1\n")
 
 	coreClient, err := coreClient(nodeConfig.AgentConfig.KubeConfigKubelet)
@@ -240,8 +239,6 @@ func Run(ctx context.Context, cfg cmds.Agent) error {
 		cfg.Token = newToken.String()
 		break
 	}
-
-	logrus.Warn("XXX - before it all in agent")
 
 	if err := run(ctx, cfg, proxy); err != nil {
 		return err

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -141,10 +141,6 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 		}
 	}
 
-	notifySocket := os.Getenv("NOTIFY_SOCKET")
-	os.Unsetenv("NOTIFY_SOCKET")
-
-	os.Setenv("NOTIFY_SOCKET", notifySocket)
 	systemd.SdNotify(true, "READY=1\n")
 
 	<-ctx.Done()

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -109,6 +109,9 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 		}
 	}
 
+	notifySocket := os.Getenv("NOTIFY_SOCKET")
+	os.Unsetenv("NOTIFY_SOCKET")
+
 	if !nodeConfig.Docker && nodeConfig.ContainerRuntimeEndpoint == "" {
 		if err := containerd.Run(ctx, nodeConfig); err != nil {
 			return err
@@ -141,6 +144,7 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 		}
 	}
 
+	os.Setenv("NOTIFY_SOCKET", notifySocket)
 	systemd.SdNotify(true, "READY=1\n")
 
 	<-ctx.Done()

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -141,6 +141,12 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 		}
 	}
 
+	notifySocket := os.Getenv("NOTIFY_SOCKET")
+	os.Unsetenv("NOTIFY_SOCKET")
+
+	os.Setenv("NOTIFY_SOCKET", notifySocket)
+	systemd.SdNotify(true, "READY=1\n")
+
 	<-ctx.Done()
 	return ctx.Err()
 }
@@ -232,7 +238,7 @@ func Run(ctx context.Context, cfg cmds.Agent) error {
 		cfg.Token = newToken.String()
 		break
 	}
-	systemd.SdNotify(true, "READY=1\n")
+	//systemd.SdNotify(true, "READY=1\n")
 	return run(ctx, cfg, proxy)
 }
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -240,11 +240,7 @@ func Run(ctx context.Context, cfg cmds.Agent) error {
 		break
 	}
 
-	if err := run(ctx, cfg, proxy); err != nil {
-		return err
-	}
-
-	return nil
+	return run(ctx, cfg, proxy)
 }
 
 func configureNode(ctx context.Context, agentConfig *daemonconfig.Agent, nodes v1.NodeInterface) error {

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -380,6 +380,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 
 		logrus.Info(version.Program + " is up and running")
 		if cfg.DisableAgent && os.Getenv("NOTIFY_SOCKET") != "" {
+			logrus.Warn("XXX - here?!")
 			systemd.SdNotify(true, "READY=1\n")
 		}
 	}()

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -363,7 +363,6 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 
 	logrus.Info("Starting " + version.Program + " " + app.App.Version)
 	notifySocket := os.Getenv("NOTIFY_SOCKET")
-	os.Unsetenv("NOTIFY_SOCKET")
 
 	ctx := signals.SetupSignalHandler(context.Background())
 
@@ -379,10 +378,13 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 			<-serverConfig.ControlConfig.Runtime.ETCDReady
 			logrus.Info("ETCD server is now running")
 		}
+
 		logrus.Info(version.Program + " is up and running")
-		if notifySocket != "" {
-			os.Setenv("NOTIFY_SOCKET", notifySocket)
-			systemd.SdNotify(true, "READY=1\n")
+		if cfg.DisableAgent {
+			if notifySocket != "" {
+				os.Setenv("NOTIFY_SOCKET", notifySocket)
+				systemd.SdNotify(true, "READY=1\n")
+			}
 		}
 	}()
 

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -380,7 +380,6 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 
 		logrus.Info(version.Program + " is up and running")
 		if cfg.DisableAgent && os.Getenv("NOTIFY_SOCKET") != "" {
-			logrus.Warn("XXX - here?!")
 			systemd.SdNotify(true, "READY=1\n")
 		}
 	}()

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -362,7 +362,6 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	}
 
 	logrus.Info("Starting " + version.Program + " " + app.App.Version)
-	notifySocket := os.Getenv("NOTIFY_SOCKET")
 
 	ctx := signals.SetupSignalHandler(context.Background())
 
@@ -380,11 +379,8 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		}
 
 		logrus.Info(version.Program + " is up and running")
-		if cfg.DisableAgent {
-			if notifySocket != "" {
-				os.Setenv("NOTIFY_SOCKET", notifySocket)
-				systemd.SdNotify(true, "READY=1\n")
-			}
+		if cfg.DisableAgent && os.Getenv("NOTIFY_SOCKET") != "" {
+			systemd.SdNotify(true, "READY=1\n")
 		}
 	}()
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Move the code for when the agent signals systemd to to be the last thing it does before waiting on the blocked context channel.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Verify that kubelet is up and processing before `systemctl start k3s` returns on an agent node.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/rancher/rke2/issues/989

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

