### PR TITLE
Nvidia container runtime discovery in containerd config template

### DIFF
--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -57,6 +57,7 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 		DisableCgroup:         disableCgroup,
 		IsRunningInUserNS:     isRunningInUserNS,
 		PrivateRegistryConfig: privRegistries.Registry(),
+		ExtraRuntimes:         findNvidiaContainerRuntimes(nil),
 	}
 
 	selEnabled, selConfigured, err := selinuxStatus()

--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package containerd
@@ -57,7 +58,7 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 		DisableCgroup:         disableCgroup,
 		IsRunningInUserNS:     isRunningInUserNS,
 		PrivateRegistryConfig: privRegistries.Registry(),
-		ExtraRuntimes:         findNvidiaContainerRuntimes(os.DirFS("/")),
+		ExtraRuntimes:         findNvidiaContainerRuntimes(os.DirFS(string(os.PathSeparator))),
 	}
 
 	selEnabled, selConfigured, err := selinuxStatus()

--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -57,7 +57,7 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 		DisableCgroup:         disableCgroup,
 		IsRunningInUserNS:     isRunningInUserNS,
 		PrivateRegistryConfig: privRegistries.Registry(),
-		ExtraRuntimes:         findNvidiaContainerRuntimes(nil),
+		ExtraRuntimes:         findNvidiaContainerRuntimes(os.DirFS("/")),
 	}
 
 	selEnabled, selConfigured, err := selinuxStatus()

--- a/pkg/agent/containerd/nvidia.go
+++ b/pkg/agent/containerd/nvidia.go
@@ -1,0 +1,61 @@
+// +build linux
+
+package containerd
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/rancher/k3s/pkg/agent/templates"
+)
+
+// findNvidiaContainerRuntimes returns a list of nvidia container runtimes that
+// are available on the system. It checks install locations used by the nvidia
+// gpu operator and by system package managers. The gpu operator installation
+// takes precedence over the system package manager installation.
+// The given fs.FS should represent the filesystem root directory. If nil,
+// os.DirFS("/") is used.
+func findNvidiaContainerRuntimes(fsys fs.FS) []templates.ContainerdRuntimeConfig {
+	rootFS := fsys
+	if rootFS == nil {
+		rootFS = os.DirFS("/")
+	}
+
+	// Check these locations in order. The GPU operator's installation should
+	// take precedence over the package manager's installation.
+	locationsToCheck := []string{
+		"usr/local/nvidia/toolkit", // Path when installing via GPU Operator
+		"usr/bin",                  // Path when installing via package manager
+	}
+
+	// Fill in the binary location with just the name of the binary,
+	// and check against each of the possible locations. If a match is found,
+	// set the location to the full path.
+	potentialRuntimes := []templates.ContainerdRuntimeConfig{
+		{
+			Name:        "nvidia",
+			RuntimeType: "io.containerd.runc.v2",
+			BinaryName:  "nvidia-container-runtime",
+		},
+		{
+			Name:        "nvidia-experimental",
+			RuntimeType: "io.containerd.runc.v2",
+			BinaryName:  "nvidia-container-runtime-experimental",
+		},
+	}
+	foundRuntimes := []templates.ContainerdRuntimeConfig{}
+RuntimeLoop:
+	for _, runtime := range potentialRuntimes {
+		for _, location := range locationsToCheck {
+			binaryPath := filepath.Join(location, runtime.BinaryName)
+			if info, err := fs.Stat(rootFS, binaryPath); err == nil && !info.IsDir() {
+				runtime.BinaryName = filepath.Join("/", binaryPath)
+				foundRuntimes = append(foundRuntimes, runtime)
+				// Skip to the next runtime to avoid duplicates.
+				continue RuntimeLoop
+			}
+		}
+	}
+	return foundRuntimes
+}

