### PR TITLE
[engine-1.21] Update build images to python3 for compat with recent gsutil change

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -9,7 +9,7 @@ ENV https_proxy=$https_proxy
 ENV no_proxy=$no_proxy
 
 RUN apk -U --no-cache add bash git gcc musl-dev docker vim less file curl wget ca-certificates jq linux-headers \
-    zlib-dev tar zip squashfs-tools npm coreutils python2 openssl-dev libffi-dev libseccomp libseccomp-dev \
+    zlib-dev tar zip squashfs-tools npm coreutils python3 openssl-dev libffi-dev libseccomp libseccomp-dev \
     libseccomp-static make libuv-static sqlite-dev sqlite-static libselinux libselinux-dev zlib-dev zlib-static \
     zstd gzip alpine-sdk binutils-gold
 RUN if [ "$(go env GOARCH)" = "arm64" ]; then                                                               \

--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -1,7 +1,7 @@
 ARG GOLANG=golang:1.16.6-alpine3.13
 FROM ${GOLANG}
 
-RUN apk -U --no-cache add bash git gcc musl-dev docker curl jq coreutils python2 openssl py-pip
+RUN apk -U --no-cache add bash git gcc musl-dev docker curl jq coreutils python3 openssl py3-pip
 
 ENV SONOBUOY_VERSION 0.50.0
 


### PR DESCRIPTION
#### Proposed Changes ####

Update build images to python3 for compat with recent gsutil change

#### Types of Changes ####

ci; bugfix

#### Verification ####

Check CI

#### Linked Issues ####

* TBD

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####