### PR TITLE
[Engine-1.21] Added configuration input to etcd-snapshot (#4280)

### DIFF
--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -11,6 +11,7 @@ const EtcdSnapshotCommand = "etcd-snapshot"
 
 var EtcdSnapshotFlags = []cli.Flag{
 	DebugFlag,
+	ConfigFlag,
 	LogFile,
 	AlsoLogToStderr,
 	cli.StringFlag{
@@ -25,7 +26,7 @@ var EtcdSnapshotFlags = []cli.Flag{
 		Destination: &ServerConfig.DataDir,
 	},
 	&cli.StringFlag{
-		Name:        "name,etcd-snapshot-name",
+		Name:        "name",
 		Usage:       "(db) Set the base name of the etcd on-demand snapshot (appended with UNIX timestamp).",
 		Destination: &ServerConfig.EtcdSnapshotName,
 		Value:       "on-demand",

--- a/pkg/configfilearg/defaultparser.go
+++ b/pkg/configfilearg/defaultparser.go
@@ -7,7 +7,7 @@ import (
 
 func MustParse(args []string) []string {
 	parser := &Parser{
-		After:         []string{"server", "agent"},
+		After:         []string{"server", "agent", "etcd-snapshot"},
 		FlagNames:     []string{"--config", "-c"},
 		EnvName:       version.ProgramUpper + "_CONFIG_FILE",
 		DefaultConfig: "/etc/rancher/" + version.Program + "/config.yaml",


### PR DESCRIPTION
Signed-off-by: dereknola <derek.nola@suse.com>

Backport of:
https://github.com/k3s-io/k3s/pull/4280

#### Proposed Changes ####
Enable `k3s etcd-snapshot` command to use values stored in `/etc/rancher/k3s/config.yaml`

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Write `/etc/rancher/k3s/config.yaml`
```
etcd-s3: "true"
etcd-s3-bucket: "derek"
etcd-s3-access-key: "REDACTED"                                           
etcd-s3-secret-key: "REDACTED"     
```

Start k3s
`k3s server --cluster-init`

Run `k3s etcd-snapshot save` command, notice that is uses the values in config.yaml to save a s3 snapshot.
```
...
INFO[0000] Saving etcd snapshot on-demand-dinux-compute-1634920562 to S3 
INFO[0000] Checking if S3 bucket derek exists  
...
```

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/4286
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
