### PR TITLE
[release-1.21] Fix issue where addon checksum was never stored

### DIFF
--- a/pkg/deploy/controller.go
+++ b/pkg/deploy/controller.go
@@ -212,8 +212,9 @@ func (w *watcher) deploy(path string, compareChecksum bool) error {
 		return err
 	}
 
-	// Emit event, Update Addon checksum and modtime only if apply was successful
+	// Emit event, Update Addon checksum only if apply was successful
 	w.recorder.Eventf(&addon, corev1.EventTypeNormal, "AppliedManifest", "Applied manifest at %q", path)
+	addon.Spec.Checksum = checksum
 	_, err = w.addons.Update(&addon)
 	return err
 }


### PR DESCRIPTION
#### Proposed Changes ####

Save Addon checksum when apply succeeds

#### Types of Changes ####

bugfix

#### Verification ####

Touch manifest in /var/lib/rancher/k3s/server/manifests without changing the content. The manifest should not be redeployed.

#### Linked Issues ####

* #3919

#### User-Facing Change ####

```release-note
Addon checksums are now properly updated when successfully applied.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
