### PR TITLE
[engine-1.21] Update peer address when running cluster-reset

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -210,7 +210,23 @@ func (e *ETCD) Reset(ctx context.Context, rebootstrap func() error) error {
 					logrus.Infof("Etcd is running, restart without --cluster-reset flag now. Backup and delete ${datadir}/server/db on each peer etcd server and rejoin the nodes")
 					os.Exit(0)
 				}
+			} else {
+				// make sure that peer ips are updated to the node ip in case the test fails
+				members, err := e.client.MemberList(ctx)
+				if err != nil {
+					logrus.Warnf("failed to list etcd members: %v", err)
+					continue
+				}
+				if len(members.Members) > 1 {
+					logrus.Warnf("failed to update peer url: etcd still has more than one member")
+					continue
+				}
+				if _, err := e.client.MemberUpdate(ctx, members.Members[0].ID, []string{e.peerURL()}); err != nil {
+					logrus.Warnf("failed to update peer url: %v", err)
+					continue
+				}
 			}
+
 		}
 	}()
 


### PR DESCRIPTION
Signed-off-by: galal-hussein <hussein.galal.ahmed.11@gmail.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Update peer address with the node's ip when running cluster-reset

#### Types of Changes ####

bugfix

#### Verification ####

- Run k3s server
- Change the node's ip
- Run cluster-reset to restore the cluster

#### Linked Issues ####

- https://github.com/k3s-io/k3s/issues/4300

