### PR TITLE
Send MAINPID to systemd when reexecing for logfile output

### DIFF
--- a/pkg/cli/cmds/log.go
+++ b/pkg/cli/cmds/log.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	systemd "github.com/coreos/go-systemd/daemon"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/natefinch/lumberjack"
 	"github.com/rancher/k3s/pkg/version"
@@ -98,7 +99,11 @@ func runWithLogging() error {
 	cmd.Stderr = l
 	cmd.Stdout = l
 	cmd.Stdin = os.Stdin
-	return cmd.Run()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	systemd.SdNotify(false, fmt.Sprintf("MAINPID=%d\n", cmd.Process.Pid))
+	return cmd.Wait()
 }
 
 func setupLogging() {


### PR DESCRIPTION

#### Proposed Changes ####

Send MAINPID to systemd when reexecing for logfile output. This allows the new process to notify systemd when it is ready, instead of having `systemctl start k3s` hang forever because only the first pid is allowed to notify.

#### Types of Changes ####

bugfix

#### Verification ####

Add `--log=/var/log/k3s.log` to flags or config file and start K3s systemd unit; note that it completes successfully.

#### Linked Issues ####

* #1356
* #2277
* #2825
* #3202

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The k3s systemd unit will no longer hang starting when the `--log` flag is used to redirect output
```

#### Further Comments ####

