### PR TITLE
[Release-1.22] Improve error message when using a "K10" prefixed token (#4180)

### DIFF
--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -176,7 +176,7 @@ func readTokenFromFile(serverToken, certs, dataDir string) (string, error) {
 func normalizeToken(token string) (string, error) {
 	_, password, ok := clientaccess.ParseUsernamePassword(token)
 	if !ok {
-		return password, errors.New("failed to normalize token")
+		return password, errors.New("failed to normalize token; must be in format K10<CA-HASH>::<USERNAME>:<PASSWORD> or <PASSWORD>")
 	}
 	return password, nil
 }


### PR DESCRIPTION
* Add new error message with a K10 prefixed secret token

Signed-off-by: dereknola <derek.nola@suse.com>

Backport of https://github.com/k3s-io/k3s/pull/4180
#### Proposed Changes ####
Improve the error message a user receives when accidentally providing a "K10" prefixed token on the first (or single node) K3s server. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Enhancement
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- Run K3s server with K10 token 
```
$ k3s server --token=K10THISISATEST
```
- Observe the error message:
```
panic: failed to normalize token; must be in format K10<CA-HASH>::<USERNAME>:<PASSWORD> or <PASSWORD>
```
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/4429
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
