### PR TITLE
Bump containerd to v1.5.7+k3s1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace (
 	github.com/containerd/btrfs => github.com/containerd/btrfs v1.0.0
 	github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
 	github.com/containerd/console => github.com/containerd/console v1.0.2
-	github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.5-k3s1 // k3s-release/1.5
+	github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.7-k3s1 // k3s-release/1.5
 	github.com/containerd/continuity => github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1
 	github.com/containerd/fifo => github.com/containerd/fifo v1.0.0
 	github.com/containerd/go-runc => github.com/containerd/go-runc v1.0.0
@@ -74,9 +74,9 @@ replace (
 )
 
 require (
-	github.com/Microsoft/hcsshim v0.8.20
+	github.com/Microsoft/hcsshim v0.8.21
 	github.com/containerd/cgroups v1.0.1
-	github.com/containerd/containerd v1.5.5
+	github.com/containerd/containerd v1.5.7
 	github.com/containerd/fuse-overlayfs-snapshotter v1.0.3
 	github.com/containerd/stargz-snapshotter v0.8.0
 	github.com/coreos/go-iptables v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -555,8 +555,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k3s-io/containerd v1.5.5-k3s1 h1:7iLg0MbBsYolqVF5r6VstF2JdZpQd3eT0oMfNBTqkWk=
-github.com/k3s-io/containerd v1.5.5-k3s1/go.mod h1:ramaQKl1FyuvtSuGToVvnQee9vx1btr5ngcRz44RtW0=
+github.com/k3s-io/containerd v1.5.7-k3s1 h1:zL6q83W5GjsOTDaTnulq7s4pxw3/7bts5crf69QkGbk=
+github.com/k3s-io/containerd v1.5.7-k3s1/go.mod h1:hObOmrfY040ivCbFVvVnwQhAfGVTE/6DqD2WHFFmgX8=
 github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1 h1:KEz2rd9IDbrQT8w6RibEYlwfTXiu0P6hQDE+6O4IJdI=
 github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
 github.com/k3s-io/cri-tools v1.21.0-k3s1 h1:MWQtAsx4HCNXenqU/B4V9eU6HMyafkd1PnW6d4HCfos=

--- a/vendor/github.com/containerd/containerd/.mailmap
+++ b/vendor/github.com/containerd/containerd/.mailmap
@@ -108,6 +108,7 @@ Tõnis Tiigi <tonistiigi@gmail.com>
 Wade Lee <weidonglee27@gmail.com>
 Wade Lee <weidonglee27@gmail.com> <weidonglee29@gmail.com>
 Wade Lee <weidonglee27@gmail.com> <21621232@zju.edu.cn>
+wanglei <wllenyj@linux.alibaba.com>
 Wei Fu <fuweid89@gmail.com>
 Wei Fu <fuweid89@gmail.com> <fhfuwei@163.com>
 Xiaodong Zhang <a4012017@sina.com>

--- a/vendor/github.com/containerd/containerd/Vagrantfile
+++ b/vendor/github.com/containerd/containerd/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.16.7",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.16.8",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/vendor/github.com/containerd/containerd/cmd/ctr/commands/run/run.go
+++ b/vendor/github.com/containerd/containerd/cmd/ctr/commands/run/run.go
@@ -247,3 +247,16 @@ func fullID(ctx context.Context, c containerd.Container) string {
 	}
 	return fmt.Sprintf("%s-%s", ns, id)
 }
+
+// buildLabel builds the labels from command line labels and the image labels
+func buildLabels(cmdLabels, imageLabels map[string]string) map[string]string {
+	labels := make(map[string]string)
+	for k, v := range imageLabels {
+		labels[k] = v
+	}
+	// labels from the command line will override image and the initial image config labels
+	for k, v := range cmdLabels {
+		labels[k] = v
+	}
+	return labels
+}

--- a/vendor/github.com/containerd/containerd/cmd/ctr/commands/run/run_unix.go
+++ b/vendor/github.com/containerd/containerd/cmd/ctr/commands/run/run_unix.go
@@ -94,8 +94,8 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		spec  containerd.NewContainerOpts
 	)
 
