### PR TITLE
Update kine to v0.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/k3s-io/helm-controller v0.11.7
-	github.com/k3s-io/kine v0.8.0
+	github.com/k3s-io/kine v0.8.1
 	github.com/klauspost/compress v1.13.5
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -572,8 +572,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.0-k3s2 h1:yw8t2/k8Gwsv462XkEVawYGn5N+FI2xG
 github.com/k3s-io/etcd/server/v3 v3.5.0-k3s2/go.mod h1:3Ah5ruV+M+7RZr0+Y/5mNLwC+eQlni+mQmOVdCRJoS4=
 github.com/k3s-io/helm-controller v0.11.7 h1:fNpBImB3h5aHvPf3zwU9sFWmeVQh0nTG1sLCoBhEeUg=
 github.com/k3s-io/helm-controller v0.11.7/go.mod h1:z0ExsRRIkTO/QC//3/Esn5ItTD6AiQSluwzMaS7RI/4=
-github.com/k3s-io/kine v0.8.0 h1:k6T9bI9DID7lIbktukXxg1QfeFoAQK4EIvAHoyPAe08=
-github.com/k3s-io/kine v0.8.0/go.mod h1:gaezUQ9c8iw8vxDV/DI8vc93h2rCpTvY37kMdYPMsyc=
+github.com/k3s-io/kine v0.8.1 h1:cuxZmENBUL5lvJORWGBjn87kKtIo8GK7o8H1hu+vd98=
+github.com/k3s-io/kine v0.8.1/go.mod h1:gaezUQ9c8iw8vxDV/DI8vc93h2rCpTvY37kMdYPMsyc=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 github.com/k3s-io/klog/v2 v2.9.0-k3s2 h1:8Dzu3wGPFMo1mPEobSEpkHWH+HXqgFXp8R7FbcdgE8k=

--- a/vendor/github.com/k3s-io/kine/pkg/drivers/generic/generic.go
+++ b/vendor/github.com/k3s-io/kine/pkg/drivers/generic/generic.go
@@ -94,6 +94,7 @@ type Generic struct {
 	DeleteSQL             string
 	CompactSQL            string
 	UpdateCompactSQL      string
+	PostCompactSQL        string
 	InsertSQL             string
 	FillSQL               string
 	InsertLastInsertIDSQL string
@@ -295,6 +296,15 @@ func (d *Generic) Compact(ctx context.Context, revision int64) (int64, error) {
 		return 0, err
 	}
 	return res.RowsAffected()
+}
+
+func (d *Generic) PostCompact(ctx context.Context) error {
+	logrus.Trace("POSTCOMPACT")
+	if d.PostCompactSQL != "" {
+		_, err := d.execute(ctx, d.PostCompactSQL)
+		return err
+	}
+	return nil
 }
 
 func (d *Generic) GetRevision(ctx context.Context, revision int64) (*sql.Rows, error) {

--- a/vendor/github.com/k3s-io/kine/pkg/drivers/sqlite/sqlite.go
+++ b/vendor/github.com/k3s-io/kine/pkg/drivers/sqlite/sqlite.go
@@ -39,6 +39,7 @@ var (
 		`CREATE INDEX IF NOT EXISTS kine_id_deleted_index ON kine (id,deleted)`,
 		`CREATE INDEX IF NOT EXISTS kine_prev_revision_index ON kine (prev_revision)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS kine_name_prev_revision_uindex ON kine (name, prev_revision)`,
+		`PRAGMA wal_checkpoint(TRUNCATE)`,
 	}
 )
 
@@ -79,6 +80,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string, connPool
 					kd.deleted != 0 AND
 					kd.id <= ?
 			)`
+	dialect.PostCompactSQL = `PRAGMA wal_checkpoint(FULL)`
 	dialect.TranslateErr = func(err error) error {
 		if err, ok := err.(sqlite3.Error); ok && err.ExtendedCode == sqlite3.ErrConstraintUnique {
 			return server.ErrKeyExists

--- a/vendor/github.com/k3s-io/kine/pkg/logstructured/sqllog/sql.go
+++ b/vendor/github.com/k3s-io/kine/pkg/logstructured/sqllog/sql.go
@@ -155,6 +155,10 @@ outer:
 			}
 		}
 
+		if err := s.postCompact(); err != nil {
+			logrus.Errorf("Post-compact operations failed: %v", err)
+		}
+
 		// Record the final results for the outer loop
 		compactRev = compactedRev
 		targetCompactRev = currentRev
@@ -216,6 +220,11 @@ func (s *SQLLog) compact(compactRev int64, targetCompactRev int64) (int64, int64
 	logrus.Debugf("COMPACT deleted %d rows from %d revisions in %s - compacted to %d/%d", deletedRows, (targetCompactRev - compactRev), time.Since(start), targetCompactRev, currentRev)
 
 	return targetCompactRev, currentRev, nil
+}
+
+// postCompact executes any post-compact database cleanup - vacuuming, WAL truncate, etc.
+func (s *SQLLog) postCompact() error {
+	return s.d.PostCompact(s.ctx)
 }
 
 func (s *SQLLog) CurrentRevision(ctx context.Context) (int64, error) {

--- a/vendor/github.com/k3s-io/kine/pkg/server/types.go
+++ b/vendor/github.com/k3s-io/kine/pkg/server/types.go
@@ -36,6 +36,7 @@ type Dialect interface {
 	GetCompactRevision(ctx context.Context) (int64, error)
 	SetCompactRevision(ctx context.Context, revision int64) error
 	Compact(ctx context.Context, revision int64) (int64, error)
+	PostCompact(ctx context.Context) error
 	Fill(ctx context.Context, revision int64) error
 	IsFill(key string) bool
 	BeginTx(ctx context.Context, opts *sql.TxOptions) (Transaction, error)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -746,7 +746,7 @@ github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1
 github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io
 github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io/v1
 github.com/k3s-io/helm-controller/pkg/helm
-# github.com/k3s-io/kine v0.8.0
+# github.com/k3s-io/kine v0.8.1
 ## explicit
 github.com/k3s-io/kine/pkg/broadcaster
 github.com/k3s-io/kine/pkg/client


### PR DESCRIPTION
#### Proposed Changes ####

bump kine to v0.8.1

#### Types of Changes ####

version bump

#### Verification ####

normal CI / QA tests

#### Linked Issues ####

* #3660 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
K3s will now ensure that the write-ahead log for the embedded sqlite datastore does not grow excessively large.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
