### PR TITLE
Wait for apiserver readyz instead of healthz

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/cloud-provider v0.22.1
 	k8s.io/component-base v0.22.1
-	k8s.io/controller-manager v0.22.1
+	k8s.io/controller-manager v0.22.1 // indirect
 	k8s.io/cri-api v0.22.1
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.9.0

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/controller-manager/app"
 	app2 "k8s.io/kubernetes/cmd/kube-proxy/app"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	utilsnet "k8s.io/utils/net"
@@ -97,7 +96,7 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 		return err
 	}
 
-	app.WaitForAPIServer(coreClient, 30*time.Second)
+	util.WaitForAPIServerReady(coreClient, 30*time.Second)
 
 	if !nodeConfig.NoFlannel {
 		if err := flannel.Run(ctx, nodeConfig, coreClient.CoreV1().Nodes()); err != nil {

--- a/pkg/util/api.go
+++ b/pkg/util/api.go
@@ -1,10 +1,17 @@
 package util
 
 import (
+	"context"
+	"fmt"
 	"net"
+	"net/http"
 	"strconv"
+	"time"
 
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
 )
 
 func GetAddresses(endpoint *v1.Endpoints) []string {
@@ -25,4 +32,33 @@ func GetAddresses(endpoint *v1.Endpoints) []string {
 		}
 	}
 	return serverAddresses
+}
+
+// WaitForAPIServerReady waits for the API Server's /readyz endpoint to report "ok" with timeout.
+// This is cribbed from the Kubernetes controller-manager app, but checks the readyz endpoint instead of the deprecated healthz endpoint.
+func WaitForAPIServerReady(client clientset.Interface, timeout time.Duration) error {
+	var lastErr error
+
+	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		healthStatus := 0
+		result := client.Discovery().RESTClient().Get().AbsPath("/readyz").Do(context.TODO()).StatusCode(&healthStatus)
+		if result.Error() != nil {
+			lastErr = fmt.Errorf("failed to get apiserver /readyz status: %v", result.Error())
+			return false, nil
+		}
+		if healthStatus != http.StatusOK {
+			content, _ := result.Raw()
+			lastErr = fmt.Errorf("APIServer isn't ready: %v", string(content))
+			logrus.Warnf("APIServer isn't ready yet: %v. Waiting a little while.", string(content))
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("%v: %v", err, lastErr)
+	}
+
+	return nil
 }


### PR DESCRIPTION
#### Proposed Changes ####

Wait for apiserver readyz instead of healthz

#### Types of Changes ####

bugfix

#### Verification ####

Upgrade multi-node cluster from 1.21 to 1.22; note that controllers don't start before all the apiserver storageversions stuff has figured itself out.

#### Linked Issues ####

* #3994 

#### User-Facing Change ####

```release-note

```

#### Further Comments ####

This adds a new utility function cribbed from controller-manager:
https://github.com/kubernetes/kubernetes/blob/release-1.22/staging/src/k8s.io/controller-manager/app/helper.go#L31-L32

Deprecation reference: https://kubernetes.io/docs/reference/using-api/health-checks/#api-endpoints-for-health