### PR TITLE
fix a runtime core panic

### DIFF
--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -182,7 +182,9 @@ func (c *Cluster) deleteNodePasswdSecret(ctx context.Context) {
 			logrus.Infof("waiting for node name to be set")
 			continue
 		}
-		if c.runtime == nil {
+		// the core factory may not yet be initialized so we
+		// want to wait until it is so not to evoke a panic.
+		if c.runtime.Core == nil {
 			logrus.Infof("runtime is not yet initialized")
 			continue
 		}


### PR DESCRIPTION
A complementary fix to the pr:
https://github.com/k3s-io/k3s/pull/3422

issues:
https://github.com/rancherlabs/rancher-security/issues/501