### PR TITLE
[release-1.20] Bump helm-controller to v0.10.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/k3s-io/helm-controller v0.8.3
+	github.com/k3s-io/helm-controller v0.10.3
 	github.com/k3s-io/kine v0.6.2
 	github.com/klauspost/compress v1.12.2
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -520,8 +520,8 @@ github.com/k3s-io/go-powershell v0.0.0-20200701182037-6845e6fcfa79 h1:9naOL3iARE
 github.com/k3s-io/go-powershell v0.0.0-20200701182037-6845e6fcfa79/go.mod h1:lsDHcxq5ugFJff6YHEwpzLh31NDv0B2cIKki1ViQ65o=
 github.com/k3s-io/go-powershell v0.0.0-20201118222746-51f4c451fbd7 h1:C+6IIP6yECS10qkq2EeGQjr2ts0k7UxrutGF+pLPSnU=
 github.com/k3s-io/go-powershell v0.0.0-20201118222746-51f4c451fbd7/go.mod h1:wJnuh+xbDmskSfAM3UikTsGO8kaWLu3iycSgUKAiYjQ=
-github.com/k3s-io/helm-controller v0.8.3 h1:GWxavyMz7Bw2ClxH5okkeOL8o5U6IBK7uauc44SDCjU=
-github.com/k3s-io/helm-controller v0.8.3/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
+github.com/k3s-io/helm-controller v0.10.3 h1:P4VK98VzTSjReQfmjOk0se437dWbdqIRVfuXFNoR6/8=
+github.com/k3s-io/helm-controller v0.10.3/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
 github.com/k3s-io/kine v0.6.2 h1:1aJTPfB8HG4exqMKFVE5H0z4bepF05tJHtYNXotWXa4=
 github.com/k3s-io/kine v0.6.2/go.mod h1:rzCs93+rQHZGOiewMd84PDrER92QeZ6eeHbWkfEy4+w=
 github.com/k3s-io/kubernetes v1.20.9-k3s1 h1:4wMCFw3JKCP02PRlSpSuM3ydpiHrotfY265n8wE/7UQ=

--- a/pkg/servicelb/controller.go
+++ b/pkg/servicelb/controller.go
@@ -34,7 +34,7 @@ var (
 )
 
 const (
-	image = "rancher/klipper-lb:v0.1.2"
+	image = "rancher/klipper-lb:v0.2.0"
 	Ready = condition.Cond("Ready")
 )
 

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,6 +1,6 @@
 docker.io/rancher/coredns-coredns:1.8.3
-docker.io/rancher/klipper-helm:v0.4.3
-docker.io/rancher/klipper-lb:v0.1.2
+docker.io/rancher/klipper-helm:v0.6.3-build20210804
+docker.io/rancher/klipper-lb:v0.2.0
 docker.io/rancher/library-busybox:1.32.1
 docker.io/rancher/library-traefik:1.7.19
 docker.io/rancher/local-path-provisioner:v0.0.19

--- a/vendor/github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1/types.go
+++ b/vendor/github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1/types.go
@@ -27,6 +27,7 @@ type HelmChartSpec struct {
 	Bootstrap       bool                          `json:"bootstrap,omitempty"`
 	ChartContent    string                        `json:"chartContent,omitempty"`
 	JobImage        string                        `json:"jobImage,omitempty"`
+	Timeout         *metav1.Duration              `json:"timeout,omitempty"`
 }
 
 type HelmChartStatus struct {

--- a/vendor/github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1/zz_generated_deepcopy.go
+++ b/vendor/github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1/zz_generated_deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -171,6 +172,11 @@ func (in *HelmChartSpec) DeepCopyInto(out *HelmChartSpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		*out = new(metav1.Duration)
+		**out = **in
 	}
 	return
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -686,7 +686,7 @@ github.com/json-iterator/go
 # github.com/k3s-io/go-powershell v0.0.0-20200701182037-6845e6fcfa79
 github.com/k3s-io/go-powershell/backend
 github.com/k3s-io/go-powershell/utils
-# github.com/k3s-io/helm-controller v0.8.3
+# github.com/k3s-io/helm-controller v0.10.3
 ## explicit
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1


### PR DESCRIPTION
#### Proposed Changes ####

Bump klipper-helm and klipper-lb image versions.

The klipper-lb version bump brings this in line with other branches which were updated as part of the k3s-io move.

#### Types of Changes ####

version bump

#### Verification ####

Check image version on running cluster

#### Linked Issues ####

* #3760

#### User-Facing Change ####

```release-note
The embedded Helm version has been updated to v3.6.3
```

#### Further Comments ####
