### PR TITLE
Revert "Use the newer klipper-lb image"

### DIFF
--- a/pkg/servicelb/controller.go
+++ b/pkg/servicelb/controller.go
@@ -32,7 +32,7 @@ var (
 	svcNameLabel       = "svccontroller." + version.Program + ".cattle.io/svcname"
 	daemonsetNodeLabel = "svccontroller." + version.Program + ".cattle.io/enablelb"
 	nodeSelectorLabel  = "svccontroller." + version.Program + ".cattle.io/nodeselector"
-	DefaultLBImage     = "rancher/klipper-lb:v0.3.0"
+	DefaultLBImage     = "rancher/klipper-lb:v0.2.0"
 )
 
 const (

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,5 +1,5 @@
 docker.io/rancher/klipper-helm:v0.6.5-build20210915
-docker.io/rancher/klipper-lb:v0.3.0
+docker.io/rancher/klipper-lb:v0.2.0
 docker.io/rancher/local-path-provisioner:v0.0.20
 docker.io/rancher/mirrored-coredns-coredns:1.8.4
 docker.io/rancher/mirrored-library-busybox:1.32.1


### PR DESCRIPTION
Reverts k3s-io/k3s#4029

We need to do additional work to bring the armv7l klipper-lb image up to date; will try this again once that's ready.