### PR TITLE
[release-1.21] Fix condition for adding kubernetes endpoints 

### DIFF
--- a/pkg/apiaddresses/controller.go
+++ b/pkg/apiaddresses/controller.go
@@ -44,23 +44,17 @@ type handler struct {
 // This controller will update the version.program/apiaddresses etcd key with a list of
 // api addresses endpoints found in the kubernetes service in the default namespace
 func (h *handler) sync(key string, endpoint *v1.Endpoints) (*v1.Endpoints, error) {
-	if endpoint == nil {
-		return nil, nil
+	if endpoint != nil &&
+		endpoint.Namespace == "default" &&
+		endpoint.Name == "kubernetes" {
+		w := &bytes.Buffer{}
+		if err := json.NewEncoder(w).Encode(util.GetAddresses(endpoint)); err != nil {
+			return nil, err
+		}
+		_, err := h.etcdClient.Put(h.ctx, etcd.AddressKey, w.String())
+		if err != nil {
+			return nil, err
+		}
 	}
-
-	if endpoint.Namespace != "default" && endpoint.Name != "kubernetes" {
-		return nil, nil
-	}
-
-	w := &bytes.Buffer{}
-	if err := json.NewEncoder(w).Encode(util.GetAddresses(endpoint)); err != nil {
-		return nil, err
-	}
-
-	_, err := h.etcdClient.Put(h.ctx, etcd.AddressKey, w.String())
-	if err != nil {
-		return nil, err
-	}
-
 	return endpoint, nil
 }


### PR DESCRIPTION
Signed-off-by: galal-hussein <hussein.galal.ahmed.11@gmail.com>

#### Proposed Changes ####

The fix will just modify the condition for apiaddresses controllers so that it will make sure that only endpoints for kubernets service in default namespace that gets added.

#### Types of Changes ####
Bug fix

#### Verification ####
- Install k3s/rke2
- deploy this yaml file:
```
apiVersion: v1
kind: Service
metadata:
  name: busyb
spec:
  selector:
    app: busy
    #  clusterIP: None
  ports:
  - name: foo # Actually, no port is needed.
    port: 1234
    targetPort: 1234
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: busydep
spec:
  replicas: 3
  selector:
    matchLabels:
      app: busy
  template:
    metadata:
      labels:
        app: busy
    spec:
      containers:
        - name: busybox
          image: busybox:1.28
          command:
            - sleep
            - "3600"
          securityContext:
            runAsUser: 1000
            runAsNonRoot: true
```
- run the following command to check apiaddresses saved in etcd
```
ETCDCTL_API=3 etcdctl --cert /var/lib/rancher/rke2/server/tls/etcd/server-client.crt --key /var/lib/rancher/rke2/server/tls/etcd/server-client.key --endpoints https://127.0.0.1:2379 --cacert /var/lib/rancher/rke2/server/tls/etcd/server-ca.crt get  rke2/apiaddresses
```

You should see only the kubernetes endpoint addresses saved

#### Linked Issues ####
- https://github.com/k3s-io/k3s/issues/3943

#### User-Facing Change ####
none