### PR TITLE
[Release 1.21] Backport new cniplugins and klipper-lb image version

### DIFF
--- a/pkg/servicelb/controller.go
+++ b/pkg/servicelb/controller.go
@@ -34,7 +34,7 @@ var (
 	svcNameLabel       = "svccontroller." + version.Program + ".cattle.io/svcname"
 	daemonsetNodeLabel = "svccontroller." + version.Program + ".cattle.io/enablelb"
 	nodeSelectorLabel  = "svccontroller." + version.Program + ".cattle.io/nodeselector"
-	DefaultLBImage     = "rancher/klipper-lb:v0.3.2"
+	DefaultLBImage     = "rancher/klipper-lb:v0.3.4"
 )
 
 const (

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,6 +1,6 @@
 docker.io/rancher/coredns-coredns:1.8.3
 docker.io/rancher/klipper-helm:v0.6.6-build20211022
-docker.io/rancher/klipper-lb:v0.3.2
+docker.io/rancher/klipper-lb:v0.3.4
 docker.io/rancher/library-busybox:1.32.1
 docker.io/rancher/library-traefik:2.4.8
 docker.io/rancher/local-path-provisioner:v0.0.19

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -37,7 +37,7 @@ if [ -z "$VERSION_K8S" ]; then
     VERSION_K8S="v0.0.0"
 fi
 
-VERSION_CNIPLUGINS="v0.8.6-k3s1"
+VERSION_CNIPLUGINS="v0.9.1-k3s1"
 
 if [[ -n "$GIT_TAG" ]]; then
     if [[ ! "$GIT_TAG" =~ ^"$VERSION_K8S"[+-] ]]; then


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

To have dual-stack properly working we need to move to `VERSION_CNIPLUGINS="v0.9.1-k3s1` in order to use a flannel and bridge binary that supports dual-stack

To have dual-stack working in arm env, we need to move to klipper-lb 0.3.4

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
#1405

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