--- a/pkg/agent/containerd/nvidia_test.go
+++ b/pkg/agent/containerd/nvidia_test.go
@@ -1,0 +1,164 @@
+package containerd
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/rancher/k3s/pkg/agent/templates"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindNvidiaContainerRuntimes(t *testing.T) {
+	// Set up sample filesystems for testing
+	executable := &fstest.MapFile{Mode: 0755}
+	tests := []struct {
+		FS      fs.StatFS
+		Results []templates.ContainerdRuntimeConfig
+	}{
+		{
+			FS:      fstest.MapFS{},
+			Results: []templates.ContainerdRuntimeConfig{},
+		},
+		{
+			FS: fstest.MapFS{
+				"usr/bin/nvidia-container-runtime": executable,
+			},
+			Results: []templates.ContainerdRuntimeConfig{
+				{
+					Name:        "nvidia",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/bin/nvidia-container-runtime",
+				},
+			},
+		},
+		{
+			FS: fstest.MapFS{
+				"usr/local/nvidia/toolkit/nvidia-container-runtime": executable,
+			},
+			Results: []templates.ContainerdRuntimeConfig{
+				{
+					Name:        "nvidia",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
+				},
+			},
+		},
+		{
+			FS: fstest.MapFS{
+				"usr/bin/nvidia-container-runtime":                  executable,
+				"usr/local/nvidia/toolkit/nvidia-container-runtime": executable,
+			},
+			Results: []templates.ContainerdRuntimeConfig{
+				{
+					Name:        "nvidia",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
+				},
+			},
+		},
+		{
+			FS: fstest.MapFS{
+				"usr/bin/nvidia-container-runtime-experimental": executable,
+			},
+			Results: []templates.ContainerdRuntimeConfig{
+				{
+					Name:        "nvidia-experimental",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/bin/nvidia-container-runtime-experimental",
+				},
+			},
+		},
+		{
+			FS: fstest.MapFS{
+				"usr/bin/nvidia-container-runtime-experimental":                  executable,
+				"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
+			},
+			Results: []templates.ContainerdRuntimeConfig{
+				{
+					Name:        "nvidia-experimental",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime-experimental",
+				},
+			},
+		},
+		{
+			FS: fstest.MapFS{
+				"usr/bin/nvidia-container-runtime-experimental": executable,
+				"usr/bin/nvidia-container-runtime":              executable,
+			},
+			Results: []templates.ContainerdRuntimeConfig{
+				{
+					Name:        "nvidia",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/bin/nvidia-container-runtime",
+				},
+				{
+					Name:        "nvidia-experimental",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/bin/nvidia-container-runtime-experimental",
+				},
+			},
+		},
+		{
+			FS: fstest.MapFS{
+				"usr/local/nvidia/toolkit/nvidia-container-runtime":              executable,
+				"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
+				"usr/bin/nvidia-container-runtime":                               executable,
+				"usr/bin/nvidia-container-runtime-experimental":                  executable,
+			},
+			Results: []templates.ContainerdRuntimeConfig{
+				{
+					Name:        "nvidia",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
+				},
+				{
+					Name:        "nvidia-experimental",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime-experimental",
+				},
+			},
+		},
+		{
+			FS: fstest.MapFS{
+				"usr/local/nvidia/toolkit/nvidia-container-runtime":              executable,
+				"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
+			},
+			Results: []templates.ContainerdRuntimeConfig{
+				{
+					Name:        "nvidia",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
+				},
+				{
+					Name:        "nvidia-experimental",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime-experimental",
+				},
+			},
+		},
+		{
+			FS: fstest.MapFS{
+				"usr/bin/nvidia-container-runtime":                               executable,
+				"usr/bin/nvidia-container-runtime-experimental":                  executable,
+				"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
+			},
+			Results: []templates.ContainerdRuntimeConfig{
+				{
+					Name:        "nvidia",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/bin/nvidia-container-runtime",
+				},
+				{
+					Name:        "nvidia-experimental",
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime-experimental",
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		assert.Equal(t, findNvidiaContainerRuntimes(test.FS), test.Results, "test %d", i+1)
+	}
+}

--- a/pkg/agent/containerd/nvidia_test.go
+++ b/pkg/agent/containerd/nvidia_test.go
@@ -1,164 +1,218 @@
+// +build linux
+
 package containerd
 
 import (
 	"io/fs"
+	"reflect"
 	"testing"
 	"testing/fstest"
 
 	"github.com/rancher/k3s/pkg/agent/templates"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestFindNvidiaContainerRuntimes(t *testing.T) {
-	// Set up sample filesystems for testing
+func Test_UnitFindNvidiaContainerRuntimes(t *testing.T) {
 	executable := &fstest.MapFile{Mode: 0755}
+	type args struct {
+		root fs.FS
+	}
 	tests := []struct {
-		FS      fs.StatFS
-		Results []templates.ContainerdRuntimeConfig
+		name string
+		args args
+		want map[string]templates.ContainerdRuntimeConfig
 	}{
 		{
-			FS:      fstest.MapFS{},
-			Results: []templates.ContainerdRuntimeConfig{},
+			name: "No runtimes",
+			args: args{
+				root: fstest.MapFS{},
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{},
 		},
 		{
-			FS: fstest.MapFS{
-				"usr/bin/nvidia-container-runtime": executable,
+			name: "Nvidia runtime in /usr/bin",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime": executable,
+				},
 			},
-			Results: []templates.ContainerdRuntimeConfig{
-				{
-					Name:        "nvidia",
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/bin/nvidia-container-runtime",
 				},
 			},
 		},
 		{
-			FS: fstest.MapFS{
-				"usr/local/nvidia/toolkit/nvidia-container-runtime": executable,
+			name: "Experimental runtime in /usr/local/nvidia/toolkit",
+			args: args{
+				root: fstest.MapFS{
+					"usr/local/nvidia/toolkit/nvidia-container-runtime": executable,
+				},
 			},
-			Results: []templates.ContainerdRuntimeConfig{
-				{
-					Name:        "nvidia",
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
 				},
 			},
 		},
 		{
-			FS: fstest.MapFS{
-				"usr/bin/nvidia-container-runtime":                  executable,
-				"usr/local/nvidia/toolkit/nvidia-container-runtime": executable,
+			name: "Two runtimes in separate directories",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime":                  executable,
+					"usr/local/nvidia/toolkit/nvidia-container-runtime": executable,
+				},
 			},
-			Results: []templates.ContainerdRuntimeConfig{
-				{
-					Name:        "nvidia",
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
 				},
 			},
 		},
 		{
-			FS: fstest.MapFS{
-				"usr/bin/nvidia-container-runtime-experimental": executable,
+			name: "Experimental runtime in /usr/bin",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime-experimental": executable,
+				},
 			},
-			Results: []templates.ContainerdRuntimeConfig{
-				{
-					Name:        "nvidia-experimental",
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia-experimental": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/bin/nvidia-container-runtime-experimental",
 				},
 			},
 		},
 		{
-			FS: fstest.MapFS{
-				"usr/bin/nvidia-container-runtime-experimental":                  executable,
-				"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
+			name: "Same runtime in two directories",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime-experimental":                  executable,
+					"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
+				},
 			},
-			Results: []templates.ContainerdRuntimeConfig{
-				{
-					Name:        "nvidia-experimental",
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia-experimental": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime-experimental",
 				},
 			},
 		},
 		{
-			FS: fstest.MapFS{
-				"usr/bin/nvidia-container-runtime-experimental": executable,
-				"usr/bin/nvidia-container-runtime":              executable,
+			name: "Both runtimes in /usr/bin",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime-experimental": executable,
+					"usr/bin/nvidia-container-runtime":              executable,
+				},
 			},
-			Results: []templates.ContainerdRuntimeConfig{
-				{
-					Name:        "nvidia",
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/bin/nvidia-container-runtime",
 				},
-				{
-					Name:        "nvidia-experimental",
+				"nvidia-experimental": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/bin/nvidia-container-runtime-experimental",
 				},
 			},
 		},
 		{
-			FS: fstest.MapFS{
-				"usr/local/nvidia/toolkit/nvidia-container-runtime":              executable,
-				"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
-				"usr/bin/nvidia-container-runtime":                               executable,
-				"usr/bin/nvidia-container-runtime-experimental":                  executable,
+			name: "Both runtimes in both directories",
+			args: args{
+				root: fstest.MapFS{
+					"usr/local/nvidia/toolkit/nvidia-container-runtime":              executable,
+					"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
+					"usr/bin/nvidia-container-runtime":                               executable,
+					"usr/bin/nvidia-container-runtime-experimental":                  executable,
+				},
 			},
-			Results: []templates.ContainerdRuntimeConfig{
-				{
-					Name:        "nvidia",
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
 				},
-				{
-					Name:        "nvidia-experimental",
+				"nvidia-experimental": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime-experimental",
 				},
 			},
 		},
 		{
-			FS: fstest.MapFS{
-				"usr/local/nvidia/toolkit/nvidia-container-runtime":              executable,
-				"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
+			name: "Both runtimes in /usr/local/nvidia/toolkit",
+			args: args{
+				root: fstest.MapFS{
+					"usr/local/nvidia/toolkit/nvidia-container-runtime":              executable,
+					"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
+				},
 			},
-			Results: []templates.ContainerdRuntimeConfig{
-				{
-					Name:        "nvidia",
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
 				},
-				{
-					Name:        "nvidia-experimental",
+				"nvidia-experimental": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime-experimental",
 				},
 			},
 		},
 		{
-			FS: fstest.MapFS{
-				"usr/bin/nvidia-container-runtime":                               executable,
-				"usr/bin/nvidia-container-runtime-experimental":                  executable,
-				"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
+			name: "Both runtimes in /usr/bin and one duplicate in /usr/local/nvidia/toolkit",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime":                               executable,
+					"usr/bin/nvidia-container-runtime-experimental":                  executable,
+					"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
+				},
 			},
-			Results: []templates.ContainerdRuntimeConfig{
-				{
-					Name:        "nvidia",
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/bin/nvidia-container-runtime",
 				},
-				{
-					Name:        "nvidia-experimental",
+				"nvidia-experimental": {
 					RuntimeType: "io.containerd.runc.v2",
 					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime-experimental",
+				},
+			},
+		},
+		{
+			name: "Runtime is a directory",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime": &fstest.MapFile{
+						Mode: fs.ModeDir,
+					},
+				},
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{},
+		},
+		{
+			name: "Runtime in both directories, but one is a directory",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime": executable,
+					"usr/local/nvidia/toolkit/nvidia-container-runtime": &fstest.MapFile{
+						Mode: fs.ModeDir,
+					},
+				},
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/bin/nvidia-container-runtime",
 				},
 			},
 		},
 	}
