### PR TITLE
[engine-1.21] Display cluster tls error only in debug mode

### DIFF
--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"crypto/tls"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -76,10 +77,17 @@ func (c *Cluster) initClusterAndHTTPS(ctx context.Context) error {
 		return err
 	}
 
+	// get log level set on the initial start
+	logLevel := logrus.GetLevel()
+
 	// Create a HTTP server with the registered request handlers, using logrus for logging
 	server := http.Server{
-		Handler:  handler,
-		ErrorLog: log.New(logrus.StandardLogger().Writer(), "Cluster-Http-Server ", log.LstdFlags),
+		Handler: handler}
+
+	if logLevel == logrus.DebugLevel {
+		server.ErrorLog = log.New(logrus.StandardLogger().Writer(), "Cluster-Http-Server ", log.LstdFlags)
+	} else {
+		server.ErrorLog = log.New(ioutil.Discard, "Cluster-Http-Server", 0)
 	}
 
 	// Start the supervisor http server on the tls listener


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Only display dynamic listener's cluster tls error in debug mode to avoid any confusion with initial joining of agent or servers in HA mode

#### Types of Changes ####

bug fix
#### Verification ####


- start k3s server
- join k3s agent or another server

Make sure that you dont see any error that looks like that in the logs:

```
INFO[0063] Cluster-Http-Server 2021/09/30 19:42:40 http: TLS handshake error from 172.17.0.3:40938: remote error: tls: bad certificate 
```

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/4067

#### User-Facing Change ####
None