### PR TITLE
Bump klipper-helm version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/k3s-io/helm-controller v0.11.5
+	github.com/k3s-io/helm-controller v0.11.7
 	github.com/k3s-io/kine v0.8.0
 	github.com/klauspost/compress v1.13.5
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -569,8 +569,8 @@ github.com/k3s-io/etcd/etcdutl/v3 v3.5.0-k3s2 h1:Feifl9EStGdmkUnOtouh0VD9n+UbgTx
 github.com/k3s-io/etcd/etcdutl/v3 v3.5.0-k3s2/go.mod h1:o98rKMCibbFAG8QS9KmvlYDGDShmmIbmRE8vSofzYNg=
 github.com/k3s-io/etcd/server/v3 v3.5.0-k3s2 h1:yw8t2/k8Gwsv462XkEVawYGn5N+FI2xG97O3lleSSMI=
 github.com/k3s-io/etcd/server/v3 v3.5.0-k3s2/go.mod h1:3Ah5ruV+M+7RZr0+Y/5mNLwC+eQlni+mQmOVdCRJoS4=
-github.com/k3s-io/helm-controller v0.11.5 h1:s3pVbNj112drfSYfZsZqIf32OMQzzK+x6mgZUJfOT34=
-github.com/k3s-io/helm-controller v0.11.5/go.mod h1:z0ExsRRIkTO/QC//3/Esn5ItTD6AiQSluwzMaS7RI/4=
+github.com/k3s-io/helm-controller v0.11.7 h1:fNpBImB3h5aHvPf3zwU9sFWmeVQh0nTG1sLCoBhEeUg=
+github.com/k3s-io/helm-controller v0.11.7/go.mod h1:z0ExsRRIkTO/QC//3/Esn5ItTD6AiQSluwzMaS7RI/4=
 github.com/k3s-io/kine v0.8.0 h1:k6T9bI9DID7lIbktukXxg1QfeFoAQK4EIvAHoyPAe08=
 github.com/k3s-io/kine v0.8.0/go.mod h1:gaezUQ9c8iw8vxDV/DI8vc93h2rCpTvY37kMdYPMsyc=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,4 +1,4 @@
-docker.io/rancher/klipper-helm:v0.6.5-build20210915
+docker.io/rancher/klipper-helm:v0.6.6-build20211022
 docker.io/rancher/klipper-lb:v0.3.2
 docker.io/rancher/local-path-provisioner:v0.0.20
 docker.io/rancher/mirrored-coredns-coredns:1.8.4

--- a/vendor/github.com/k3s-io/helm-controller/pkg/helm/controller.go
+++ b/vendor/github.com/k3s-io/helm-controller/pkg/helm/controller.go
@@ -30,7 +30,8 @@ import (
 var (
 	trueVal         = true
 	commaRE         = regexp.MustCompile(`\\*,`)
-	DefaultJobImage = "rancher/klipper-helm:v0.6.5-build20210915"
+	deletePolicy    = meta.DeletePropagationForeground
+	DefaultJobImage = "rancher/klipper-helm:v0.6.6-build20211022"
 )
 
 type Controller struct {
@@ -64,7 +65,7 @@ func Register(ctx context.Context, apply apply.Apply,
 	apply = apply.WithSetID(Name).
 		WithCacheTypes(helms, confs, jobs, crbs, sas, cm).
 		WithStrictCaching().WithPatcher(batch.SchemeGroupVersion.WithKind("Job"), func(namespace, name string, pt types.PatchType, data []byte) (runtime.Object, error) {
-		err := jobs.Delete(namespace, name, &meta.DeleteOptions{})
+		err := jobs.Delete(namespace, name, &meta.DeleteOptions{PropagationPolicy: &deletePolicy})
 		if err == nil {
 			return nil, fmt.Errorf("replace job")
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -735,7 +735,7 @@ github.com/jonboulle/clockwork
 github.com/josharian/intern
 # github.com/json-iterator/go v1.1.11
 github.com/json-iterator/go
-# github.com/k3s-io/helm-controller v0.11.5
+# github.com/k3s-io/helm-controller v0.11.7
 ## explicit
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1


### PR DESCRIPTION
#### Proposed Changes ####

Update helm-controller and klipper-helm to time out the `helm_v2 ls --all` that is done to check for deprecated helm chart versions. This will hang indefinitely if tiller crashes, even if tiller is restarted, so it needs to be worked around otherwise.

#### Types of Changes ####

bugfix, ci

#### Verification ####

Check klipper-helm image version on running node

#### Linked Issues ####

* #4288 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
