### PR TITLE
Dual-stack support in serviceLB controller

### DIFF
--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,5 +1,5 @@
 docker.io/rancher/klipper-helm:v0.6.5-build20210915
-docker.io/rancher/klipper-lb:v0.3.0
+docker.io/rancher/klipper-lb:v0.3.2
 docker.io/rancher/local-path-provisioner:v0.0.20
 docker.io/rancher/mirrored-coredns-coredns:1.8.4
 docker.io/rancher/mirrored-library-busybox:1.32.1


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This PR provides dual-stack support in the servicelb controller. There are basically three main changes:

1 - Depending on the value of  "svc.Spec.IPFamilyPolicy", the service will set ipv4, ipv6 or dual-stack externalIPs
2 - Depending on the value of "svc.Spec.IPFamilies[0]", i.e. what class of IP has more priority, either ipv4 or ipv6 addressess will get first

Note that these two points are basically replicating what is explained in the docs https://kubernetes.io/docs/concepts/services-networking/dual-stack/

3 -  klipper-lb daemonset will get the svc.Spec.ClusterIPs as DEST_IPs env variable instead of svc.Spec.ClusterIP. This basically means supporting dual-stack services that have two ip addresses:
```
  clusterIP: 10.43.189.134
  clusterIPs:
  - 10.43.189.134
  - 2001:cafe:42:1::51f4
```

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
New feature

#### Verification ####
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
k apply -f https://gist.githubusercontent.com/aojea/90768935ab71cb31950b6a13078a7e92/raw/99ceac308f2b2658c7313198a39fbe24b155ae68/dual-stack.yaml

And then change the Type of the four services to `LoadBalancer`. You should see:

```
default       my-service-v6             LoadBalancer   2001:cafe:42:1::a62f   2a05:d012:c6f:4611:5c2:5602:eed2:898c             8080:30111/TCP               6m26s   app=MyDualApp
default       my-service-v4             LoadBalancer   10.43.218.132          10.0.10.7                                         8081:30541/TCP               6m26s   app=MyDualApp
default       my-service-prefer-dual    LoadBalancer   10.43.104.103          10.0.10.7,2a05:d012:c6f:4611:5c2:5602:eed2:898c   8082:31258/TCP               6m26s   app=MyDualApp
default       my-service-require-dual   LoadBalancer   2001:cafe:42:1::5f60   10.0.10.7,2a05:d012:c6f:4611:5c2:5602:eed2:898c   8083:30520/TCP               99s     app=MyDualApp
```
And be able to curl on both ipv4 and ipv6 ips. For example
```
curl http://[2a05:d012:c6f:4611:5c2:5602:eed2:898c]:8083
curl http://10.0.10.7:8083
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/k3s-io/k3s/issues/4021

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
Support for dual stack in serviceLB controller
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Signed-off-by: Manuel Buil <mbuil@suse.com>