-	cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(context.StringSlice("label"))))
 	if config {
+		cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(context.StringSlice("labels"))))
 		opts = append(opts, oci.WithSpecFromFile(context.String("config")))
 	} else {
 		var (
@@ -116,6 +116,7 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 				return nil, err
 			}
 			opts = append(opts, oci.WithRootFSPath(rootfs))
+			cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(context.StringSlice("labels"))))
 		} else {
 			snapshotter := context.String("snapshotter")
 			var image containerd.Image
@@ -142,9 +143,12 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 					return nil, err
 				}
 			}
+			labels := buildLabels(commands.LabelArgs(context.StringSlice("label")), image.Labels())
 			opts = append(opts, oci.WithImageConfig(image))
 			cOpts = append(cOpts,
 				containerd.WithImage(image),
+				containerd.WithImageConfigLabels(image),
+				containerd.WithAdditionalContainerLabels(labels),
 				containerd.WithSnapshotter(snapshotter))
 			if uidmap, gidmap := context.String("uidmap"), context.String("gidmap"); uidmap != "" && gidmap != "" {
 				uidMap, err := parseIDMapping(uidmap)

--- a/vendor/github.com/containerd/containerd/cmd/ctr/commands/run/run_windows.go
+++ b/vendor/github.com/containerd/containerd/cmd/ctr/commands/run/run_windows.go
@@ -51,6 +51,7 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 	if config {
 		id = context.Args().First()
 		opts = append(opts, oci.WithSpecFromFile(context.String("config")))
+		cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(context.StringSlice("label"))))
 	} else {
 		var (
 			ref  = context.Args().First()
@@ -88,9 +89,13 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			}
 		}
 		opts = append(opts, oci.WithImageConfig(image))
-		cOpts = append(cOpts, containerd.WithImage(image))
-		cOpts = append(cOpts, containerd.WithSnapshotter(snapshotter))
-		cOpts = append(cOpts, containerd.WithNewSnapshot(id, image))
+		labels := buildLabels(commands.LabelArgs(context.StringSlice("label")), image.Labels())
+		cOpts = append(cOpts,
+			containerd.WithImage(image),
+			containerd.WithImageConfigLabels(image),
+			containerd.WithSnapshotter(snapshotter),
+			containerd.WithNewSnapshot(id, image),
+			containerd.WithAdditionalContainerLabels(labels))
 
 		if len(args) > 0 {
 			opts = append(opts, oci.WithProcessArgs(args...))
@@ -124,7 +129,6 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		}
 	}
 
