### PR TITLE
install.sh: initial support for sle-micro

### DIFF
--- a/.github/workflows/cgroup2.yaml
+++ b/.github/workflows/cgroup2.yaml
@@ -3,9 +3,13 @@ on:
   push:
     paths-ignore: 
       - "**.md"
+      - "install.sh"
+      - "tests/install"
   pull_request:
     paths-ignore:
       - "**.md"
+      - "install.sh"
+      - "tests/install"
   workflow_dispatch: {}
 jobs:
   build:

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -1,0 +1,95 @@
+name: Installer
+on:
+  push:
+    paths:
+      - "install.sh"
+      - "tests/install"
+  pull_request:
+    paths:
+      - "install.sh"
+      - "tests/install"
+  workflow_dispatch: {}
+jobs:
+  install-centos-7:
+    name: "CentOS 7"
+    # nested virtualization is only available on macOS hosts
+    runs-on: macos-10.15
+    timeout-minutes: 40
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: "VagrantPlugin::K3S"
+        working-directory: tests/install/centos-7
+        run: vagrant plugin install vagrant-k3s
+      - name: "Vagrant::⬆"
+        working-directory: tests/install/centos-7
+        run: vagrant up
+  install-centos-8:
+    name: "CentOS 8"
+    # nested virtualization is only available on macOS hosts
+    runs-on: macos-10.15
+    timeout-minutes: 40
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: "VagrantPlugin::K3S"
+        working-directory: tests/install/centos-8
+        run: vagrant plugin install vagrant-k3s
+      - name: "Vagrant::⬆"
+        working-directory: tests/install/centos-8
+        run: vagrant up
+  install-opensuse-leap:
+    name: "openSUSE Leap"
+    # nested virtualization is only available on macOS hosts
+    runs-on: macos-10.15
+    timeout-minutes: 40
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: "VagrantPlugin::K3S"
+        working-directory: tests/install/opensuse-leap
+        run: vagrant plugin install vagrant-k3s
+      - name: "Vagrant::⬆"
+        working-directory: tests/install/opensuse-leap
+        run: vagrant up
+#  install-opensuse-microos:
+#    name: "openSUSE MicroOS"
+#    # nested virtualization is only available on macOS hosts
+#    runs-on: macos-10.15
+#    timeout-minutes: 40
+#    steps:
+#      - name: "Checkout"
+#        uses: actions/checkout@v2
+#        with:
+#          fetch-depth: 1
+#      - name: "VagrantPlugin::Reload"
+#        working-directory: tests/install/opensuse-microos
+#        run: vagrant plugin install vagrant-reload
+#      - name: "VagrantPlugin::K3S"
+#        working-directory: tests/install/opensuse-microos
+#        run: vagrant plugin install vagrant-k3s
+#      - name: "Vagrant::⬆"
+#        working-directory: tests/install/opensuse-microos
+#        run: vagrant up
+  install-ubuntu-focal:
+    name: "Ubuntu Focal"
+    # nested virtualization is only available on macOS hosts
+    runs-on: macos-10.15
+    timeout-minutes: 40
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: "VagrantPlugin::K3S"
+        working-directory: tests/install/ubuntu-focal
+        run: vagrant plugin install vagrant-k3s
+      - name: "Vagrant::⬆"
+        working-directory: tests/install/ubuntu-focal
+        run: vagrant up

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,11 +1,15 @@
 name: Integration Test Coverage
 on: 
   push:
-    paths-ignore: 
+    paths-ignore:
       - "**.md"
+      - "install.sh"
+      - "tests/install"
   pull_request:
     paths-ignore:
       - "**.md"
+      - "install.sh"
+      - "tests/install"
   workflow_dispatch: {}
 jobs:
   build:

--- a/.github/workflows/unitcoverage.yaml
+++ b/.github/workflows/unitcoverage.yaml
@@ -1,11 +1,15 @@
 name: Unit Test Coverage
-on: 
+on:
   push:
-    paths-ignore: 
+    paths-ignore:
       - "**.md"
+      - "install.sh"
+      - "tests/install"
   pull_request:
     paths-ignore:
       - "**.md"
