### PR TITLE
fix: add govet field alignment linting + changes to structs for better memory allocation

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -10,6 +10,13 @@
 			"gofmt"
 		]
 	},
+	"linters-settings": {
+		"govet": {
+			"enable": [
+				"fieldalignment"
+			]
+		}
+	},
 	"run": {
 		"skip-dirs": [
 			"build",

--- a/pkg/agent/containerd/nvidia_test.go
+++ b/pkg/agent/containerd/nvidia_test.go
@@ -17,9 +17,9 @@ func Test_UnitFindNvidiaContainerRuntimes(t *testing.T) {
 		root fs.FS
 	}
 	tests := []struct {
-		name string
 		args args
 		want map[string]templates.ContainerdRuntimeConfig
+		name string
 	}{
 		{
 			name: "No runtimes",

--- a/pkg/agent/loadbalancer/loadbalancer.go
+++ b/pkg/agent/loadbalancer/loadbalancer.go
@@ -15,20 +15,19 @@ import (
 )
 
 type LoadBalancer struct {
-	mutex  sync.Mutex
-	dialer *net.Dialer
-	proxy  *tcpproxy.Proxy
-
+	mutex                 sync.Mutex
+	Listener              net.Listener
+	proxy                 *tcpproxy.Proxy
+	dialer                *net.Dialer
 	configFile            string
 	localAddress          string
 	localServerURL        string
-	originalServerAddress string
 	ServerURL             string
+	currentServerAddress  string
+	originalServerAddress string
 	ServerAddresses       []string
 	randomServers         []string
-	currentServerAddress  string
 	nextServerIndex       int
-	Listener              net.Listener
 }
 
 const RandomPort = 0

--- a/pkg/agent/loadbalancer/loadbalancer_test.go
+++ b/pkg/agent/loadbalancer/loadbalancer_test.go
@@ -18,8 +18,8 @@ import (
 
 type server struct {
 	listener net.Listener
-	conns    []net.Conn
 	prefix   string
+	conns    []net.Conn
 }
 
 func createServer(prefix string) (*server, error) {

--- a/pkg/agent/netpol/network_policy_controller.go
+++ b/pkg/agent/netpol/network_policy_controller.go
@@ -51,74 +51,66 @@ const (
 
 // NetworkPolicyController struct to hold information required by NetworkPolicyController
 type NetworkPolicyController struct {
-	nodeIP                  net.IP
-	nodeHostName            string
-	serviceClusterIPRange   net.IPNet
-	serviceExternalIPRanges []net.IPNet
-	serviceNodePortRange    string
-	mu                      sync.Mutex
-	syncPeriod              time.Duration
-	fullSyncRequestChan     chan struct{}
-	ipsetMutex              *sync.Mutex
-
-	ipSetHandler *utils.IPSet
-
-	podLister cache.Indexer
-	npLister  cache.Indexer
-	nsLister  cache.Indexer
-
-	PodEventHandler           cache.ResourceEventHandler
-	NamespaceEventHandler     cache.ResourceEventHandler
+	mu                        sync.Mutex
+	filterTableRules          bytes.Buffer
+	npLister                  cache.Indexer
 	NetworkPolicyEventHandler cache.ResourceEventHandler
-
-	filterTableRules bytes.Buffer
+	PodEventHandler           cache.ResourceEventHandler
+	nsLister                  cache.Indexer
+	NamespaceEventHandler     cache.ResourceEventHandler
+	podLister                 cache.Indexer
+	ipsetMutex                *sync.Mutex
+	ipSetHandler              *utils.IPSet
+	fullSyncRequestChan       chan struct{}
+	serviceNodePortRange      string
+	nodeHostName              string
+	serviceClusterIPRange     net.IPNet
+	nodeIP                    net.IP
+	serviceExternalIPRanges   []net.IPNet
+	syncPeriod                time.Duration
 }
 
 // internal structure to represent a network policy
 type networkPolicyInfo struct {
-	name        string
-	namespace   string
 	podSelector labels.Selector
-
 	// set of pods matching network policy spec podselector label selector
 	targetPods map[string]podInfo
-
-	// whitelist ingress rules from the network policy spec
-	ingressRules []ingressRule
-
-	// whitelist egress rules from the network policy spec
-	egressRules []egressRule
-
+	name       string
+	namespace  string
 	// policy type "ingress" or "egress" or "both" as defined by PolicyType in the spec
 	policyType string
+	// whitelist ingress rules from the network policy spec
+	ingressRules []ingressRule
+	// whitelist egress rules from the network policy spec
+	egressRules []egressRule
 }
 
 // internal structure to represent Pod
 type podInfo struct {
+	labels    map[string]string
 	ip        string
 	name      string
 	namespace string
-	labels    map[string]string
 }
 
 // internal structure to represent NetworkPolicyIngressRule in the spec
 type ingressRule struct {
-	matchAllPorts  bool
 	ports          []protocolAndPort
 	namedPorts     []endPoints
-	matchAllSource bool
 	srcPods        []podInfo
 	srcIPBlocks    [][]string
+	matchAllPorts  bool
+	matchAllSource bool
 }
 
 // internal structure to represent NetworkPolicyEgressRule in the spec
 type egressRule struct {
-	matchAllPorts        bool
 	ports                []protocolAndPort
 	namedPorts           []endPoints
-	matchAllDestinations bool
 	dstPods              []podInfo
 	dstIPBlocks          [][]string
+	matchAllPorts        bool
+	matchAllDestinations bool
 }
 
 type protocolAndPort struct {
@@ -128,8 +120,8 @@ type protocolAndPort struct {
 }
 
 type endPoints struct {
-	ips []string
 	protocolAndPort
+	ips []string
 }
 
 type numericPort2eps map[string]*endPoints

--- a/pkg/agent/netpol/network_policy_controller_test.go
+++ b/pkg/agent/netpol/network_policy_controller_test.go
@@ -40,8 +40,8 @@ func newFakeInformersFromClient(kubeClient clientset.Interface) (informers.Share
 }
 
 type tNamespaceMeta struct {
-	name   string
 	labels labels.Set
+	name   string
 }
 
 // Add resources to Informer Store object to simulate updating the Informer
@@ -211,12 +211,12 @@ func newUneventfulNetworkPolicyController(podInformer cache.SharedIndexInformer,
 // 				  the expected selected targets (targetPods, inSourcePods for ingress targets, and outDestPods
 //				  for egress targets) as maps with key being the namespace and a csv of pod names
 type tNetpolTestCase struct {
-	name         string
-	netpol       tNetpol
 	targetPods   tPodNamespaceMap
 	inSourcePods tPodNamespaceMap
 	outDestPods  tPodNamespaceMap
+	name         string
 	expectedRule string
+	netpol       tNetpol
 }
 
 // tGetNotTargetedPods finds set of pods that should not be targeted by netpol selectors
@@ -291,10 +291,10 @@ func newMinimalNodeConfig(serviceIPCIDR string, nodePortRange string, hostNameOv
 }
 
 type tNetPolConfigTestCase struct {
-	name        string
 	config      *config.Node
-	expectError bool
+	name        string
 	errorText   string
+	expectError bool
 }
 
 func Test_UnitNewNetworkPolicySelectors(t *testing.T) {
@@ -600,46 +600,46 @@ func Test_UnitNetworkPolicyBuilder(t *testing.T) {
 func Test_UnitNetworkPolicyController(t *testing.T) {
 	testCases := []tNetPolConfigTestCase{
 		{
-			"Default options are successful",
-			newMinimalNodeConfig("", "", "node", nil),
-			false,
-			"",
+			errorText:   "Default options are successful",
+			config:      newMinimalNodeConfig("", "", "node", nil),
+			expectError: false,
+			name:        "",
 		},
 		{
-			"Missing nodename fails appropriately",
-			newMinimalNodeConfig("", "", "", nil),
-			true,
-			"failed to identify the node by NODE_NAME, hostname or --hostname-override",
+			errorText:   "Missing nodename fails appropriately",
+			config:      newMinimalNodeConfig("", "", "", nil),
+			expectError: true,
+			name:        "failed to identify the node by NODE_NAME, hostname or --hostname-override",
 		},
 		{
-			"Test good cluster CIDR (using single IP with a /32)",
-			newMinimalNodeConfig("10.10.10.10/32", "", "node", nil),
-			false,
-			"",
+			errorText:   "Test good cluster CIDR (using single IP with a /32)",
+			config:      newMinimalNodeConfig("10.10.10.10/32", "", "node", nil),
+			expectError: false,
+			name:        "",
 		},
 		{
-			"Test good cluster CIDR (using normal range with /24)",
-			newMinimalNodeConfig("10.10.10.0/24", "", "node", nil),
-			false,
-			"",
+			errorText:   "Test good cluster CIDR (using normal range with /24)",
+			config:      newMinimalNodeConfig("10.10.10.0/24", "", "node", nil),
+			expectError: false,
+			name:        "",
 		},
 		{
-			"Test good node port specification (using hyphen separator)",
-			newMinimalNodeConfig("", "8080-8090", "node", nil),
-			false,
-			"",
+			errorText:   "Test good node port specification (using hyphen separator)",
+			config:      newMinimalNodeConfig("", "8080-8090", "node", nil),
+			expectError: false,
+			name:        "",
 		},
 		{
-			"Test good external IP CIDR (using single IP with a /32)",
-			newMinimalNodeConfig("", "", "node", []string{"199.10.10.10/32"}),
-			false,
-			"",
+			errorText:   "Test good external IP CIDR (using single IP with a /32)",
+			config:      newMinimalNodeConfig("", "", "node", []string{"199.10.10.10/32"}),
+			expectError: false,
+			name:        "",
 		},
 		{
-			"Test good external IP CIDR (using normal range with /24)",
-			newMinimalNodeConfig("", "", "node", []string{"199.10.10.10/24"}),
-			false,
-			"",
+			errorText:   "Test good external IP CIDR (using normal range with /24)",
+			config:      newMinimalNodeConfig("", "", "node", []string{"199.10.10.10/24"}),
+			expectError: false,
+			name:        "",
 		},
 	}
 	client := fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{*newFakeNode("node", "10.10.10.10")}})

--- a/pkg/agent/proxy/apiproxy.go
+++ b/pkg/agent/proxy/apiproxy.go
@@ -59,20 +59,18 @@ func NewSupervisorProxy(ctx context.Context, lbEnabled bool, dataDir, supervisor
 }
 
 type proxy struct {
-	dataDir          string
-	lbEnabled        bool
-	lbServerPort     int
-	apiServerEnabled bool
-
-	apiServerURL              string
-	supervisorURL             string
-	supervisorPort            string
+	apiServerLB               *loadbalancer.LoadBalancer
+	supervisorLB              *loadbalancer.LoadBalancer
+	dataDir                   string
 	initialSupervisorURL      string
 	fallbackSupervisorAddress string
+	supervisorPort            string
+	apiServerURL              string
+	supervisorURL             string
 	supervisorAddresses       []string
-
-	apiServerLB  *loadbalancer.LoadBalancer
-	supervisorLB *loadbalancer.LoadBalancer
+	lbServerPort              int
+	lbEnabled                 bool
+	apiServerEnabled          bool
 }
 
 func (p *proxy) Update(addresses []string) {

--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -13,8 +13,8 @@ type ContainerdRuntimeConfig struct {
 
 type ContainerdConfig struct {
 	NodeConfig            *config.Node
-	DisableCgroup         bool
-	IsRunningInUserNS     bool
 	PrivateRegistryConfig *registries.Registry
 	ExtraRuntimes         map[string]ContainerdRuntimeConfig
+	DisableCgroup         bool
+	IsRunningInUserNS     bool
 }

--- a/pkg/authenticator/basicauth/basicauth_test.go
+++ b/pkg/authenticator/basicauth/basicauth_test.go
@@ -27,13 +27,12 @@ import (
 )
 
 type testPassword struct {
+	User     user.Info
+	Err      error
 	Username string
 	Password string
 	Called   bool
-
-	User user.Info
-	OK   bool
-	Err  error
+	OK       bool
 }
 
 func (t *testPassword) AuthenticatePassword(ctx context.Context, user, password string) (*authenticator.Response, bool, error) {
@@ -45,16 +44,14 @@ func (t *testPassword) AuthenticatePassword(ctx context.Context, user, password 
 
 func Test_UnitBasicAuth(t *testing.T) {
 	testCases := map[string]struct {
-		Header   string
-		Password testPassword
-
-		ExpectedCalled   bool
+		Header           string
 		ExpectedUsername string
 		ExpectedPassword string
-
-		ExpectedUser string
-		ExpectedOK   bool
-		ExpectedErr  bool
+		ExpectedUser     string
+		Password         testPassword
+		ExpectedCalled   bool
+		ExpectedOK       bool
+		ExpectedErr      bool
 	}{
 		"no auth": {},
 		"empty password basic header": {

--- a/pkg/authenticator/passwordfile/passwordfile_test.go
+++ b/pkg/authenticator/passwordfile/passwordfile_test.go
@@ -41,9 +41,9 @@ password7,user7,uid7,"group1,group2",otherdata
 	}
 
 	testCases := []struct {
+		User     *user.DefaultInfo
 		Username string
 		Password string
-		User     *user.DefaultInfo
 		Ok       bool
 		Err      bool
 	}{

--- a/pkg/bootstrap/bootstrap_test.go
+++ b/pkg/bootstrap/bootstrap_test.go
@@ -11,9 +11,9 @@ func TestObjToMap(t *testing.T) {
 		obj interface{}
 	}
 	tests := []struct {
-		name    string
 		args    args
 		want    map[string]string
+		name    string
 		wantErr bool
 	}{
 		{

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -10,45 +10,45 @@ import (
 )
 
 type Agent struct {
-	Token                    string
-	TokenFile                string
-	ClusterSecret            string
-	ServerURL                string
 	APIAddressCh             chan string
-	DisableLoadBalancer      bool
-	DisableServiceLB         bool
-	ETCDAgent                bool
-	LBServerPort             int
+	AgentReady               chan<- struct{}
+	ContainerRuntimeEndpoint string
+	ServerURL                string
+	ClusterSecret            string
+	TokenFile                string
+	ImageCredProvConfig      string
+	ImageCredProvBinDir      string
+	SystemDefaultRegistry    string
 	ResolvConf               string
 	DataDir                  string
-	NodeIP                   cli.StringSlice
-	NodeExternalIP           cli.StringSlice
+	PrivateRegistry          string
+	FlannelConf              string
 	NodeName                 string
 	PauseImage               string
 	Snapshotter              string
-	Docker                   bool
-	ContainerRuntimeEndpoint string
-	NoFlannel                bool
 	FlannelIface             string
-	FlannelConf              string
-	Debug                    bool
-	Rootless                 bool
-	RootlessAlreadyUnshared  bool
-	WithNodeID               bool
-	EnableSELinux            bool
-	ProtectKernelDefaults    bool
-	ClusterReset             bool
-	PrivateRegistry          string
-	SystemDefaultRegistry    string
-	AirgapExtraRegistry      cli.StringSlice
-	ExtraKubeletArgs         cli.StringSlice
-	ExtraKubeProxyArgs       cli.StringSlice
-	Labels                   cli.StringSlice
-	Taints                   cli.StringSlice
-	ImageCredProvBinDir      string
-	ImageCredProvConfig      string
-	AgentReady               chan<- struct{}
+	Token                    string
 	AgentShared
+	Taints                  cli.StringSlice
+	NodeExternalIP          cli.StringSlice
+	Labels                  cli.StringSlice
+	ExtraKubeProxyArgs      cli.StringSlice
+	ExtraKubeletArgs        cli.StringSlice
+	AirgapExtraRegistry     cli.StringSlice
+	NodeIP                  cli.StringSlice
+	LBServerPort            int
+	ProtectKernelDefaults   bool
+	EnableSELinux           bool
+	ClusterReset            bool
+	WithNodeID              bool
+	RootlessAlreadyUnshared bool
+	Rootless                bool
+	Debug                   bool
+	Docker                  bool
+	ETCDAgent               bool
+	DisableServiceLB        bool
+	DisableLoadBalancer     bool
+	NoFlannel               bool
 }
 
 type AgentShared struct {

--- a/pkg/cli/cmds/log.go
+++ b/pkg/cli/cmds/log.go
@@ -11,9 +11,9 @@ import (
 )
 
 type Log struct {
-	VLevel          int
 	VModule         string
 	LogFile         string
+	VLevel          int
 	AlsoLogToStderr bool
 }
 

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -16,83 +16,80 @@ const (
 
 type StartupHookArgs struct {
 	APIServerReady  <-chan struct{}
-	KubeConfigAdmin string
 	Skips           map[string]bool
 	Disables        map[string]bool
+	KubeConfigAdmin string
 }
 
 type StartupHook func(context.Context, *sync.WaitGroup, StartupHookArgs) error
 
 type Server struct {
-	ClusterCIDR          cli.StringSlice
-	AgentToken           string
-	AgentTokenFile       string
-	Token                string
-	TokenFile            string
-	ClusterSecret        string
-	ServiceCIDR          cli.StringSlice
-	ServiceNodePortRange string
-	ClusterDNS           cli.StringSlice
-	ClusterDomain        string
-	// The port which kubectl clients can access k8s
-	HTTPSPort int
-	// The port which custom k3s API runs on
-	SupervisorPort int
-	// The port which kube-apiserver runs on
-	APIServerPort            int
+	AdvertiseIP              string
+	AgentToken               string
+	AgentTokenFile           string
+	Token                    string
+	TokenFile                string
+	ClusterSecret            string
+	EtcdSnapshotDir          string
+	ServiceNodePortRange     string
+	KubeConfigOutput         string
+	ClusterDomain            string
+	EtcdS3Folder             string
+	EtcdS3Region             string
+	EtcdS3BucketName         string
 	APIServerBindAddress     string
 	DataDir                  string
-	DisableAgent             bool
-	KubeConfigOutput         string
+	EtcdS3SecretKey          string
+	EtcdSnapshotCron         string
 	KubeConfigMode           string
-	TLSSan                   cli.StringSlice
+	EtcdS3Endpoint           string
 	BindAddress              string
-	ExtraAPIArgs             cli.StringSlice
-	ExtraEtcdArgs            cli.StringSlice
-	ExtraSchedulerArgs       cli.StringSlice
-	ExtraControllerArgs      cli.StringSlice
-	ExtraCloudControllerArgs cli.StringSlice
-	Rootless                 bool
+	ServerURL                string
+	DefaultLocalStoragePath  string
+	FlannelBackend           string
+	EtcdSnapshotName         string
+	EtcdS3EndpointCA         string
+	EtcdS3AccessKey          string
 	DatastoreEndpoint        string
 	DatastoreCAFile          string
 	DatastoreCertFile        string
 	DatastoreKeyFile         string
-	AdvertiseIP              string
-	AdvertisePort            int
-	DisableScheduler         bool
-	ServerURL                string
-	FlannelBackend           string
-	DefaultLocalStoragePath  string
-	DisableCCM               bool
-	DisableNPC               bool
-	DisableHelmController    bool
-	DisableKubeProxy         bool
-	DisableAPIServer         bool
-	DisableControllerManager bool
-	DisableETCD              bool
-	ClusterInit              bool
-	ClusterReset             bool
 	ClusterResetRestorePath  string
-	EncryptSecrets           bool
 	SystemDefaultRegistry    string
+	ExtraAPIArgs             cli.StringSlice
+	ExtraCloudControllerArgs cli.StringSlice
+	ExtraControllerArgs      cli.StringSlice
+	ExtraEtcdArgs            cli.StringSlice
+	TLSSan                   cli.StringSlice
+	ClusterCIDR              cli.StringSlice
+	ServiceCIDR              cli.StringSlice
 	StartupHooks             []StartupHook
-	EtcdSnapshotName         string
+	ExtraSchedulerArgs       cli.StringSlice
+	ClusterDNS               cli.StringSlice
+	EtcdSnapshotRetention    int
+	EtcdS3Timeout            time.Duration
+	HTTPSPort                int
+	SupervisorPort           int
+	APIServerPort            int
+	AdvertisePort            int
+	DisableETCD              bool
+	EtcdS3Insecure           bool
 	EtcdDisableSnapshots     bool
 	EtcdExposeMetrics        bool
-	EtcdSnapshotDir          string
-	EtcdSnapshotCron         string
-	EtcdSnapshotRetention    int
+	DisableHelmController    bool
+	DisableNPC               bool
+	DisableKubeProxy         bool
 	EtcdS3                   bool
-	EtcdS3Endpoint           string
-	EtcdS3EndpointCA         string
+	DisableCCM               bool
+	DisableScheduler         bool
 	EtcdS3SkipSSLVerify      bool
-	EtcdS3AccessKey          string
-	EtcdS3SecretKey          string
-	EtcdS3BucketName         string
-	EtcdS3Region             string
-	EtcdS3Folder             string
-	EtcdS3Timeout            time.Duration
-	EtcdS3Insecure           bool
+	DisableAPIServer         bool
+	DisableAgent             bool
+	EncryptSecrets           bool
+	DisableControllerManager bool
+	ClusterReset             bool
+	ClusterInit              bool
+	Rootless                 bool
 }
 
 var (

--- a/pkg/clientaccess/token.go
+++ b/pkg/clientaccess/token.go
@@ -41,11 +41,11 @@ var (
 type OverrideURLCallback func(config []byte) (*url.URL, error)
 
 type Info struct {
-	CACerts  []byte `json:"cacerts,omitempty"`
 	BaseURL  string `json:"baseurl,omitempty"`
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
 	caHash   string
+	CACerts  []byte `json:"cacerts,omitempty"`
 }
 
 // String returns the token data, templated according to the token format

--- a/pkg/cluster/bootstrap_test.go
+++ b/pkg/cluster/bootstrap_test.go
@@ -22,10 +22,10 @@ func Test_isDirEmpty(t *testing.T) {
 		name string
 	}
 	tests := []struct {
-		name     string
-		args     args
 		setup    func() error
 		teardown func() error
+		name     string
+		args     args
 		want     bool
 		wantErr  bool
 	}{
@@ -96,10 +96,10 @@ func TestCluster_certDirsExist(t *testing.T) {
 		saveBootstrap    bool
 	}
 	tests := []struct {
-		name     string
-		fields   fields
 		setup    func() error
 		teardown func() error
+		name     string
+		fields   fields
 		wantErr  bool
 	}{
 		{
@@ -164,10 +164,10 @@ func TestCluster_migrateBootstrapData(t *testing.T) {
 		files bootstrap.PathsDataformat
 	}
 	tests := []struct {
-		name     string
 		args     args
-		setup    func() error // Optional, delete if unused
-		teardown func() error // Optional, delete if unused
+		setup    func() error
+		teardown func() error
+		name     string
 		wantErr  bool
 	}{
 		{
@@ -219,9 +219,9 @@ func TestCluster_Snapshot(t *testing.T) {
 		config *config.Control
 	}
 	tests := []struct {
+		args    args
 		name    string
 		fields  fields
-		args    args
 		wantErr bool
 	}{
 		{

--- a/pkg/configfilearg/parser.go
+++ b/pkg/configfilearg/parser.go
@@ -19,11 +19,11 @@ import (
 )
 
 type Parser struct {
-	After         []string
-	FlagNames     []string
+	ValidFlags    map[string][]cli.Flag
 	EnvName       string
 	DefaultConfig string
-	ValidFlags    map[string][]cli.Flag
+	After         []string
+	FlagNames     []string
 }
 
 // Parse will parse an os.Args style slice looking for Parser.FlagNames after Parse.After.

--- a/pkg/configfilearg/parser_test.go
+++ b/pkg/configfilearg/parser_test.go
@@ -116,10 +116,10 @@ func Test_UnitParser_findConfigFileFlag(t *testing.T) {
 		env           string
 	}
 	tests := []struct {
-		name   string
 		fields fields
-		arg    []string
+		name   string
 		want   string
+		arg    []string
 		found  bool
 	}{
 		{
@@ -241,10 +241,10 @@ func Test_UnitParser_Parse(t *testing.T) {
 		"--e-slice=two",
 	}
 	type fields struct {
-		After         []string
-		FlagNames     []string
 		EnvName       string
 		DefaultConfig string
+		After         []string
+		FlagNames     []string
 	}
 	tests := []struct {
 		name    string
@@ -345,20 +345,20 @@ func Test_UnitParser_Parse(t *testing.T) {
 
 func Test_UnitParser_FindString(t *testing.T) {
 	type fields struct {
-		After         []string
-		FlagNames     []string
 		EnvName       string
 		DefaultConfig string
+		After         []string
+		FlagNames     []string
 	}
 	type args struct {
-		osArgs []string
 		target string
+		osArgs []string
 	}
 	tests := []struct {
 		name    string
+		want    string
 		fields  fields
 		args    args
-		want    string
 		wantErr bool
 	}{
 		{

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -26,20 +26,20 @@ const (
 )
 
 type Node struct {
-	Docker                   bool
-	ContainerRuntimeEndpoint string
-	NoFlannel                bool
-	SELinux                  bool
+	FlannelIface             *net.Interface
+	Certificate              *tls.Certificate
+	Images                   string
+	Token                    string
 	FlannelBackend           string
 	FlannelConf              string
-	FlannelConfOverride      bool
-	FlannelIface             *net.Interface
+	ContainerRuntimeEndpoint string
 	Containerd               Containerd
-	Images                   string
 	AgentConfig              Agent
-	Token                    string
-	Certificate              *tls.Certificate
 	ServerHTTPSPort          int
+	FlannelConfOverride      bool
+	SELinux                  bool
+	NoFlannel                bool
+	Docker                   bool
 }
 
 type Containerd struct {
@@ -54,132 +54,131 @@ type Containerd struct {
 }
 
 type Agent struct {
-	PodManifests            string
-	NodeName                string
-	NodeConfigPath          string
+	ServiceCIDR             *net.IPNet
+	ClusterCIDR             *net.IPNet
+	PauseImage              string
 	ServingKubeletCert      string
 	ServingKubeletKey       string
-	ServiceCIDR             *net.IPNet
-	ServiceCIDRs            []*net.IPNet
-	ServiceNodePortRange    utilnet.PortRange
-	ClusterCIDR             *net.IPNet
-	ClusterCIDRs            []*net.IPNet
-	ClusterDNS              net.IP
-	ClusterDNSs             []net.IP
-	ClusterDomain           string
+	NodeConfigPath          string
+	PodManifests            string
+	ImageCredProvBinDir     string
+	NodeName                string
+	SystemDefaultRegistry   string
+	PrivateRegistry         string
+	StrongSwanDir           string
+	IPSECPSK                string
 	ResolvConf              string
 	RootDir                 string
 	KubeConfigKubelet       string
 	KubeConfigKubeProxy     string
 	KubeConfigK3sController string
 	NodeIP                  string
-	NodeIPs                 []net.IP
+	ImageCredProvConfig     string
 	NodeExternalIP          string
-	NodeExternalIPs         []net.IP
+	Snapshotter             string
 	RuntimeSocket           string
 	ImageServiceSocket      string
 	ListenAddress           string
 	ClientCA                string
 	CNIBinDir               string
 	CNIConfDir              string
+	ClusterDomain           string
+	ClusterDNSs             []net.IP
 	ExtraKubeletArgs        []string
-	ExtraKubeProxyArgs      []string
-	PauseImage              string
-	Snapshotter             string
-	CNIPlugin               bool
+	NodeExternalIPs         []net.IP
+	ClusterCIDRs            []*net.IPNet
 	NodeTaints              []string
 	NodeLabels              []string
-	ImageCredProvBinDir     string
-	ImageCredProvConfig     string
-	IPSECPSK                string
-	StrongSwanDir           string
-	PrivateRegistry         string
-	SystemDefaultRegistry   string
+	ClusterDNS              net.IP
+	NodeIPs                 []net.IP
+	ServiceCIDRs            []*net.IPNet
+	ExtraKubeProxyArgs      []string
 	AirgapExtraRegistry     []string
+	ServiceNodePortRange    utilnet.PortRange
+	EnableIPv6              bool
+	CNIPlugin               bool
 	DisableCCM              bool
 	DisableNPC              bool
 	Rootless                bool
 	ProtectKernelDefaults   bool
 	DisableServiceLB        bool
-	EnableIPv6              bool
 }
 
 type Control struct {
-	AdvertisePort int
-	AdvertiseIP   string
-	// The port which kubectl clients can access k8s
-	HTTPSPort int
-	// The port which custom k3s API runs on
-	SupervisorPort int
-	// The port which kube-apiserver runs on
-	APIServerPort            int
-	APIServerBindAddress     string
-	AgentToken               string `json:"-"`
-	Token                    string `json:"-"`
 	ClusterIPRange           *net.IPNet
-	ClusterIPRanges          []*net.IPNet
+	Disables                 map[string]bool
+	Skips                    map[string]bool
+	Runtime                  *ControlRuntime `json:"-"`
 	ServiceIPRange           *net.IPNet
-	ServiceIPRanges          []*net.IPNet
 	ServiceNodePortRange     *utilnet.PortRange
-	ClusterDNS               net.IP
-	ClusterDNSs              []net.IP
+	Datastore                endpoint.Config
+	IPSECPSK                 string
+	Token                    string `json:"-"`
+	EtcdS3EndpointCA         string
+	APIServerBindAddress     string
+	EtcdS3AccessKey          string
+	EtcdSnapshotDir          string
+	EtcdS3SecretKey          string
+	EtcdS3BucketName         string
 	ClusterDomain            string
-	DisableServiceLB         bool
-	NoCoreDNS                bool
+	PrivateIP                string
+	EtcdS3Endpoint           string
 	KubeConfigOutput         string
 	KubeConfigMode           string
 	DataDir                  string
-	Skips                    map[string]bool
-	Disables                 map[string]bool
-	Datastore                endpoint.Config
-	ExtraAPIArgs             []string
-	ExtraControllerArgs      []string
-	ExtraCloudControllerArgs []string
-	ExtraEtcdArgs            []string
-	ExtraSchedulerAPIArgs    []string
-	NoLeaderElect            bool
-	JoinURL                  string
-	FlannelBackend           string
-	IPSECPSK                 string
-	DefaultLocalStoragePath  string
-	SystemDefaultRegistry    string
-	DisableCCM               bool
-	DisableNPC               bool
-	DisableHelmController    bool
-	DisableKubeProxy         bool
-	DisableAPIServer         bool
-	DisableControllerManager bool
-	DisableScheduler         bool
-	DisableETCD              bool
-	ClusterInit              bool
-	ClusterReset             bool
 	ClusterResetRestorePath  string
-	EncryptSecrets           bool
-	TLSMinVersion            uint16
-	TLSCipherSuites          []uint16
-	EtcdSnapshotName         string
-	EtcdDisableSnapshots     bool
-	EtcdExposeMetrics        bool
-	EtcdSnapshotDir          string
 	EtcdSnapshotCron         string
-	EtcdSnapshotRetention    int
-	EtcdS3                   bool
-	EtcdS3Endpoint           string
-	EtcdS3EndpointCA         string
-	EtcdS3SkipSSLVerify      bool
-	EtcdS3AccessKey          string
-	EtcdS3SecretKey          string
-	EtcdS3BucketName         string
-	EtcdS3Region             string
+	AdvertiseIP              string
 	EtcdS3Folder             string
-	EtcdS3Timeout            time.Duration
-	EtcdS3Insecure           bool
+	FlannelBackend           string
 	ServerNodeName           string
-
-	BindAddress string
-	SANs        []string
-	PrivateIP   string
-	Runtime     *ControlRuntime `json:"-"`
+	EtcdS3Region             string
+	SystemDefaultRegistry    string
+	BindAddress              string
+	JoinURL                  string
+	DefaultLocalStoragePath  string
+	AgentToken               string `json:"-"`
+	EtcdSnapshotName         string
+	ClusterIPRanges          []*net.IPNet
+	ExtraSchedulerAPIArgs    []string
+	ExtraCloudControllerArgs []string
+	TLSCipherSuites          []uint16
+	ExtraAPIArgs             []string
+	SANs                     []string
+	ClusterDNSs              []net.IP
+	ExtraEtcdArgs            []string
+	ServiceIPRanges          []*net.IPNet
+	ClusterDNS               net.IP
+	ExtraControllerArgs      []string
+	// The port which kube-apiserver runs on
+	APIServerPort int
+	// The port which custom k3s API runs on
+	SupervisorPort        int
+	EtcdSnapshotRetention int
+	// The port which kubectl clients can access k8s
+	HTTPSPort                int
+	EtcdS3Timeout            time.Duration
+	AdvertisePort            int
+	TLSMinVersion            uint16
+	EtcdExposeMetrics        bool
+	EtcdDisableSnapshots     bool
+	EncryptSecrets           bool
+	EtcdS3                   bool
+	ClusterReset             bool
+	ClusterInit              bool
+	EtcdS3SkipSSLVerify      bool
+	DisableETCD              bool
+	DisableScheduler         bool
+	DisableControllerManager bool
+	DisableAPIServer         bool
+	DisableKubeProxy         bool
+	DisableHelmController    bool
+	EtcdS3Insecure           bool
+	DisableNPC               bool
+	NoLeaderElect            bool
+	NoCoreDNS                bool
+	DisableServiceLB         bool
+	DisableCCM               bool
 }
 
 type ControlRuntimeBootstrap struct {
@@ -200,38 +199,32 @@ type ControlRuntimeBootstrap struct {
 }
 
 type ControlRuntime struct {
-	ControlRuntimeBootstrap
-
-	HTTPBootstrap                       bool
+	Authenticator                       authenticator.Request
+	Tunnel                              http.Handler
+	Handler                             http.Handler
+	APIServer                           http.Handler
+	Core                                *core.Factory
+	ClusterControllerStart              func(ctx context.Context) error
+	LeaderElectedClusterControllerStart func(ctx context.Context) error
 	APIServerReady                      <-chan struct{}
 	AgentReady                          <-chan struct{}
 	ETCDReady                           <-chan struct{}
-	ClusterControllerStart              func(ctx context.Context) error
-	LeaderElectedClusterControllerStart func(ctx context.Context) error
-
-	ClientKubeAPICert string
-	ClientKubeAPIKey  string
-	NodePasswdFile    string
-
-	KubeConfigAdmin           string
-	KubeConfigController      string
+	ControlRuntimeBootstrap
+	ServerToken               string
 	KubeConfigScheduler       string
 	KubeConfigAPIServer       string
 	KubeConfigCloudController string
-
-	ServingKubeAPICert string
-	ServingKubeAPIKey  string
-	ServingKubeletKey  string
-	ServerToken        string
-	AgentToken         string
-	APIServer          http.Handler
-	Handler            http.Handler
-	Tunnel             http.Handler
-	Authenticator      authenticator.Request
-
-	ClientAuthProxyCert string
-	ClientAuthProxyKey  string
-
+	ServingKubeAPICert        string
+	ServingKubeAPIKey         string
+	ServingKubeletKey         string
+	KubeConfigController      string
+	AgentToken                string
+	KubeConfigAdmin           string
+	NodePasswdFile            string
+	ClientKubeAPIKey          string
+	ClientKubeAPICert         string
+	ClientAuthProxyCert       string
+	ClientAuthProxyKey        string
 	ClientAdminCert           string
 	ClientAdminKey            string
 	ClientControllerCert      string
@@ -245,15 +238,13 @@ type ControlRuntime struct {
 	ClientCloudControllerKey  string
 	ClientK3sControllerCert   string
 	ClientK3sControllerKey    string
-
-	ServerETCDCert           string
-	ServerETCDKey            string
-	PeerServerClientETCDCert string
-	PeerServerClientETCDKey  string
-	ClientETCDCert           string
-	ClientETCDKey            string
-
-	Core *core.Factory
+	ServerETCDCert            string
+	ClientETCDKey             string
+	PeerServerClientETCDCert  string
+	PeerServerClientETCDKey   string
+	ClientETCDCert            string
+	ServerETCDKey             string
+	HTTPBootstrap             bool
 }
 
 type ArgString []string

--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -36,34 +36,34 @@ type Executor interface {
 
 type ETCDConfig struct {
 	InitialOptions      `json:",inline"`
-	Name                string      `json:"name,omitempty"`
+	Logger              string      `json:"logger"`
 	ListenClientURLs    string      `json:"listen-client-urls,omitempty"`
 	ListenMetricsURLs   string      `json:"listen-metrics-urls,omitempty"`
 	ListenPeerURLs      string      `json:"listen-peer-urls,omitempty"`
 	AdvertiseClientURLs string      `json:"advertise-client-urls,omitempty"`
 	DataDir             string      `json:"data-dir,omitempty"`
-	SnapshotCount       int         `json:"snapshot-count,omitempty"`
+	Name                string      `json:"name,omitempty"`
 	ServerTrust         ServerTrust `json:"client-transport-security"`
 	PeerTrust           PeerTrust   `json:"peer-transport-security"`
-	ForceNewCluster     bool        `json:"force-new-cluster,omitempty"`
+	LogOutputs          []string    `json:"log-outputs"`
 	HeartbeatInterval   int         `json:"heartbeat-interval"`
 	ElectionTimeout     int         `json:"election-timeout"`
-	Logger              string      `json:"logger"`
-	LogOutputs          []string    `json:"log-outputs"`
+	SnapshotCount       int         `json:"snapshot-count,omitempty"`
+	ForceNewCluster     bool        `json:"force-new-cluster,omitempty"`
 }
 
 type ServerTrust struct {
 	CertFile       string `json:"cert-file"`
 	KeyFile        string `json:"key-file"`
-	ClientCertAuth bool   `json:"client-cert-auth"`
 	TrustedCAFile  string `json:"trusted-ca-file"`
+	ClientCertAuth bool   `json:"client-cert-auth"`
 }
 
 type PeerTrust struct {
 	CertFile       string `json:"cert-file"`
 	KeyFile        string `json:"key-file"`
-	ClientCertAuth bool   `json:"client-cert-auth"`
 	TrustedCAFile  string `json:"trusted-ca-file"`
+	ClientCertAuth bool   `json:"client-cert-auth"`
 }
 
 type InitialOptions struct {

--- a/pkg/deploy/controller.go
+++ b/pkg/deploy/controller.go
@@ -66,10 +66,10 @@ type watcher struct {
 	apply      apply.Apply
 	addonCache controllersv1.AddonCache
 	addons     controllersv1.AddonClient
-	bases      []string
+	recorder   record.EventRecorder
 	disables   map[string]bool
 	modTime    map[string]time.Time
-	recorder   record.EventRecorder
+	bases      []string
 }
 
 // start calls listFiles at regular intervals to trigger application of manifests that have changed on disk.

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -79,18 +79,18 @@ type NodeControllerGetter func() controllerv1.NodeController
 type ETCD struct {
 	client  *clientv3.Client
 	config  *config.Control
-	name    string
 	runtime *config.ControlRuntime
-	address string
 	cron    *cron.Cron
 	s3      *S3
+	name    string
+	address string
 }
 
 type learnerProgress struct {
-	ID               uint64      `json:"id,omitempty"`
-	Name             string      `json:"name,omitempty"`
-	RaftAppliedIndex uint64      `json:"raftAppliedIndex,omitempty"`
 	LastProgress     metav1.Time `json:"lastProgress,omitempty"`
+	Name             string      `json:"name,omitempty"`
+	ID               uint64      `json:"id,omitempty"`
+	RaftAppliedIndex uint64      `json:"raftAppliedIndex,omitempty"`
 }
 
 // Members contains a slice that holds all
@@ -989,24 +989,24 @@ func (e *ETCD) Snapshot(ctx context.Context, config *config.Control) error {
 type s3Config struct {
 	Endpoint      string `json:"endpoint,omitempty"`
 	EndpointCA    string `json:"endpointCA,omitempty"`
-	SkipSSLVerify bool   `json:"skipSSLVerify,omitempty"`
 	Bucket        string `json:"bucket,omitempty"`
 	Region        string `json:"region,omitempty"`
 	Folder        string `json:"folder,omitempty"`
+	SkipSSLVerify bool   `json:"skipSSLVerify,omitempty"`
 	Insecure      bool   `json:"insecure,omitempty"`
 }
 
 // SnapshotFile represents a single snapshot and it's
 // metadata.
 type SnapshotFile struct {
-	Name string `json:"name"`
+	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
+	S3        *s3Config    `json:"s3Config,omitempty"`
+	Name      string       `json:"name"`
 	// Location contains the full path of the snapshot. For
 	// local paths, the location will be prefixed with "file://".
-	Location  string       `json:"location,omitempty"`
-	NodeName  string       `json:"nodeName,omitempty"`
-	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
-	Size      int64        `json:"size,omitempty"`
-	S3        *s3Config    `json:"s3Config,omitempty"`
+	Location string `json:"location,omitempty"`
+	NodeName string `json:"nodeName,omitempty"`
+	Size     int64  `json:"size,omitempty"`
 }
 
 // listSnapshots provides a list of the currently stored

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -58,10 +58,10 @@ func Test_UnitETCD_IsInitialized(t *testing.T) {
 		config *config.Control
 	}
 	tests := []struct {
-		name     string
 		args     args
 		setup    func(*config.Control) error
 		teardown func(*config.Control) error
+		name     string
 		want     bool
 		wantErr  bool
 	}{
@@ -134,10 +134,10 @@ func Test_UnitETCD_Register(t *testing.T) {
 		handler http.Handler
 	}
 	tests := []struct {
-		name     string
 		args     args
 		setup    func(cnf *config.Control) error
 		teardown func(cnf *config.Control) error
+		name     string
 		wantErr  bool
 	}{
 		{
@@ -210,20 +210,20 @@ func Test_UnitETCD_Start(t *testing.T) {
 		context contextInfo
 		client  *clientv3.Client
 		config  *config.Control
-		name    string
-		address string
 		cron    *cron.Cron
 		s3      *S3
+		name    string
+		address string
 	}
 	type args struct {
 		clientAccessInfo *clientaccess.Info
 	}
 	tests := []struct {
-		name     string
-		fields   fields
 		args     args
 		setup    func(cnf *config.Control, ctxInfo *contextInfo) error
 		teardown func(cnf *config.Control, ctxInfo *contextInfo) error
+		fields   fields
+		name     string
 		wantErr  bool
 	}{
 		{

--- a/pkg/etcd/etcdproxy.go
+++ b/pkg/etcd/etcdproxy.go
@@ -45,15 +45,14 @@ func NewETCDProxy(ctx context.Context, enabled bool, dataDir, etcdURL string) (P
 }
 
 type etcdproxy struct {
-	dataDir   string
-	etcdLBURL string
-
+	etcdLB              *loadbalancer.LoadBalancer
+	dataDir             string
 	initialETCDURL      string
 	etcdURL             string
 	etcdPort            string
 	fallbackETCDAddress string
+	etcdLBURL           string
 	etcdAddresses       []string
-	etcdLB              *loadbalancer.LoadBalancer
 }
 
 func (e *etcdproxy) Update(addresses []string) {

--- a/pkg/node/controller.go
+++ b/pkg/node/controller.go
@@ -30,10 +30,10 @@ func Register(ctx context.Context,
 }
 
 type handler struct {
-	modCoreDNS   bool
 	secretClient coreclient.SecretClient
 	configCache  coreclient.ConfigMapCache
 	configClient coreclient.ConfigMapClient
+	modCoreDNS   bool
 }
 
 func (h *handler) onChange(key string, node *core.Node) (*core.Node, error) {

--- a/pkg/nodeconfig/nodeconfig_test.go
+++ b/pkg/nodeconfig/nodeconfig_test.go
@@ -62,12 +62,12 @@ func Test_UnitSetNodeConfigAnnotations(t *testing.T) {
 	}
 	tests := []struct {
 		name               string
-		args               args
-		want               bool
-		wantErr            bool
 		wantNodeArgs       string
 		wantNodeEnv        string
 		wantNodeConfigHash string
+		args               args
+		want               bool
+		wantErr            bool
 	}{
 		{
 			name: "Set empty NodeConfigAnnotations",

--- a/pkg/passwd/passwd.go
+++ b/pkg/passwd/passwd.go
@@ -17,8 +17,8 @@ type entry struct {
 }
 
 type Passwd struct {
-	changed bool
 	names   map[string]entry
+	changed bool
 }
 
 func Read(file string) (*Passwd, error) {

--- a/pkg/rootlessports/controller.go
+++ b/pkg/rootlessports/controller.go
@@ -57,12 +57,12 @@ func Register(ctx context.Context, serviceController coreClients.ServiceControll
 }
 
 type handler struct {
-	enabled        bool
 	rootlessClient client.Client
 	serviceClient  coreClients.ServiceController
 	serviceCache   coreClients.ServiceCache
-	httpsPort      int
 	ctx            context.Context
+	httpsPort      int
+	enabled        bool
 }
 
 func (h *handler) serviceChanged(key string, svc *v1.Service) (*v1.Service, error) {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -8,14 +8,14 @@ import (
 )
 
 type Config struct {
-	DisableAgent      bool
-	DisableServiceLB  bool
-	ControlConfig     config.Control
-	Rootless          bool
-	SupervisorPort    int
-	StartupHooks      []cmds.StartupHook
 	LeaderControllers CustomControllers
 	Controllers       CustomControllers
+	StartupHooks      []cmds.StartupHook
+	ControlConfig     config.Control
+	SupervisorPort    int
+	Rootless          bool
+	DisableAgent      bool
+	DisableServiceLB  bool
 }
 
 type CustomControllers []func(ctx context.Context, sc *Context) error

--- a/pkg/servicelb/controller.go
+++ b/pkg/servicelb/controller.go
@@ -82,16 +82,16 @@ func Register(ctx context.Context,
 }
 
 type handler struct {
-	rootless        bool
-	enabled         bool
+	serviceCache    coreclient.ServiceCache
+	services        coregetter.ServicesGetter
 	nodeCache       coreclient.NodeCache
 	podCache        coreclient.PodCache
 	deploymentCache appclient.DeploymentCache
 	processor       apply.Apply
-	serviceCache    coreclient.ServiceCache
-	services        coregetter.ServicesGetter
 	daemonsets      v1getter.DaemonSetsGetter
 	deployments     v1getter.DeploymentsGetter
+	rootless        bool
+	enabled         bool
 }
 
 func (h *handler) onResourceChange(name, namespace string, obj runtime.Object) ([]relatedresource.Key, error) {


### PR DESCRIPTION
#### Proposed Changes ####

- Change linter to catch unoptimized structs that implement additional memory padding.
  - Implement fixes suggested by linter which is just rearranging the order of struct fields

#### Types of Changes ####

fix - better memory allocation when initializing structs

#### Verification ####

This is simply rearranging struct fields, so long as it compiles, changes are good.

#### Linked Issues ####

N/A

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####

NONE

```release-note
Improve memory allocation when initializing structs
```

#### Further Comments ####

This isn't a huge change, but I thought it be useful to save on memory where possible in order to keep k3s as lightweight as can be.
