### PR TITLE
Wrap context with lease before importing images

### DIFF
--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/reference/docker"
+	"github.com/containerd/cri/pkg/constants"
 	"github.com/klauspost/compress/zstd"
 	"github.com/natefinch/lumberjack"
 	"github.com/pierrec/lz4"
@@ -155,9 +156,9 @@ func preloadImages(ctx context.Context, cfg *config.Node) error {
 	}
 	defer criConn.Close()
 
-	// Ensure that nothing else can modify the image store while we're importing,
-	// and that our images are imported into the k8s.io namespace
-	ctx = namespaces.WithNamespace(ctx, "k8s.io")
+	// Ensure that our images are imported into the correct namespace
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
+
 	// At startup all leases from k3s are cleared
 	ls := client.LeasesService()
 	existingLeases, err := ls.List(ctx)
@@ -173,10 +174,13 @@ func preloadImages(ctx context.Context, cfg *config.Node) error {
 	}
 
 	// Any images found on import are given a lease that never expires
-	_, err = ls.Create(ctx, leases.WithID(version.Program))
+	lease, err := ls.Create(ctx, leases.WithID(version.Program))
 	if err != nil {
 		return err
 	}
+
+	// Ensure that our images are locked by the lease
+	ctx = leases.WithLease(ctx, lease.ID)
 
 	for _, fileInfo := range fileInfos {
 		if fileInfo.IsDir() {


### PR DESCRIPTION
#### Proposed Changes ####

Wrap context with lease before importing images

#### Types of Changes ####

Bugfix

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

There does not appear to be any way to verify that the image content is reference from the lease using `ctr`. I used [boltbrowser](https://github.com/br0xen/boltbrowser) to ensure that the lease references image content following this change - while k3s is stopped, you can run `boltbrowser -ro /var/lib/rancher/k3s/agent/containerd/io.containerd.metadata.v1.bolt/meta.db` and browse to `v1/k8s.io/leases/k3s/content`.

#### Linked Issues ####

* #3752 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Images imported from airgap tarballs are now properly lease-locked to prevent garbage collection
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