+      - "install.sh"
+      - "tests/install"
   workflow_dispatch: {}
 jobs:
   test:

--- a/tests/install/centos-7/Vagrantfile
+++ b/tests/install/centos-7/Vagrantfile
@@ -1,0 +1,99 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+
+ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = {
+    'vagrant-k3s' => {:version => '~> 0.1.2'},
+  }
+
+  config.vm.define 'install-centos-7', primary: true do |test|
+    test.vm.box = 'centos/7'
+    test.vm.hostname = 'install'
+    test.vm.provision 'selinux-status', type: 'shell', run: 'once', inline: 'sestatus'
+    test.vm.provision 'k3s-upload', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
+    test.vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+      k3s.installer_url = 'file:///home/vagrant/install.sh'
+      k3s.args = %w[server]
+      k3s.env = %w[INSTALL_K3S_NAME=server]
+      k3s.config = {
+        :selinux => true,
+        :token => 'vagrant',
+      }
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+    test.vm.provision "k3s-wait-for-node", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        echo 'Waiting for node to be ready ...'
+        time timeout 120 bash -c 'while ! (kubectl wait --for condition=ready node/$(hostname) 2>/dev/null); do sleep 5; done'
+        kubectl get node,all -A -o wide
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-coredns", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/coredns 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-local-storage", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/local-path-provisioner 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-metrics-server", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/metrics-server 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-traefik", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/traefik 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-status", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eux -o pipefail
+        kubectl get node,all -A -o wide
+      SHELL
+    end
+    test.vm.provision "k3s-status-selinux", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eux -o pipefail
+        ps auxZ | grep container_ | grep -v grep
+      SHELL
+    end
+  end
+
+  %w[hyperv libvirt virtualbox vmware_desktop].each do |p|
+    config.vm.provider p do |v|
+      v.cpus = ENV['TEST_VM_CPUS'] || 2
+      v.memory = ENV['TEST_VM_MEMORY'] || 2048
+    end
+  end
+  config.vm.provider :virtualbox do |v,o|
+    v.gui = false
+    v.check_guest_additions = false
+  end
+
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+end

--- a/tests/install/centos-8/Vagrantfile
+++ b/tests/install/centos-8/Vagrantfile
@@ -1,0 +1,99 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+
+ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = {
+    'vagrant-k3s' => {:version => '~> 0.1.2'},
+  }
+
+  config.vm.define 'install-centos-8', primary: true do |test|
+    test.vm.box = 'centos/stream8'
+    test.vm.hostname = 'install'
+    test.vm.provision 'selinux-status', type: 'shell', run: 'once', inline: 'sestatus'
+    test.vm.provision 'k3s-upload', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
+    test.vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+      k3s.installer_url = 'file:///home/vagrant/install.sh'
+      k3s.args = %w[server]
+      k3s.env = %w[INSTALL_K3S_NAME=server]
+      k3s.config = {
+        :selinux => true,
+        :token => 'vagrant',
+      }
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+    test.vm.provision "k3s-wait-for-node", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        echo 'Waiting for node to be ready ...'
+        time timeout 120 bash -c 'while ! (kubectl wait --for condition=ready node/$(hostname) 2>/dev/null); do sleep 5; done'
+        kubectl get node,all -A -o wide
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-coredns", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/coredns 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-local-storage", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/local-path-provisioner 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-metrics-server", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/metrics-server 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-traefik", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/traefik 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-status", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eux -o pipefail
+        kubectl get node,all -A -o wide
+      SHELL
+    end
+    test.vm.provision "k3s-status-selinux", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eux -o pipefail
+        ps auxZ | grep container_ | grep -v grep
+      SHELL
+    end
+  end
+
+  %w[hyperv libvirt virtualbox vmware_desktop].each do |p|
+    config.vm.provider p do |v|
+      v.cpus = ENV['TEST_VM_CPUS'] || 2
+      v.memory = ENV['TEST_VM_MEMORY'] || 2048
+    end
+  end
+  config.vm.provider :virtualbox do |v,o|
+    v.gui = false
+    v.check_guest_additions = false
+  end
+
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+end

