### PR TITLE
[Release-engine-1.21] Make sure there are no duplicates in etcd member list 

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -222,6 +222,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	if err != nil {
 		return err
 	}
+	serverConfig.ControlConfig.ServerNodeName = nodeName
 	serverConfig.ControlConfig.SANs = append(serverConfig.ControlConfig.SANs, "127.0.0.1", "localhost", nodeName)
 	for _, ip := range nodeIPs {
 		serverConfig.ControlConfig.SANs = append(serverConfig.ControlConfig.SANs, ip.String())

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -166,6 +166,7 @@ type Control struct {
 	EtcdS3BucketName         string
 	EtcdS3Region             string
 	EtcdS3Folder             string
+	ServerNodeName           string
 
 	BindAddress string
 	SANs        []string


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

- Using node names and not os.Hostname for etcd membership
- making sure there are no duplicates when joining a new etcd node

#### Types of Changes ####
bug fix

#### Verification ####

- Start a server with node name node1
- join another server with the same node name

you should get an error stating the following:
```
FATA[0000] starting kubernetes: preparing server: start managed database: joining etcd cluster: Failed to join etcd cluster due to duplicate node names, please use unique node name for the server
```

#### Linked Issues ####

- https://github.com/k3s-io/k3s/issues/4049


#### User-Facing Change ####

There are none, this shouldnt affect the current way we join etcd members, as for current etcd members they wont get affected since they are using the node name that is on file already
