### PR TITLE
install.sh: capture quoted environment variables

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -727,9 +727,8 @@ create_env_file() {
     info "env: Creating environment file ${FILE_K3S_ENV}"
     $SUDO touch ${FILE_K3S_ENV}
     $SUDO chmod 0600 ${FILE_K3S_ENV}
-    env | grep '^K3S_' | $SUDO tee ${FILE_K3S_ENV} >/dev/null
-    env | grep '^CONTAINERD_' | $SUDO tee -a ${FILE_K3S_ENV} >/dev/null
-    env | grep -Ei '^(NO|HTTP|HTTPS)_PROXY' | $SUDO tee -a ${FILE_K3S_ENV} >/dev/null
+    sh -c export | while read x v; do echo $v; done | grep -E '^(K3S|CONTAINERD)_' | $SUDO tee ${FILE_K3S_ENV} >/dev/null
+    sh -c export | while read x v; do echo $v; done | grep -Ei '^(NO|HTTP|HTTPS)_PROXY' | $SUDO tee -a ${FILE_K3S_ENV} >/dev/null
 }
 
 # --- write systemd service file ---


### PR DESCRIPTION
Leverage posix builtins + grep (with regex matching) to emit quoted
environment variables to K3S_FILE_ENV, e.g.:

```shell
$ export CONTAINERD_TEST_1='one!1' K3S_TEST_2=two K3S_TEST_3='thr ee' TEST_4='!@#$%^&*()_+four!'
$ sh -c export | while read x v; do echo $v; done | grep -E '^(K3S|CONTAINERD)_'
CONTAINERD_TEST_1='one!1'
K3S_TEST_2='two'
K3S_TEST_3='thr ee'
```

Fixes #3395
Addresses rancher/k3os#708

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
