### PR TITLE
Disable automounting service account token in servicelb pods

### DIFF
--- a/pkg/servicelb/controller.go
+++ b/pkg/servicelb/controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	v1getter "k8s.io/client-go/kubernetes/typed/apps/v1"
 	coregetter "k8s.io/client-go/kubernetes/typed/core/v1"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 var (
@@ -326,6 +327,9 @@ func (h *handler) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 						"app":        name,
 						svcNameLabel: svc.Name,
 					},
+				},
+				Spec: core.PodSpec{
+					AutomountServiceAccountToken: utilpointer.Bool(false),
 				},
 			},
 			UpdateStrategy: apps.DaemonSetUpdateStrategy{


### PR DESCRIPTION
#### Proposed Changes ####

Disable automounting service account token in servicelb pods

They don't need em, don't mount em.

#### Types of Changes ####

* enhancement

#### Verification ####

See `kubectl describe` output in linked issue; no tokens should be mounted.

#### Linked Issues ####

* #4040 

#### User-Facing Change ####

```release-note
servicelb pods no longer mount the kube-system default service account token
```

#### Further Comments ####

This wasn't hurting anything but it seems like an easy optimization / reduction in unnecessary privilege.