### PR TITLE
Verify new control plane nodes joining the cluster share the same config as cluster members

### DIFF
--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -104,7 +104,28 @@ type Agent struct {
 	EnableIPv6              bool
 }
 
+// CriticalControlArgs contains parameters that all control plane nodes in HA must share
+type CriticalControlArgs struct {
+	ClusterDNSs           []net.IP
+	ClusterIPRanges       []*net.IPNet
+	ClusterDNS            net.IP
+	ClusterDomain         string
+	ClusterIPRange        *net.IPNet
+	DisableCCM            bool
+	DisableHelmController bool
+	DisableKubeProxy      bool
+	DisableNPC            bool
+	Disables              map[string]bool
+	DisableServiceLB      bool
+	FlannelBackend        string
+	NoCoreDNS             bool
+	ServiceIPRange        *net.IPNet
+	ServiceIPRanges       []*net.IPNet
+	Skips                 map[string]bool
+}
+
 type Control struct {
+	CriticalControlArgs
 	AdvertisePort int
 	AdvertiseIP   string
 	// The port which kubectl clients can access k8s
@@ -116,22 +137,15 @@ type Control struct {
 	APIServerBindAddress     string
 	AgentToken               string `json:"-"`
 	Token                    string `json:"-"`
-	ClusterIPRange           *net.IPNet
-	ClusterIPRanges          []*net.IPNet
-	ServiceIPRange           *net.IPNet
-	ServiceIPRanges          []*net.IPNet
 	ServiceNodePortRange     *utilnet.PortRange
-	ClusterDNS               net.IP
-	ClusterDNSs              []net.IP
-	ClusterDomain            string
-	DisableServiceLB         bool
-	NoCoreDNS                bool
 	KubeConfigOutput         string
 	KubeConfigMode           string
 	DataDir                  string
-	Skips                    map[string]bool
-	Disables                 map[string]bool
 	Datastore                endpoint.Config
+	DisableAPIServer         bool
+	DisableControllerManager bool
+	DisableETCD              bool
+	DisableScheduler         bool
 	ExtraAPIArgs             []string
 	ExtraControllerArgs      []string
 	ExtraCloudControllerArgs []string
@@ -139,18 +153,9 @@ type Control struct {
 	ExtraSchedulerAPIArgs    []string
 	NoLeaderElect            bool
 	JoinURL                  string
-	FlannelBackend           string
 	IPSECPSK                 string
 	DefaultLocalStoragePath  string
 	SystemDefaultRegistry    string
-	DisableCCM               bool
-	DisableNPC               bool
-	DisableHelmController    bool
-	DisableKubeProxy         bool
-	DisableAPIServer         bool
-	DisableControllerManager bool
-	DisableScheduler         bool
-	DisableETCD              bool
 	ClusterInit              bool
 	ClusterReset             bool
 	ClusterResetRestorePath  string

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -29,23 +29,26 @@ func mustGetAddress() string {
 func generateTestConfig() *config.Control {
 	agentReady := make(chan struct{})
 	close(agentReady)
+	criticalControlArgs := config.CriticalControlArgs{
+		ClusterDomain:  "cluster.local",
+		ClusterDNS:     net.ParseIP("10.43.0.10"),
+		ClusterIPRange: testutil.ClusterIPNet(),
+		FlannelBackend: "vxlan",
+		ServiceIPRange: testutil.ServiceIPNet(),
+	}
 	return &config.Control{
 		Runtime:               &config.ControlRuntime{AgentReady: agentReady},
 		HTTPSPort:             6443,
 		SupervisorPort:        6443,
 		AdvertisePort:         6443,
-		ClusterDomain:         "cluster.local",
-		ClusterDNS:            net.ParseIP("10.43.0.10"),
-		ClusterIPRange:        testutil.ClusterIPNet(),
 		DataDir:               "/tmp/k3s/", // Different than the default value
-		FlannelBackend:        "vxlan",
 		EtcdSnapshotName:      "etcd-snapshot",
 		EtcdSnapshotCron:      "0 */12 * * *",
 		EtcdSnapshotRetention: 5,
 		EtcdS3Endpoint:        "s3.amazonaws.com",
 		EtcdS3Region:          "us-east-1",
 		SANs:                  []string{"127.0.0.1"},
-		ServiceIPRange:        testutil.ServiceIPNet(),
+		CriticalControlArgs:   criticalControlArgs,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This PR guardrails users of k3s-HA. It verifies if the new member's config is shared across the cluster. If not, it fails and asks to verify the config.

To do so, a few important config parameters:
- ClusterIPRanges
- ServiceIPRanges
- ClusterDNSs
- ClusterDomain
- FlannelBackend
- Disables
- Skips
- DisableCCM
- DisableNPC
- DisableHelmController
- DisableKubeProxy
- NoCoreDNS
- DisableServiceLB

are moved to a struct called CriticalControlArgs. All those fields are anonymous to the current Control struct where they belong, so the change is transparent for the code that uses those fields.

Once a new control plane node tries to join the cluster, fetches the cluster config via `$Cluster-VIP:6443//v1-k3s/config` and compares it with the local Config. If the result is not the same, it fails. For example:
```
ec2-user@ip-10-0-10-29 ~]$ sudo K3S_TOKEN=SECRET /usr/local/bin/k3s server --server https://k3s-lb-4cd6766c8e8e2158.elb.eu-west-3.amazonaws.com:6443 --tls-san k3s-lb-4cd6766c8e8e2158.elb.eu-west-3.amazonaws.com --cluster-cidr 192.168.0.0/16
INFO[0000] Acquiring lock file /var/lib/rancher/k3s/data/.lock 
INFO[0000] Preparing data dir /var/lib/rancher/k3s/data/989710e98d2b52d0df474cfb9e2a67239cc67d368cf4e6367588eb097501e5ed 
INFO[0000] Starting k3s v1.22.4+k3s-d57b3ed1 (d57b3ed1) 
WARN[0000] Cluster CA certificate is not trusted by the host CA bundle, but the token does not include a CA hash. Use the full token from the server's node-token file to enable Cluster CA validation. 
INFO[0000] Managed etcd cluster not yet initialized     
FATA[0000] starting kubernetes: preparing server: Node can't join the cluster. Its config is different from the cluster's config. Please use the same config for all control plane nodes 
```

I'm assuming this check should only happen in the `managedDB = true` scenario but I might be wrong. I'm not super familiar with this part of the code. I'm sure @briandowns will help me understand what's the best place for it :)

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
New feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Deploy k3s in HA mode and use a different config for one of the joining control plane members. It should fail to join the cluster


#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/4579

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
