### PR TITLE
Sync DisableKubeProxy into control struct

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -49,7 +49,7 @@ RETRY:
 	for {
 		agentConfig, err := get(ctx, &agent, proxy)
 		if err != nil {
-			logrus.Infof("Failed to retrieve agent configuration: %v", err)
+			logrus.Infof("Waiting to retrieve agent configuration; server is not ready: %v", err)
 			for range ticker.C {
 				continue RETRY
 			}
@@ -69,7 +69,7 @@ RETRY:
 	for {
 		disabled, err := getKubeProxyDisabled(ctx, node, proxy)
 		if err != nil {
-			logrus.Infof("Failed to retrieve kube-proxy configuration: %v", err)
+			logrus.Infof("Waiting to retrieve kube-proxy configuration; server is not ready: %v", err)
 			for range ticker.C {
 				continue RETRY
 			}

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -368,7 +368,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 
 	ctx := signals.SetupSignalHandler(context.Background())
 
-	if err := server.StartServer(ctx, &serverConfig); err != nil {
+	if err := server.StartServer(ctx, &serverConfig, cfg); err != nil {
 		return err
 	}
 

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	certutil "github.com/rancher/dynamiclistener/cert"
 	"github.com/rancher/k3s/pkg/bootstrap"
+	"github.com/rancher/k3s/pkg/cli/cmds"
 	"github.com/rancher/k3s/pkg/daemons/config"
 	"github.com/rancher/k3s/pkg/nodepassword"
 	"github.com/rancher/k3s/pkg/version"
@@ -31,7 +32,7 @@ const (
 	staticURL = "/static/"
 )
 
-func router(ctx context.Context, config *Config) http.Handler {
+func router(ctx context.Context, config *Config, cfg *cmds.Server) http.Handler {
 	serverConfig := &config.ControlConfig
 	nodeAuth := passwordBootstrap(ctx, config)
 
@@ -45,7 +46,7 @@ func router(ctx context.Context, config *Config) http.Handler {
 	authed.Path(prefix + "/client-" + version.Program + "-controller.crt").Handler(fileHandler(serverConfig.Runtime.ClientK3sControllerCert, serverConfig.Runtime.ClientK3sControllerKey))
 	authed.Path(prefix + "/client-ca.crt").Handler(fileHandler(serverConfig.Runtime.ClientCA))
 	authed.Path(prefix + "/server-ca.crt").Handler(fileHandler(serverConfig.Runtime.ServerCA))
-	authed.Path(prefix + "/config").Handler(configHandler(serverConfig))
+	authed.Path(prefix + "/config").Handler(configHandler(serverConfig, cfg))
 	authed.Path(prefix + "/readyz").Handler(readyzHandler(serverConfig))
 
 	nodeAuthed := mux.NewRouter()
@@ -256,12 +257,17 @@ func fileHandler(fileName ...string) http.Handler {
 	})
 }
 
-func configHandler(server *config.Control) http.Handler {
+func configHandler(server *config.Control, cfg *cmds.Server) http.Handler {
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if req.TLS == nil {
 			resp.WriteHeader(http.StatusNotFound)
 			return
 		}
+		// Startup hooks may read and modify cmds.Server in a goroutine, but as these are copied into
+		// config.Control before the startup hooks are called, any modifications need to be sync'd back
+		// into the struct before it is sent to agents.
+		// At this time we don't sync all the fields, just those known to be touched by startup hooks.
+		server.DisableKubeProxy = cfg.DisableKubeProxy
 		resp.Header().Set("content-type", "application/json")
 		json.NewEncoder(resp).Encode(server)
 	})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -49,7 +49,7 @@ func ResolveDataDir(dataDir string) (string, error) {
 	return filepath.Join(dataDir, "server"), err
 }
 
-func StartServer(ctx context.Context, config *Config) error {
+func StartServer(ctx context.Context, config *Config, cfg *cmds.Server) error {
 	if err := setupDataDirAndChdir(&config.ControlConfig); err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func StartServer(ctx context.Context, config *Config) error {
 	wg := &sync.WaitGroup{}
 	wg.Add(len(config.StartupHooks))
 
-	config.ControlConfig.Runtime.Handler = router(ctx, config)
+	config.ControlConfig.Runtime.Handler = router(ctx, config, cfg)
 	shArgs := cmds.StartupHookArgs{
 		APIServerReady:  config.ControlConfig.Runtime.APIServerReady,
 		KubeConfigAdmin: config.ControlConfig.Runtime.KubeConfigAdmin,


### PR DESCRIPTION
#### Proposed Changes ####

Sync DisableKubeProxy from cfg into control before sending control to clients, as it may have been modified by a startup hook.

This is a follow-up to #3716 - I missed the fact that the RKE2 startup hooks only have access to cfg.

#### Types of Changes ####

Bugfix

#### Verification ####

Normal tests in K3s; not really needed here.
Will need to be tested in RKE2 when pulled through.

#### Linked Issues ####

* #3725

#### User-Facing Change ####
```release-note

```

#### Further Comments ####
Thanks @dweomer for talking this through with me
