### PR TITLE
[release-1.21] Dispatch to rancher/system-agent-installer-k3s when tagged

### DIFF
--- a/scripts/dispatch
+++ b/scripts/dispatch
@@ -9,3 +9,11 @@ curl -XPOST -u "${PAT_USERNAME}:${PAT_TOKEN}" \
         -H "Accept: application/vnd.github.everest-preview+json"  \
         -H "Content-Type: application/json" $REPO \
         --data '{"event_type": "create_tag", "client_payload": {"tag":"'"$DRONE_TAG"'"}}'
+
+SYSTEM_AGENT_INSTALLER_K3S_REPO="https://api.github.com/repos/rancher/system-agent-installer-k3s/dispatches"
+
+# send dispatch event to SYSTEM_AGENT_INSTALLER_K3S_REPO
+curl -XPOST -u "${PAT_USERNAME}:${PAT_TOKEN}" \
+        -H "Accept: application/vnd.github.everest-preview+json"  \
+        -H "Content-Type: application/json" $SYSTEM_AGENT_INSTALLER_K3S_REPO \
+        --data '{"event_type": "create_tag", "client_payload": {"tag":"'"$DRONE_TAG"'"}}'


### PR DESCRIPTION
Backport of https://github.com/k3s-io/k3s/pull/3589

#### Proposed Changes ####
Add additional steps to dispatch to send a dispatch event to the `rancher/system-agent-installer-k3s` repository to create a tag when a new release is made

#### Types of Changes ####
CI change

#### Verification ####
Cut a release, and observe that a corresponding `rancher/system-agent-installer-k3s` tag is created

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/3582

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

