### PR TITLE
Fail to start k3s if nm-cloud-setup is enabled

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -744,6 +744,7 @@ TasksMax=infinity
 TimeoutStartSec=0
 Restart=always
 RestartSec=5s
+ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service'
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=${BIN_DIR}/k3s \\

--- a/k3s.service
+++ b/k3s.service
@@ -9,6 +9,7 @@ Type=notify
 EnvironmentFile=-/etc/default/%N
 EnvironmentFile=-/etc/sysconfig/%N
 EnvironmentFile=-/etc/systemd/system/k3s.service.env
+ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service'
 ExecStart=/usr/local/bin/k3s server
 KillMode=process
 Delegate=yes

--- a/package/rpm/install.sh
+++ b/package/rpm/install.sh
@@ -669,6 +669,7 @@ TasksMax=infinity
 TimeoutStartSec=0
 Restart=always
 RestartSec=5s
+ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service'
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=${BIN_DIR}/k3s ${CMD_K3S} \$${CMD_K3S_ARGS_VAR}


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

#### Proposed Changes ####
Even though we are documenting that nm-cloud-setup service breaks the k3s cluster: rancher/docs#3336, it is a good idea to verify this when starting the k3s service and not allow it to start if the user forgot to disable that service. If the OS is not running systemd, it will deploy k3s.

**Required** ==> /bin/sh (which I think is a quite safe assumption)

#### Types of Changes ####
New Feature. Verifies if nm-cloud-setup is enabled

#### Verification ####
Deploy RHEL8.4 which use nm-cloud-setup by default and run k3s. It should fail to start with the following log in journactl:
```
sh[1118717]: + /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service
sh[1118717]: + exit 1
```

#### Linked Issues ####
rancher/rke2#1053