### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -706,9 +706,13 @@ rm -rf /var/lib/kubelet
 rm -f ${BIN_DIR}/k3s
 rm -f ${KILLALL_K3S_SH}
 
-if type yum >/dev/null 2>&1; then
-    yum remove -y k3s-selinux
-    rm -f /etc/yum.repos.d/rancher-k3s-common*.repo
+if [ "$INSTALL_K3S_SKIP_SELINUX_RPM" = true ] || can_skip_download; then
+    info "Skipping uninstall of SELinux RPM becuase we didn't install it"
+else
+    if type yum >/dev/null 2>&1; then
+        yum remove -y k3s-selinux
+        rm -f /etc/yum.repos.d/rancher-k3s-common*.repo
+    fi
 fi
 EOF
     $SUDO chmod 755 ${UNINSTALL_K3S_SH}

--- a/install.sh
+++ b/install.sh
@@ -707,7 +707,7 @@ rm -f ${BIN_DIR}/k3s
 rm -f ${KILLALL_K3S_SH}
 
 if [ "$INSTALL_K3S_SKIP_SELINUX_RPM" = true ] || can_skip_download; then
-    info "Skipping uninstall of SELinux RPM becuase we didn't install it"
+    info "Skipping uninstall of SELinux RPM because we didn't install it"
 else
     if type yum >/dev/null 2>&1; then
         yum remove -y k3s-selinux


### PR DESCRIPTION
#### Proposed Changes ####

Add the same logic that installs k3s-selinux, to the uninstall portion. If you didn't install the package then you shouldn't uninstall it.

#### Types of Changes ####

New Feature

#### Verification ####

install k3s with INSTALL_K3S_SKIP_SELINUX_RPM=true. Check UNINSTALL_K3S_SH script has:
```bash
if [ "true" = true ] || can_skip_download; then
    info "Skipping uninstall of SELinux RPM because we didn't install it"
else
    if type yum >/dev/null 2>&1; then
        yum remove -y k3s-selinux
        rm -f /etc/yum.repos.d/rancher-k3s-common*.repo
    fi
fi
```

install k3s without INSTALL_K3S_SKIP_SELINUX_RPM=true. Check UNINSTALL_K3S_SH script has:
```bash
if [ "false" = true ] || can_skip_download; then
    info "Skipping uninstall of SELinux RPM because we didn't install it"
else
    if type yum >/dev/null 2>&1; then
        yum remove -y k3s-selinux
        rm -f /etc/yum.repos.d/rancher-k3s-common*.repo
    fi
fi
```
