### PR TITLE
Add missing node name entry to apiserver SAN list

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -100,7 +100,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.KubeConfigOutput = cfg.KubeConfigOutput
 	serverConfig.ControlConfig.KubeConfigMode = cfg.KubeConfigMode
 	serverConfig.Rootless = cfg.Rootless
-	serverConfig.ControlConfig.SANs = knownIPs(cfg.TLSSan)
+	serverConfig.ControlConfig.SANs = cfg.TLSSan
 	serverConfig.ControlConfig.BindAddress = cfg.BindAddress
 	serverConfig.ControlConfig.SupervisorPort = cfg.SupervisorPort
 	serverConfig.ControlConfig.HTTPSPort = cfg.HTTPSPort
@@ -213,6 +213,18 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	/// https://github.com/kubernetes/kubeadm/issues/1612#issuecomment-772583989
 	if serverConfig.ControlConfig.AdvertiseIP != "" {
 		serverConfig.ControlConfig.SANs = append(serverConfig.ControlConfig.SANs, serverConfig.ControlConfig.AdvertiseIP)
+	}
+
+	// Ensure that we add the localhost name/ip and node name/ip to the SAN list. This list is shared by the
+	// certs for the supervisor, kube-apiserver cert, and etcd. DNS entries for the in-cluster kubernetes
+	// service endpoint are added later when the certificates are created.
+	nodeName, nodeIPs, err := util.GetHostnameAndIPs(cmds.AgentConfig.NodeName, cmds.AgentConfig.NodeIP)
+	if err != nil {
+		return err
+	}
+	serverConfig.ControlConfig.SANs = append(serverConfig.ControlConfig.SANs, "127.0.0.1", "localhost", nodeName)
+	for _, ip := range nodeIPs {
+		serverConfig.ControlConfig.SANs = append(serverConfig.ControlConfig.SANs, ip.String())
 	}
 
 	// configure ClusterIPRanges
@@ -462,15 +474,6 @@ func validateNetworkConfiguration(serverConfig server.Config) error {
 	}
 
 	return nil
-}
-
-func knownIPs(ips []string) []string {
-	ips = append(ips, "127.0.0.1")
-	ip, err := utilnet.ChooseHostInterface()
-	if err == nil {
-		ips = append(ips, ip.String())
-	}
-	return ips
 }
 
 func getArgValueFromList(searchArg string, argList []string) string {

--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -45,7 +45,7 @@ func (c *Cluster) newListener(ctx context.Context) (net.Listener, http.Handler, 
 	return dynamiclistener.NewListener(tcp, storage, cert, key, dynamiclistener.Config{
 		ExpirationDaysCheck: config.CertificateRenewDays,
 		Organization:        []string{version.Program},
-		SANs:                append(c.config.SANs, "localhost", "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc."+c.config.ClusterDomain),
+		SANs:                append(c.config.SANs, "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc."+c.config.ClusterDomain),
 		CN:                  version.Program,
 		TLSConfig: &tls.Config{
 			ClientAuth:   tls.RequestClientCert,

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
-	"k8s.io/kubernetes/pkg/controlplane"
 )
 
 const (
@@ -370,14 +369,8 @@ func genServerCerts(config *config.Control, runtime *config.ControlRuntime) erro
 		return err
 	}
 
-	_, apiServerServiceIP, err := controlplane.ServiceIPRange(*config.ServiceIPRange)
-	if err != nil {
-		return err
-	}
-
 	altNames := &certutil.AltNames{
-		DNSNames: []string{"localhost", "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc." + config.ClusterDomain},
-		IPs:      []net.IP{apiServerServiceIP},
+		DNSNames: []string{"kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc." + config.ClusterDomain},
 	}
 
 	addSANs(altNames, config.SANs)
@@ -402,9 +395,7 @@ func genETCDCerts(config *config.Control, runtime *config.ControlRuntime) error 
 		return err
 	}
 
-	altNames := &certutil.AltNames{
-		DNSNames: []string{"localhost"},
-	}
+	altNames := &certutil.AltNames{}
 	addSANs(altNames, config.SANs)
 
 	if _, err := createClientCertKey(regen, "etcd-server", nil,

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -2,8 +2,13 @@ package util
 
 import (
 	"errors"
+	"fmt"
 	"net"
+	"os"
 	"strings"
+
+	"github.com/urfave/cli"
+	apinet "k8s.io/apimachinery/pkg/util/net"
 )
 
 // JoinIPs stringifies and joins a list of IP addresses with commas.
@@ -84,4 +89,42 @@ func JoinIP6Nets(elems []*net.IPNet) string {
 		}
 	}
 	return strings.Join(strs, ",")
+}
+
+// GetHostnameAndIPs takes a node name and list of IPs, usually from CLI args.
+// If set, these are used to return the node's name and addresses. If not set,
+// the system hostname and primary interface address are returned instead.
+func GetHostnameAndIPs(name string, nodeIPs cli.StringSlice) (string, []net.IP, error) {
+	ips := []net.IP{}
+	if len(nodeIPs) == 0 {
+		hostIP, err := apinet.ChooseHostInterface()
+		if err != nil {
+			return "", nil, err
+		}
+		ips = append(ips, hostIP)
+	} else {
+		for _, hostIP := range nodeIPs {
+			for _, v := range strings.Split(hostIP, ",") {
+				ip := net.ParseIP(v)
+				if ip == nil {
+					return "", nil, fmt.Errorf("invalid node-ip %s", v)
+				}
+				ips = append(ips, ip)
+			}
+		}
+	}
+
+	if name == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			return "", nil, err
+		}
+		name = hostname
+	}
+
+	// Use lower case hostname to comply with kubernetes constraint:
+	// https://github.com/kubernetes/kubernetes/issues/71140
+	name = strings.ToLower(name)
+
+	return name, ips, nil
 }


### PR DESCRIPTION
#### Proposed Changes ####

Add missing node name entry to apiserver SAN list. Also honor node-ip when adding the node address to the SAN list, instead of hardcoding the autodetected IP address.

This converts the agent getHostnameAndIPs function into a utility function, and cleans up some import aliases resolved by moving it out of the agent config module.

#### Types of Changes ####

bugfix

#### Verification ####

* `echo QUIT |openssl s_client -connect localhost:6444 2>&1 | openssl x509 -noout -text | grep -A1 Alternative`
* Verify that the list contains the node name IP address; the hostname and private IP should be used by default, or --node-name and --node-ip values if set.

#### Linked Issues ####

* #3960

#### User-Facing Change ####

This is mostly only visible on RKE2, but...

```release-note
The local kube-apiserver that is available on port 6444 on server nodes now includes the node name in the certificate SAN list
```

#### Further Comments ####

