### PR TITLE
Fix to allow prune to correctly cleanup custom named snapshots

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -41,7 +41,6 @@ import (
 )
 
 const (
-	snapshotPrefix      = "etcd-snapshot-"
 	endpoint            = "https://127.0.0.1:2379"
 	testTimeout         = time.Second * 10
 	manageTickerTime    = time.Second * 15
@@ -854,7 +853,7 @@ func (e *ETCD) Snapshot(ctx context.Context, config *config.Control) error {
 
 	// check if we need to perform a retention check
 	if e.config.EtcdSnapshotRetention >= 1 {
-		if err := snapshotRetention(e.config.EtcdSnapshotRetention, snapshotDir); err != nil {
+		if err := snapshotRetention(e.config.EtcdSnapshotRetention, e.config.EtcdSnapshotName, snapshotDir); err != nil {
 			return errors.Wrap(err, "failed to apply snapshot retention")
 		}
 	}
@@ -986,7 +985,7 @@ func (e *ETCD) PruneSnapshots(ctx context.Context) error {
 		return e.s3.snapshotRetention(ctx)
 	}
 
-	return snapshotRetention(e.config.EtcdSnapshotRetention, snapshotDir)
+	return snapshotRetention(e.config.EtcdSnapshotRetention, e.config.EtcdSnapshotName, snapshotDir)
 }
 
 // ListSnapshots is an exported wrapper method that wraps an
@@ -1206,7 +1205,7 @@ func (e *ETCD) Restore(ctx context.Context) error {
 
 // snapshotRetention iterates through the snapshots and removes the oldest
 // leaving the desired number of snapshots.
-func snapshotRetention(retention int, snapshotDir string) error {
+func snapshotRetention(retention int, snapshotPrefix string, snapshotDir string) error {
 	nodeName := os.Getenv("NODE_NAME")
 
 	var snapshotFiles []os.FileInfo
@@ -1214,7 +1213,7 @@ func snapshotRetention(retention int, snapshotDir string) error {
 		if err != nil {
 			return err
 		}
-		if strings.HasPrefix(info.Name(), snapshotPrefix+nodeName) {
+		if strings.HasPrefix(info.Name(), snapshotPrefix+"-"+nodeName) {
 			snapshotFiles = append(snapshotFiles, info)
 		}
 		return nil

--- a/pkg/etcd/s3.go
+++ b/pkg/etcd/s3.go
@@ -157,7 +157,7 @@ func (s *S3) Download(ctx context.Context) error {
 // naming of the snapshots.
 func (s *S3) snapshotPrefix() string {
 	nodeName := os.Getenv("NODE_NAME")
-	fullSnapshotPrefix := snapshotPrefix + nodeName
+	fullSnapshotPrefix := s.config.EtcdSnapshotName + "-" + nodeName
 	var prefix string
 	if s.config.EtcdS3Folder != "" {
 		prefix = filepath.Join(s.config.EtcdS3Folder, fullSnapshotPrefix)


### PR DESCRIPTION
Signed-off-by: dereknola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
This removed the hardcoded snapshotPrefix variable in `etcd.go` and instead supplies the `e.config.EtcdSnapshotName` as the  prefix to look for when pruning snapshots.

#### Types of Changes ####
Bugfix

#### Verification ####
- Start k3s with: 
`sudo ./dist/artifacts/k3s server --cluster-init --etcd-snapshot-schedule-cron "* * * * *" --etcd-snapshot-name DEADBEEF --etcd-snapshot-retention 2`
- Wait 3 minutes
- Check number of snaphshots, it should be 2
```
sudo ./dist/artifacts/k3s etcd-snapshot ls
DEADBEEF-dinux-compute-1626387000 file:///var/lib/rancher/k3s/server/db/snapshots/DEADBEEF-dinux-compute-1626387000 1835040 2021-07-15T15:10:00-07:00
DEADBEEF-dinux-compute-1626387060 file:///var/lib/rancher/k3s/server/db/snapshots/DEADBEEF-dinux-compute-1626387060 1962016 2021-07-15T15:11:00-07:00
```
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/3648
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Custom named etcd snapshots will now be cleanup by etcd-snapshot prune correctly.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
