### PR TITLE
[release-1.21] Add nodename to UA string for deploy controller

### DIFF
--- a/pkg/deploy/controller.go
+++ b/pkg/deploy/controller.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	ns       = "kube-system"
-	startKey = "_start_"
+	ControllerName = "deploy"
+	ns             = "kube-system"
+	startKey       = "_start_"
 )
 
 func WatchFiles(ctx context.Context, apply apply.Apply, addons v1.AddonController, disables map[string]bool, bases ...string) error {

--- a/pkg/server/context.go
+++ b/pkg/server/context.go
@@ -2,9 +2,14 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"runtime"
 
 	"github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io"
+	"github.com/rancher/k3s/pkg/deploy"
 	"github.com/rancher/k3s/pkg/generated/controllers/k3s.cattle.io"
+	"github.com/rancher/k3s/pkg/version"
 	"github.com/rancher/wrangler-api/pkg/generated/controllers/apps"
 	"github.com/rancher/wrangler-api/pkg/generated/controllers/batch"
 	"github.com/rancher/wrangler-api/pkg/generated/controllers/core"
@@ -12,6 +17,8 @@ import (
 	"github.com/rancher/wrangler/pkg/apply"
 	"github.com/rancher/wrangler/pkg/crd"
 	"github.com/rancher/wrangler/pkg/start"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -37,6 +44,16 @@ func NewContext(ctx context.Context, cfg string) (*Context, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Construct a custom user-agent string for the apply client used by the deploy controller
+	// so that we can track which node's deploy controller most recently modified a resource.
+	nodeName := os.Getenv("NODE_NAME")
+	managerName := deploy.ControllerName + "@" + nodeName
+	if nodeName == "" || len(managerName) > validation.FieldManagerMaxLength {
+		logrus.Warn("Deploy controller node name is empty or too long, and will not be tracked via server side apply field management")
+		managerName = deploy.ControllerName
+	}
+	restConfig.UserAgent = fmt.Sprintf("%s/%s (%s/%s) %s/%s", managerName, version.Version, runtime.GOOS, runtime.GOARCH, version.Program, version.GitCommit)
 
 	if err := crds(ctx, restConfig); err != nil {
 		return nil, err


### PR DESCRIPTION
#### Proposed Changes ####

Use Kubernetes managedFields's manager name string to track the node that last modified a resource. This sets deploy@NODENAME as the field manager on all resources created by the deploy controller, which can be used by other components that might want to know what node created something - due to the deploy controller not using any sort of leader election.

Wrangler's apply library doesn't have any way to set the manager field when applying a DesiredSet, but we can instead rely on the fact that server-side-apply uses everything before the first `/` in the client's user-agent as the manager name if the manager field is empty.

#### Types of Changes ####

deploy controller

#### Verification ####

* Install K3s
* `kubectl get service -n kube-system kube-dns -o yaml --show-managed-fields`; note entry in managedFields list showing `manager: deploy@NODENAME`

#### Linked Issues ####

* #3613
* rancher/rke2#1124 - Helm Job Pod Affinity Implementation Options / Option B: Use managedFields to track the updating node

#### Further Comments ####

```yaml
# kubectl get service -n kube-system kube-dns -o yaml --show-managed-fields
apiVersion: v1
kind: Service
metadata:
  annotations:
    objectset.rio.cattle.io/id: ""
    objectset.rio.cattle.io/owner-gvk: k3s.cattle.io/v1, Kind=Addon
    objectset.rio.cattle.io/owner-name: coredns
    objectset.rio.cattle.io/owner-namespace: kube-system
    prometheus.io/port: "9153"
    prometheus.io/scrape: "true"
  creationTimestamp: "2021-06-10T18:40:37Z"
  labels:
    k8s-app: kube-dns
    kubernetes.io/cluster-service: "true"
    kubernetes.io/name: CoreDNS
    objectset.rio.cattle.io/hash: bce283298811743a0386ab510f2f67ef74240c57
  managedFields:
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1: {}
    manager: deploy@b90c915f9f05
    operation: Update
    time: "2021-06-10T19:17:53Z"
  name: kube-dns
  namespace: kube-system
  resourceVersion: "11836"
  uid: f65b153e-f11d-474b-b9d0-733b53e8e5f1
```