### PR TITLE
[release-1.21] Add missing node name entry to apiserver SAN list

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -9,7 +9,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
-	sysnet "net"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -32,7 +32,6 @@ import (
 	"github.com/rancher/wrangler/pkg/slice"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/json"
-	"k8s.io/apimachinery/pkg/util/net"
 )
 
 const (
@@ -66,7 +65,7 @@ func Request(path string, info *clientaccess.Info, requester HTTPRequester) ([]b
 	return requester(u.String(), clientaccess.GetHTTPClient(info.CACerts), info.Username, info.Password)
 }
 
-func getNodeNamedCrt(nodeName string, nodeIPs []sysnet.IP, nodePasswordFile string) HTTPRequester {
+func getNodeNamedCrt(nodeName string, nodeIPs []net.IP, nodePasswordFile string) HTTPRequester {
 	return func(u string, client *http.Client, username, password string) ([]byte, error) {
 		req, err := http.NewRequest(http.MethodGet, u, nil)
 		if err != nil {
@@ -146,7 +145,7 @@ func upgradeOldNodePasswordPath(oldNodePasswordFile, newNodePasswordFile string)
 	}
 }
 
-func getServingCert(nodeName string, nodeIPs []sysnet.IP, servingCertFile, servingKeyFile, nodePasswordFile string, info *clientaccess.Info) (*tls.Certificate, error) {
+func getServingCert(nodeName string, nodeIPs []net.IP, servingCertFile, servingKeyFile, nodePasswordFile string, info *clientaccess.Info) (*tls.Certificate, error) {
 	servingCert, err := Request("/v1-"+version.Program+"/serving-kubelet.crt", info, getNodeNamedCrt(nodeName, nodeIPs, nodePasswordFile))
 	if err != nil {
 		return nil, err
@@ -209,7 +208,7 @@ func splitCertKeyPEM(bytes []byte) (certPem []byte, keyPem []byte) {
 	return
 }
 
-func getNodeNamedHostFile(filename, keyFile, nodeName string, nodeIPs []sysnet.IP, nodePasswordFile string, info *clientaccess.Info) error {
+func getNodeNamedHostFile(filename, keyFile, nodeName string, nodeIPs []net.IP, nodePasswordFile string, info *clientaccess.Info) error {
 	basename := filepath.Base(filename)
 	fileBytes, err := Request("/v1-"+version.Program+"/"+basename, info, getNodeNamedCrt(nodeName, nodeIPs, nodePasswordFile))
 	if err != nil {
@@ -226,42 +225,6 @@ func getNodeNamedHostFile(filename, keyFile, nodeName string, nodeIPs []sysnet.I
 	return nil
 }
 
-func getHostnameAndIPs(info cmds.Agent) (string, []sysnet.IP, error) {
-	ips := []sysnet.IP{}
-	if len(info.NodeIP) == 0 {
-		hostIP, err := net.ChooseHostInterface()
-		if err != nil {
-			return "", nil, err
-		}
-		ips = append(ips, hostIP)
-	} else {
-		for _, hostIP := range info.NodeIP {
-			for _, v := range strings.Split(hostIP, ",") {
-				ip := sysnet.ParseIP(v)
-				if ip == nil {
-					return "", nil, fmt.Errorf("invalid node-ip %s", v)
-				}
-				ips = append(ips, ip)
-			}
-		}
-	}
-
-	name := info.NodeName
-	if name == "" {
-		hostname, err := os.Hostname()
-		if err != nil {
-			return "", nil, err
-		}
-		name = hostname
-	}
-
-	// Use lower case hostname to comply with kubernetes constraint:
-	// https://github.com/kubernetes/kubernetes/issues/71140
-	name = strings.ToLower(name)
-
-	return name, ips, nil
-}
-
 func isValidResolvConf(resolvConfFile string) bool {
 	file, err := os.Open(resolvConfFile)
 	if err != nil {
@@ -274,7 +237,7 @@ func isValidResolvConf(resolvConfFile string) bool {
 	for scanner.Scan() {
 		ipMatch := nameserver.FindStringSubmatch(scanner.Text())
 		if len(ipMatch) == 2 {
-			ip := sysnet.ParseIP(ipMatch[1])
+			ip := net.ParseIP(ipMatch[1])
 			if ip == nil || !ip.IsGlobalUnicast() {
 				return false
 			}
@@ -327,9 +290,9 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		}
 	}
 
-	var flannelIface *sysnet.Interface
+	var flannelIface *net.Interface
 	if !envInfo.NoFlannel && len(envInfo.FlannelIface) > 0 {
-		flannelIface, err = sysnet.InterfaceByName(envInfo.FlannelIface)
+		flannelIface, err = net.InterfaceByName(envInfo.FlannelIface)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to find interface")
 		}
@@ -361,7 +324,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	newNodePasswordFile := filepath.Join(nodeConfigPath, "password")
 	upgradeOldNodePasswordPath(oldNodePasswordFile, newNodePasswordFile)
 
-	nodeName, nodeIPs, err := getHostnameAndIPs(*envInfo)
+	nodeName, nodeIPs, err := util.GetHostnameAndIPs(envInfo.NodeName, envInfo.NodeIP)
 	if err != nil {
 		return nil, err
 	}
@@ -476,7 +439,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 
 	for _, externalIP := range envInfo.NodeExternalIP {
 		for _, v := range strings.Split(externalIP, ",") {
-			ip := sysnet.ParseIP(v)
+			ip := net.ParseIP(v)
 			if ip == nil {
 				return nil, fmt.Errorf("invalid node-external-ip %s", v)
 			}
@@ -524,7 +487,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 
 	if controlConfig.ClusterIPRange != nil {
 		nodeConfig.AgentConfig.ClusterCIDR = controlConfig.ClusterIPRange
-		nodeConfig.AgentConfig.ClusterCIDRs = []*sysnet.IPNet{controlConfig.ClusterIPRange}
+		nodeConfig.AgentConfig.ClusterCIDRs = []*net.IPNet{controlConfig.ClusterIPRange}
 	}
 
 	if len(controlConfig.ClusterIPRanges) > 0 {
@@ -533,7 +496,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 
 	if controlConfig.ServiceIPRange != nil {
 		nodeConfig.AgentConfig.ServiceCIDR = controlConfig.ServiceIPRange
-		nodeConfig.AgentConfig.ServiceCIDRs = []*sysnet.IPNet{controlConfig.ServiceIPRange}
+		nodeConfig.AgentConfig.ServiceCIDRs = []*net.IPNet{controlConfig.ServiceIPRange}
 	}
 
 	if len(controlConfig.ServiceIPRanges) > 0 {
@@ -545,7 +508,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	}
 
 	if len(controlConfig.ClusterDNSs) == 0 {
-		nodeConfig.AgentConfig.ClusterDNSs = []sysnet.IP{controlConfig.ClusterDNS}
+		nodeConfig.AgentConfig.ClusterDNSs = []net.IP{controlConfig.ClusterDNS}
 	} else {
 		nodeConfig.AgentConfig.ClusterDNSs = controlConfig.ClusterDNSs
 	}

--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -45,7 +45,7 @@ func (c *Cluster) newListener(ctx context.Context) (net.Listener, http.Handler, 
 	return dynamiclistener.NewListener(tcp, storage, cert, key, dynamiclistener.Config{
 		ExpirationDaysCheck: config.CertificateRenewDays,
 		Organization:        []string{version.Program},
-		SANs:                append(c.config.SANs, "localhost", "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc."+c.config.ClusterDomain),
+		SANs:                append(c.config.SANs, "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc."+c.config.ClusterDomain),
 		CN:                  version.Program,
 		TLSConfig: &tls.Config{
 			ClientAuth:   tls.RequestClientCert,

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
-	"k8s.io/kubernetes/pkg/controlplane"
 )
 
 const (
@@ -313,14 +312,8 @@ func genServerCerts(config *config.Control, runtime *config.ControlRuntime) erro
 		return err
 	}
 
-	_, apiServerServiceIP, err := controlplane.ServiceIPRange(*config.ServiceIPRange)
-	if err != nil {
-		return err
-	}
-
 	altNames := &certutil.AltNames{
-		DNSNames: []string{"localhost", "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc." + config.ClusterDomain},
-		IPs:      []net.IP{apiServerServiceIP},
+		DNSNames: []string{"kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc." + config.ClusterDomain},
 	}
 
 	addSANs(altNames, config.SANs)
@@ -345,9 +338,7 @@ func genETCDCerts(config *config.Control, runtime *config.ControlRuntime) error 
 		return err
 	}
 
-	altNames := &certutil.AltNames{
-		DNSNames: []string{"localhost"},
-	}
+	altNames := &certutil.AltNames{}
 	addSANs(altNames, config.SANs)
 
 	if _, err := createClientCertKey(regen, "etcd-server", nil,

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -2,8 +2,13 @@ package util
 
 import (
 	"errors"
+	"fmt"
 	"net"
+	"os"
 	"strings"
+
+	"github.com/urfave/cli"
+	apinet "k8s.io/apimachinery/pkg/util/net"
 )
 
 // JoinIPs stringifies and joins a list of IP addresses with commas.
@@ -62,4 +67,42 @@ func GetFirst4String(elems []string) (string, error) {
 		return "", err
 	}
 	return ip.String(), nil
+}
+
+// GetHostnameAndIPs takes a node name and list of IPs, usually from CLI args.
+// If set, these are used to return the node's name and addresses. If not set,
+// the system hostname and primary interface address are returned instead.
+func GetHostnameAndIPs(name string, nodeIPs cli.StringSlice) (string, []net.IP, error) {
+	ips := []net.IP{}
+	if len(nodeIPs) == 0 {
+		hostIP, err := apinet.ChooseHostInterface()
+		if err != nil {
+			return "", nil, err
+		}
+		ips = append(ips, hostIP)
+	} else {
+		for _, hostIP := range nodeIPs {
+			for _, v := range strings.Split(hostIP, ",") {
+				ip := net.ParseIP(v)
+				if ip == nil {
+					return "", nil, fmt.Errorf("invalid node-ip %s", v)
+				}
+				ips = append(ips, ip)
+			}
+		}
+	}
+
+	if name == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			return "", nil, err
+		}
+		name = hostname
+	}
+
+	// Use lower case hostname to comply with kubernetes constraint:
+	// https://github.com/kubernetes/kubernetes/issues/71140
+	name = strings.ToLower(name)
+
+	return name, ips, nil
 }


### PR DESCRIPTION
#### Proposed Changes ####

Add missing node name entry to apiserver SAN list. Also honor node-ip when adding the node address to the SAN list, instead of hardcoding the autodetected IP address.

This converts the agent getHostnameAndIPs function into a utility function, and cleans up some import aliases resolved by moving it out of the agent config module.

#### Types of Changes ####

bugfix

#### Verification ####

* `echo QUIT |openssl s_client -connect localhost:6444 2>&1 | openssl x509 -noout -text | grep -A1 Alternative`
* Verify that the list contains the node name IP address; the hostname and private IP should be used by default, or --node-name and --node-ip values if set.

#### Linked Issues ####

* #3961

#### User-Facing Change ####

This is mostly only visible on RKE2, but...

```release-note
The local kube-apiserver that is available on port 6444 on server nodes now includes the node name in the certificate SAN list
```

#### Further Comments ####

