### PR TITLE
Add functions to separate ipv4 and ipv6 CIDRs

### DIFF
--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -63,3 +63,25 @@ func GetFirst4String(elems []string) (string, error) {
 	}
 	return ip.String(), nil
 }
+
+// JoinIP4Nets stringifies and joins a list of IPv4 networks with commas.
+func JoinIP4Nets(elems []*net.IPNet) string {
+	var strs []string
+	for _, elem := range elems {
+		if elem != nil && elem.IP.To4() != nil {
+			strs = append(strs, elem.String())
+		}
+	}
+	return strings.Join(strs, ",")
+}
+
+// JoinIP6Nets stringifies and joins a list of IPv6 networks with commas.
+func JoinIP6Nets(elems []*net.IPNet) string {
+	var strs []string
+	for _, elem := range elems {
+		if elem != nil && elem.IP.To4() == nil {
+			strs = append(strs, elem.String())
+		}
+	}
+	return strings.Join(strs, ",")
+}


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This PR adds two functions to discriminate ipv4 and ipv6 addresses. This will simplify our lives if we want to use dual-stack with cni plugins such as Calico which does not follow the kubernetes convention "cluster-cidr: $CIDR_ipv4,$CIDR_ipv6"

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
New feature. Two new functions in a library

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/rancher/rke2/issues/1717

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
