### PR TITLE
[Backport 1.22] Enable the inheritance of settings for ipv6

### DIFF
--- a/pkg/agent/syssetup/setup.go
+++ b/pkg/agent/syssetup/setup.go
@@ -50,6 +50,7 @@ func Configure(enableIPv6 bool, config *kubeproxyconfig.KubeProxyConntrackConfig
 		sysctls["net/ipv6/conf/all/forwarding"] = 1
 		sysctls["net/ipv6/conf/default/forwarding"] = 1
 		sysctls["net/bridge/bridge-nf-call-ip6tables"] = 1
+		sysctls["net/core/devconf_inherit_init_net"] = 1
 	}
 
 	if conntrackMax := getConntrackMax(config); conntrackMax > 0 {


### PR DESCRIPTION
Backport form: https://github.com/k3s-io/k3s/pull/4098
Linked issue: https://github.com/k3s-io/k3s/issues/4100

Signed-off-by: Manuel Buil <mbuil@suse.com>