### PR TITLE
[release-1.22] Increase agent's apiserver ready timeout

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -106,7 +106,9 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 		return err
 	}
 
-	util.WaitForAPIServerReady(coreClient, 30*time.Second)
+	if err := util.WaitForAPIServerReady(ctx, coreClient, util.DefaultAPIServerReadyTimeout); err != nil {
+		return errors.Wrap(err, "failed to wait for apiserver ready")
+	}
 
 	if err := configureNode(ctx, &nodeConfig.AgentConfig, coreClient.CoreV1().Nodes()); err != nil {
 		return err

--- a/pkg/agent/tunnel/tunnel.go
+++ b/pkg/agent/tunnel/tunnel.go
@@ -78,7 +78,9 @@ func Setup(ctx context.Context, config *config.Node, proxy proxy.Proxy) error {
 	// and go from the cluster. We go into a faster but noisier connect loop if the watch fails
 	// following a successful connection.
 	go func() {
-		util.WaitForAPIServerReady(client, 30*time.Second)
+		if err := util.WaitForAPIServerReady(ctx, client, util.DefaultAPIServerReadyTimeout); err != nil {
+			logrus.Warnf("Tunnel endpoint watch failed to wait for apiserver ready: %v", err)
+		}
 	connect:
 		for {
 			time.Sleep(5 * time.Second)

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -419,7 +419,7 @@ func waitForAPIServerInBackground(ctx context.Context, runtime *config.ControlRu
 			select {
 			case <-ctx.Done():
 				return
-			case err := <-promise(func() error { return util.WaitForAPIServerReady(k8sClient, 30*time.Second) }):
+			case err := <-promise(func() error { return util.WaitForAPIServerReady(ctx, k8sClient, 30*time.Second) }):
 				if err != nil {
 					logrus.Infof("Waiting for API server to become available")
 					continue


### PR DESCRIPTION
#### Proposed Changes ####

Since we now start the server's agent sooner and in the background, we
may need to wait longer than 30 seconds for the apiserver to become
ready on downstream projects such as RKE2.

Since this essentially just serves as an analogue for the server's
apiReady channel, there's little danger in setting it to something
relatively high.
#### Types of Changes ####

bugfix

#### Verification ####

* Normal CI checks on K3s.
* Should resolve CI failures currently seen when updating K3s in RKE2.

#### Linked Issues ####

* TBD

#### User-Facing Change ####
```release-note

```

#### Further Comments ####