### PR TITLE
Allow higher system sysctl values

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kube-proxy/app/conntrack.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-proxy/app/conntrack.go
@@ -99,7 +99,7 @@ func (realConntracker) setIntSysCtl(name string, value int) error {
 	entry := "net/netfilter/" + name
 
 	sys := sysctl.New()
-	if val, _ := sys.GetSysctl(entry); val != value {
+	if val, _ := sys.GetSysctl(entry); val != value && val < value {
 		klog.Infof("Set sysctl '%v' to %v", entry, value)
 		if err := sys.SetSysctl(entry, value); err != nil {
 			return err


### PR DESCRIPTION
With this commit kube-proxy accepts current system values (retrieved by sysctl) which are higher than the internally known and expected values.
This should solve the Rancher start problems documented in https://github.com/rancher/rancher/issues/33360 .
Signed-off-by: Claudio Kuenzler <ck@claudiokuenzler.com>

#### Proposed Changes ####

This PR improves compatibility of a nested Rancher installation (running Rancher container inside a container), where not all sysctl values can be set. It now checks (as before) whether nor not the current sysctl value matches the "known" one but additionally also allows higher values.

See the mentioned issue (below) for more details.

#### Types of Changes ####

Bugfix

#### Verification ####

- Start Rancher2 (Single Install) inside a LXC container (requires special config, see https://discuss.linuxcontainers.org/t/rancher-2-5-privileged-docker-container-in-privileged-lxc/11416)
- Change `net.netfilter.nf_conntrack_max` to a higher value on LXC host
- Restart rancher container inside the LXC container
- Rancher container should restart now (does not without this PR)

#### Linked Issues ####

https://github.com/rancher/rancher/issues/33360

#### Further Comments ####
none