-	cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(context.StringSlice("label"))))
 	runtime := context.String("runtime")
 	var runtimeOpts interface{}
 	if runtime == "io.containerd.runhcs.v1" {

--- a/vendor/github.com/containerd/containerd/container_opts.go
+++ b/vendor/github.com/containerd/containerd/container_opts.go
@@ -18,14 +18,19 @@ package containerd
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/typeurl"
 	"github.com/gogo/protobuf/types"
 	"github.com/opencontainers/image-spec/identity"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -91,6 +96,39 @@ func WithImageName(n string) NewContainerOpts {
 func WithContainerLabels(labels map[string]string) NewContainerOpts {
 	return func(_ context.Context, _ *Client, c *containers.Container) error {
 		c.Labels = labels
+		return nil
+	}
+}
+
+// WithImageConfigLabels sets the image config labels on the container.
+// The existing labels are cleared as this is expected to be the first
+// operation in setting up a container's labels. Use WithAdditionalContainerLabels
+// to add/overwrite the existing image config labels.
+func WithImageConfigLabels(image Image) NewContainerOpts {
+	return func(ctx context.Context, _ *Client, c *containers.Container) error {
+		ic, err := image.Config(ctx)
+		if err != nil {
+			return err
+		}
+		var (
+			ociimage v1.Image
+			config   v1.ImageConfig
+		)
+		switch ic.MediaType {
+		case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
+			p, err := content.ReadBlob(ctx, image.ContentStore(), ic)
+			if err != nil {
+				return err
+			}
+
+			if err := json.Unmarshal(p, &ociimage); err != nil {
+				return err
+			}
+			config = ociimage.Config
+		default:
+			return fmt.Errorf("unknown image config media type %s", ic.MediaType)
+		}
+		c.Labels = config.Labels
 		return nil
 	}
 }

--- a/vendor/github.com/containerd/containerd/content/helpers.go
+++ b/vendor/github.com/containerd/containerd/content/helpers.go
@@ -144,8 +144,13 @@ func Copy(ctx context.Context, cw Writer, r io.Reader, size int64, expected dige
 		}
 	}
 
-	if _, err := copyWithBuffer(cw, r); err != nil {
+	copied, err := copyWithBuffer(cw, r)
+	if err != nil {
 		return errors.Wrap(err, "failed to copy")
+	}
+	if size != 0 && copied < size-ws.Offset {
+		// Short writes would return its own error, this indicates a read failure
+		return errors.Wrapf(io.ErrUnexpectedEOF, "failed to read expected number of bytes")
 	}
 
 	if err := cw.Commit(ctx, size, expected, opts...); err != nil {
@@ -165,8 +170,15 @@ func CopyReaderAt(cw Writer, ra ReaderAt, n int64) error {
 		return err
 	}
 
-	_, err = copyWithBuffer(cw, io.NewSectionReader(ra, ws.Offset, n))
-	return err
+	copied, err := copyWithBuffer(cw, io.NewSectionReader(ra, ws.Offset, n))
+	if err != nil {
+		return errors.Wrap(err, "failed to copy")
+	}
+	if copied < n {
+		// Short writes would return its own error, this indicates a read failure
+		return errors.Wrap(io.ErrUnexpectedEOF, "failed to read expected number of bytes")
+	}
+	return nil
 }
 
 // CopyReader copies to a writer from a given reader, returning

--- a/vendor/github.com/containerd/containerd/contrib/seccomp/seccomp_default.go
+++ b/vendor/github.com/containerd/containerd/contrib/seccomp/seccomp_default.go
@@ -49,6 +49,7 @@ func arches() []specs.Arch {
 
 // DefaultProfile defines the allowed syscalls for the default seccomp profile.
 func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
+	nosys := uint(unix.ENOSYS)
 	syscalls := []specs.LinuxSyscall{
 		{
 			Names: []string{
@@ -526,6 +527,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				Names: []string{
 					"bpf",
 					"clone",
+					"clone3",
 					"fanotify_init",
 					"fsconfig",
 					"fsmount",
@@ -657,6 +659,15 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				},
 			})
 		}
+		// clone3 is explicitly requested to give ENOSYS instead of the default EPERM, when CAP_SYS_ADMIN is unset
+		// https://github.com/moby/moby/pull/42681
+		s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+			Names: []string{
+				"clone3",
+			},
+			Action:   specs.ActErrno,
+			ErrnoRet: &nosys,
+		})
 	}
 
 	return s

--- a/vendor/github.com/containerd/containerd/go.mod
+++ b/vendor/github.com/containerd/containerd/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Microsoft/go-winio v0.4.17
-	github.com/Microsoft/hcsshim v0.8.18
+	github.com/Microsoft/hcsshim v0.8.21
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/btrfs v1.0.0
 	github.com/containerd/cgroups v1.0.1
