### PR TITLE
Fix multiple bootstrap keys found

### DIFF
--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -226,5 +226,8 @@ func doMigrateToken(ctx context.Context, storageClient client.Client, keyValue c
 	}
 	logrus.Infof("created bootstrap key %s", newTokenKey)
 	// deleting the old key
-	return storageClient.Delete(ctx, oldTokenKey, keyValue.Modified)
+	if err := storageClient.Delete(ctx, oldTokenKey, keyValue.Modified); err != nil {
+		logrus.Warnf("failed to delete old bootstrap key %s", oldTokenKey)
+	}
+	return nil
 }

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -54,7 +54,7 @@ func (c *Cluster) save(ctx context.Context) error {
 
 	if err := storageClient.Create(ctx, storageKey(normalizedToken), data); err != nil {
 		if err.Error() == "key exists" {
-			logrus.Warnln("bootstrap key exists; please follow documentation on updating a node after snapshot restore")
+			logrus.Warnln("bootstrap key already exists")
 			return nil
 		} else if strings.Contains(err.Error(), "not supported for learner") {
 			logrus.Debug("skipping bootstrap data save on learner")

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -216,7 +216,7 @@ func doMigrateToken(ctx context.Context, storageClient client.Client, keyValue c
 	// saving the new encrypted data with the right token key
 	if err := storageClient.Create(ctx, newTokenKey, encryptedData); err != nil {
 		if err.Error() == "key exists" {
-			logrus.Warnln("bootstrap key exists")
+			logrus.Warn("bootstrap key exists")
 		} else if strings.Contains(err.Error(), "not supported for learner") {
 			logrus.Debug("skipping bootstrap data save on learner")
 			return nil

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -142,7 +142,7 @@ func (c *Cluster) getBootstrapKeyFromStorage(ctx context.Context, storageClient 
 		return nil, err
 	}
 	for _, bootstrapKV := range bootstrapList {
-		// checking for empty string bootstrap key
+		// ensure bootstrap is stored in the current token's key
 		if string(bootstrapKV.Key) == tokenKey {
 			return &bootstrapKV, nil
 		}


### PR DESCRIPTION
Signed-off-by: galal-hussein <hussein.galal.ahmed.11@gmail.com>

change the return error when multiple keys are found to a warning
loop over the keys and delete the empty string key only

#### Types of Changes ####

bugfix


#### Linked Issues ####
* https://github.com/rancher/rke2/issues/1401

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

