### PR TITLE
Adding support for waitgroup to the Startuphooks (#3654)

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"context"
+	"sync"
 
 	"github.com/rancher/k3s/pkg/version"
 	"github.com/urfave/cli"
@@ -62,7 +63,8 @@ type Server struct {
 	ClusterReset             bool
 	ClusterResetRestorePath  string
 	EncryptSecrets           bool
-	StartupHooks             []func(context.Context, <-chan struct{}, string) error
+	SystemDefaultRegistry    string
+	StartupHooks             []func(context.Context, *sync.WaitGroup, <-chan struct{}, string) error
 	EtcdSnapshotName         string
 	EtcdDisableSnapshots     bool
 	EtcdSnapshotDir          string

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -68,8 +69,10 @@ func StartServer(ctx context.Context, config *Config) error {
 		return errors.Wrap(err, "starting tls server")
 	}
 
+	config.StartupHooksWg = &sync.WaitGroup{}
+	config.StartupHooksWg.Add(len(config.StartupHooks))
 	for _, hook := range config.StartupHooks {
-		if err := hook(ctx, config.ControlConfig.Runtime.APIServerReady, config.ControlConfig.Runtime.KubeConfigAdmin); err != nil {
+		if err := hook(ctx, config.StartupHooksWg, config.ControlConfig.Runtime.APIServerReady, config.ControlConfig.Runtime.KubeConfigAdmin); err != nil {
 			return errors.Wrap(err, "startup hook")
 		}
 	}
@@ -127,6 +130,7 @@ func runControllers(ctx context.Context, config *Config) error {
 		return err
 	}
 
+	config.StartupHooksWg.Wait()
 	if err := stageFiles(ctx, sc, controlConfig); err != nil {
 		return err
 	}

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"sync"
 
 	"github.com/rancher/k3s/pkg/daemons/config"
 )
@@ -12,7 +13,8 @@ type Config struct {
 	ControlConfig     config.Control
 	Rootless          bool
 	SupervisorPort    int
-	StartupHooks      []func(context.Context, <-chan struct{}, string) error
+	StartupHooks      []func(context.Context, *sync.WaitGroup, <-chan struct{}, string) error
+	StartupHooksWg    *sync.WaitGroup
 	LeaderControllers CustomControllers
 	Controllers       CustomControllers
 }


### PR DESCRIPTION
The startup hooks where executing after the deploy controller. We needed the deploy controller to wait until the startup hooks had completed.

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/1198
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
