### PR TITLE
[release-1.22] Fix log/reap reexec

### DIFF
--- a/pkg/cli/cmds/log_linux.go
+++ b/pkg/cli/cmds/log_linux.go
@@ -58,7 +58,7 @@ func forkIfLoggingOrReaping() error {
 		args := append([]string{version.Program}, os.Args[1:]...)
 		env := append(os.Environ(), "_K3S_LOG_REEXEC_=true", "NOTIFY_SOCKET=")
 		cmd := &exec.Cmd{
-			Path:   os.Args[0],
+			Path:   "/proc/self/exe",
 			Dir:    pwd,
 			Args:   args,
 			Env:    env,
@@ -66,7 +66,7 @@ func forkIfLoggingOrReaping() error {
 			Stdout: stdout,
 			Stderr: stderr,
 			SysProcAttr: &syscall.SysProcAttr{
-				Setsid: true,
+				Pdeathsig: unix.SIGTERM,
 			},
 		}
 		if err := cmd.Start(); err != nil {


### PR DESCRIPTION
#### Proposed Changes ####

Ensure that the forked k3s process is started with the correct binary and gets SIGTERM when parent dies.

This restores the behavior previously used by the docker/reexec package.

#### Types of Changes ####

bugfix

#### Verification ####

Start k3s as systemd unit with `--log` argument specified. Restart k3s service; confirm that k3s is stopped and started successfully.

#### Linked Issues ####

* #4195

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
