### PR TITLE
[engine-1.21] Properly handle operation as init process

### DIFF
--- a/pkg/cli/agent/agent.go
+++ b/pkg/cli/agent/agent.go
@@ -23,9 +23,16 @@ func Run(ctx *cli.Context) error {
 	// database credentials or other secrets.
 	gspt.SetProcTitle(os.Args[0] + " agent")
 
+	// Do init stuff if pid 1.
+	// This must be done before InitLogging as that may reexec in order to capture log output
+	if err := cmds.HandleInit(); err != nil {
+		return err
+	}
+
 	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
+
 	if os.Getuid() != 0 && runtime.GOOS != "windows" {
 		return fmt.Errorf("agent must be ran as root")
 	}

--- a/pkg/cli/cmds/init_default.go
+++ b/pkg/cli/cmds/init_default.go
@@ -1,0 +1,7 @@
+// +build !linux !cgo
+
+package cmds
+
+func HandleInit() error {
+	return nil
+}

--- a/pkg/cli/cmds/init_linux.go
+++ b/pkg/cli/cmds/init_linux.go
@@ -1,0 +1,83 @@
+// +build linux,cgo
+
+package cmds
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/erikdubbelboer/gspt"
+	"github.com/pkg/errors"
+	"github.com/rancher/k3s/pkg/version"
+	"github.com/rootless-containers/rootlesskit/pkg/parent/cgrouputil"
+)
+
+// HandleInit takes care of things that need to be done when running as process 1, usually in a
+// Docker container. This includes evacuating the root cgroup and reaping child pids.
+func HandleInit() error {
+	if os.Getpid() != 1 {
+		return nil
+	}
+
+	// The root cgroup has to be empty to enable subtree_control, so evacuate it by placing
+	// ourselves in the init cgroup.
+	if err := cgrouputil.EvacuateCgroup2("init"); err != nil {
+		return errors.Wrap(err, "failed to evacuate root cgroup")
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return errors.Wrap(err, "failed to get working directory for init process")
+	}
+
+	go reapChildren()
+
+	// fork the main process to do work so that this init process can handle reaping pids
+	// without interfering with any other exec's that the rest of the codebase may do.
+	var wstatus syscall.WaitStatus
+	pattrs := &syscall.ProcAttr{
+		Dir: pwd,
+		Env: os.Environ(),
+		Sys: &syscall.SysProcAttr{Setsid: true},
+		Files: []uintptr{
+			uintptr(syscall.Stdin),
+			uintptr(syscall.Stdout),
+			uintptr(syscall.Stderr),
+		},
+	}
+	pid, err := syscall.ForkExec(os.Args[0], os.Args, pattrs)
+	if err != nil {
+		return errors.Wrap(err, "failed to fork/exec "+version.Program)
+	}
+
+	gspt.SetProcTitle(os.Args[0] + " init")
+	// wait for main process to exit, and return its status when it does
+	_, err = syscall.Wait4(pid, &wstatus, 0, nil)
+	for err == syscall.EINTR {
+		_, err = syscall.Wait4(pid, &wstatus, 0, nil)
+	}
+	os.Exit(wstatus.ExitStatus())
+	return nil
+}
+
+//reapChildren calls Wait4 whenever SIGCHLD is received
+func reapChildren() {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGCHLD)
+	for {
+		select {
+		case <-sigs:
+		}
+		for {
+			var wstatus syscall.WaitStatus
+			_, err := syscall.Wait4(-1, &wstatus, 0, nil)
+			for err == syscall.EINTR {
+				_, err = syscall.Wait4(-1, &wstatus, 0, nil)
+			}
+			if err == nil || err == syscall.ECHILD {
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
#### Proposed Changes ####

Properly handle operation as init process. This includes both vacating the root cgroup on cgroupv2 systems, and reaping child processes since containerd doesn't clean up after its own shims.

This is a Go adaptation of the behavior proposed in #3237; we rejected doing this in shell and K3d has been using a workaround ever since.

#### Types of Changes ####

bugfix

#### Verification ####

* Build RKE2 with this release and run it in Docker on a system with cgroup v2; note that it works
* Note that there are no `<defunct>` processes inside the Docker container

#### Linked Issues ####
* Backport of #4086 
* #4092 
* #4093

#### User-Facing Change ####
```release-note
The K3s docker image now works on cgroup v2 systems, and properly reaps terminated containerd shim processes.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
