### PR TITLE
Bump the packaged runc binary version

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -4,7 +4,7 @@ cd $(dirname $0)/..
 
 . ./scripts/version.sh
 
-RUNC_VERSION=v1.0.0-rc95
+RUNC_VERSION=v1.0.0
 ROOT_VERSION=v0.8.1
 TRAEFIK_VERSION=9.18.2  # appVersion: 2.4.8
 CHARTS_DIR=build/static/charts


### PR DESCRIPTION
#### Proposed Changes ####
Bump the packaged runc binary version

Not bumping runc in go.mod yet, as upstream Kubernetes still requires
runc/libcontainer v1.0.0-rc95

#### Types of Changes ####

packaged runc

#### Verification ####

`/var/lib/rancher/k3s/data/current/bin/runc --version`

#### Linked Issues ####

* #3600

#### User-Facing Change ####

```release-note
Update packaged runc binary version to v1.0.0
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
