### PR TITLE
Fix regression with cluster reset

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -189,7 +189,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 			tokenFile := filepath.Join(dataDir, "server", "token")
 			if _, err := os.Stat(tokenFile); err != nil {
 				if os.IsNotExist(err) {
-					return errors.New(tokenFile + " doesnt exist, please pass --token to complete the restoration")
+					return errors.New(tokenFile + " does not exist, please pass --token to complete the restoration")
 				}
 			}
 		}

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -174,17 +174,22 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		serverConfig.ControlConfig.DisableScheduler = true
 		serverConfig.ControlConfig.DisableCCM = true
 
+		dataDir, err := datadir.LocalHome(cfg.DataDir, false)
+		if err != nil {
+			return err
+		}
 		// delete local loadbalancers state for apiserver and supervisor servers
-		loadbalancer.ResetLoadBalancer(filepath.Join(cfg.DataDir, "agent"), loadbalancer.SupervisorServiceName)
-		loadbalancer.ResetLoadBalancer(filepath.Join(cfg.DataDir, "agent"), loadbalancer.APIServerServiceName)
+		loadbalancer.ResetLoadBalancer(filepath.Join(dataDir, "agent"), loadbalancer.SupervisorServiceName)
+		loadbalancer.ResetLoadBalancer(filepath.Join(dataDir, "agent"), loadbalancer.APIServerServiceName)
 
 		// at this point we're doing a restore. Check to see if we've
 		// passed in a token and if not, check if the token file exists.
 		// If it doesn't, return an error indicating the token is necessary.
 		if cfg.Token == "" {
-			if _, err := os.Stat(filepath.Join(cfg.DataDir, "server/token")); err != nil {
+			tokenFile := filepath.Join(dataDir, "server", "token")
+			if _, err := os.Stat(tokenFile); err != nil {
 				if os.IsNotExist(err) {
-					return errors.New("")
+					return errors.New(tokenFile + " doesnt exist, please pass --token to complete the restoration")
 				}
 			}
 		}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Fix a regression bug with cluster reset restore path, where the data dir is not read correctly.

#### Types of Changes ####

bug fix
#### Verification ####
- start k3s server
- take a snapshot
- try to restore with --cluster-reset and --cluster-reset-restore-path

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
- https://github.com/k3s-io/k3s/issues/4522

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
