### PR TITLE
Add in stalebot config, starting with 6mo old stale issues.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,48 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 180
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 14
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - internal
+  - kind/bug
+  - kind/bug-qa
+  - kind/task
+  - kind/feature
+  - kind/design
+  - kind/ci-improvements
+  - kind/performance
+  - kind/flaky-test
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true
+
+# Label to use when marking as stale
+staleLabel: status/stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This repository uses a bot to automatically label issues which have not had any activity (commit/comment/label) 
+  for 180 days. This helps us manage the community issues better. If the issue is still relevant, please add a comment to the 
+  issue so the bot can remove the label and we know it is still valid. If it is no longer relevant (or possibly fixed in the 
+  latest release), the bot will automatically close the issue in 14 days. Thank you for your contributions.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues`
+only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -26,7 +26,7 @@ exemptLabels:
 exemptProjects: true
 
 # Set to true to ignore issues in a milestone (defaults to false)
-exemptMilestones: true
+exemptMilestones: false
 
 # Set to true to ignore issues with an assignee (defaults to false)
 exemptAssignees: true

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,6 +17,7 @@ exemptLabels:
   - kind/bug-qa
   - kind/task
   - kind/feature
+  - kind/enhancement
   - kind/design
   - kind/ci-improvements
   - kind/performance


### PR DESCRIPTION
Signed-off-by: Chris Wayne <cwayne18@gmail.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Add in a sensible start for stalebot, closing only issues not on the project board, after 180 days of inactivity.  We can start here and pare down pending community response.

#### Types of Changes ####

Bot yaml config addition

#### Verification ####

Check that .github/stale.yaml is sensible

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/3478

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
