### PR TITLE
[release-1.19] Bump klipper-helm version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.1
-	github.com/k3s-io/helm-controller v0.10.5
+	github.com/k3s-io/helm-controller v0.10.8
 	github.com/k3s-io/kine v0.6.2
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -474,8 +474,8 @@ github.com/k3s-io/cri v1.4.0-k3s.7 h1:1ycdF3dMDJMW/k/UxDC6eMsyGSMZ/p0AoUBVdJvNGQ
 github.com/k3s-io/cri v1.4.0-k3s.7/go.mod h1:fGPUUHMKQik/vIegSe05DtX/m4miovdtvVLqRUFAkK0=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea h1:7cwby0GoNAi8IsVrT0q+JfQpB6V76ZaEGhj6qts/mvU=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20201208200253-50621aee4aea/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
-github.com/k3s-io/helm-controller v0.10.5 h1:zrStmx4ZkhtFU/OqJYoAZFGFB1Bu+jZs0N8dtlVRxDk=
-github.com/k3s-io/helm-controller v0.10.5/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
+github.com/k3s-io/helm-controller v0.10.8 h1:O7zoqUBp3W+6+nRCUWNiAoQMzOX6xw9IsBDXc5lP3Ns=
+github.com/k3s-io/helm-controller v0.10.8/go.mod h1:nZP8FH3KZrNNUf5r+SwwiMR63HS6lxdHdpHijgPfF74=
 github.com/k3s-io/kine v0.6.2 h1:1aJTPfB8HG4exqMKFVE5H0z4bepF05tJHtYNXotWXa4=
 github.com/k3s-io/kine v0.6.2/go.mod h1:rzCs93+rQHZGOiewMd84PDrER92QeZ6eeHbWkfEy4+w=
 github.com/k3s-io/kubernetes v1.19.15-k3s1 h1:A1RJfAmS3JinAk0s9TJD5W82wnuuLMC8P88UZutZPQE=

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,5 +1,5 @@
 docker.io/rancher/coredns-coredns:1.8.3
-docker.io/rancher/klipper-helm:v0.6.4-build20210813
+docker.io/rancher/klipper-helm:v0.6.6-build20211022
 docker.io/rancher/klipper-lb:v0.2.0
 docker.io/rancher/library-busybox:1.32.1
 docker.io/rancher/library-traefik:1.7.19

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -684,7 +684,7 @@ github.com/jmespath/go-jmespath
 github.com/jonboulle/clockwork
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
-# github.com/k3s-io/helm-controller v0.10.5
+# github.com/k3s-io/helm-controller v0.10.8
 ## explicit
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io
 github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1


### PR DESCRIPTION
#### Proposed Changes ####

Update helm-controller and klipper-helm to time out the `helm_v2 ls --all` that is done to check for deprecated helm chart versions. This will hang indefinitely if tiller crashes, even if tiller is restarted, so it needs to be worked around otherwise.

#### Types of Changes ####

bugfix, ci

#### Verification ####

Check klipper-helm image version on running node

#### Linked Issues ####

* #3846 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
