### PR TITLE
account for an s3 folder when listing objects

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -904,11 +904,10 @@ func (e *ETCD) listSnapshots(ctx context.Context, snapshotDir string) ([]Snapsho
 			return nil, err
 		}
 
-		s3FolderInUse := e.config.EtcdS3Folder != ""
-
 		var loo minio.ListObjectsOptions
-		if s3FolderInUse {
+		if e.config.EtcdS3Folder != "" {
 			loo = minio.ListObjectsOptions{
+				Prefix:    e.config.EtcdS3Folder,
 				Recursive: true,
 			}
 		}
@@ -921,12 +920,6 @@ func (e *ETCD) listSnapshots(ctx context.Context, snapshotDir string) ([]Snapsho
 			}
 			if obj.Size == 0 {
 				continue
-			}
-
-			if s3FolderInUse {
-				if !strings.Contains(obj.Key, e.config.EtcdS3Folder) {
-					continue
-				}
 			}
 
 			ca, err := time.Parse(time.RFC3339, obj.LastModified.Format(time.RFC3339))


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Additional logic needed to be added to account for the use of folders within AWS S3 buckets in the "list snapshots" routine.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Run the command below and verify that what is listed in the ConfigMap is what's in the AWS folder. 

```sh
kubectl get cm -n kube-system k3s-etcd-snapshots -o yaml 
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/rancher/rke2/issues/1551

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
