### PR TITLE
[release-1.21] Fix URL pruning when joining an etcd member

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -746,8 +746,12 @@ members:
 		if member.IsLearner {
 			continue
 		}
-		for _, url := range member.ClientURLs {
-			if strings.Contains(url, ip) {
+		for _, clientURL := range member.ClientURLs {
+			u, err := url.Parse(clientURL)
+			if err != nil {
+				continue
+			}
+			if u.Hostname() == ip {
 				continue members
 			}
 		}


### PR DESCRIPTION
Problem:
Existing member clientURLs were checked if they contain the joining
node's IP. In some edge cases this would prune valid URLs when the
joining IP is a substring match of the only existing member's IP.
Because of this, it was impossible to e.g. join 10.0.0.2 to an existing
node that has an IP of 10.0.0.2X or 10.0.0.2XX:

level=fatal msg="starting kubernetes: preparing server: start managed database:
joining etcd cluster: etcdclient: no available endpoints"

Solution:
Fixed by properly parsing the URLs and comparing the IPs for equality
instead of substring match.

Signed-off-by: Malte Starostik <info@stellaware.de>

#### Proposed Changes ####
When joining an etcd node, only discard an existing node's clientURL if it's strictly the same address as opposed to a substring match.

#### Types of Changes ####
Bugfix

#### Verification ####
Try to join (etcd role) 10.0.0.2 to --cluster-init'ed node with 10.0.0.255

#### Linked Issues ####
* #3833

#### User-Facing Change ####
```
NONE
```

#### Further Comments ####
N/A