--- a/tests/install/opensuse-leap/Vagrantfile
+++ b/tests/install/opensuse-leap/Vagrantfile
@@ -1,0 +1,91 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+
+ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = {
+    'vagrant-k3s' => {:version => '~> 0.1.2'},
+  }
+
+  config.vm.define 'install-opensuse-leap', primary: true do |test|
+    test.vm.box = 'opensuse/Leap-15.3.x86_64'
+    test.vm.hostname = 'install'
+    test.vm.provision 'k3s-upload', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
+    # /sbin/apparmor_parser is needed by the 1.21 kubelet if the value of /sys/module/apparmor/parameters/enabled is Y
+    test.vm.provision 'k3s-prepare', type: 'shell', run: 'once', inline: 'zypper install -y apparmor-parser'
+    test.vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+      k3s.installer_url = 'file:///home/vagrant/install.sh'
+      k3s.args = %w[server]
+      k3s.env = %w[INSTALL_K3S_NAME=server INSTALL_K3S_SKIP_SELINUX_RPM=true]
+      k3s.config = {
+        :token => 'vagrant',
+      }
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+    test.vm.provision "k3s-wait-for-node", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        echo 'Waiting for node to be ready ...'
+        time timeout 120 bash -c 'while ! (kubectl wait --for condition=ready node/$(hostnamectl --static) 2>/dev/null); do sleep 5; done'
+        kubectl get node,all -A -o wide
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-coredns", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/coredns 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-local-storage", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/local-path-provisioner 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-metrics-server", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/metrics-server 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-traefik", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/traefik 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-status", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eux -o pipefail
+        kubectl get node,all -A -o wide
+      SHELL
+    end
+  end
+
+  %w[hyperv libvirt virtualbox vmware_desktop].each do |p|
+    config.vm.provider p do |v|
+      v.cpus = ENV['TEST_VM_CPUS'] || 2
+      v.memory = ENV['TEST_VM_MEMORY'] || 2048
+    end
+  end
+  config.vm.provider :virtualbox do |v,o|
+    v.gui = false
+    v.check_guest_additions = false
+  end
+
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+end

--- a/tests/install/opensuse-microos/Vagrantfile
+++ b/tests/install/opensuse-microos/Vagrantfile
@@ -1,0 +1,112 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+
+ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = {
+    'vagrant-k3s' => {:version => '~> 0.1.2'},
+    'vagrant-reload' => {},
+  }
+
+  config.vm.define 'install-microos', primary: true do |test|
+    test.vm.box = 'opensuse/MicroOS.x86_64'
+    test.vm.hostname = 'install'
+    # microos does not ship selinux-enabled but such is just an update + reboot away
+    test.vm.provision 'selinux-setup', type: 'shell', run: 'once' do |sh|
+        sh.inline = <<~EOF
+            transactional-update -n \
+                setup-selinux \
+                pkg install -y apparmor-parser
+        EOF
+    end
+    # reboot to have the snapshot from the previous step as the rootfs
+    test.vm.provision 'selinux-reload', type: 'reload', run: 'once'
+    test.vm.provision 'selinux-status', type: 'shell', run: 'once', inline: 'sestatus'
+    test.vm.provision 'k3s-upload', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
+    test.vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+      k3s.installer_url = 'file:///home/vagrant/install.sh'
+      k3s.args = %w[server]
+      k3s.env = %w[INSTALL_K3S_NAME=server]
+      k3s.config = {
+        :selinux => true,
+        :token => 'vagrant',
+      }
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+    # install.sh will move the snapshot forward when installing k3s-selinux policy, so, we reboot to pick that up
+    test.vm.provision 'k3s-reload', type: 'reload', run: 'once'
+    test.vm.provision "k3s-wait-for-node", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        echo 'Waiting for node to be ready ...'
+        time timeout 120 bash -c 'while ! (kubectl wait --for condition=ready node/$(hostnamectl --static) 2>/dev/null); do sleep 5; done'
+        kubectl get node,all -A -o wide
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-coredns", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/coredns 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-local-storage", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/local-path-provisioner 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-metrics-server", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/metrics-server 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-traefik", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/traefik 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-status", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eux -o pipefail
+        kubectl get node,all -A -o wide
+      SHELL
+    end
+    test.vm.provision "k3s-status-selinux", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eux -o pipefail
+        ps auxZ | grep container_ | grep -v grep
+      SHELL
+    end
+  end
+
+  %w[hyperv libvirt virtualbox vmware_desktop].each do |p|
+    config.vm.provider p do |v|
+      v.cpus = ENV['TEST_VM_CPUS'] || 2
+      v.memory = ENV['TEST_VM_MEMORY'] || 2048
+    end
+  end
+  config.vm.provider :virtualbox do |v,o|
+    v.gui = false
+    v.check_guest_additions = false
+  end
+
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+end

