### PR TITLE
Add option to disable the built-in Helm Controller

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -53,6 +53,7 @@ type Server struct {
 	DefaultLocalStoragePath  string
 	DisableCCM               bool
 	DisableNPC               bool
+	DisableHelmController    bool
 	DisableKubeProxy         bool
 	DisableAPIServer         bool
 	DisableControllerManager bool
@@ -338,6 +339,11 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Name:        "disable-network-policy",
 				Usage:       "(components) Disable " + version.Program + " default network policy controller",
 				Destination: &ServerConfig.DisableNPC,
+			},
+			cli.BoolFlag{
+				Name:        "disable-helm-controller",
+				Usage:       "(components) Disable Helm controller",
+				Destination: &ServerConfig.DisableHelmController,
 			},
 			cli.BoolFlag{
 				Name:        "disable-apiserver",

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -119,6 +119,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.ExtraCloudControllerArgs = cfg.ExtraCloudControllerArgs
 	serverConfig.ControlConfig.DisableCCM = cfg.DisableCCM
 	serverConfig.ControlConfig.DisableNPC = cfg.DisableNPC
+	serverConfig.ControlConfig.DisableHelmController = cfg.DisableHelmController
 	serverConfig.ControlConfig.DisableKubeProxy = cfg.DisableKubeProxy
 	serverConfig.ControlConfig.DisableETCD = cfg.DisableETCD
 	serverConfig.ControlConfig.DisableAPIServer = cfg.DisableAPIServer

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -140,6 +140,7 @@ type Control struct {
 	SystemDefaultRegistry    string
 	DisableCCM               bool
 	DisableNPC               bool
+	DisableHelmController    bool
 	DisableKubeProxy         bool
 	DisableAPIServer         bool
 	DisableControllerManager bool

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -186,14 +186,17 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 		servicelb.DefaultLBImage = config.ControlConfig.SystemDefaultRegistry + "/" + servicelb.DefaultLBImage
 	}
 
-	helm.Register(ctx,
-		sc.Apply,
-		sc.Helm.Helm().V1().HelmChart(),
-		sc.Helm.Helm().V1().HelmChartConfig(),
-		sc.Batch.Batch().V1().Job(),
-		sc.Auth.Rbac().V1().ClusterRoleBinding(),
-		sc.Core.Core().V1().ServiceAccount(),
-		sc.Core.Core().V1().ConfigMap())
+	if !config.ControlConfig.DisableHelmController {
+		helm.Register(ctx,
+			sc.Apply,
+			sc.Helm.Helm().V1().HelmChart(),
+			sc.Helm.Helm().V1().HelmChartConfig(),
+			sc.Batch.Batch().V1().Job(),
+			sc.Auth.Rbac().V1().ClusterRoleBinding(),
+			sc.Core.Core().V1().ServiceAccount(),
+			sc.Core.Core().V1().ConfigMap())
+	}
+
 	if err := servicelb.Register(ctx,
 		sc.K8s,
 		sc.Apply,


### PR DESCRIPTION
Adds a command-line flag '--disable-helm-controller' that will disable the server's built-in helm controller.

Problem:
Testing installation and uninstallation of the Helm Controller on k3s is
not possible if the Helm Controller is baked into the k3s server.

Solution:
The Helm Controller can optionally be disabled, which will allow users
to manage its installation manually.

Signed-off-by: Joe Kralicky <joe.kralicky@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This change will increase the flexibility of testing and development of components that are normally baked into k3s.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

New Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Running the server with the --disable-helm-controller flag will start the server without the controller. Any Helmchart resources will not be reconciled. 

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#1445

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

This change intentionally does not prevent the installation of the associated CRDs. The usual helmchart resources will be created, and if the Helm Controller is installed separately after startup, these resources will then be reconciled. 
Can still pass `--disable=traefik` etc. flags to prevent creation of these resources.