### PR TITLE
Adding support for waitgroup to the Startuphooks

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"context"
+	"sync"
 
 	"github.com/rancher/k3s/pkg/version"
 	"github.com/urfave/cli"
@@ -63,7 +64,7 @@ type Server struct {
 	ClusterResetRestorePath  string
 	EncryptSecrets           bool
 	SystemDefaultRegistry    string
-	StartupHooks             []func(context.Context, <-chan struct{}, string) error
+	StartupHooks             []func(context.Context, *sync.WaitGroup, <-chan struct{}, string) error
 	EtcdSnapshotName         string
 	EtcdDisableSnapshots     bool
 	EtcdExposeMetrics        bool

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"sync"
 
 	"github.com/rancher/k3s/pkg/daemons/config"
 )
@@ -12,7 +13,8 @@ type Config struct {
 	ControlConfig     config.Control
 	Rootless          bool
 	SupervisorPort    int
-	StartupHooks      []func(context.Context, <-chan struct{}, string) error
+	StartupHooks      []func(context.Context, *sync.WaitGroup, <-chan struct{}, string) error
+	StartupHooksWg    *sync.WaitGroup
 	LeaderControllers CustomControllers
 	Controllers       CustomControllers
 }


### PR DESCRIPTION
The startup hooks where executing after the deploy controller. We needed the deploy controller to wait until the startup hooks had completed.

* https://github.com/k3s-io/k3s/issues/3653
* https://github.com/rancher/rke2/issues/1301
