### PR TITLE
Corrected skip check for dualstack on CI

### DIFF
--- a/tests/integration/dualstack/dualstack_int_test.go
+++ b/tests/integration/dualstack/dualstack_int_test.go
@@ -19,7 +19,7 @@ var dualStackServerArgs = []string{
 	"--disable-network-policy",
 }
 var _ = BeforeSuite(func() {
-	if !testutil.IsExistingServer() && os.Getenv("CI") != "" {
+	if !testutil.IsExistingServer() && os.Getenv("CI") != "true" {
 		var err error
 		dualStackServer, err = testutil.K3sStartServer(dualStackServerArgs...)
 		Expect(err).ToNot(HaveOccurred())
@@ -51,7 +51,7 @@ var _ = Describe("dual stack", func() {
 })
 
 var _ = AfterSuite(func() {
-	if !testutil.IsExistingServer() && os.Getenv("CI") != "" {
+	if !testutil.IsExistingServer() && os.Getenv("CI") != "true" {
 		Expect(testutil.K3sKillServer(dualStackServer)).To(Succeed())
 	}
 })


### PR DESCRIPTION
Signed-off-by: dereknola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Fixed checks on dualstack test in CI. Test is currently flaky because depending on how fast/slow the test "skips" through the body, the k3s server may have already crashed from an incorrect startup, causing failures in later tests.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
`export CI=true`
`go test -v ./test/integration/dualstack/... -run Integration` properly skips both the test body and startup/teardown

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/4339
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
