### PR TITLE
[engine-1.21] Add exposed metrics listener instead of replacing loopback listener

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -523,10 +523,11 @@ func (e *ETCD) clientURL() string {
 
 // metricsURL returns the metrics access address
 func (e *ETCD) metricsURL(expose bool) string {
+	address := "http://127.0.0.1:2381"
 	if expose {
-		return fmt.Sprintf("http://%s:2381", e.address)
+		address = fmt.Sprintf("http://%s:2381,%s", e.address, address)
 	}
-	return "http://127.0.0.1:2381"
+	return address
 }
 
 // cluster returns ETCDConfig for a cluster
@@ -535,7 +536,7 @@ func (e *ETCD) cluster(ctx context.Context, forceNew bool, options executor.Init
 		Name:                e.name,
 		InitialOptions:      options,
 		ForceNewCluster:     forceNew,
-		ListenClientURLs:    fmt.Sprintf(e.clientURL() + ",https://127.0.0.1:2379"),
+		ListenClientURLs:    e.clientURL() + ",https://127.0.0.1:2379",
 		ListenMetricsURLs:   e.metricsURL(e.config.EtcdExposeMetrics),
 		ListenPeerURLs:      e.peerURL(),
 		AdvertiseClientURLs: e.clientURL(),


### PR DESCRIPTION
#### Proposed Changes ####

When exposing etcd metrics, add an exposed listener instead of replacing the loopback listener

#### Types of Changes ####

bugfix

#### Verification ####

Start k3s with --etcd-expose-metrics; note that it is listening on the metrics port on both loopback and the host IP

#### Linked Issues ####

* #3984

#### User-Facing Change ####

```release-note
Exposing etcd metrics on the host IP no longer disables the localhost metrics listener
```

#### Further Comments ####