### PR TITLE
Reset load balancer state during restoraion

### DIFF
--- a/pkg/agent/loadbalancer/loadbalancer.go
+++ b/pkg/agent/loadbalancer/loadbalancer.go
@@ -157,7 +157,10 @@ func onDialError(src net.Conn, dstDialErr error) {
 }
 
 // ResetLoadBalancer will delete the local state file for the load balacner on disk
-func ResetLoadBalancer(dataDir, serviceName string) {
+func ResetLoadBalancer(dataDir, serviceName string) error {
 	stateFile := filepath.Join(dataDir, "etc", serviceName+".json")
-	os.Remove(stateFile)
+	if err := os.Remove(stateFile); err != nil {
+		logrus.Warn(err)
+	}
+	return nil
 }

--- a/pkg/agent/loadbalancer/loadbalancer.go
+++ b/pkg/agent/loadbalancer/loadbalancer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -153,4 +154,10 @@ func (lb *LoadBalancer) dialContext(ctx context.Context, network, address string
 func onDialError(src net.Conn, dstDialErr error) {
 	logrus.Debugf("Incoming conn %v, error dialing load balancer servers: %v", src.RemoteAddr().String(), dstDialErr)
 	src.Close()
+}
+
+// ResetLoadBalancer will delete the local state file for the load balacner on disk
+func ResetLoadBalancer(dataDir, serviceName string) {
+	stateFile := filepath.Join(dataDir, "etc", serviceName+".json")
+	os.Remove(stateFile)
 }

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/erikdubbelboer/gspt"
 	"github.com/pkg/errors"
 	"github.com/rancher/k3s/pkg/agent"
+	"github.com/rancher/k3s/pkg/agent/loadbalancer"
 	"github.com/rancher/k3s/pkg/cli/cmds"
 	"github.com/rancher/k3s/pkg/clientaccess"
 	"github.com/rancher/k3s/pkg/datadir"
@@ -160,6 +161,10 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		serverConfig.ControlConfig.DisableControllerManager = true
 		serverConfig.ControlConfig.DisableScheduler = true
 		serverConfig.ControlConfig.DisableCCM = true
+
+		// delete local loadbalancers state for apiserver and supervisor servers
+		loadbalancer.ResetLoadBalancer(filepath.Join(cfg.DataDir, "agent"), loadbalancer.SupervisorServiceName)
+		loadbalancer.ResetLoadBalancer(filepath.Join(cfg.DataDir, "agent"), loadbalancer.APIServerServiceName)
 	}
 
 	serverConfig.ControlConfig.ClusterReset = cfg.ClusterReset


### PR DESCRIPTION
Signed-off-by: galal-hussein <hussein.galal.ahmed.11@gmail.com>

#### Proposed Changes ####
Delete local state of internal load balancers during restoration

#### Types of Changes ####

bug fix

#### Verification ####

Restoration should work on etcd only node

#### Linked Issues ####

- https://github.com/k3s-io/k3s/issues/3873

#### User-Facing Change ####
none

