### PR TITLE
Fix regression from commit 137e80cd865efe51aa3ef0323fd6b0a014b7b9de

### DIFF
--- a/contrib/util/check-config.sh
+++ b/contrib/util/check-config.sh
@@ -341,7 +341,7 @@ case "${cgroupVariant}" in
         cgroupFile='/proc/self/cgroup'
         ;;
     esac
-    if [ "$(tr -s ' ' '\n' <"${cgroupFile}" 2>/dev/null | grep -Ec "^(${cgroupMatch})\$")" -eq ${cgroupMatchNum} ]; then
+    if [ "$(tr -s ' ' '\n' <"${cgroupFile}" 2>/dev/null | grep -Ec "(^|:)(${cgroupMatch})(\$|:)")" -eq ${cgroupMatchNum} ]; then
       cgroupStatus='good'
     else
       cgroupStatus='bad'


### PR DESCRIPTION
Problem:

A false-negative in check-config.sh for cgroups v2 systems was fixed but the commit introduced a regression based on a small assumption that content of /sys/fs/cgroup/cgroup.controllers would have the same format as the content of /proc/self/cgroup. It doesn't.

Solution:

This just tweaks the regex to count occurrences of either cgroup subsystem-names on each line (as occurs in the sysfs pseudo-file), or those names with colons either side (as occurs in the procfs pseudo-file).

* #4013