### PR TITLE
Fix race condition in cloud provider

### DIFF
--- a/pkg/cloudprovider/instances.go
+++ b/pkg/cloudprovider/instances.go
@@ -36,9 +36,12 @@ func (k *k3s) InstanceID(ctx context.Context, nodeName types.NodeName) (string, 
 		return "", errors.New("Node informer has not synced yet")
 	}
 
-	_, err := k.nodeInformer.Lister().Get(string(nodeName))
+	node, err := k.nodeInformer.Lister().Get(string(nodeName))
 	if err != nil {
-		return "", fmt.Errorf("Failed to find node %s: %v", nodeName, err)
+		return "", fmt.Errorf("failed to get node %s: %w", nodeName, err)
+	}
+	if (node.Annotations[InternalIPKey] == "") && (node.Labels[InternalIPKey] == "") {
+		return string(nodeName), errors.New("address annotations not yet set")
 	}
 	return string(nodeName), nil
 }


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This PR forces kubernetes to not clean the taint "node.cloudprovider.kubernetes.io/uninitialized" while annotations are not set. Without this PR, we get this:

```
435407-Oct 14 18:59:11 ip-10-0-10-7 k3s[2268670]: I1014 18:59:11.239823 2268670 node_controller.go:330] Skipping node address update for node "ip-10-0-10-7" since cloud provider did not return any
435408:Oct 14 18:59:11 ip-10-0-10-7 k3s[2268670]: I1014 18:59:11.239847 2268670 node_controller.go:454] Successfully initialized node ip-10-0-10-7 with cloud provider
```
And the reason is that, by the time the k3s cloud provider reports to be ready, the node annotations are not set yet by the agent. As a consequence, node addresses update needs to wait until the next iteration. That creates a delay for, among others, the ipv6 address of the node which generates problems in dual-stack mode 


#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Right after deploying k3s, run:
`for i in $(seq 500); do echo && sleep 2 && kubectl get nodes -o yaml | grep cloudprovider -n3 || echo "Taint disappeared" && kubectl get nodes -o yaml | grep annotations -n5 && date; done`

without this PR, you will see that the taint "node.cloudprovider.kubernetes.io/uninitialized" disappears before the annotations like " k3s.io/internal-ip: 10.0.10.7,2a05:d012:c6f:4611:5c2:5602:eed2:898c" are created. And in the logs of k3s you will see:
```
435407-Oct 14 18:59:11 ip-10-0-10-7 k3s[2268670]: I1014 18:59:11.239823 2268670 node_controller.go:330] Skipping node address update for node "ip-10-0-10-7" since cloud provider did not return any
435408:Oct 14 18:59:11 ip-10-0-10-7 k3s[2268670]: I1014 18:59:11.239847 2268670 node_controller.go:454] Successfully initialized node ip-10-0-10-7 with cloud provider
```

When using this PR, the "skipping address update" should not appear and annotations appear before the taint is gone


#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/k3s-io/k3s/issues/1405
https://github.com/k3s-io/k3s/issues/4217

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
