### PR TITLE
[release-1.21] Bump golang and containerd versions

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-ARG GOLANG=golang:1.16.8-alpine3.13
+ARG GOLANG=golang:1.16.10-alpine3.13
 FROM ${GOLANG}
 
 ARG http_proxy=$http_proxy

--- a/Dockerfile.manifest
+++ b/Dockerfile.manifest
@@ -1,4 +1,4 @@
-ARG GOLANG=golang:1.16.8-alpine3.13
+ARG GOLANG=golang:1.16.10-alpine3.13
 FROM ${GOLANG}
 
 COPY --from=plugins/manifest:1.2.3 /bin/* /bin/

--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -1,9 +1,9 @@
-ARG GOLANG=golang:1.16.8-alpine3.13
+ARG GOLANG=golang:1.16.10-alpine3.13
 FROM ${GOLANG}
 
 RUN apk -U --no-cache add bash git gcc musl-dev docker curl jq coreutils python3 openssl py3-pip
 
-ENV SONOBUOY_VERSION 0.50.0
+ENV SONOBUOY_VERSION 0.55.0
 
 RUN OS=linux; \
     ARCH=$(go env GOARCH); \

--- a/Dockerfile.test.mod.dapper
+++ b/Dockerfile.test.mod.dapper
@@ -1,4 +1,4 @@
-ARG GOLANG=golang:1.16.8-alpine3.13
+ARG GOLANG=golang:1.16.10-alpine3.13
 FROM ${GOLANG}
 
 RUN apk -U --no-cache add bash jq

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace (
 	github.com/containerd/btrfs => github.com/containerd/btrfs v1.0.0
 	github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
 	github.com/containerd/console => github.com/containerd/console v1.0.2
-	github.com/containerd/containerd => github.com/k3s-io/containerd v1.4.11-k3s1 // k3s-release/1.4
+	github.com/containerd/containerd => github.com/k3s-io/containerd v1.4.12-k3s1 // k3s-release/1.4
 	github.com/containerd/continuity => github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1
 	github.com/containerd/cri => github.com/k3s-io/cri v1.4.0-k3s.7 // k3s-release/1.4
 	github.com/containerd/fifo => github.com/containerd/fifo v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -526,8 +526,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k3s-io/containerd v1.4.11-k3s1 h1:nSUL3uWxoe1tZy3+bWii9wEBXCvt/+6X8zijx2wSKq0=
-github.com/k3s-io/containerd v1.4.11-k3s1/go.mod h1:g3v4rA/cI6WVYoSAYfUfAnrUSzEgbSZnu7uF1ZzkTmY=
+github.com/k3s-io/containerd v1.4.12-k3s1 h1:WVr0W45uXTIDujMtqsfEigIVuEwhW9E8WjV/06/j03w=
+github.com/k3s-io/containerd v1.4.12-k3s1/go.mod h1:g3v4rA/cI6WVYoSAYfUfAnrUSzEgbSZnu7uF1ZzkTmY=
 github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1 h1:KEz2rd9IDbrQT8w6RibEYlwfTXiu0P6hQDE+6O4IJdI=
 github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
 github.com/k3s-io/cri v1.4.0-k3s.7 h1:1ycdF3dMDJMW/k/UxDC6eMsyGSMZ/p0AoUBVdJvNGQs=

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -240,7 +240,7 @@ sonobuoy-test() {
 
     local sonobuoyPID=$!
     local code=0
-    time timeout --foreground 30m bash -c test-wait $sonobuoyPID || code=$?
+    time timeout --foreground 60m bash -c test-wait $sonobuoyPID || code=$?
     echo "Sonobuoy finished with code $code"
     retrieve-sonobuoy-logs
     return $code

--- a/vendor/github.com/containerd/containerd/.travis.yml
+++ b/vendor/github.com/containerd/containerd/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.16.8"
+  - "1.16.10"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/vendor/github.com/containerd/containerd/Vagrantfile
+++ b/vendor/github.com/containerd/containerd/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.16.8",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.16.10",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/vendor/github.com/containerd/containerd/remotes/docker/fetcher.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/fetcher.go
@@ -60,6 +60,10 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 				log.G(ctx).WithError(err).Debug("failed to parse")
 				continue
 			}
+			if u.Scheme != "http" && u.Scheme != "https" {
+				log.G(ctx).Debug("non-http(s) alternative url is unsupported")
+				continue
+			}
 			log.G(ctx).Debug("trying alternative url")
 
 			// Try this first, parse it

--- a/vendor/github.com/containerd/containerd/remotes/docker/schema1/converter.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/schema1/converter.go
@@ -256,6 +256,9 @@ func (c *Converter) fetchManifest(ctx context.Context, desc ocispec.Descriptor) 
 	if err := json.Unmarshal(b, &m); err != nil {
 		return err
 	}
+	if len(m.Manifests) != 0 || len(m.Layers) != 0 {
+		return errors.New("converter: expected schema1 document but found extra keys")
+	}
 	c.pulledManifest = &m
 
 	return nil
@@ -472,8 +475,10 @@ type history struct {
 }
 
 type manifest struct {
-	FSLayers []fsLayer `json:"fsLayers"`
-	History  []history `json:"history"`
+	FSLayers  []fsLayer       `json:"fsLayers"`
+	History   []history       `json:"history"`
+	Layers    json.RawMessage `json:"layers,omitempty"`    // OCI manifest
+	Manifests json.RawMessage `json:"manifests,omitempty"` // OCI index
 }
 
 type v1History struct {

--- a/vendor/github.com/containerd/containerd/version/version.go
+++ b/vendor/github.com/containerd/containerd/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.4.11+unknown"
+	Version = "1.4.12+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -177,7 +177,7 @@ github.com/containerd/cgroups/v2
 github.com/containerd/cgroups/v2/stats
 # github.com/containerd/console v1.0.2 => github.com/containerd/console v1.0.2
 github.com/containerd/console
-# github.com/containerd/containerd v1.5.1 => github.com/k3s-io/containerd v1.4.11-k3s1
+# github.com/containerd/containerd v1.5.1 => github.com/k3s-io/containerd v1.4.12-k3s1
 ## explicit
 github.com/containerd/containerd
 github.com/containerd/containerd/api/events
@@ -3195,7 +3195,7 @@ sigs.k8s.io/yaml
 # github.com/containerd/btrfs => github.com/containerd/btrfs v1.0.0
 # github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
 # github.com/containerd/console => github.com/containerd/console v1.0.2
-# github.com/containerd/containerd => github.com/k3s-io/containerd v1.4.11-k3s1
+# github.com/containerd/containerd => github.com/k3s-io/containerd v1.4.12-k3s1
 # github.com/containerd/continuity => github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1
 # github.com/containerd/cri => github.com/k3s-io/cri v1.4.0-k3s.7
 # github.com/containerd/fifo => github.com/containerd/fifo v1.0.0


### PR DESCRIPTION
#### Proposed Changes ####
Backport https://github.com/k3s-io/k3s/pull/4538
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/4441
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump golang to 1.16.10
Bump containerd to v1.4.12-k3s1
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
