### PR TITLE
[Release-1.19] fix Node stuck at deletion

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -35,6 +35,10 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 )
 
+const (
+	memberRemovalTimeout = time.Minute * 1
+)
+
 type ETCD struct {
 	client  *etcd.Client
 	config  *config.Control
@@ -535,6 +539,8 @@ func (e *ETCD) cluster(ctx context.Context, forceNew bool, options executor.Init
 
 // removePeer removes a peer from the cluster. The peer ID and IP address must both match.
 func (e *ETCD) removePeer(ctx context.Context, id, address string, removeSelf bool) error {
+	ctx, cancel := context.WithTimeout(ctx, memberRemovalTimeout)
+	defer cancel()
 	members, err := e.client.MemberList(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: galal-hussein <hussein.galal.ahmed.11@gmail.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Add a context timeout for the etcd remove peer function

#### Types of Changes ####

bug fix

#### Verification ####

- create cluster with 3 server nodes and etcd backend
- delete one of the nodes using kubectl delete node

node should be deleted normally from the node list

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/3774

#### Further Comments ####

The issue is not always reproducible
