### PR TITLE
Fixing various bugs related to windows.

### DIFF
--- a/pkg/agent/config/config_windows.go
+++ b/pkg/agent/config/config_windows.go
@@ -10,5 +10,5 @@ import (
 
 func applyContainerdStateAndAddress(nodeConfig *config.Node) {
 	nodeConfig.Containerd.State = filepath.Join(nodeConfig.Containerd.Root, "state")
-	nodeConfig.Containerd.Address = "npipe://///./pipe/containerd-containerd"
+	nodeConfig.Containerd.Address = "npipe:////./pipe/containerd-containerd"
 }

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	unixPrefix    = "unix://"
-	windowsPrefix = "npipe:"
+	windowsPrefix = "npipe://"
 )
 
 func Agent(config *config.Agent) error {

--- a/pkg/daemons/agent/agent_windows_test.go
+++ b/pkg/daemons/agent/agent_windows_test.go
@@ -1,0 +1,47 @@
+// +build windows
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/rancher/k3s/pkg/daemons/config"
+)
+
+func TestCheckRuntimeEndpoint(t *testing.T) {
+	type args struct {
+		cfg *config.Agent
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Runtime endpoint unaltered",
+			args: args{
+				cfg: &config.Agent{RuntimeSocket: "npipe:////./pipe/containerd-containerd"},
+			},
+			want: "npipe:////./pipe/containerd-containerd",
+		},
+		{
+			name: "Runtime endpoint altered",
+			args: args{
+				cfg: &config.Agent{RuntimeSocket: "//./pipe/containerd-containerd"},
+			},
+			want: "npipe:////./pipe/containerd-containerd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argsMap := map[string]string{}
+			checkRuntimeEndpoint(tt.args.cfg, argsMap)
+			if argsMap["container-runtime-endpoint"] != tt.want {
+				got := argsMap["container-runtime-endpoint"]
+				t.Errorf("error, input was " + tt.args.cfg.RuntimeSocket + " should be " + tt.want + ", but got " + got)
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
This changes the crictl template for issues with the socket information. It also addresses a typo in the socket address. Last it makes tweaks to configuration that aren't required or had incorrect logic.

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

This fixes bugs in the containerd socket for windows and a bug related to generating the correct source-vip.

#### Types of Changes ####

These are all bugfix changes.

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

The issue in this repo: #3585
This work for Windows enablement: rancher/windows#55
