### PR TITLE
[release-1.22] Don't evacuate the root cgroup when rootless

### DIFF
--- a/pkg/cli/cmds/init_linux.go
+++ b/pkg/cli/cmds/init_linux.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/containerd/containerd/pkg/userns"
 	"github.com/erikdubbelboer/gspt"
 	"github.com/pkg/errors"
 	"github.com/rancher/k3s/pkg/version"
@@ -20,10 +21,12 @@ func HandleInit() error {
 		return nil
 	}
 
-	// The root cgroup has to be empty to enable subtree_control, so evacuate it by placing
-	// ourselves in the init cgroup.
-	if err := cgrouputil.EvacuateCgroup2("init"); err != nil {
-		return errors.Wrap(err, "failed to evacuate root cgroup")
+	if !userns.RunningInUserNS() {
+		// The root cgroup has to be empty to enable subtree_control, so evacuate it by placing
+		// ourselves in the init cgroup.
+		if err := cgrouputil.EvacuateCgroup2("init"); err != nil {
+			return errors.Wrap(err, "failed to evacuate root cgroup")
+		}
 	}
 
 	pwd, err := os.Getwd()


### PR DESCRIPTION
#### Proposed Changes ####

Don't evacuate the root cgroup when rootless; fixes regression introduced by #4088

#### Types of Changes ####

rootless

#### Verification ####

Start K3s rootless; verify that it works

#### Linked Issues ####

* #4085

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a regression introduced by #4088 that broke rootless support
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
