### PR TITLE
Revert "Enable K3s integration test to run on existing cluster"

### DIFF
--- a/pkg/etcd/etcd_int_test.go
+++ b/pkg/etcd/etcd_int_test.go
@@ -12,21 +12,13 @@ import (
 )
 
 var server *testutil.K3sServer
-var serverArgs = []string{"--cluster-init"}
 var _ = BeforeSuite(func() {
-	if !testutil.IsExistingServer() {
-		var err error
-		server, err = testutil.K3sStartServer(serverArgs...)
-		Expect(err).ToNot(HaveOccurred())
-	}
+	var err error
+	server, err = testutil.K3sStartServer("--cluster-init")
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = Describe("etcd snapshots", func() {
-	BeforeEach(func() {
-		if !testutil.ServerArgsPresent(serverArgs) {
-			Skip("Test needs k3s server with: " + strings.Join(serverArgs, " "))
-		}
-	})
 	When("a new etcd is created", func() {
 		It("starts up with no problems", func() {
 			Eventually(func() (string, error) {
@@ -52,6 +44,9 @@ var _ = Describe("etcd snapshots", func() {
 		})
 	})
 	When("saving a custom name", func() {
+		It("starts with no snapshots", func() {
+			Expect(testutil.K3sCmd("etcd-snapshot", "ls")).To(BeEmpty())
+		})
 		It("saves an etcd snapshot with a custom name", func() {
 			Expect(testutil.K3sCmd("etcd-snapshot", "save", "--name", "ALIVEBEEF")).
 				To(ContainSubstring("Saving etcd snapshot to /var/lib/rancher/k3s/server/db/snapshots/ALIVEBEEF"))
@@ -67,6 +62,9 @@ var _ = Describe("etcd snapshots", func() {
 		})
 	})
 	When("using etcd snapshot prune", func() {
+		It("starts with no snapshots", func() {
+			Expect(testutil.K3sCmd("etcd-snapshot", "ls")).To(BeEmpty())
+		})
 		It("saves 3 different snapshots", func() {
 			Expect(testutil.K3sCmd("etcd-snapshot", "save", "-name", "PRUNE_TEST")).
 				To(ContainSubstring("Saving current etcd snapshot set to k3s-etcd-snapshots"))
@@ -81,9 +79,10 @@ var _ = Describe("etcd snapshots", func() {
 		It("lists all 3 snapshots", func() {
 			lsResult, err := testutil.K3sCmd("etcd-snapshot", "ls")
 			Expect(err).ToNot(HaveOccurred())
-			reg, err := regexp.Compile(`:///var/lib/rancher/k3s/server/db/snapshots/PRUNE_TEST`)
-			Expect(err).ToNot(HaveOccurred())
-			sepLines := reg.FindAllString(lsResult, -1)
+			sepLines := strings.FieldsFunc(lsResult, func(c rune) bool {
+				return c == '\n'
+			})
+			Expect(lsResult).To(MatchRegexp(`:///var/lib/rancher/k3s/server/db/snapshots/PRUNE_TEST`))
 			Expect(sepLines).To(HaveLen(3))
 		})
 		It("prunes snapshots down to 2", func() {
@@ -91,9 +90,10 @@ var _ = Describe("etcd snapshots", func() {
 				To(BeEmpty())
 			lsResult, err := testutil.K3sCmd("etcd-snapshot", "ls")
 			Expect(err).ToNot(HaveOccurred())
-			reg, err := regexp.Compile(`:///var/lib/rancher/k3s/server/db/snapshots/PRUNE_TEST`)
-			Expect(err).ToNot(HaveOccurred())
-			sepLines := reg.FindAllString(lsResult, -1)
+			sepLines := strings.FieldsFunc(lsResult, func(c rune) bool {
+				return c == '\n'
+			})
+			Expect(lsResult).To(MatchRegexp(`:///var/lib/rancher/k3s/server/db/snapshots/PRUNE_TEST`))
 			Expect(sepLines).To(HaveLen(2))
 		})
 		It("cleans up remaining snapshots", func() {
@@ -110,9 +110,7 @@ var _ = Describe("etcd snapshots", func() {
 })
 
 var _ = AfterSuite(func() {
-	if !testutil.IsExistingServer() {
-		Expect(testutil.K3sKillServer(server)).To(Succeed())
-	}
+	Expect(testutil.K3sKillServer(server)).To(Succeed())
 })
 
 func Test_IntegrationEtcd(t *testing.T) {

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -71,14 +71,8 @@ See the [local storage test](https://github.com/k3s-io/k3s/blob/master/tests/int
 
 ### Running
 
-Integration tests can be run with no k3s cluster present, each test will spin up and kill the appropriate k3s server it needs.
 ```bash
 go test ./pkg/... ./tests/... -run Integration
-```
-
-Integration tests can also be run on an existing cluster via compile time flag, tests will skip if the server is not configured correctly.
-```
-go test -ldflags "-X 'github.com/rancher/k3s/tests/util.existingServer=True'" ./pkg/... ./tests/... -run Integration
 ```
 
 ___

--- a/tests/integration/localstorage_int_test.go
+++ b/tests/integration/localstorage_int_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -13,21 +12,13 @@ import (
 )
 
 var server *testutil.K3sServer
-var serverArgs = []string{"--cluster-init"}
 var _ = BeforeSuite(func() {
-	if !testutil.IsExistingServer() {
-		var err error
-		server, err = testutil.K3sStartServer(serverArgs...)
-		Expect(err).ToNot(HaveOccurred())
-	}
+	var err error
+	server, err = testutil.K3sStartServer("--cluster-init")
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = Describe("local storage", func() {
-	BeforeEach(func() {
-		if !testutil.ServerArgsPresent(serverArgs) {
-			Skip("Test needs k3s server with: " + strings.Join(serverArgs, " "))
-		}
-	})
 	When("a new local storage is created", func() {
 		It("starts up with no problems", func() {
 			Eventually(func() (string, error) {
@@ -75,12 +66,11 @@ var _ = Describe("local storage", func() {
 })
 
 var _ = AfterSuite(func() {
-	if !testutil.IsExistingServer() {
-		Expect(testutil.K3sKillServer(server)).To(Succeed())
-	}
+	Expect(testutil.K3sKillServer(server)).To(Succeed())
 })
 
 func Test_IntegrationLocalStorage(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Local Storage Suite")
+
 }

--- a/tests/util/cmd.go
+++ b/tests/util/cmd.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"bufio"
-	"encoding/json"
 	"os"
 	"os/exec"
 	"os/user"
@@ -12,18 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Compile-time variable
-var existingServer string = "False"
-
 func findK3sExecutable() string {
-	// if running on an existing cluster, it maybe installed via k3s.service
-	// or run manually from dist/artifacts/k3s
-	if IsExistingServer() {
-		k3sBin, err := exec.LookPath("k3s")
-		if err == nil {
-			return k3sBin
-		}
-	}
 	k3sBin := "dist/artifacts/k3s"
 	for {
 		_, err := os.Stat(k3sBin)
@@ -45,10 +33,6 @@ func IsRoot() bool {
 	return currentUser.Uid == "0"
 }
 
-func IsExistingServer() bool {
-	return existingServer == "True"
-}
-
 // K3sCmd launches the provided K3s command via exec. Command blocks until finished.
 // Command output from both Stderr and Stdout is provided via string.
 //   cmdEx1, err := K3sCmd("etcd-snapshot", "ls")
@@ -66,41 +50,6 @@ func K3sCmd(cmdName string, cmdArgs ...string) (string, error) {
 	}
 	byteOut, err := cmd.CombinedOutput()
 	return string(byteOut), err
-}
-
-func contains(source []string, target string) bool {
-	for _, s := range source {
-		if s == target {
-			return true
-		}
-	}
-	return false
-}
-
-// ServerArgsPresent checks if the given arguments are found in the running k3s server
-func ServerArgsPresent(neededArgs []string) bool {
-	currentArgs := K3sServerArgs()
-	for _, arg := range neededArgs {
-		if !contains(currentArgs, arg) {
-			return false
-		}
-	}
-	return true
-}
-
-// K3sServerArgs returns the list of arguments that the k3s server launched with
-func K3sServerArgs() []string {
-	results, err := K3sCmd("kubectl", "get", "nodes", "-o", `jsonpath='{.items[0].metadata.annotations.k3s\.io/node-args}'`)
-	if err != nil {
-		return nil
-	}
-	res := strings.Replace(results, "'", "", -1)
-	var args []string
-	if err := json.Unmarshal([]byte(res), &args); err != nil {
-		logrus.Error(err)
-		return nil
-	}
-	return args
 }
 
 func FindStringInCmdAsync(scanner *bufio.Scanner, target string) bool {


### PR DESCRIPTION
Reverts k3s-io/k3s#3892
Included a typo that causes drone publish to fail on golang lint