-	for i, test := range tests {
-		assert.Equal(t, findNvidiaContainerRuntimes(test.FS), test.Results, "test %d", i+1)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findNvidiaContainerRuntimes(tt.args.root); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findNvidiaContainerRuntimes() = %+v\nWant = %+v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -6,9 +6,16 @@ import (
 	"github.com/rancher/k3s/pkg/daemons/config"
 )
 
+type ContainerdRuntimeConfig struct {
+	Name        string
+	RuntimeType string
+	BinaryName  string
+}
+
 type ContainerdConfig struct {
 	NodeConfig            *config.Node
 	DisableCgroup         bool
 	IsRunningInUserNS     bool
 	PrivateRegistryConfig *registries.Registry
+	ExtraRuntimes         []ContainerdRuntimeConfig
 }

--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -7,7 +7,6 @@ import (
 )
 
 type ContainerdRuntimeConfig struct {
-	Name        string
 	RuntimeType string
 	BinaryName  string
 }
@@ -17,5 +16,5 @@ type ContainerdConfig struct {
 	DisableCgroup         bool
 	IsRunningInUserNS     bool
 	PrivateRegistryConfig *registries.Registry
-	ExtraRuntimes         []ContainerdRuntimeConfig
+	ExtraRuntimes         map[string]ContainerdRuntimeConfig
 }

--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -114,9 +114,9 @@ enable_keychain = true
 {{end}}
 
 {{range $k, $v := .ExtraRuntimes}}
-[plugins.cri.containerd.runtimes."{{$v.Name}}"]
+[plugins.cri.containerd.runtimes."{{$k}}"]
   runtime_type = "{{$v.RuntimeType}}"
-[plugins.cri.containerd.runtimes."{{$v.Name}}".options]
+[plugins.cri.containerd.runtimes."{{$k}}".options]
   BinaryName = "{{$v.BinaryName}}"
 {{end}}
 `

--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -112,6 +112,13 @@ enable_keychain = true
 {{end}}
 {{end}}
 {{end}}
+
+{{range $k, $v := .ExtraRuntimes}}
+[plugins.cri.containerd.runtimes."{{$v.Name}}"]
+  runtime_type = "{{$v.RuntimeType}}"
+[plugins.cri.containerd.runtimes."{{$v.Name}}".options]
+  BinaryName = "{{$v.BinaryName}}"
+{{end}}
 `
 
 func ParseTemplateFromConfig(templateBuffer string, config interface{}) (string, error) {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This patch updates the default containerd config template with support for adding extra container runtimes, and adds logic to discover nvidia container runtimes installed via the the gpu operator or package manager.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
New Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
`go test -run ^Test_UnitFindNvidiaContainerRuntimes$ github.com/rancher/k3s/pkg/agent/containerd`

#### Linked Issues ####

A related bugfix has been submitted to the GPU Operator
(update: will be fixed in gpu-operator v1.8.1)
https://gitlab.com/nvidia/kubernetes/gpu-operator/-/merge_requests/288/diffs#d77d1d7e623dc09e3e576662f914bbe1cf2b5226

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
