### PR TITLE
install: /usr/sbin/transactional-update (and uninstall fix)

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -3,11 +3,11 @@ on:
   push:
     paths:
       - "install.sh"
-      - "tests/install"
+      - "tests/install/**"
   pull_request:
     paths:
       - "install.sh"
-      - "tests/install"
+      - "tests/install/**"
   workflow_dispatch: {}
 jobs:
   install-centos-7:
@@ -42,6 +42,22 @@ jobs:
       - name: "Vagrant::⬆"
         working-directory: tests/install/centos-8
         run: vagrant up
+  install-fedora-coreos:
+    name: "Fedora CoreOS"
+    # nested virtualization is only available on macOS hosts
+    runs-on: macos-10.15
+    timeout-minutes: 40
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: "VagrantPlugin::K3S"
+        working-directory: tests/install/fedora-coreos
+        run: vagrant plugin install vagrant-k3s
+      - name: "Vagrant::⬆"
+        working-directory: tests/install/fedora-coreos
+        run: vagrant up
   install-opensuse-leap:
     name: "openSUSE Leap"
     # nested virtualization is only available on macOS hosts
@@ -58,25 +74,25 @@ jobs:
       - name: "Vagrant::⬆"
         working-directory: tests/install/opensuse-leap
         run: vagrant up
-#  install-opensuse-microos:
-#    name: "openSUSE MicroOS"
-#    # nested virtualization is only available on macOS hosts
-#    runs-on: macos-10.15
-#    timeout-minutes: 40
-#    steps:
-#      - name: "Checkout"
-#        uses: actions/checkout@v2
-#        with:
-#          fetch-depth: 1
-#      - name: "VagrantPlugin::Reload"
-#        working-directory: tests/install/opensuse-microos
-#        run: vagrant plugin install vagrant-reload
-#      - name: "VagrantPlugin::K3S"
-#        working-directory: tests/install/opensuse-microos
-#        run: vagrant plugin install vagrant-k3s
-#      - name: "Vagrant::⬆"
-#        working-directory: tests/install/opensuse-microos
-#        run: vagrant up
+  install-opensuse-microos:
+    name: "openSUSE MicroOS"
+    # nested virtualization is only available on macOS hosts
+    runs-on: macos-10.15
+    timeout-minutes: 40
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: "VagrantPlugin::Reload"
+        working-directory: tests/install/opensuse-microos
+        run: vagrant plugin install vagrant-reload
+      - name: "VagrantPlugin::K3S"
+        working-directory: tests/install/opensuse-microos
+        run: vagrant plugin install vagrant-k3s
+      - name: "Vagrant::⬆"
+        working-directory: tests/install/opensuse-microos
+        run: vagrant up
   install-ubuntu-focal:
     name: "Ubuntu Focal"
     # nested virtualization is only available on macOS hosts

--- a/tests/install/centos-7/Vagrantfile
+++ b/tests/install/centos-7/Vagrantfile
@@ -6,7 +6,7 @@ ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = {
-    'vagrant-k3s' => {:version => '~> 0.1.2'},
+    'vagrant-k3s' => {:version => '~> 0.1.3'},
   }
 
   config.vm.define 'install-centos-7', primary: true do |test|

--- a/tests/install/centos-8/Vagrantfile
+++ b/tests/install/centos-8/Vagrantfile
@@ -6,7 +6,7 @@ ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = {
-    'vagrant-k3s' => {:version => '~> 0.1.2'},
+    'vagrant-k3s' => {:version => '~> 0.1.3'},
   }
 
   config.vm.define 'install-centos-8', primary: true do |test|

--- a/tests/install/fedora-coreos/Vagrantfile
+++ b/tests/install/fedora-coreos/Vagrantfile
@@ -7,16 +7,15 @@ ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = {
     'vagrant-k3s' => {:version => '~> 0.1.3'},
-    'vagrant-reload' => {},
   }
 
-  config.vm.define 'install-microos', primary: true do |test|
-    test.vm.box = 'dweomer/microos.amd64'
+  config.vm.define 'install-fedora-coreos', primary: true do |test|
+    test.vm.box = 'dhml/fedora-coreos-34.20210725.3.0-20210813'
     test.vm.hostname = 'install'
     test.vm.provision 'selinux-status', type: 'shell', run: 'once', inline: 'sestatus'
     test.vm.provision 'k3s-upload', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
     test.vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
-      k3s.installer_url = 'file:///home/vagrant/install.sh'
+      k3s.installer_url = 'file:///var/home/core/install.sh'
       k3s.args = %w[server]
       k3s.env = %w[INSTALL_K3S_NAME=server]
       k3s.config = {
@@ -25,15 +24,13 @@ Vagrant.configure("2") do |config|
       }
       k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
     end
-    # install.sh will move the snapshot forward when installing k3s-selinux policy, so, we reboot to pick that up
-    test.vm.provision 'k3s-reload', type: 'reload', run: 'once'
     test.vm.provision "k3s-wait-for-node", type: "shell", run: "once" do |sh|
       sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
       sh.inline = <<~SHELL
         #!/usr/bin/env bash
         set -eu -o pipefail
         echo 'Waiting for node to be ready ...'
-        time timeout 120 bash -c 'while ! (kubectl wait --for condition=ready node/$(hostnamectl --static) 2>/dev/null); do sleep 5; done'
+        time timeout 120 bash -c 'while ! (kubectl wait --for condition=ready node/$(hostname) 2>/dev/null); do sleep 5; done'
         kubectl get node,all -A -o wide
       SHELL
     end
@@ -75,14 +72,6 @@ Vagrant.configure("2") do |config|
         #!/usr/bin/env bash
         set -eux -o pipefail
         kubectl get node,all -A -o wide
-      SHELL
-    end
-    test.vm.provision "k3s-status-selinux", type: "shell", run: "once" do |sh|
-      sh.env = { :PATH => "/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin" }
-      sh.inline = <<~SHELL
-        #!/usr/bin/env bash
-        set -eux -o pipefail
-        ps auxZ | grep container_ | grep -v grep
       SHELL
     end
   end

--- a/tests/install/opensuse-leap/Vagrantfile
+++ b/tests/install/opensuse-leap/Vagrantfile
@@ -6,7 +6,7 @@ ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = {
-    'vagrant-k3s' => {:version => '~> 0.1.2'},
+    'vagrant-k3s' => {:version => '~> 0.1.3'},
   }
 
   config.vm.define 'install-opensuse-leap', primary: true do |test|

--- a/tests/install/ubuntu-focal/Vagrantfile
+++ b/tests/install/ubuntu-focal/Vagrantfile
@@ -6,7 +6,7 @@ ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = {
-    'vagrant-k3s' => {:version => '~> 0.1.2'},
+    'vagrant-k3s' => {:version => '~> 0.1.3'},
   }
 
   config.vm.define 'install-ubuntu-focal', primary: true do |test|


### PR DESCRIPTION
#### Proposed Changes ####
Fix for sle-micro / microos to use the correct location when attempting to detect for `transactional-update`

#### Types of Changes ####

installer script

#### Verification ####

```shell
cd tests/install/opensuse-microos
vagrant plugin install vagrant-reload vagrant-k3s
vagrant up --provider=virtualbox
```

#### Linked Issues ####

#4402 
#4409 

#### User-Facing Change ####

```release-note
Improved MicroOS support for k3s-uninstall.sh
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
