### PR TITLE
Improved cleanup for etcd unit test

### DIFF
--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/rancher/k3s/pkg/daemons/config"
 	testutil "github.com/rancher/k3s/tests/util"
 	"github.com/robfig/cron/v3"
-	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/etcdserver"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 )
 
@@ -249,10 +249,8 @@ func Test_UnitETCD_Start(t *testing.T) {
 			},
 			teardown: func(e *ETCD, ctxInfo *contextInfo) error {
 				// RemoveSelf will fail with a specific error, but it still does cleanup for testing purposes
-				if err := e.RemoveSelf(ctxInfo.ctx); err != nil {
-					if _, ok := err.(rpctypes.EtcdError); !ok {
-						return err
-					}
+				if err := e.RemoveSelf(ctxInfo.ctx); err != nil && err.Error() != etcdserver.ErrNotEnoughStartedMembers.Error() {
+					return err
 				}
 				ctxInfo.cancel()
 				time.Sleep(10 * time.Second)
@@ -282,10 +280,8 @@ func Test_UnitETCD_Start(t *testing.T) {
 			},
 			teardown: func(e *ETCD, ctxInfo *contextInfo) error {
 				// RemoveSelf will fail with a specific error, but it still does cleanup for testing purposes
-				if err := e.RemoveSelf(ctxInfo.ctx); err != nil {
-					if _, ok := err.(rpctypes.EtcdError); !ok {
-						return err
-					}
+				if err := e.RemoveSelf(ctxInfo.ctx); err != nil && err.Error() != etcdserver.ErrNotEnoughStartedMembers.Error() {
+					return err
 				}
 				ctxInfo.cancel()
 				time.Sleep(5 * time.Second)
@@ -319,10 +315,8 @@ func Test_UnitETCD_Start(t *testing.T) {
 			},
 			teardown: func(e *ETCD, ctxInfo *contextInfo) error {
 				// RemoveSelf will fail with a specific error, but it still does cleanup for testing purposes
-				if err := e.RemoveSelf(ctxInfo.ctx); err != nil {
-					if _, ok := err.(rpctypes.EtcdError); !ok {
-						return err
-					}
+				if err := e.RemoveSelf(ctxInfo.ctx); err != nil && err.Error() != etcdserver.ErrNotEnoughStartedMembers.Error() {
+					return err
 				}
 				ctxInfo.cancel()
 				time.Sleep(5 * time.Second)


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Improved the cleanup of etcd after test end, Previously several go routines would continue to run for the life of the testing process.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Flaky Test Fix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Stress tested by runnig the test on a 90% CPU utilization to slow things down. Was able to get the test to fail consistently before the patch.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
TBD
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
