### PR TITLE
Allow svclb pod to enable ipv6 forwarding

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -567,6 +567,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	nodeConfig.AgentConfig.Rootless = envInfo.Rootless
 	nodeConfig.AgentConfig.PodManifests = filepath.Join(envInfo.DataDir, "agent", DefaultPodManifestPath)
 	nodeConfig.AgentConfig.ProtectKernelDefaults = envInfo.ProtectKernelDefaults
+	nodeConfig.AgentConfig.DisableServiceLB = envInfo.DisableServiceLB
 
 	if err := validateNetworkConfig(nodeConfig); err != nil {
 		return nil, err

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -65,6 +65,7 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 		return errors.Wrap(err, "failed to validate kube-proxy conntrack configuration")
 	}
 	syssetup.Configure(enableIPv6, conntrackConfig)
+	nodeConfig.AgentConfig.EnableIPv6 = enableIPv6
 
 	if err := setupCriCtlConfig(cfg, nodeConfig); err != nil {
 		return err

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -16,6 +16,7 @@ type Agent struct {
 	ServerURL                string
 	APIAddressCh             chan string
 	DisableLoadBalancer      bool
+	DisableServiceLB         bool
 	ETCDAgent                bool
 	LBServerPort             int
 	ResolvConf               string

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -454,6 +454,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	agentConfig.ServerURL = url
 	agentConfig.Token = token
 	agentConfig.DisableLoadBalancer = !serverConfig.ControlConfig.DisableAPIServer
+	agentConfig.DisableServiceLB = serverConfig.DisableServiceLB
 	agentConfig.ETCDAgent = serverConfig.ControlConfig.DisableAPIServer
 	agentConfig.ClusterReset = serverConfig.ControlConfig.ClusterReset
 

--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -168,5 +168,10 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 	if cfg.ProtectKernelDefaults {
 		argsMap["protect-kernel-defaults"] = "true"
 	}
+
+	if !cfg.DisableServiceLB && cfg.EnableIPv6 {
+		argsMap["allowed-unsafe-sysctls"] = "net.ipv6.conf.all.forwarding"
+	}
+
 	return argsMap
 }

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -100,6 +100,8 @@ type Agent struct {
 	DisableNPC              bool
 	Rootless                bool
 	ProtectKernelDefaults   bool
+	DisableServiceLB        bool
+	EnableIPv6              bool
 }
 
 type Control struct {
@@ -122,6 +124,7 @@ type Control struct {
 	ClusterDNS               net.IP
 	ClusterDNSs              []net.IP
 	ClusterDomain            string
+	DisableServiceLB         bool
 	NoCoreDNS                bool
 	KubeConfigOutput         string
 	KubeConfigMode           string


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

As explained in the issue, in kernels older than 5.1, the klipper-lb image should set `net.ipv6.conf.all.forwarding` to 1 because the default is 0. When kernels are newer or equal to 5.1, we can inherit that config from the root namespace instead of using the default.

Distros like centos or RHEL use a kernel older than 5.1

We are whitelisting `net.ipv6.conf.all.forwarding` in Kubelet so that pods can change that parameter. Then, starting the svclb pod changing that parameter to one. The whitelisting only happens when svclb is not disabled and we are in dual-stack mode (pod, services and node-ip having both ipv4 and ipv6). svclb adding `net.ipv6.conf.all.forwarding` only happens if the ipFamily of the service contains IPv6 

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
bug fix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Deploy dual-stack on centos and verify that ip6tables are successful

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/4400

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
