### PR TITLE
[release-1.21] Bump helm-controller to v0.10.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/k3s-io/helm-controller v0.9.1
+	github.com/k3s-io/helm-controller v0.10.1
 	github.com/k3s-io/kine v0.6.0
 	github.com/klauspost/compress v1.12.2
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -540,8 +540,8 @@ github.com/k3s-io/cri-tools v1.21.0-k3s1 h1:MWQtAsx4HCNXenqU/B4V9eU6HMyafkd1PnW6
 github.com/k3s-io/cri-tools v1.21.0-k3s1/go.mod h1:Qsz54zxINPR+WVWX9Kc3CTmuDFB1dNLCNV8jE8lUbtU=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea h1:7cwby0GoNAi8IsVrT0q+JfQpB6V76ZaEGhj6qts/mvU=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
-github.com/k3s-io/helm-controller v0.9.1 h1:qtHWTNHiuCPRbA2YZ7z7jTgSHo7Yc5He52oMga72yUk=
-github.com/k3s-io/helm-controller v0.9.1/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
+github.com/k3s-io/helm-controller v0.10.1 h1:w98iQsKfA5RnvzdVzU4LTDuLzA3SyoN31ebDUKQUDpM=
+github.com/k3s-io/helm-controller v0.10.1/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
 github.com/k3s-io/kine v0.6.0 h1:4l7wjgCxb2oD+7Hyf3xIhkGd/6s1sXpRFdQiyy+7Ki8=
 github.com/k3s-io/kine v0.6.0/go.mod h1:rzCs93+rQHZGOiewMd84PDrER92QeZ6eeHbWkfEy4+w=
 github.com/k3s-io/kubernetes v1.21.2-k3s1 h1:e5R77BWsEEiZqoZ68t9iKF08KwSVBqASwy4N9Uq4FHw=

--- a/pkg/cluster/encrypt.go
+++ b/pkg/cluster/encrypt.go
@@ -30,7 +30,7 @@ func keyHash(passphrase string) string {
 }
 
 // encrypt encrypts a byte slice using aes+gcm with a pbkdf2 key derived from the passphrase and a random salt.
-// It returns a byte slice containing the salt and base64-encoded cyphertext.
+// It returns a byte slice containing the salt and base64-encoded ciphertext.
 func encrypt(passphrase string, plaintext []byte) ([]byte, error) {
 	salt, err := token.Random(8)
 	if err != nil {
@@ -59,7 +59,7 @@ func encrypt(passphrase string, plaintext []byte) ([]byte, error) {
 }
 
 // decrypt attempts to decrypt the byte slice using the supplied passphrase.
-// The input byte slice should be the cyphertext output from the encrypt function.
+// The input byte slice should be the ciphertext output from the encrypt function.
 func decrypt(passphrase string, ciphertext []byte) ([]byte, error) {
 	parts := strings.SplitN(string(ciphertext), ":", 2)
 	if len(parts) != 2 {

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,5 +1,5 @@
 docker.io/rancher/coredns-coredns:1.8.3
-docker.io/rancher/klipper-helm:v0.5.0-build20210505
+docker.io/rancher/klipper-helm:v0.6.1-build20210616
 docker.io/rancher/klipper-lb:v0.2.0
 docker.io/rancher/library-busybox:1.32.1
 docker.io/rancher/library-traefik:2.4.8

--- a/vendor/github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1/types.go
+++ b/vendor/github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1/types.go
@@ -27,6 +27,7 @@ type HelmChartSpec struct {
 	Bootstrap       bool                          `json:"bootstrap,omitempty"`
 	ChartContent    string                        `json:"chartContent,omitempty"`
 	JobImage        string                        `json:"jobImage,omitempty"`
+	Timeout         *metav1.Duration              `json:"timeout,omitempty"`
 }
 
 type HelmChartStatus struct {

--- a/vendor/github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1/zz_generated_deepcopy.go
+++ b/vendor/github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1/zz_generated_deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -171,6 +172,11 @@ func (in *HelmChartSpec) DeepCopyInto(out *HelmChartSpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		*out = new(metav1.Duration)
+		**out = **in
 	}
 	return
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -692,7 +692,7 @@ github.com/jmespath/go-jmespath
 github.com/jonboulle/clockwork
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
-# github.com/k3s-io/helm-controller v0.9.1
+# github.com/k3s-io/helm-controller v0.10.1
 ## explicit
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1


### PR DESCRIPTION
#### Proposed Changes ####
Bump `k3s-io/helm-controller` to `v0.10.1`

#### Types of Changes ####
Packaged component version change

#### Verification ####
Verify that `k3s-io/helm-controller` is `v0.10.1` i.e. `go mod graph | grep helm-controller`

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/3427

#### Further Comments ####