--- a/tests/install/ubuntu-focal/Vagrantfile
+++ b/tests/install/ubuntu-focal/Vagrantfile
@@ -1,0 +1,91 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+
+ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = {
+    'vagrant-k3s' => {:version => '~> 0.1.2'},
+  }
+
+  config.vm.define 'install-ubuntu-focal', primary: true do |test|
+    test.vm.box = 'generic/ubuntu2004'
+    test.vm.hostname = 'install'
+    test.vm.provision 'k3s-upload', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
+    # sh is a symlink to dash, so, we need to sidestep this: https://github.com/dweomer/vagrant-k3s/blob/v0.1.2/lib/vagrant-k3s/provisioner.rb#L71
+    test.vm.provision 'k3s-prepare', type: 'shell', run: 'once', inline: 'ln -nsf bash /usr/bin/sh'
+    test.vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+      k3s.installer_url = 'file:///home/vagrant/install.sh'
+      k3s.args = %w[server]
+      k3s.env = %w[INSTALL_K3S_NAME=server INSTALL_K3S_SKIP_SELINUX_RPM=true]
+      k3s.config = {
+        :token => 'vagrant',
+      }
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+    test.vm.provision "k3s-wait-for-node", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        echo 'Waiting for node to be ready ...'
+        time timeout 120 bash -c 'while ! (kubectl wait --for condition=ready node/$(hostname) 2>/dev/null); do sleep 5; done'
+        kubectl get node,all -A -o wide
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-coredns", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/coredns 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-local-storage", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/local-path-provisioner 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-metrics-server", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/metrics-server 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-wait-for-traefik", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        time timeout 180 bash -c 'while ! (kubectl --namespace kube-system rollout status --timeout 10s deploy/traefik 2>/dev/null); do sleep 5; done'
+      SHELL
+    end
+    test.vm.provision "k3s-status", type: "shell", run: "once" do |sh|
+      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eux -o pipefail
+        kubectl get node,all -A -o wide
+      SHELL
+    end
+  end
+
+  %w[hyperv libvirt virtualbox vmware_desktop].each do |p|
+    config.vm.provider p do |v|
+      v.cpus = ENV['TEST_VM_CPUS'] || 2
+      v.memory = ENV['TEST_VM_MEMORY'] || 2048
+    end
+  end
+  config.vm.provider :virtualbox do |v,o|
+    v.gui = false
+    v.check_guest_additions = false
+  end
+
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+end


### PR DESCRIPTION
#### Proposed Changes ####

Support invoking install.sh on SLE Micro with or without SELinux enabled. Same deal for SLES.

#### Types of Changes ####

_New-ish Feature-like Thing :tm:_ 

#### Verification ####

Additionally, easy-to-invoke assertions, via Vagrant, to verify that the local install.sh works correctly:
- tests/install/centos-7 (stand-in for rhel 7)
- tests/install/centos-8 (stand-in for rhel 8)
- tests/install/opensuse-leap (stand-in for sles)
- tests/install/opensuse-microos (stand-in for sle-micro, only via libvirt for now)
- tests/install/ubuntu-focal

Pre-requisites:
- Install Vagrant: https://www.vagrantup.com/downloads
- `vagrant plugin install vagrant-k3s`
- `vagrant plugin install vagrant-reload`

`cd` into one of these directories and `vagrant up`. A non-zero exit code means that the assertion failed (outbound network connectivity is required for installing packages) whereas an exit code of zero is a win :tada: 

#### Linked Issues ####

Addresses #3188 
Addresses #3917

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Initial support for SLE Micro with SELinux via https://get.k3s.io
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>