### PR TITLE
[release-1.21] Upgrade k3s-root version

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -5,7 +5,7 @@ cd $(dirname $0)/..
 . ./scripts/version.sh
 
 RUNC_VERSION=v1.0.0
-ROOT_VERSION=v0.8.1
+ROOT_VERSION=v0.9.1
 TRAEFIK_VERSION=9.18.2  # appVersion: 2.4.8
 CHARTS_DIR=build/static/charts
 RUNC_DIR=build/src/github.com/opencontainers/runc


### PR DESCRIPTION
Bump k3s-root to 0.9.1

Linked issue: https://github.com/k3s-io/k3s/issues/3633

Signed-off-by: Manuel Buil <mbuil@suse.com>