### PR TITLE
[Backport 1.21] Fix to allow prune to correctly cleanup custom named snapshots (#3649)

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -41,7 +41,6 @@ import (
 )
 
 const (
-	snapshotPrefix      = "etcd-snapshot-"
 	endpoint            = "https://127.0.0.1:2379"
 	testTimeout         = time.Second * 10
 	manageTickerTime    = time.Second * 15
@@ -854,7 +853,7 @@ func (e *ETCD) Snapshot(ctx context.Context, config *config.Control) error {
 
 	// check if we need to perform a retention check
 	if e.config.EtcdSnapshotRetention >= 1 {
-		if err := snapshotRetention(e.config.EtcdSnapshotRetention, snapshotDir); err != nil {
+		if err := snapshotRetention(e.config.EtcdSnapshotRetention, e.config.EtcdSnapshotName, snapshotDir); err != nil {
 			return errors.Wrap(err, "failed to apply snapshot retention")
 		}
 	}
@@ -986,7 +985,7 @@ func (e *ETCD) PruneSnapshots(ctx context.Context) error {
 		return e.s3.snapshotRetention(ctx)
 	}
 
-	return snapshotRetention(e.config.EtcdSnapshotRetention, snapshotDir)
+	return snapshotRetention(e.config.EtcdSnapshotRetention, e.config.EtcdSnapshotName, snapshotDir)
 }
 
 // ListSnapshots is an exported wrapper method that wraps an
@@ -1206,7 +1205,7 @@ func (e *ETCD) Restore(ctx context.Context) error {
 
 // snapshotRetention iterates through the snapshots and removes the oldest
 // leaving the desired number of snapshots.
-func snapshotRetention(retention int, snapshotDir string) error {
+func snapshotRetention(retention int, snapshotPrefix string, snapshotDir string) error {
 	nodeName := os.Getenv("NODE_NAME")
 
 	var snapshotFiles []os.FileInfo
@@ -1214,7 +1213,7 @@ func snapshotRetention(retention int, snapshotDir string) error {
 		if err != nil {
 			return err
 		}
-		if strings.HasPrefix(info.Name(), snapshotPrefix+nodeName) {
+		if strings.HasPrefix(info.Name(), snapshotPrefix+"-"+nodeName) {
 			snapshotFiles = append(snapshotFiles, info)
 		}
 		return nil

--- a/pkg/etcd/s3.go
+++ b/pkg/etcd/s3.go
@@ -157,7 +157,7 @@ func (s *s3) download(ctx context.Context) error {
 // naming of the snapshots.
 func (s *s3) snapshotPrefix() string {
 	nodeName := os.Getenv("NODE_NAME")
-	fullSnapshotPrefix := snapshotPrefix + nodeName
+	fullSnapshotPrefix := s.config.EtcdSnapshotName + "-" + nodeName
 	var prefix string
 	if s.config.EtcdS3Folder != "" {
 		prefix = filepath.Join(s.config.EtcdS3Folder, fullSnapshotPrefix)


### PR DESCRIPTION
- Backported fix for prune to work on custom names snapshots

Signed-off-by: dereknola <derek.nola@suse.com>

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/3670
Original Issue: https://github.com/k3s-io/k3s/issues/3648
Original PR: https://github.com/k3s-io/k3s/pull/3649

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
