### PR TITLE
Add missing labels to stalebot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -22,6 +22,12 @@ exemptLabels:
   - kind/ci-improvements
   - kind/performance
   - kind/flaky-test
+  - kind/documentation
+  - kind/backport
+  - priority/backlog
+  - priority/critical-urgent
+  - priority/important-longterm
+  - priority/important-soon
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true


### PR DESCRIPTION
#### Proposed Changes ####
Adding missing labels to stalebot config.

#### Types of Changes ####
just a config change.

#### Verification ####
None needed, or if someone really wanted to, the could verify the labels I added actually exist

#### Linked Issues ####
No issue, just a bot config change.

#### User-Facing Change ####
None