### PR TITLE
Bump kine to resolve race condition and unrevisioned delete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/k3s-io/helm-controller v0.9.1
-	github.com/k3s-io/kine v0.6.1
+	github.com/k3s-io/kine v0.6.2
 	github.com/klauspost/compress v1.12.2
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -543,8 +543,8 @@ github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea h1:7cwby0GoN
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
 github.com/k3s-io/helm-controller v0.9.1 h1:qtHWTNHiuCPRbA2YZ7z7jTgSHo7Yc5He52oMga72yUk=
 github.com/k3s-io/helm-controller v0.9.1/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
-github.com/k3s-io/kine v0.6.1 h1:GcxxxtfmXIRiVqImZoGCHgJl6+S4Be3tY9nm2ArY7/U=
-github.com/k3s-io/kine v0.6.1/go.mod h1:rzCs93+rQHZGOiewMd84PDrER92QeZ6eeHbWkfEy4+w=
+github.com/k3s-io/kine v0.6.2 h1:1aJTPfB8HG4exqMKFVE5H0z4bepF05tJHtYNXotWXa4=
+github.com/k3s-io/kine v0.6.2/go.mod h1:rzCs93+rQHZGOiewMd84PDrER92QeZ6eeHbWkfEy4+w=
 github.com/k3s-io/kubernetes v1.21.1-k3s1 h1:X8nEv12/bI3iR2+ARLuzvosPW8iMOisMlklOAeovISw=
 github.com/k3s-io/kubernetes v1.21.1-k3s1/go.mod h1:ef++isEL1PW0taH6z7DXrSztPglrZ7jQhyvcMEtm0gQ=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/api v1.21.1-k3s1 h1:7iwn62FGlOqG9oRHwTY/+AbFlSZffWMqx6WUXjRpQPk=

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -132,15 +132,15 @@ func (c *Cluster) getBootstrapKeyFromStorage(ctx context.Context, storageClient 
 		return nil, false, nil
 	}
 	if len(bootstrapList) > 1 {
-		return nil, false, errors.New("found more than one bootstrap keys in storage")
+		return nil, false, errors.New("found multiple bootstrap keys in storage")
 	}
 	bootstrapKV := bootstrapList[0]
 	// checking for empty string bootstrap key
 	switch string(bootstrapKV.Key) {
 	case emptyStringKey:
-		logrus.Warn("bootstrap data already found and encrypted with empty string, deleting empty key")
+		logrus.Warn("bootstrap data encrypted with empty string, deleting and resaving with token")
 		c.saveBootstrap = true
-		if err := storageClient.Delete(ctx, emptyStringKey); err != nil {
+		if err := storageClient.Delete(ctx, emptyStringKey, bootstrapKV.Modified); err != nil {
 			return nil, false, err
 		}
 		return &bootstrapKV, true, nil

--- a/vendor/github.com/k3s-io/kine/pkg/logstructured/sqllog/sql.go
+++ b/vendor/github.com/k3s-io/kine/pkg/logstructured/sqllog/sql.go
@@ -53,9 +53,9 @@ type Dialect interface {
 	BeginTx(ctx context.Context, opts *sql.TxOptions) (*generic.Tx, error)
 }
 
-func (s *SQLLog) Start(ctx context.Context) (err error) {
+func (s *SQLLog) Start(ctx context.Context) error {
 	s.ctx = ctx
-	return
+	return s.compactStart(s.ctx)
 }
 
 func (s *SQLLog) compactStart(ctx context.Context) error {
@@ -365,10 +365,6 @@ func filter(events interface{}, checkPrefix bool, prefix string) ([]*server.Even
 }
 
 func (s *SQLLog) startWatch() (chan interface{}, error) {
-	if err := s.compactStart(s.ctx); err != nil {
-		return nil, err
-	}
-
 	pollStart, err := s.d.GetCompactRevision(s.ctx)
 	if err != nil {
 		return nil, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -709,7 +709,7 @@ github.com/k3s-io/helm-controller/pkg/generated/informers/externalversions/helm.
 github.com/k3s-io/helm-controller/pkg/generated/informers/externalversions/internalinterfaces
 github.com/k3s-io/helm-controller/pkg/generated/listers/helm.cattle.io/v1
 github.com/k3s-io/helm-controller/pkg/helm
-# github.com/k3s-io/kine v0.6.1
+# github.com/k3s-io/kine v0.6.2
 ## explicit
 github.com/k3s-io/kine/pkg/broadcaster
 github.com/k3s-io/kine/pkg/client


### PR DESCRIPTION
#### Proposed Changes ####

Bump kine for #3523

Fix bug (no issue) where deletion of empty-string bootstrap token would always fail due to kine not supporting delete without a transaction.

#### Types of Changes ####

Bugfix

#### Verification ####

* Check CI; no failures
* Validate #3422 and rancherlabs/rancher-security#501; note that the old bootstrap key is successfully deleted

#### Linked Issues ####

#3523

#### Further Comments ####