### PR TITLE
Fix rootless regression in 1.22 (Set KubeletInUserNamespace gate)

### DIFF
--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -18,6 +18,7 @@ import (
 )
 
 func createRootlessConfig(argsMap map[string]string, hasCFS, hasPIDs bool) {
+	argsMap["feature-gates=KubeletInUserNamespace"] = "true"
 	// "/sys/fs/cgroup" is namespaced
 	cgroupfsWritable := unix.Access("/sys/fs/cgroup", unix.W_OK) == nil
 	if hasCFS && hasPIDs && cgroupfsWritable {


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Fix k 1.22 regression (#3900)

Kubernetes 1.22 requires `KuebletInUserNamespace` feature gate to be set for rootless:
https://kubernetes.io/docs/tasks/administer-cluster/kubelet-in-userns/#userns-the-hard-way


#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

BugFix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Observe CI

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

Fix #3900
