### PR TITLE
[release-1.21] Bump helm-controller to work around tiller crashes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/k3s-io/helm-controller v0.10.3
+	github.com/k3s-io/helm-controller v0.10.5
 	github.com/k3s-io/kine v0.6.2
 	github.com/klauspost/compress v1.12.2
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -534,8 +534,8 @@ github.com/k3s-io/cri-tools v1.21.0-k3s1 h1:MWQtAsx4HCNXenqU/B4V9eU6HMyafkd1PnW6
 github.com/k3s-io/cri-tools v1.21.0-k3s1/go.mod h1:Qsz54zxINPR+WVWX9Kc3CTmuDFB1dNLCNV8jE8lUbtU=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea h1:7cwby0GoNAi8IsVrT0q+JfQpB6V76ZaEGhj6qts/mvU=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
-github.com/k3s-io/helm-controller v0.10.3 h1:P4VK98VzTSjReQfmjOk0se437dWbdqIRVfuXFNoR6/8=
-github.com/k3s-io/helm-controller v0.10.3/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
+github.com/k3s-io/helm-controller v0.10.5 h1:zrStmx4ZkhtFU/OqJYoAZFGFB1Bu+jZs0N8dtlVRxDk=
+github.com/k3s-io/helm-controller v0.10.5/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
 github.com/k3s-io/kine v0.6.2 h1:1aJTPfB8HG4exqMKFVE5H0z4bepF05tJHtYNXotWXa4=
 github.com/k3s-io/kine v0.6.2/go.mod h1:rzCs93+rQHZGOiewMd84PDrER92QeZ6eeHbWkfEy4+w=
 github.com/k3s-io/kubernetes v1.21.3-k3s1 h1:tx3stNWTT1dcAh47pS06oEqOS7APkOtAW8KKjU/USno=

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,5 +1,5 @@
 docker.io/rancher/coredns-coredns:1.8.3
-docker.io/rancher/klipper-helm:v0.6.3-build20210804
+docker.io/rancher/klipper-helm:v0.6.4-build20210813
 docker.io/rancher/klipper-lb:v0.2.0
 docker.io/rancher/library-busybox:1.32.1
 docker.io/rancher/library-traefik:2.4.8

--- a/vendor/github.com/k3s-io/helm-controller/pkg/helm/controller.go
+++ b/vendor/github.com/k3s-io/helm-controller/pkg/helm/controller.go
@@ -30,7 +30,7 @@ import (
 var (
 	trueVal         = true
 	commaRE         = regexp.MustCompile(`\\*,`)
-	DefaultJobImage = "rancher/klipper-helm:v0.6.3-build20210804"
+	DefaultJobImage = "rancher/klipper-helm:v0.6.4-build20210813"
 )
 
 type Controller struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -700,7 +700,7 @@ github.com/jmespath/go-jmespath
 github.com/jonboulle/clockwork
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
-# github.com/k3s-io/helm-controller v0.10.3
+# github.com/k3s-io/helm-controller v0.10.5
 ## explicit
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1


### PR DESCRIPTION
#### Proposed Changes ####

Bump helm-controller to work around tiller crashes

#### Types of Changes ####

bugfix

#### Verification ####

Check klipper-helm image version

#### Linked Issues ####

* #3844

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The embedded Helm controller should no longer hang while checking for Helm v2 releases
```

#### Further Comments ####

Waiting merge and tag of
* https://github.com/k3s-io/helm-controller/pull/114
