### PR TITLE
[release-1.20] Bump helm-controller to work around tiller crashes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/k3s-io/helm-controller v0.10.3
+	github.com/k3s-io/helm-controller v0.10.5
 	github.com/k3s-io/kine v0.6.2
 	github.com/klauspost/compress v1.12.2
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -520,8 +520,8 @@ github.com/k3s-io/go-powershell v0.0.0-20200701182037-6845e6fcfa79 h1:9naOL3iARE
 github.com/k3s-io/go-powershell v0.0.0-20200701182037-6845e6fcfa79/go.mod h1:lsDHcxq5ugFJff6YHEwpzLh31NDv0B2cIKki1ViQ65o=
 github.com/k3s-io/go-powershell v0.0.0-20201118222746-51f4c451fbd7 h1:C+6IIP6yECS10qkq2EeGQjr2ts0k7UxrutGF+pLPSnU=
 github.com/k3s-io/go-powershell v0.0.0-20201118222746-51f4c451fbd7/go.mod h1:wJnuh+xbDmskSfAM3UikTsGO8kaWLu3iycSgUKAiYjQ=
-github.com/k3s-io/helm-controller v0.10.3 h1:P4VK98VzTSjReQfmjOk0se437dWbdqIRVfuXFNoR6/8=
-github.com/k3s-io/helm-controller v0.10.3/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
+github.com/k3s-io/helm-controller v0.10.5 h1:zrStmx4ZkhtFU/OqJYoAZFGFB1Bu+jZs0N8dtlVRxDk=
+github.com/k3s-io/helm-controller v0.10.5/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
 github.com/k3s-io/kine v0.6.2 h1:1aJTPfB8HG4exqMKFVE5H0z4bepF05tJHtYNXotWXa4=
 github.com/k3s-io/kine v0.6.2/go.mod h1:rzCs93+rQHZGOiewMd84PDrER92QeZ6eeHbWkfEy4+w=
 github.com/k3s-io/kubernetes v1.20.9-k3s1 h1:4wMCFw3JKCP02PRlSpSuM3ydpiHrotfY265n8wE/7UQ=

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,5 +1,5 @@
 docker.io/rancher/coredns-coredns:1.8.3
-docker.io/rancher/klipper-helm:v0.6.3-build20210804
+docker.io/rancher/klipper-helm:v0.6.4-build20210813
 docker.io/rancher/klipper-lb:v0.2.0
 docker.io/rancher/library-busybox:1.32.1
 docker.io/rancher/library-traefik:1.7.19

--- a/vendor/github.com/k3s-io/helm-controller/pkg/helm/controller.go
+++ b/vendor/github.com/k3s-io/helm-controller/pkg/helm/controller.go
@@ -30,7 +30,7 @@ import (
 var (
 	trueVal         = true
 	commaRE         = regexp.MustCompile(`\\*,`)
-	DefaultJobImage = "rancher/klipper-helm:v0.6.3-build20210804"
+	DefaultJobImage = "rancher/klipper-helm:v0.6.4-build20210813"
 )
 
 type Controller struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -686,7 +686,7 @@ github.com/json-iterator/go
 # github.com/k3s-io/go-powershell v0.0.0-20200701182037-6845e6fcfa79
 github.com/k3s-io/go-powershell/backend
 github.com/k3s-io/go-powershell/utils
-# github.com/k3s-io/helm-controller v0.10.3
+# github.com/k3s-io/helm-controller v0.10.5
 ## explicit
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1


### PR DESCRIPTION
#### Proposed Changes ####

Bump helm-controller to work around tiller crashes

#### Types of Changes ####

bugfix

#### Verification ####

Check klipper-helm image version

#### Linked Issues ####

* #3845

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The embedded Helm controller should no longer hang while checking for Helm v2 releases
```

#### Further Comments ####

Waiting merge and tag of
* https://github.com/k3s-io/helm-controller/pull/114
