### PR TITLE
Update etcd snapshot error message to be more informative

### DIFF
--- a/pkg/cli/etcdsnapshot/etcd_snapshot.go
+++ b/pkg/cli/etcdsnapshot/etcd_snapshot.go
@@ -89,7 +89,7 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 		return err
 	}
 	if !initialized {
-		return errors.New("managed etcd database has not been initialized")
+		return fmt.Errorf("etcd database not found in %s", dataDir)
 	}
 
 	cluster := cluster.New(&serverConfig.ControlConfig)


### PR DESCRIPTION
#### Proposed Changes ####
Update the error message that is encountered when performing an etcd snapshot operation when K3s is unable to find an initialized etcd database.

#### Types of Changes ####
UX Change

#### Verification ####
Run a `k3s etcd-snapshot` on a system that is running K3s at a "global" level using a `non-root` user. Observe that the error message encountered tells you that K3s could not find the etcd database in the local K3s home directory.

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/3438

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update the error message encountered when running `k3s etcd-snapshot` where K3s cannot find an initialized etcd database to be more informative.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