@@ -39,7 +39,7 @@ require (
 	github.com/moby/sys/symlink v0.1.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
-	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/runc v1.0.2
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/selinux v1.8.2
 	github.com/pelletier/go-toml v1.8.1

--- a/vendor/github.com/containerd/containerd/go.sum
+++ b/vendor/github.com/containerd/containerd/go.sum
@@ -41,8 +41,8 @@ github.com/Microsoft/go-winio v0.4.17 h1:iT12IBVClFevaf8PuVyi3UmZOVh4OqnaLxDTW2O
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
-github.com/Microsoft/hcsshim v0.8.18 h1:cYnKADiM1869gvBpos3YCteeT6sZLB48lB5dmMMs8Tg=
-github.com/Microsoft/hcsshim v0.8.18/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
+github.com/Microsoft/hcsshim v0.8.21 h1:btRfUDThBE5IKcvI8O8jOiIkujUsAMBSRsYDYmEi6oM=
+github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -419,8 +419,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/runc v1.0.1 h1:G18PGckGdAm3yVQRWDVQ1rLSLntiniKJ0cNRT2Tm5gs=
-github.com/opencontainers/runc v1.0.1/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
+github.com/opencontainers/runc v1.0.2 h1:opHZMaswlyxz1OuGpBE53Dwe4/xF7EZTY0A2L/FpCOg=
+github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=

--- a/vendor/github.com/containerd/containerd/metadata/content.go
+++ b/vendor/github.com/containerd/containerd/metadata/content.go
@@ -551,13 +551,13 @@ func (nw *namespacedWriter) createAndCopy(ctx context.Context, desc ocispec.Desc
 	if desc.Size > 0 {
 		ra, err := nw.provider.ReaderAt(ctx, nw.desc)
 		if err != nil {
+			w.Close()
 			return err
 		}
 		defer ra.Close()
 
 		if err := content.CopyReaderAt(w, ra, desc.Size); err != nil {
-			nw.w.Close()
-			nw.w = nil
+			w.Close()
 			return err
 		}
 	}

--- a/vendor/github.com/containerd/containerd/oci/spec_opts_linux.go
+++ b/vendor/github.com/containerd/containerd/oci/spec_opts_linux.go
@@ -48,13 +48,13 @@ func WithDevices(devicePath, containerPath, permissions string) SpecOpts {
 		if err != nil {
 			return err
 		}
-		for _, dev := range devs {
-			s.Linux.Devices = append(s.Linux.Devices, dev)
+		for i := range devs {
+			s.Linux.Devices = append(s.Linux.Devices, devs[i])
 			s.Linux.Resources.Devices = append(s.Linux.Resources.Devices, specs.LinuxDeviceCgroup{
 				Allow:  true,
-				Type:   dev.Type,
-				Major:  &dev.Major,
-				Minor:  &dev.Minor,
+				Type:   devs[i].Type,
+				Major:  &devs[i].Major,
+				Minor:  &devs[i].Minor,
 				Access: permissions,
 			})
 		}

--- a/vendor/github.com/containerd/containerd/pkg/cri/server/container_create.go
+++ b/vendor/github.com/containerd/containerd/pkg/cri/server/container_create.go
@@ -230,7 +230,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		return nil, errors.Wrap(err, "failed to get container spec opts")
 	}
 
-	containerLabels := buildLabels(config.Labels, containerKindContainer)
+	containerLabels := buildLabels(config.Labels, image.ImageSpec.Config.Labels, containerKindContainer)
 
 	runtimeOptions, err := getRuntimeOptions(sandboxInfo)
 	if err != nil {

--- a/vendor/github.com/containerd/containerd/pkg/cri/server/container_create_linux.go
+++ b/vendor/github.com/containerd/containerd/pkg/cri/server/container_create_linux.go
@@ -213,6 +213,9 @@ func (c *criService) containerSpec(
 		}
 	}
 
+	specOpts = append(specOpts, customopts.WithDevices(c.os, config),
+		customopts.WithCapabilities(securityContext, c.allCaps))
+
 	if securityContext.GetPrivileged() {
 		if !sandboxConfig.GetLinux().GetSecurityContext().GetPrivileged() {
 			return nil, errors.New("no privileged container allowed in sandbox")
@@ -220,14 +223,7 @@ func (c *criService) containerSpec(
 		specOpts = append(specOpts, oci.WithPrivileged)
 		if !ociRuntime.PrivilegedWithoutHostDevices {
 			specOpts = append(specOpts, oci.WithHostDevices, oci.WithAllDevicesAllowed)
-		} else {
-			// add requested devices by the config as host devices are not automatically added
-			specOpts = append(specOpts, customopts.WithDevices(c.os, config),
-				customopts.WithCapabilities(securityContext, c.allCaps))
 		}
-	} else { // not privileged
-		specOpts = append(specOpts, customopts.WithDevices(c.os, config),
-			customopts.WithCapabilities(securityContext, c.allCaps))
 	}
 
 	// Clear all ambient capabilities. The implication of non-root + caps

--- a/vendor/github.com/containerd/containerd/pkg/cri/server/helpers.go
+++ b/vendor/github.com/containerd/containerd/pkg/cri/server/helpers.go
@@ -283,8 +283,12 @@ func filterLabel(k, v string) string {
 }
 
 // buildLabel builds the labels from config to be passed to containerd
-func buildLabels(configLabels map[string]string, containerType string) map[string]string {
+func buildLabels(configLabels, imageConfigLabels map[string]string, containerType string) map[string]string {
 	labels := make(map[string]string)
+	for k, v := range imageConfigLabels {
+		labels[k] = v
+	}
+	// labels from the CRI request (config) will override labels in the image config
 	for k, v := range configLabels {
 		labels[k] = v
 	}

--- a/vendor/github.com/containerd/containerd/pkg/cri/server/helpers_linux.go
+++ b/vendor/github.com/containerd/containerd/pkg/cri/server/helpers_linux.go
@@ -48,9 +48,6 @@ const (
 	defaultShmSize = int64(1024 * 1024 * 64)
 	// relativeRootfsPath is the rootfs path relative to bundle path.
 	relativeRootfsPath = "rootfs"
-	// According to http://man7.org/linux/man-pages/man5/resolv.conf.5.html:
-	// "The search list is currently limited to six domains with a total of 256 characters."
-	maxDNSSearches = 6
 	// devShm is the default path of /dev/shm.
 	devShm = "/dev/shm"
 	// etcHosts is the default path of /etc/hosts file.

--- a/vendor/github.com/containerd/containerd/pkg/cri/server/sandbox_run.go
+++ b/vendor/github.com/containerd/containerd/pkg/cri/server/sandbox_run.go
@@ -192,7 +192,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		return nil, errors.Wrap(err, "failed to generate sanbdox container spec options")
 	}
 
-	sandboxLabels := buildLabels(config.Labels, containerKindSandbox)
+	sandboxLabels := buildLabels(config.Labels, image.ImageSpec.Config.Labels, containerKindSandbox)
 
 	runtimeOpts, err := generateRuntimeOptions(ociRuntime, c.config)
 	if err != nil {

--- a/vendor/github.com/containerd/containerd/pkg/cri/server/sandbox_run_linux.go
+++ b/vendor/github.com/containerd/containerd/pkg/cri/server/sandbox_run_linux.go
@@ -275,10 +275,6 @@ func (c *criService) setupSandboxFiles(id string, config *runtime.PodSandboxConf
 func parseDNSOptions(servers, searches, options []string) (string, error) {
 	resolvContent := ""
 
-	if len(searches) > maxDNSSearches {
-		return "", errors.Errorf("DNSOption.Searches has more than %d domains", maxDNSSearches)
-	}
-
 	if len(searches) > 0 {
 		resolvContent += fmt.Sprintf("search %s\n", strings.Join(searches, " "))
 	}

--- a/vendor/github.com/containerd/containerd/runtime/v2/bundle.go
+++ b/vendor/github.com/containerd/containerd/runtime/v2/bundle.go
@@ -72,7 +72,10 @@ func NewBundle(ctx context.Context, root, state, id string, spec []byte) (b *Bun
 	if err := os.MkdirAll(filepath.Dir(b.Path), 0711); err != nil {
 		return nil, err
 	}
-	if err := os.Mkdir(b.Path, 0711); err != nil {
+	if err := os.Mkdir(b.Path, 0700); err != nil {
+		return nil, err
+	}
+	if err := prepareBundleDirectoryPermissions(b.Path, spec); err != nil {
 		return nil, err
 	}
 	paths = append(paths, b.Path)

--- a/vendor/github.com/containerd/containerd/runtime/v2/bundle_default.go
+++ b/vendor/github.com/containerd/containerd/runtime/v2/bundle_default.go
@@ -1,3 +1,6 @@
+//go:build !linux
+// +build !linux
+
 /*
    Copyright The containerd Authors.
 
@@ -14,21 +17,8 @@
    limitations under the License.
 */
 
-package version
+package v2
 
-import "runtime"
-
-var (
-	// Package is filled at linking time
-	Package = "github.com/containerd/containerd"
-
-	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.5.7+unknown"
-
-	// Revision is filled with the VCS (e.g. git) revision being used to build
-	// the program at linking time.
-	Revision = ""
-
-	// GoVersion is Go tree's version.
-	GoVersion = runtime.Version()
-)
+// prepareBundleDirectoryPermissions prepares the permissions of the bundle
+// directory according to the needs of the current platform.
+func prepareBundleDirectoryPermissions(path string, spec []byte) error { return nil }

--- a/vendor/github.com/containerd/containerd/runtime/v2/bundle_linux.go
+++ b/vendor/github.com/containerd/containerd/runtime/v2/bundle_linux.go
@@ -1,0 +1,74 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// prepareBundleDirectoryPermissions prepares the permissions of the bundle
+// directory according to the needs of the current platform.
+// On Linux when user namespaces are enabled, the permissions are modified to
+// allow the remapped root GID to access the bundle.
+func prepareBundleDirectoryPermissions(path string, spec []byte) error {
+	gid, err := remappedGID(spec)
+	if err != nil {
+		return err
+	}
+	if gid == 0 {
+		return nil
+	}
+	if err := os.Chown(path, -1, int(gid)); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0710)
+}
+
+// ociSpecUserNS is a subset of specs.Spec used to reduce garbage during
+// unmarshal.
+type ociSpecUserNS struct {
+	Linux *linuxSpecUserNS
+}
+
+// linuxSpecUserNS is a subset of specs.Linux used to reduce garbage during
+// unmarshal.
+type linuxSpecUserNS struct {
+	GIDMappings []specs.LinuxIDMapping
+}
+
+// remappedGID reads the remapped GID 0 from the OCI spec, if it exists. If
+// there is no remapping, remappedGID returns 0. If the spec cannot be parsed,
+// remappedGID returns an error.
+func remappedGID(spec []byte) (uint32, error) {
+	var ociSpec ociSpecUserNS
+	err := json.Unmarshal(spec, &ociSpec)
+	if err != nil {
+		return 0, err
+	}
+	if ociSpec.Linux == nil || len(ociSpec.Linux.GIDMappings) == 0 {
+		return 0, nil
+	}
+	for _, mapping := range ociSpec.Linux.GIDMappings {
+		if mapping.ContainerID == 0 {
+			return mapping.HostID, nil
+		}
+	}
+	return 0, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -48,7 +48,7 @@ github.com/Microsoft/go-winio/pkg/etwlogrus
 github.com/Microsoft/go-winio/pkg/guid
 github.com/Microsoft/go-winio/pkg/security
 github.com/Microsoft/go-winio/vhd
-# github.com/Microsoft/hcsshim v0.8.20 => github.com/Microsoft/hcsshim v0.8.20
+# github.com/Microsoft/hcsshim v0.8.21 => github.com/Microsoft/hcsshim v0.8.20
 ## explicit
 github.com/Microsoft/hcsshim
 github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options
@@ -182,7 +182,7 @@ github.com/containerd/cgroups/v2
 github.com/containerd/cgroups/v2/stats
 # github.com/containerd/console v1.0.3 => github.com/containerd/console v1.0.2
 github.com/containerd/console
-# github.com/containerd/containerd v1.5.5 => github.com/k3s-io/containerd v1.5.5-k3s1
+# github.com/containerd/containerd v1.5.7 => github.com/k3s-io/containerd v1.5.7-k3s1
 ## explicit
 github.com/containerd/containerd
 github.com/containerd/containerd/api/events
@@ -3388,7 +3388,7 @@ sigs.k8s.io/yaml
 # github.com/containerd/btrfs => github.com/containerd/btrfs v1.0.0
 # github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
 # github.com/containerd/console => github.com/containerd/console v1.0.2
-# github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.5-k3s1
+# github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.7-k3s1
 # github.com/containerd/continuity => github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1
 # github.com/containerd/fifo => github.com/containerd/fifo v1.0.0
 # github.com/containerd/go-runc => github.com/containerd/go-runc v1.0.0


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to v1.5.7+k3s1

#### Types of Changes ####

CVE

#### Verification ####

`kubectl get nodes -o wide`

#### Linked Issues ####

* #4141

#### User-Facing Change ####
```release-note
The embedded containerd has been updated to v1.5.7+k3s1 to address CVE-2021-41103
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
