### PR TITLE
[Release-1.22] Improved regex for double equals arguments

### DIFF
--- a/pkg/configfilearg/defaultparser_test.go
+++ b/pkg/configfilearg/defaultparser_test.go
@@ -29,7 +29,7 @@ func Test_UnitMustParse(t *testing.T) {
 			args:   []string{"k3s", "server", "--write-kubeconfig-mode 644"},
 			config: "./testdata/defaultdata.yaml",
 			want: []string{"k3s", "server", "--token=12345", "--node-label=DEAFBEEF",
-				"--etcd-s3=true", "--etcd-s3-bucket=my-backup", "--write-kubeconfig-mode 644"},
+				"--etcd-s3=true", "--etcd-s3-bucket=my-backup", "--kubelet-arg=max-pods=999", "--write-kubeconfig-mode 644"},
 		},
 		{
 			name: "Basic etcd-snapshot",
@@ -60,7 +60,7 @@ func Test_UnitMustParse(t *testing.T) {
 			args:   []string{"k3s", "agent"},
 			config: "./testdata/defaultdata.yaml",
 			want: []string{"k3s", "agent", "--token=12345", "--node-label=DEAFBEEF",
-				"--etcd-s3=true", "--etcd-s3-bucket=my-backup", "--notaflag=true"},
+				"--etcd-s3=true", "--etcd-s3-bucket=my-backup", "--notaflag=true", "--kubelet-arg=max-pods=999"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/configfilearg/parser.go
+++ b/pkg/configfilearg/parser.go
@@ -78,7 +78,7 @@ func (p *Parser) stripInvalidFlags(command string, args []string) ([]string, err
 		}
 	}
 
-	re, err := regexp.Compile("^-+(.+)=")
+	re, err := regexp.Compile("^-+([^=]*)=")
 	if err != nil {
 		return args, err
 	}

--- a/pkg/configfilearg/testdata/defaultdata.yaml
+++ b/pkg/configfilearg/testdata/defaultdata.yaml
@@ -3,3 +3,4 @@ node-label: DEAFBEEF
 etcd-s3: true
 etcd-s3-bucket: my-backup
 notaflag : true
+kubelet-arg: "max-pods=999"


### PR DESCRIPTION
Backport of https://github.com/k3s-io/k3s/pull/4505

Signed-off-by: Derek Nola <derek.nola@suse.com>
#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/4510
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an issue where config.yaml arguments with an equal sign would be skipped by server.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
