### PR TITLE
SupportPodPidsLimit is locked to true of 1.20, making pids cgroup support mandatory

### DIFF
--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -139,10 +139,7 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 		argsMap["cpu-cfs-quota"] = "false"
 	}
 	if !hasPIDs {
-		logrus.Warn("Disabling pod PIDs limit feature due to missing cgroup pids support")
-		argsMap["cgroups-per-qos"] = "false"
-		argsMap["enforce-node-allocatable"] = ""
-		argsMap["feature-gates"] = util.AddFeatureGate(argsMap["feature-gates"], "SupportPodPidsLimit=false")
+		logrus.Fatal("PIDS cgroup support not found")
 	}
 	if kubeletRoot != "" {
 		argsMap["kubelet-cgroups"] = kubeletRoot


### PR DESCRIPTION
#### Proposed Changes ####

Don't attempt to start the Kubelet with the feature-gate disabled; it's locked on. Just print an error and fail early.

#### Types of Changes ####

bugfix

#### Verification ####

Attempt to start K3s on a system without PIDS cgroup support (not sure how to find such a system)

#### Linked Issues ####

* #3786

#### User-Facing Change ####
```release-note
K3s will no longer attempt to disable the SupportPodPidsLimit FeatureGate on nodes without PIDS cgroup support. PIDS cgroup support is mandatory as of Kubernetes 1.20.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
