### PR TITLE
Wait until server is ready before configuring kube-proxy

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -614,7 +614,10 @@ func getKubeProxyDisabled(ctx context.Context, node *config.Node, proxy proxy.Pr
 		return false, err
 	}
 
-	if err := getReadyz(info); err != nil {
+	// 500 error indicates that the health check has failed; other errors (for example 401 Unauthorized)
+	// indicate that the server is down-level and doesn't support readyz, so we should just use whatever
+	// the server has for us.
+	if err := getReadyz(info); err != nil && strings.HasSuffix(err.Error(), "500 Internal Server Error") {
 		return false, err
 	}
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -327,14 +327,22 @@ func updateAddressAnnotations(agentConfig *daemonconfig.Agent, nodeAnnotations m
 // start the agent before the tunnel is setup to allow kubelet to start first and start the pods
 func setupTunnelAndRunAgent(ctx context.Context, nodeConfig *daemonconfig.Node, cfg cmds.Agent, proxy proxy.Proxy) error {
 	var agentRan bool
+	// IsAPIServerLBEnabled is used as a shortcut for detecting RKE2, where the kubelet needs to
+	// be run earlier in order to manage static pods. This should probably instead query a
+	// flag on the executor or something.
 	if cfg.ETCDAgent {
-		// only in rke2 run the agent before the tunnel setup and check for that later in the function
+		// ETCDAgent is only set to true on servers that are started with --disable-apiserver.
+		// In this case, we may be running without an apiserver available in the cluster, and need
+		// to wait for one to register and post it's address into APIAddressCh so that we can update
+		// the LB proxy with its address.
 		if proxy.IsAPIServerLBEnabled() {
-			if err := agent.Agent(&nodeConfig.AgentConfig); err != nil {
+			// On RKE2, the agent needs to be started early to run the etcd static pod.
+			if err := agent.Agent(ctx, nodeConfig, proxy); err != nil {
 				return err
 			}
 			agentRan = true
 		}
+
 		select {
 		case address := <-cfg.APIAddressCh:
 			cfg.ServerURL = address
@@ -347,7 +355,9 @@ func setupTunnelAndRunAgent(ctx context.Context, nodeConfig *daemonconfig.Node, 
 			return ctx.Err()
 		}
 	} else if cfg.ClusterReset && proxy.IsAPIServerLBEnabled() {
-		if err := agent.Agent(&nodeConfig.AgentConfig); err != nil {
+		// If we're doing a cluster-reset on RKE2, the kubelet needs to be started early to clean
+		// up static pods.
+		if err := agent.Agent(ctx, nodeConfig, proxy); err != nil {
 			return err
 		}
 		agentRan = true
@@ -357,7 +367,7 @@ func setupTunnelAndRunAgent(ctx context.Context, nodeConfig *daemonconfig.Node, 
 		return err
 	}
 	if !agentRan {
-		return agent.Agent(&nodeConfig.AgentConfig)
+		return agent.Agent(ctx, nodeConfig, proxy)
 	}
 	return nil
 }

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -31,7 +31,7 @@ func Agent(ctx context.Context, nodeConfig *daemonconfig.Node, proxy proxy.Proxy
 	}
 
 	go func() {
-		if !config.GetKubeProxyDisabled(ctx, nodeConfig, proxy) {
+		if !config.KubeProxyDisabled(ctx, nodeConfig, proxy) {
 			if err := startKubeProxy(&nodeConfig.AgentConfig); err != nil {
 				logrus.Fatalf("Failed to start kube-proxy: %v", err)
 			}

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -1,11 +1,14 @@
 package agent
 
 import (
+	"context"
 	"math/rand"
 	"os"
 	"time"
 
-	"github.com/rancher/k3s/pkg/daemons/config"
+	"github.com/rancher/k3s/pkg/agent/config"
+	"github.com/rancher/k3s/pkg/agent/proxy"
+	daemonconfig "github.com/rancher/k3s/pkg/daemons/config"
 	"github.com/rancher/k3s/pkg/daemons/executor"
 	"github.com/sirupsen/logrus"
 	"k8s.io/component-base/logs"
@@ -18,34 +21,38 @@ const (
 	windowsPrefix = "npipe://"
 )
 
-func Agent(config *config.Agent) error {
+func Agent(ctx context.Context, nodeConfig *daemonconfig.Node, proxy proxy.Proxy) error {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	logs.InitLogs()
 	defer logs.FlushLogs()
-	if err := startKubelet(config); err != nil {
+	if err := startKubelet(&nodeConfig.AgentConfig); err != nil {
 		return err
 	}
 
-	if !config.DisableKubeProxy {
-		return startKubeProxy(config)
-	}
+	go func() {
+		if !config.GetKubeProxyDisabled(ctx, nodeConfig, proxy) {
+			if err := startKubeProxy(&nodeConfig.AgentConfig); err != nil {
+				logrus.Fatalf("Failed to start kube-proxy: %v", err)
+			}
+		}
+	}()
 
 	return nil
 }
 
-func startKubeProxy(cfg *config.Agent) error {
+func startKubeProxy(cfg *daemonconfig.Agent) error {
 	argsMap := kubeProxyArgs(cfg)
-	args := config.GetArgsList(argsMap, cfg.ExtraKubeProxyArgs)
-	logrus.Infof("Running kube-proxy %s", config.ArgString(args))
+	args := daemonconfig.GetArgsList(argsMap, cfg.ExtraKubeProxyArgs)
+	logrus.Infof("Running kube-proxy %s", daemonconfig.ArgString(args))
 	return executor.KubeProxy(args)
 }
 
-func startKubelet(cfg *config.Agent) error {
+func startKubelet(cfg *daemonconfig.Agent) error {
 	argsMap := kubeletArgs(cfg)
 
-	args := config.GetArgsList(argsMap, cfg.ExtraKubeletArgs)
-	logrus.Infof("Running kubelet %s", config.ArgString(args))
+	args := daemonconfig.GetArgsList(argsMap, cfg.ExtraKubeletArgs)
+	logrus.Infof("Running kubelet %s", daemonconfig.ArgString(args))
 
 	return executor.Kubelet(args)
 }
@@ -59,7 +66,7 @@ func addFeatureGate(current, new string) string {
 
 // ImageCredProvAvailable checks to see if the kubelet image credential provider bin dir and config
 // files exist and are of the correct types. This is exported so that it may be used by downstream projects.
-func ImageCredProvAvailable(cfg *config.Agent) bool {
+func ImageCredProvAvailable(cfg *daemonconfig.Agent) bool {
 	if info, err := os.Stat(cfg.ImageCredProvBinDir); err != nil || !info.IsDir() {
 		logrus.Debugf("Kubelet image credential provider bin directory check failed: %v", err)
 		return false

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -36,7 +36,7 @@ type Node struct {
 	Containerd               Containerd
 	Images                   string
 	AgentConfig              Agent
-	CACerts                  []byte
+	Token                    string
 	Certificate              *tls.Certificate
 	ServerHTTPSPort          int
 }
@@ -96,7 +96,6 @@ type Agent struct {
 	AirgapExtraRegistry     []string
 	DisableCCM              bool
 	DisableNPC              bool
-	DisableKubeProxy        bool
 	Rootless                bool
 	ProtectKernelDefaults   bool
 }

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -46,6 +46,7 @@ func router(ctx context.Context, config *Config) http.Handler {
 	authed.Path(prefix + "/client-ca.crt").Handler(fileHandler(serverConfig.Runtime.ClientCA))
 	authed.Path(prefix + "/server-ca.crt").Handler(fileHandler(serverConfig.Runtime.ServerCA))
 	authed.Path(prefix + "/config").Handler(configHandler(serverConfig))
+	authed.Path(prefix + "/readyz").Handler(readyzHandler(serverConfig))
 
 	nodeAuthed := mux.NewRouter()
 	nodeAuthed.Use(authMiddleware(serverConfig, "system:nodes"))
@@ -263,6 +264,21 @@ func configHandler(server *config.Control) http.Handler {
 		}
 		resp.Header().Set("content-type", "application/json")
 		json.NewEncoder(resp).Encode(server)
+	})
+}
+
+func readyzHandler(server *config.Control) http.Handler {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		code := http.StatusOK
+		data := []byte("ok")
+		if server.Runtime.Core == nil {
+			code = http.StatusInternalServerError
+			data = []byte("runtime core not ready")
+		}
+		resp.WriteHeader(code)
+		resp.Header().Set("Content-Type", "text/plain")
+		resp.Header().Set("Content-length", strconv.Itoa(len(data)))
+		resp.Write(data)
 	})
 }
 


### PR DESCRIPTION
#### Proposed Changes ####

* Add a /v1-k3s/readyz endpoint to the server to indicate when runtime.core is available; this occurs after all startup hooks are complete and should be a good checkpoint for having the final system configuration in place.
* Remove KubeProxyDisabled from config.Agent; replace it with a blocking function call that waits for the server readyz to return health before retrieving just this one bit of config.
* Move startKubeProxy into a goroutine that blocks until the server is ready to tell the agent whether or not it should run kube-proxy

#### Types of Changes ####

bugfix 

#### Verification ####

Start RKE2 with rke2-kube-proxy HelmChartConfig present; note that the kube-proxy static pod does not start

#### Linked Issues ####

rancher/rke2#1455

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

This feels ugly but I don't see another good way around it.

We need to retrieve MOST of the system configuration from the server prior to starting the agent (kubelet), but we're allowing RKE2's startup hook to [mutate the DisableKubeProxy](https://github.com/rancher/rke2/blob/master/pkg/rke2/kp.go#L46) field after the kubelet is started, so we need to defer using that bit of configuration agent-side until after the server startup has completed.