### PR TITLE
[release-1.21] Add events to deploy controller

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -188,7 +188,8 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 		servicelb.DefaultLBImage = config.ControlConfig.SystemDefaultRegistry + "/" + servicelb.DefaultLBImage
 	}
 
-	helm.Register(ctx, sc.Apply,
+	helm.Register(ctx,
+		sc.Apply,
 		sc.Helm.Helm().V1().HelmChart(),
 		sc.Helm.Helm().V1().HelmChartConfig(),
 		sc.Batch.Batch().V1().Job(),
@@ -204,7 +205,8 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 		sc.Core.Core().V1().Pod(),
 		sc.Core.Core().V1().Service(),
 		sc.Core.Core().V1().Endpoints(),
-		!config.DisableServiceLB, config.Rootless); err != nil {
+		!config.DisableServiceLB,
+		config.Rootless); err != nil {
 		return err
 	}
 
@@ -213,7 +215,10 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 	}
 
 	if config.Rootless {
-		return rootlessports.Register(ctx, sc.Core.Core().V1().Service(), !config.DisableServiceLB, config.ControlConfig.HTTPSPort)
+		return rootlessports.Register(ctx,
+			sc.Core.Core().V1().Service(),
+			!config.DisableServiceLB,
+			config.ControlConfig.HTTPSPort)
 	}
 
 	return nil
@@ -242,7 +247,11 @@ func stageFiles(ctx context.Context, sc *Context, controlConfig *config.Control)
 		return err
 	}
 
-	return deploy.WatchFiles(ctx, sc.Apply, sc.K3s.K3s().V1().Addon(), controlConfig.Disables, dataDir)
+	return deploy.WatchFiles(ctx,
+		sc.Apply,
+		sc.K3s.K3s().V1().Addon(),
+		controlConfig.Disables,
+		dataDir)
 }
 
 // registryTemplate behaves like the system_default_registry template in Rancher helm charts,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -248,6 +248,7 @@ func stageFiles(ctx context.Context, sc *Context, controlConfig *config.Control)
 	}
 
 	return deploy.WatchFiles(ctx,
+		sc.K8s,
 		sc.Apply,
 		sc.K3s.K3s().V1().Addon(),
 		controlConfig.Disables,


### PR DESCRIPTION
Proposed changes
======
* Addresses issues with visibility (were errors encountered when parsing or applying the manifest) by adding change/failure events viewable via `kubectl get events -n kube-system` or `kubectl describe addon -n kube-system <addon>`. Events are inspired by k/k event behavior for Pods, where Events are created for container pull start, container pull success/failure, etc. They should be meaningful but not spammy.

Types of changes
======
- New feature

Verification
===
Note events when describing AddOn: kubectl describe addon -n kube-system coredns`

Linked Issues
======
* #3612

This is a stripped-down version of #2169 that only adds events; it doesn't attempt to address any of the other issues with tracking who modified the resource, since this can be (minimally) accomplished with #3433

Example output
===
```
Name:         traefik
Namespace:    kube-system
Labels:       <none>
Annotations:  <none>
API Version:  k3s.cattle.io/v1
Kind:         Addon
Metadata:
  Creation Timestamp:  2020-08-27T06:33:10Z
  Generation:          1
  Resource Version:  234
  Self Link:         /apis/k3s.cattle.io/v1/namespaces/kube-system/addons/traefik
  UID:               9485676f-0e38-481b-8989-b5efe3e43f1a
Spec:
  Checksum:  6d311bade7254b59e7b2bb3838032ab2686cb92d725408092f568960973927a6
  Source:    /var/lib/repos/k3s/server/manifests/traefik.yaml
Status:
Events:
  Type    Reason            Age   From                                Message
  ----    ------            ----  ----                                -------
  Normal  ApplyingManifest  30s   deploy, dev01.lan.khaus  Applying manifest at "/var/lib/repos/k3s/server/manifests/traefik.yaml"
  Normal  AppliedManifest   30s   deploy, dev01.lan.khaus  Applied manifest at "/var/lib/repos/k3s/server/manifests/traefik.yaml"
```