### PR TITLE
Allow option to disable s3 over https when using etcd-snapshot

### DIFF
--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -77,6 +77,11 @@ var EtcdSnapshotFlags = []cli.Flag{
 		Usage:       "(db) S3 folder",
 		Destination: &ServerConfig.EtcdS3Folder,
 	},
+	&cli.BoolFlag{
+		Name:        "s3-insecure",
+		Usage:       "(db) Disables S3 over HTTPS",
+		Destination: &ServerConfig.EtcdS3Insecure,
+	},
 }
 
 func NewEtcdSnapshotCommand(action func(*cli.Context) error, subcommands []cli.Command) cli.Command {

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -89,6 +89,7 @@ type Server struct {
 	EtcdS3BucketName         string
 	EtcdS3Region             string
 	EtcdS3Folder             string
+	EtcdS3Insecure           bool
 }
 
 var (
@@ -330,6 +331,11 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Name:        "etcd-s3-folder",
 				Usage:       "(db) S3 folder",
 				Destination: &ServerConfig.EtcdS3Folder,
+			},
+			&cli.BoolFlag{
+				Name:        "etcd-s3-insecure",
+				Usage:       "(db) Disables S3 over HTTPS",
+				Destination: &ServerConfig.EtcdS3Insecure,
 			},
 			cli.StringFlag{
 				Name:        "default-local-storage-path",

--- a/pkg/cli/etcdsnapshot/etcd_snapshot.go
+++ b/pkg/cli/etcdsnapshot/etcd_snapshot.go
@@ -49,6 +49,7 @@ func commandSetup(app *cli.Context, cfg *cmds.Server, sc *server.Config) (string
 	sc.ControlConfig.EtcdS3BucketName = cfg.EtcdS3BucketName
 	sc.ControlConfig.EtcdS3Region = cfg.EtcdS3Region
 	sc.ControlConfig.EtcdS3Folder = cfg.EtcdS3Folder
+	sc.ControlConfig.EtcdS3Insecure = cfg.EtcdS3Insecure
 	sc.ControlConfig.Runtime = &config.ControlRuntime{}
 
 	return server.ResolveDataDir(cfg.DataDir)

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -145,6 +145,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		serverConfig.ControlConfig.EtcdS3BucketName = cfg.EtcdS3BucketName
 		serverConfig.ControlConfig.EtcdS3Region = cfg.EtcdS3Region
 		serverConfig.ControlConfig.EtcdS3Folder = cfg.EtcdS3Folder
+		serverConfig.ControlConfig.EtcdS3Insecure = cfg.EtcdS3Insecure
 	} else {
 		logrus.Info("ETCD snapshots are disabled")
 	}

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -167,6 +167,7 @@ type Control struct {
 	EtcdS3BucketName         string
 	EtcdS3Region             string
 	EtcdS3Folder             string
+	EtcdS3Insecure           bool
 
 	BindAddress string
 	SANs        []string

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -879,6 +879,7 @@ type s3Config struct {
 	Bucket        string `json:"bucket,omitempty"`
 	Region        string `json:"region,omitempty"`
 	Folder        string `json:"folder,omitempty"`
+	Insecure      bool   `json:"insecure,omitempty"`
 }
 
 // SnapshotFile represents a single snapshot and it's
@@ -945,6 +946,7 @@ func (e *ETCD) listSnapshots(ctx context.Context, snapshotDir string) ([]Snapsho
 					Bucket:        e.config.EtcdS3BucketName,
 					Region:        e.config.EtcdS3Region,
 					Folder:        e.config.EtcdS3Folder,
+					Insecure:      e.config.EtcdS3Insecure,
 				},
 			})
 		}

--- a/pkg/etcd/s3.go
+++ b/pkg/etcd/s3.go
@@ -53,7 +53,7 @@ func NewS3(ctx context.Context, config *config.Control) (*S3, error) {
 
 	opt := minio.Options{
 		Creds:        creds,
-		Secure:       true,
+		Secure:       !config.EtcdS3Insecure,
 		Region:       config.EtcdS3Region,
 		Transport:    tr,
 		BucketLookup: bucketLookupType(config.EtcdS3Endpoint),


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Adds a `--s3-insecure` flag to disable s3 over HTTPS in the etcd-snapshot feature

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

New feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- Set up a local minio instance that's only accessable over HTTP.
- Create a etcd snapshot with the new flag. e.g.

```
sudo k3s etcd-snapshot \
  --s3 \
  --s3-endpoint="192.168.42.60:9000" \
  --s3-bucket="etcd-snapshots" \
  --s3-access-key="" \
  --s3-secret-key="" \
  --s3-insecure
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

* https://github.com/k3s-io/k3s/issues/3972

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
