### PR TITLE
Drop broken SupportNoneCgroupDriver support

### DIFF
--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -26,12 +26,7 @@ func createRootlessConfig(argsMap map[string]string, hasCFS, hasPIDs bool) {
 		// cgroupfs v2, delegated for rootless by systemd
 		argsMap["cgroup-driver"] = "cgroupfs"
 	} else {
-		logrus.Warn("cgroup v2 controllers are not delegated for rootless. Setting cgroup driver to \"none\".")
-		// flags are from https://github.com/rootless-containers/usernetes/blob/v20190826.0/boot/kubelet.sh
-		argsMap["cgroup-driver"] = "none"
-		argsMap["feature-gates=SupportNoneCgroupDriver"] = "true"
-		argsMap["cgroups-per-qos"] = "false"
-		argsMap["enforce-node-allocatable"] = ""
+		logrus.Fatal("delegated cgroup v2 controllers are required for rootless.")
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes ####

Drop broken SupportNoneCgroupDriver support

#### Types of Changes ####

rootless

#### Verification ####

Run k3s rootless

#### Linked Issues ####

#3596 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Rootless support now requires delegated cgroup v2 support.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
