### PR TITLE
Updated the code to use GetNetworkByName and tweaked logic.

### DIFF
--- a/pkg/daemons/agent/agent_windows.go
+++ b/pkg/daemons/agent/agent_windows.go
@@ -133,12 +133,15 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 
 func waitForManagementIp(networkName string) string {
 	for range time.Tick(time.Second * 5) {
-		network, err := hcsshim.GetHNSEndpointByName(networkName)
+		network, err := hcsshim.GetHNSNetworkByName(networkName)
 		if err != nil {
-			logrus.WithError(err).Warning("can't find HNS endpoint for network, retrying", networkName)
+			logrus.WithError(err).Warning("can't find HNS network, retrying", networkName)
 			continue
 		}
-		return network.IPAddress.String()
+		if network.ManagementIP == "" {
+			continue
+		}
+		return network.ManagementIP
 	}
 	return ""
 }


### PR DESCRIPTION
Updated the method being called and tweaked the logic.

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

The waitManagementIP function in pkg/daemons/agent/agent_windows.go is calling the incorrect HNS function. It is calling GetHNSEndpointByName instead of calling GetHNSNetworkByName.

#### Types of Changes ####

Bugfix

#### Verification ####

Deploy a  windows cluster and ensure that the following doesn't appear in the log files.

```
time="2021-08-10T08:40:17-07:00" level=warning msg="can't find HNS endpoint for network, retryingExternal" error="Endpoint External not found"
```

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/3817

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
