### PR TITLE
Export cli server flags and etcd restoration functions

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -81,7 +81,51 @@ type Server struct {
 	EtcdS3Folder             string
 }
 
-var ServerConfig Server
+var (
+	ServerConfig Server
+	ClusterCIDR  = cli.StringSliceFlag{
+		Name:  "cluster-cidr",
+		Usage: "(networking) IPv4/IPv6 network CIDRs to use for pod IPs (default: 10.42.0.0/16)",
+		Value: &ServerConfig.ClusterCIDR,
+	}
+	ServiceCIDR = cli.StringSliceFlag{
+		Name:  "service-cidr",
+		Usage: "(networking) IPv4/IPv6 network CIDRs to use for service IPs (default: 10.43.0.0/16)",
+		Value: &ServerConfig.ServiceCIDR,
+	}
+	ServiceNodePortRange = cli.StringFlag{
+		Name:        "service-node-port-range",
+		Usage:       "(networking) Port range to reserve for services with NodePort visibility",
+		Destination: &ServerConfig.ServiceNodePortRange,
+		Value:       "30000-32767",
+	}
+	ClusterDNS = cli.StringSliceFlag{
+		Name:  "cluster-dns",
+		Usage: "(networking) IPv4 Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
+		Value: &ServerConfig.ClusterDNS,
+	}
+	ClusterDomain = cli.StringFlag{
+		Name:        "cluster-domain",
+		Usage:       "(networking) Cluster Domain",
+		Destination: &ServerConfig.ClusterDomain,
+		Value:       "cluster.local",
+	}
+	ExtraAPIArgs = cli.StringSliceFlag{
+		Name:  "kube-apiserver-arg",
+		Usage: "(flags) Customized flag for kube-apiserver process",
+		Value: &ServerConfig.ExtraAPIArgs,
+	}
+	ExtraSchedulerArgs = cli.StringSliceFlag{
+		Name:  "kube-scheduler-arg",
+		Usage: "(flags) Customized flag for kube-scheduler process",
+		Value: &ServerConfig.ExtraSchedulerArgs,
+	}
+	ExtraControllerArgs = cli.StringSliceFlag{
+		Name:  "kube-controller-manager-arg",
+		Usage: "(flags) Customized flag for kube-controller-manager process",
+		Value: &ServerConfig.ExtraControllerArgs,
+	}
+)
 
 func NewServerCommand(action func(*cli.Context) error) cli.Command {
 	return cli.Command{
@@ -128,33 +172,11 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
 				Destination: &ServerConfig.DataDir,
 			},
-			cli.StringSliceFlag{
-				Name:  "cluster-cidr",
-				Usage: "(networking) IPv4/IPv6 network CIDRs to use for pod IPs (default: 10.42.0.0/16)",
-				Value: &ServerConfig.ClusterCIDR,
-			},
-			cli.StringSliceFlag{
-				Name:  "service-cidr",
-				Usage: "(networking) IPv4/IPv6 network CIDRs to use for service IPs (default: 10.43.0.0/16)",
-				Value: &ServerConfig.ServiceCIDR,
-			},
-			cli.StringFlag{
-				Name:        "service-node-port-range",
-				Usage:       "(networking) Port range to reserve for services with NodePort visibility",
-				Destination: &ServerConfig.ServiceNodePortRange,
-				Value:       "30000-32767",
-			},
-			cli.StringSliceFlag{
-				Name:  "cluster-dns",
-				Usage: "(networking) IPv4 Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
-				Value: &ServerConfig.ClusterDNS,
-			},
-			cli.StringFlag{
-				Name:        "cluster-domain",
-				Usage:       "(networking) Cluster Domain",
-				Destination: &ServerConfig.ClusterDomain,
-				Value:       "cluster.local",
-			},
+			ClusterCIDR,
+			ServiceCIDR,
+			ServiceNodePortRange,
+			ClusterDNS,
+			ClusterDomain,
 			cli.StringFlag{
 				Name:        "flannel-backend",
 				Usage:       "(networking) One of 'none', 'vxlan', 'ipsec', 'host-gw', or 'wireguard'",
@@ -185,21 +207,9 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Destination: &ServerConfig.KubeConfigMode,
 				EnvVar:      version.ProgramUpper + "_KUBECONFIG_MODE",
 			},
-			cli.StringSliceFlag{
-				Name:  "kube-apiserver-arg",
-				Usage: "(flags) Customized flag for kube-apiserver process",
-				Value: &ServerConfig.ExtraAPIArgs,
-			},
-			cli.StringSliceFlag{
-				Name:  "kube-scheduler-arg",
-				Usage: "(flags) Customized flag for kube-scheduler process",
-				Value: &ServerConfig.ExtraSchedulerArgs,
-			},
-			cli.StringSliceFlag{
-				Name:  "kube-controller-manager-arg",
-				Usage: "(flags) Customized flag for kube-controller-manager process",
-				Value: &ServerConfig.ExtraControllerArgs,
-			},
+			ExtraAPIArgs,
+			ExtraControllerArgs,
+			ExtraSchedulerArgs,
 			cli.StringSliceFlag{
 				Name:  "kube-cloud-controller-manager-arg",
 				Usage: "(flags) Customized flag for kube-cloud-controller-manager process",

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -71,7 +71,7 @@ type ETCD struct {
 	runtime *config.ControlRuntime
 	address string
 	cron    *cron.Cron
-	s3      *s3
+	s3      *S3
 }
 
 type learnerProgress struct {

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -210,7 +210,7 @@ func (e *ETCD) Reset(ctx context.Context, rebootstrap func() error) error {
 				return err
 			}
 			logrus.Infof("Retrieving etcd snapshot %s from S3", e.config.ClusterResetRestorePath)
-			if err := e.s3.download(ctx); err != nil {
+			if err := e.s3.Download(ctx); err != nil {
 				return err
 			}
 			logrus.Infof("S3 download complete for %s", e.config.ClusterResetRestorePath)
@@ -960,7 +960,7 @@ func (e *ETCD) listSnapshots(ctx context.Context, snapshotDir string) ([]Snapsho
 // if it hasn't yet been initialized.
 func (e *ETCD) initS3IfNil(ctx context.Context) error {
 	if e.s3 == nil {
-		s3, err := newS3(ctx, e.config)
+		s3, err := NewS3(ctx, e.config)
 		if err != nil {
 			return err
 		}

--- a/pkg/etcd/s3.go
+++ b/pkg/etcd/s3.go
@@ -34,7 +34,7 @@ type s3 struct {
 // newS3 creates a new value of type s3 pointer with a
 // copy of the config.Control pointer and initializes
 // a new Minio client.
-func newS3(ctx context.Context, config *config.Control) (*s3, error) {
+func NewS3(ctx context.Context, config *config.Control) (*s3, error) {
 	tr := http.DefaultTransport
 	if config.EtcdS3EndpointCA != "" {
 		trCA, err := setTransportCA(tr, config.EtcdS3EndpointCA, config.EtcdS3SkipSSLVerify)
@@ -109,7 +109,7 @@ func (s *s3) upload(ctx context.Context, snapshot string) error {
 
 // download downloads the given snapshot from the configured S3
 // compatible backend.
-func (s *s3) download(ctx context.Context) error {
+func (s *s3) Download(ctx context.Context) error {
 	var remotePath string
 	if s.config.EtcdS3Folder != "" {
 		remotePath = filepath.Join(s.config.EtcdS3Folder, s.config.ClusterResetRestorePath)

--- a/pkg/etcd/s3.go
+++ b/pkg/etcd/s3.go
@@ -25,8 +25,8 @@ import (
 
 const defaultS3OpTimeout = time.Second * 30
 
-// s3 maintains state for S3 functionality.
-type s3 struct {
+// S3 maintains state for S3 functionality.
+type S3 struct {
 	config *config.Control
 	client *minio.Client
 }
@@ -34,7 +34,7 @@ type s3 struct {
 // newS3 creates a new value of type s3 pointer with a
 // copy of the config.Control pointer and initializes
 // a new Minio client.
-func NewS3(ctx context.Context, config *config.Control) (*s3, error) {
+func NewS3(ctx context.Context, config *config.Control) (*S3, error) {
 	tr := http.DefaultTransport
 	if config.EtcdS3EndpointCA != "" {
 		trCA, err := setTransportCA(tr, config.EtcdS3EndpointCA, config.EtcdS3SkipSSLVerify)
@@ -77,7 +77,7 @@ func NewS3(ctx context.Context, config *config.Control) (*s3, error) {
 	}
 	logrus.Infof("S3 bucket %s exists", config.EtcdS3BucketName)
 
-	return &s3{
+	return &S3{
 		config: config,
 		client: c,
 	}, nil
@@ -85,7 +85,7 @@ func NewS3(ctx context.Context, config *config.Control) (*s3, error) {
 
 // upload uploads the given snapshot to the configured S3
 // compatible backend.
-func (s *s3) upload(ctx context.Context, snapshot string) error {
+func (s *S3) upload(ctx context.Context, snapshot string) error {
 	basename := filepath.Base(snapshot)
 	var snapshotFileName string
 	if s.config.EtcdS3Folder != "" {
@@ -109,7 +109,7 @@ func (s *s3) upload(ctx context.Context, snapshot string) error {
 
 // download downloads the given snapshot from the configured S3
 // compatible backend.
-func (s *s3) Download(ctx context.Context) error {
+func (s *S3) Download(ctx context.Context) error {
 	var remotePath string
 	if s.config.EtcdS3Folder != "" {
 		remotePath = filepath.Join(s.config.EtcdS3Folder, s.config.ClusterResetRestorePath)
@@ -155,7 +155,7 @@ func (s *s3) Download(ctx context.Context) error {
 
 // snapshotPrefix returns the prefix used in the
 // naming of the snapshots.
-func (s *s3) snapshotPrefix() string {
+func (s *S3) snapshotPrefix() string {
 	nodeName := os.Getenv("NODE_NAME")
 	fullSnapshotPrefix := snapshotPrefix + nodeName
 	var prefix string
@@ -169,7 +169,7 @@ func (s *s3) snapshotPrefix() string {
 
 // snapshotRetention deletes the given snapshot from the configured S3
 // compatible backend.
-func (s *s3) snapshotRetention(ctx context.Context) error {
+func (s *S3) snapshotRetention(ctx context.Context) error {
 	var snapshotFiles []minio.ObjectInfo
 
 	toCtx, cancel := context.WithTimeout(ctx, defaultS3OpTimeout)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Exporting some cli flags to be used in the migration agent directly as well as two function in s3 restoration