### PR TITLE
[Release-1.20] Fix cluster reset call

### DIFF
--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -63,17 +63,18 @@ func (c *Cluster) start(ctx context.Context) error {
 		rebootstrap := func() error {
 			return c.storageBootstrap(ctx)
 		}
-		if err := c.managedDB.Reset(ctx, rebootstrap); err != nil {
-			return err
-		}
+		return c.managedDB.Reset(ctx, rebootstrap)
 	case c.config.ClusterReset:
 		if _, err := os.Stat(resetFile); err != nil {
 			if !os.IsNotExist(err) {
 				return err
 			}
-		} else {
-			return fmt.Errorf("cluster-reset was successfully performed, please remove the cluster-reset flag and start %s normally, if you need to perform another cluster reset, you must first manually delete the %s file", version.Program, resetFile)
+			rebootstrap := func() error {
+				return c.storageBootstrap(ctx)
+			}
+			return c.managedDB.Reset(ctx, rebootstrap)
 		}
+		return fmt.Errorf("cluster-reset was successfully performed, please remove the cluster-reset flag and start %s normally, if you need to perform another cluster reset, you must first manually delete the %s file", version.Program, resetFile)
 	}
 
 	if _, err := os.Stat(resetFile); err == nil {


### PR DESCRIPTION
#### Proposed Changes ####

Call managed db reset function when cluster reset flag is passed

#### Types of Changes ####

bug fix

#### Verification ####

- running k3s server --cluster-reset should work as expected and reset quorum of the cluster

#### Linked Issues ####

- https://github.com/k3s-io/k3s/issues/3651

