### PR TITLE
Enable K3s integration test to run on existing cluster

### DIFF
--- a/pkg/etcd/etcd_int_test.go
+++ b/pkg/etcd/etcd_int_test.go
@@ -1,13 +1,13 @@
 package etcd_test
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	testutil "github.com/rancher/k3s/tests/util"
 )
@@ -15,9 +15,7 @@ import (
 var server *testutil.K3sServer
 var serverArgs = []string{"--cluster-init"}
 var _ = BeforeSuite(func() {
-	if testutil.IsExistingServer() {
-		fmt.Println("Test needs k3s server with: " + strings.Join(serverArgs, " "))
-	} else {
+	if !testutil.IsExistingServer() {
 		var err error
 		server, err = testutil.K3sStartServer(serverArgs...)
 		Expect(err).ToNot(HaveOccurred())
@@ -25,6 +23,11 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = Describe("etcd snapshots", func() {
+	BeforeEach(func() {
+		if !testutil.ServerArgsPresent(serverArgs) {
+			Skip("Test needs k3s server with: " + strings.Join(serverArgs, " "))
+		}
+	})
 	When("a new etcd is created", func() {
 		It("starts up with no problems", func() {
 			Eventually(func() (string, error) {
@@ -115,5 +118,7 @@ var _ = AfterSuite(func() {
 
 func Test_IntegrationEtcd(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Etcd Suite")
+	RunSpecsWithDefaultAndCustomReporters(t, "Etcd Suite", []Reporter{
+		reporters.NewJUnitReporter("/tmp/results/etcd_junit.xml"),
+	})
 }

--- a/pkg/etcd/etcd_int_test.go
+++ b/pkg/etcd/etcd_int_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	testutil "github.com/rancher/k3s/tests/util"
 )
@@ -118,7 +117,5 @@ var _ = AfterSuite(func() {
 
 func Test_IntegrationEtcd(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Etcd Suite", []Reporter{
-		reporters.NewJUnitReporter("/tmp/results/etcd_junit.xml"),
-	})
+	RunSpecs(t, "Etcd Suite")
 }

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -71,8 +71,14 @@ See the [local storage test](https://github.com/k3s-io/k3s/blob/master/tests/int
 
 ### Running
 
+Integration tests can be run with no k3s cluster present, each test will spin up and kill the appropriate k3s server it needs.
 ```bash
 go test ./pkg/... ./tests/... -run Integration
+```
+
+Integration tests can also be run on an existing cluster via compile time flag, tests will skip if the server is not configured correctly.
+```
+go test -ldflags "-X 'github.com/rancher/k3s/tests/util.existingServer=True'" ./pkg/... ./tests/... -run Integration
 ```
 
 ___

--- a/tests/integration/localstorage_int_test.go
+++ b/tests/integration/localstorage_int_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	testutil "github.com/rancher/k3s/tests/util"
 )
@@ -30,7 +29,6 @@ var _ = Describe("local storage", func() {
 		}
 	})
 	When("a new local storage is created", func() {
-
 		It("starts up with no problems", func() {
 			Eventually(func() (string, error) {
 				return testutil.K3sCmd("kubectl", "get", "pods", "-A")
@@ -84,7 +82,5 @@ var _ = AfterSuite(func() {
 
 func Test_IntegrationLocalStorage(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Local Storage Suite", []Reporter{
-		reporters.NewJUnitReporter("/tmp/results/local_storage_junit.xml"),
-	})
+	RunSpecs(t, "Local Storage Suite")
 }

--- a/tests/integration/localstorage_int_test.go
+++ b/tests/integration/localstorage_int_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -12,10 +13,15 @@ import (
 )
 
 var server *testutil.K3sServer
+var serverArgs = []string{"--cluster-init"}
 var _ = BeforeSuite(func() {
-	var err error
-	server, err = testutil.K3sStartServer("--cluster-init")
-	Expect(err).ToNot(HaveOccurred())
+	if testutil.IsExistingServer() {
+		fmt.Println("Test needs k3s server with: " + strings.Join(serverArgs, " "))
+	} else {
+		var err error
+		server, err = testutil.K3sStartServer(serverArgs...)
+		Expect(err).ToNot(HaveOccurred())
+	}
 })
 
 var _ = Describe("local storage", func() {
@@ -66,11 +72,12 @@ var _ = Describe("local storage", func() {
 })
 
 var _ = AfterSuite(func() {
-	Expect(testutil.K3sKillServer(server)).To(Succeed())
+	if !testutil.IsExistingServer() {
+		Expect(testutil.K3sKillServer(server)).To(Succeed())
+	}
 })
 
 func Test_IntegrationLocalStorage(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Local Storage Suite")
-
 }

--- a/tests/util/cmd.go
+++ b/tests/util/cmd.go
@@ -11,7 +11,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Compile-time variable
+var existingServer string = "False"
+
 func findK3sExecutable() string {
+	// if running on an existing cluster, it maybe installed via k3s.service
+	// or run manually from dist/artifacts/k3s
+	if IsExistingServer() {
+		k3sBin, err := exec.LookPath("k3s")
+		if err == nil {
+			return k3sBin
+		}
+	}
 	k3sBin := "dist/artifacts/k3s"
 	for {
 		_, err := os.Stat(k3sBin)
@@ -31,6 +42,10 @@ func IsRoot() bool {
 		return false
 	}
 	return currentUser.Uid == "0"
+}
+
+func IsExistingServer() bool {
+	return existingServer == "True"
 }
 
 // K3sCmd launches the provided K3s command via exec. Command blocks until finished.


### PR DESCRIPTION
#### Proposed Changes ####
The existing integration tests that require a K3s server have been modified. Tests now can run on an existing k3s server via a compile time flag. Tests will skip if the running server is not configured with the flags required of the test.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Documentation change to explain this option.
Changed test util cmd.go to support checks for existing clusters, and exec k3s commands with installed executable.
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- Start a k3s cluster without etcd
`k3s server`
Run integration tests
`go test -v -ldflags "-X 'github.com/rancher/k3s/tests/util.existingServer=True'" ./pkg/... ./tests/... -run Integration`
Observe that the tests pass, but each integration testlet skip due to missing flags.

- Start a k3s cluster with etcd
`k3s server --cluster-init`
Run integration tests
`go test -v -ldflags "-X 'github.com/rancher/k3s/tests/util.existingServer=True'" ./pkg/... ./tests/... -run Integration`
Observe that the tests pass, no skips.


#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/3891
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
