### PR TITLE
[release-1.22] Bump klog fork version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,8 +53,8 @@ replace (
 	k8s.io/controller-manager => github.com/k3s-io/kubernetes/staging/src/k8s.io/controller-manager v1.22.2-k3s1
 	k8s.io/cri-api => github.com/k3s-io/kubernetes/staging/src/k8s.io/cri-api v1.22.2-k3s1
 	k8s.io/csi-translation-lib => github.com/k3s-io/kubernetes/staging/src/k8s.io/csi-translation-lib v1.22.2-k3s1
-	k8s.io/klog => github.com/k3s-io/klog v1.0.0-k3s1 // k3s-release-1.x
-	k8s.io/klog/v2 => github.com/k3s-io/klog/v2 v2.9.0-k3s1 // k3s-main
+	k8s.io/klog => github.com/k3s-io/klog v1.0.0-k3s2 // k3s-release-1.x
+	k8s.io/klog/v2 => github.com/k3s-io/klog/v2 v2.9.0-k3s2 // k3s-main
 	k8s.io/kube-aggregator => github.com/k3s-io/kubernetes/staging/src/k8s.io/kube-aggregator v1.22.2-k3s1
 	k8s.io/kube-controller-manager => github.com/k3s-io/kubernetes/staging/src/k8s.io/kube-controller-manager v1.22.2-k3s1
 	k8s.io/kube-proxy => github.com/k3s-io/kubernetes/staging/src/k8s.io/kube-proxy v1.22.2-k3s1

--- a/go.sum
+++ b/go.sum
@@ -573,10 +573,10 @@ github.com/k3s-io/helm-controller v0.11.5 h1:s3pVbNj112drfSYfZsZqIf32OMQzzK+x6mg
 github.com/k3s-io/helm-controller v0.11.5/go.mod h1:z0ExsRRIkTO/QC//3/Esn5ItTD6AiQSluwzMaS7RI/4=
 github.com/k3s-io/kine v0.8.0 h1:k6T9bI9DID7lIbktukXxg1QfeFoAQK4EIvAHoyPAe08=
 github.com/k3s-io/kine v0.8.0/go.mod h1:gaezUQ9c8iw8vxDV/DI8vc93h2rCpTvY37kMdYPMsyc=
-github.com/k3s-io/klog v1.0.0-k3s1 h1:Bg+gRta3s4sfbaYUSWbHcMEyVdxdaU1cJCRtWcaxjBE=
-github.com/k3s-io/klog v1.0.0-k3s1/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
-github.com/k3s-io/klog/v2 v2.9.0-k3s1 h1:q4DqcZgBG+D2TSTGx6JcP1cuXeoxSoixSLE3casDcSw=
-github.com/k3s-io/klog/v2 v2.9.0-k3s1/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
+github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=
+github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+github.com/k3s-io/klog/v2 v2.9.0-k3s2 h1:8Dzu3wGPFMo1mPEobSEpkHWH+HXqgFXp8R7FbcdgE8k=
+github.com/k3s-io/klog/v2 v2.9.0-k3s2/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 github.com/k3s-io/kubernetes v1.22.2-k3s1 h1:A69iFa6z4k8M7s9B/LHgnu2aag58tjV69sYtJBuqRUQ=
 github.com/k3s-io/kubernetes v1.22.2-k3s1/go.mod h1:Snea7fgIObGgHmLbUJ3OgjGEr5bjj16iEdp5oHS6eS8=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/api v1.22.2-k3s1 h1:J+a4JAvA1+jYnngUil3lF7BtyvNKfWDiVUyOhxqdBAA=

--- a/vendor/k8s.io/klog/klog.go
+++ b/vendor/k8s.io/klog/klog.go
@@ -812,6 +812,8 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 		}
 	}
 	if s == fatalLog {
+		l.mu.Unlock()
+		timeoutFlush(10 * time.Second)
 		panic(string(data))
 	}
 	l.putBuffer(buf)

--- a/vendor/k8s.io/klog/v2/klog.go
+++ b/vendor/k8s.io/klog/v2/klog.go
@@ -965,6 +965,8 @@ func (l *loggingT) output(s severity, log logr.Logger, buf *buffer, depth int, f
 		}
 	}
 	if s == fatalLog {
+		l.mu.Unlock()
+		timeoutFlush(10 * time.Second)
 		panic(string(data))
 	}
 	l.putBuffer(buf)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2322,10 +2322,10 @@ k8s.io/gengo/generator
 k8s.io/gengo/namer
 k8s.io/gengo/parser
 k8s.io/gengo/types
-# k8s.io/klog v1.0.0 => github.com/k3s-io/klog v1.0.0-k3s1
+# k8s.io/klog v1.0.0 => github.com/k3s-io/klog v1.0.0-k3s2
 ## explicit
 k8s.io/klog
-# k8s.io/klog/v2 v2.9.0 => github.com/k3s-io/klog/v2 v2.9.0-k3s1
+# k8s.io/klog/v2 v2.9.0 => github.com/k3s-io/klog/v2 v2.9.0-k3s2
 ## explicit
 k8s.io/klog/v2
 # k8s.io/kube-aggregator v0.18.0 => github.com/k3s-io/kubernetes/staging/src/k8s.io/kube-aggregator v1.22.2-k3s1
@@ -3431,8 +3431,8 @@ sigs.k8s.io/yaml
 # k8s.io/controller-manager => github.com/k3s-io/kubernetes/staging/src/k8s.io/controller-manager v1.22.2-k3s1
 # k8s.io/cri-api => github.com/k3s-io/kubernetes/staging/src/k8s.io/cri-api v1.22.2-k3s1
 # k8s.io/csi-translation-lib => github.com/k3s-io/kubernetes/staging/src/k8s.io/csi-translation-lib v1.22.2-k3s1
-# k8s.io/klog => github.com/k3s-io/klog v1.0.0-k3s1
-# k8s.io/klog/v2 => github.com/k3s-io/klog/v2 v2.9.0-k3s1
+# k8s.io/klog => github.com/k3s-io/klog v1.0.0-k3s2
+# k8s.io/klog/v2 => github.com/k3s-io/klog/v2 v2.9.0-k3s2
 # k8s.io/kube-aggregator => github.com/k3s-io/kubernetes/staging/src/k8s.io/kube-aggregator v1.22.2-k3s1
 # k8s.io/kube-controller-manager => github.com/k3s-io/kubernetes/staging/src/k8s.io/kube-controller-manager v1.22.2-k3s1
 # k8s.io/kube-proxy => github.com/k3s-io/kubernetes/staging/src/k8s.io/kube-proxy v1.22.2-k3s1


### PR DESCRIPTION
#### Proposed Changes ####

bump klog fork

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* #4239

#### User-Facing Change ####
```release-note
K3s should now reliably exit when core Kubernetes components (apiserver, controller-manager, etc) experience fatal errors.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
