### PR TITLE
add --etcd-advertise-address support

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -76,6 +76,7 @@ type Server struct {
 	EncryptSecrets           bool
 	SystemDefaultRegistry    string
 	StartupHooks             []StartupHook
+	EtcdAdvertiseAddress     string
 	EtcdSnapshotName         string
 	EtcdDisableSnapshots     bool
 	EtcdExposeMetrics        bool
@@ -251,6 +252,11 @@ var ServerFlags = []cli.Flag{
 		Usage:       "(db) TLS key file used to secure datastore backend communication",
 		Destination: &ServerConfig.DatastoreKeyFile,
 		EnvVar:      version.ProgramUpper + "_DATASTORE_KEYFILE",
+	},
+	cli.StringFlag{
+		Name:        "etcd-advertise-address",
+		Usage:       "(db) Address that etcd uses to set peer and client advertise addresses",
+		Destination: &ServerConfig.EtcdAdvertiseAddress,
 	},
 	&cli.BoolFlag{
 		Name:        "etcd-expose-metrics",

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -42,7 +42,7 @@ func (c *Cluster) Start(ctx context.Context) (<-chan struct{}, error) {
 		defer close(ready)
 
 		// try to get /db/info urls first before attempting to use join url
-		clientURLs, _, err := etcd.ClientURLs(ctx, c.clientAccessInfo, c.config.PrivateIP)
+		clientURLs, _, err := etcd.ClientURLs(ctx, c.clientAccessInfo, c.config.EtcdAdvertiseAddress)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -157,6 +157,7 @@ type Control struct {
 	EncryptSecrets           bool
 	TLSMinVersion            uint16
 	TLSCipherSuites          []uint16
+	EtcdAdvertiseAddress     string
 	EtcdSnapshotName         string
 	EtcdDisableSnapshots     bool
 	EtcdExposeMetrics        bool

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -639,18 +639,16 @@ func (e *ETCD) clientURL() string {
 func (e *ETCD) listenPeerURLs() string {
 	if net.ParseIP(e.address) == nil {
 		return "https://0.0.0.0:2380"
-	} else {
-		return e.peerURL()
 	}
+	return e.peerURL()
 }
 
 // listenClientURLs returns the list of urls to listen for client
 func (e *ETCD) listenClientUrls() string {
 	if net.ParseIP(e.address) == nil {
 		return "https://0.0.0.0:2379"
-	} else {
-		return fmt.Sprintf("https://%s:2379,https://127.0.0.1:2379", e.address)
 	}
+	return fmt.Sprintf("https://%s:2379,https://127.0.0.1:2379", e.address)
 }
 
 // metricsURL returns the metrics access address

--- a/pkg/server/etcd.go
+++ b/pkg/server/etcd.go
@@ -82,7 +82,7 @@ func setETCDLabelsAndAnnotations(ctx context.Context, config *Config) error {
 		etcdNodeName := string(data)
 		node.Annotations[etcd.NodeNameAnnotation] = etcdNodeName
 
-		address, err := etcd.GetAdvertiseAddress(controlConfig.PrivateIP)
+		address, err := etcd.GetAdvertiseAddress(controlConfig.EtcdAdvertiseAddress)
 		if err != nil {
 			logrus.Infof("Waiting for etcd node address to be available: %v", err)
 			continue


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
New Feature 
#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Etcd advertise address can now be set through `--etcd-advertise-address`, which works both with IPv4 and domain name
#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/4576

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added support for explicitely setting etcd advertise address via `--etcd-advertise-address`
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
