### PR TITLE
Enable JobTrackingWithFinalizers FeatureGate

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -92,6 +92,7 @@ func Server(ctx context.Context, cfg *config.Control) error {
 
 func controllerManager(ctx context.Context, cfg *config.Control, runtime *config.ControlRuntime) error {
 	argsMap := map[string]string{
+		"feature-gates":                    "JobTrackingWithFinalizers=true",
 		"kubeconfig":                       runtime.KubeConfigController,
 		"authorization-kubeconfig":         runtime.KubeConfigController,
 		"authentication-kubeconfig":        runtime.KubeConfigController,
@@ -145,7 +146,9 @@ func scheduler(ctx context.Context, cfg *config.Control, runtime *config.Control
 }
 
 func apiServer(ctx context.Context, cfg *config.Control, runtime *config.ControlRuntime) (authenticator.Request, http.Handler, error) {
-	argsMap := make(map[string]string)
+	argsMap := map[string]string{
+		"feature-gates": "JobTrackingWithFinalizers=true",
+	}
 
 	setupStorageBackend(argsMap, cfg)
 


### PR DESCRIPTION
#### Proposed Changes ####

Enable JobTrackingWithFinalizers FeatureGate

Works around issue with Job controller not tracking job pods that are in CrashloopBackoff during upgrade from 1.21 to 1.22.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* #3994

#### User-Facing Change ####
```release-note
The JobTrackingWithFinalizers alpha feature-gate is now enabled by default.
```

#### Further Comments ####

