### PR TITLE
Bump helm-controller and klipper-helm image version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/k3s-io/helm-controller v0.11.3
+	github.com/k3s-io/helm-controller v0.11.5
 	github.com/k3s-io/kine v0.8.0
 	github.com/klauspost/compress v1.13.5
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -570,8 +570,8 @@ github.com/k3s-io/etcd/etcdutl/v3 v3.5.0-k3s2 h1:Feifl9EStGdmkUnOtouh0VD9n+UbgTx
 github.com/k3s-io/etcd/etcdutl/v3 v3.5.0-k3s2/go.mod h1:o98rKMCibbFAG8QS9KmvlYDGDShmmIbmRE8vSofzYNg=
 github.com/k3s-io/etcd/server/v3 v3.5.0-k3s2 h1:yw8t2/k8Gwsv462XkEVawYGn5N+FI2xG97O3lleSSMI=
 github.com/k3s-io/etcd/server/v3 v3.5.0-k3s2/go.mod h1:3Ah5ruV+M+7RZr0+Y/5mNLwC+eQlni+mQmOVdCRJoS4=
-github.com/k3s-io/helm-controller v0.11.3 h1:DSPAOCGHxF5pmF4vzQP5AgPT3tiGRJRZu+08hwWtbGI=
-github.com/k3s-io/helm-controller v0.11.3/go.mod h1:z0ExsRRIkTO/QC//3/Esn5ItTD6AiQSluwzMaS7RI/4=
+github.com/k3s-io/helm-controller v0.11.5 h1:s3pVbNj112drfSYfZsZqIf32OMQzzK+x6mgZUJfOT34=
+github.com/k3s-io/helm-controller v0.11.5/go.mod h1:z0ExsRRIkTO/QC//3/Esn5ItTD6AiQSluwzMaS7RI/4=
 github.com/k3s-io/kine v0.8.0 h1:k6T9bI9DID7lIbktukXxg1QfeFoAQK4EIvAHoyPAe08=
 github.com/k3s-io/kine v0.8.0/go.mod h1:gaezUQ9c8iw8vxDV/DI8vc93h2rCpTvY37kMdYPMsyc=
 github.com/k3s-io/klog v1.0.0-k3s1 h1:Bg+gRta3s4sfbaYUSWbHcMEyVdxdaU1cJCRtWcaxjBE=

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,4 +1,4 @@
-docker.io/rancher/klipper-helm:v0.6.4-build20210813
+docker.io/rancher/klipper-helm:v0.6.5-build20210915
 docker.io/rancher/klipper-lb:v0.2.0
 docker.io/rancher/local-path-provisioner:v0.0.20
 docker.io/rancher/mirrored-coredns-coredns:1.8.4

--- a/vendor/github.com/k3s-io/helm-controller/pkg/helm/controller.go
+++ b/vendor/github.com/k3s-io/helm-controller/pkg/helm/controller.go
@@ -30,7 +30,7 @@ import (
 var (
 	trueVal         = true
 	commaRE         = regexp.MustCompile(`\\*,`)
-	DefaultJobImage = "rancher/klipper-helm:v0.6.4-build20210813"
+	DefaultJobImage = "rancher/klipper-helm:v0.6.5-build20210915"
 )
 
 type Controller struct {
@@ -47,6 +47,11 @@ const (
 	CRDName       = "helmcharts.helm.cattle.io"
 	ConfigCRDName = "helmchartconfigs.helm.cattle.io"
 	Name          = "helm-controller"
+
+	TaintExternalCloudProvider = "node.cloudprovider.kubernetes.io/uninitialized"
+	LabelNodeRolePrefix        = "node-role.kubernetes.io/"
+	LabelControlPlaneSuffix    = "control-plane"
+	LabelEtcdSuffix            = "etcd"
 )
 
 func Register(ctx context.Context, apply apply.Apply,
@@ -279,15 +284,19 @@ func job(chart *helmv1.HelmChart) (*batch.Job, *core.ConfigMap, *core.ConfigMap)
 		})
 	}
 
+	job.Spec.Template.Spec.NodeSelector = make(map[string]string)
+	job.Spec.Template.Spec.NodeSelector[core.LabelOSStable] = "linux"
+
 	if chart.Spec.Bootstrap {
+		job.Spec.Template.Spec.NodeSelector[LabelNodeRolePrefix+LabelControlPlaneSuffix] = "true"
 		job.Spec.Template.Spec.HostNetwork = true
 		job.Spec.Template.Spec.Tolerations = []core.Toleration{
 			{
-				Key:    "node.kubernetes.io/not-ready",
+				Key:    core.TaintNodeNotReady,
 				Effect: core.TaintEffectNoSchedule,
 			},
 			{
-				Key:      "node.cloudprovider.kubernetes.io/uninitialized",
+				Key:      TaintExternalCloudProvider,
 				Operator: core.TolerationOpEqual,
 				Value:    "true",
 				Effect:   core.TaintEffectNoSchedule,
@@ -297,12 +306,12 @@ func job(chart *helmv1.HelmChart) (*batch.Job, *core.ConfigMap, *core.ConfigMap)
 				Operator: core.TolerationOpExists,
 			},
 			{
-				Key:      "node-role.kubernetes.io/etcd",
+				Key:      LabelNodeRolePrefix + LabelEtcdSuffix,
 				Operator: core.TolerationOpExists,
 				Effect:   core.TaintEffectNoExecute,
 			},
 			{
-				Key:      "node-role.kubernetes.io/control-plane",
+				Key:      LabelNodeRolePrefix + LabelControlPlaneSuffix,
 				Operator: core.TolerationOpExists,
 				Effect:   core.TaintEffectNoSchedule,
 			},
@@ -318,8 +327,6 @@ func job(chart *helmv1.HelmChart) (*batch.Job, *core.ConfigMap, *core.ConfigMap)
 				Name:  "BOOTSTRAP",
 				Value: "true"},
 		}...)
-		job.Spec.Template.Spec.NodeSelector = make(map[string]string)
-		job.Spec.Template.Spec.NodeSelector["node-role.kubernetes.io/master"] = "true"
 	}
 
 	setProxyEnv(job)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -735,7 +735,7 @@ github.com/jonboulle/clockwork
 github.com/josharian/intern
 # github.com/json-iterator/go v1.1.11
 github.com/json-iterator/go
-# github.com/k3s-io/helm-controller v0.11.3
+# github.com/k3s-io/helm-controller v0.11.5
 ## explicit
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1


### PR DESCRIPTION

#### Proposed Changes ####

Bump helm-controller and klipper-helm image version

*Waiting for merge and tag of https://github.com/k3s-io/helm-controller/pull/118*

#### Types of Changes ####

bugfix

#### Verification ####

Upgrade a K3s cluster from 1.21 to 1.22

#### Linked Issues ####

* #3994 

#### User-Facing Change ####
```release-note
The embedded Helm controller now ensures that deprecated or removed Kubernetes api versions are handled properly during upgrades.
```

#### Further Comments ####
