### PR TITLE
Make consistent use of os-release vars

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -460,19 +460,19 @@ setup_selinux() {
     fi
 
     [ -r /etc/os-release ] && . /etc/os-release
-    if [ "${ID_LIKE:-}" = suse ] ; then
-        policy_hint='k3s with SELinux is currently not supported on SUSE/openSUSE systems.
-    please disable SELinux before installing k3s
-'
+    if [ "${ID_LIKE:-}" = suse ]; then
+        policy_hint="k3s with SELinux is currently not supported on SUSE/openSUSE systems.
+    Please disable SELinux before installing k3s.
+"
     else
         policy_hint="please install:
     yum install -y container-selinux selinux-policy-base
-    yum install -y https://${rpm_site}/k3s/${rpm_channel}/common/centos/7/noarch/k3s-selinux-0.2-1.el7_8.noarch.rpm
+    yum install -y https://${rpm_site}/k3s/${rpm_channel}/common/centos/${VERSION_ID:-7}/noarch/k3s-selinux-0.3-0.el${VERSION_ID:-7}.noarch.rpm
 "
     fi
 
     policy_error=fatal
-    if [ "$INSTALL_K3S_SELINUX_WARN" = true ] || grep -q 'ID=flatcar' /etc/os-release; then
+    if [ "$INSTALL_K3S_SELINUX_WARN" = true ] || [ "${ID_LIKE:-}" = coreos ]; then
         policy_error=warn
     fi
 


### PR DESCRIPTION
#### Proposed Changes ####

Make consistent use of os-release variables when checking for the current distro.

This is a follow-up to address some minor nits in #3088

#### Types of Changes ####

install script

#### Verification ####

Run install.sh on opensuse/flatcar/rhel; ensure proper selinux messages are printed

#### Linked Issues ####

* #3917

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
