### PR TITLE
Update stable to v1.21.5+k3s2

### DIFF
--- a/channel.yaml
+++ b/channel.yaml
@@ -1,7 +1,7 @@
 # Example channels config
 channels:
 - name: stable
-  latest: v1.21.5+k3s1
+  latest: v1.21.5+k3s2
 - name: latest
   latestRegexp: .*
   excludeRegexp: ^[^+]+-


### PR DESCRIPTION
#### Proposed Changes ####

Mark v1.21.5+k3s2 as stable due to CVE

#### Types of Changes ####

channel server

#### Verification ####

Install K3s from install.sh

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/4143

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
