### PR TITLE
[release-1.22] etcd snapshot functionality enhancements

### DIFF
--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -26,6 +26,11 @@ var EtcdSnapshotFlags = []cli.Flag{
 		Destination: &ServerConfig.DataDir,
 	},
 	&cli.StringFlag{
+		Name:        "dir,etcd-snapshot-dir",
+		Usage:       "(db) Directory to save etcd on-demand snapshot. (default: ${data-dir}/db/snapshots)",
+		Destination: &ServerConfig.EtcdSnapshotDir,
+	},
+	&cli.StringFlag{
 		Name:        "name",
 		Usage:       "(db) Set the base name of the etcd on-demand snapshot (appended with UNIX timestamp).",
 		Destination: &ServerConfig.EtcdSnapshotName,
@@ -101,11 +106,7 @@ func NewEtcdSnapshotCommand(action func(*cli.Context) error, subcommands []cli.C
 		SkipArgReorder:  true,
 		Action:          action,
 		Subcommands:     subcommands,
-		Flags: append(EtcdSnapshotFlags, &cli.StringFlag{
-			Name:        "dir,etcd-snapshot-dir",
-			Usage:       "(db) Directory to save etcd on-demand snapshot. (default: ${data-dir}/db/snapshots)",
-			Destination: &ServerConfig.EtcdSnapshotDir,
-		}),
+		Flags:           EtcdSnapshotFlags,
 	}
 }
 
@@ -130,7 +131,7 @@ func NewEtcdSnapshotSubcommands(delete, list, prune, save func(ctx *cli.Context)
 		},
 		{
 			Name:            "prune",
-			Usage:           "Remove snapshots that exceed the configured retention count",
+			Usage:           "Remove snapshots that match the name prefix that exceed the configured retention count",
 			SkipFlagParsing: false,
 			SkipArgReorder:  true,
 			Action:          prune,
@@ -147,11 +148,7 @@ func NewEtcdSnapshotSubcommands(delete, list, prune, save func(ctx *cli.Context)
 			SkipFlagParsing: false,
 			SkipArgReorder:  true,
 			Action:          save,
-			Flags: append(EtcdSnapshotFlags, &cli.StringFlag{
-				Name:        "dir",
-				Usage:       "(db) Directory to save etcd on-demand snapshot. (default: ${data-dir}/db/snapshots)",
-				Destination: &ServerConfig.EtcdSnapshotDir,
-			}),
+			Flags:           EtcdSnapshotFlags,
 		},
 	}
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -104,7 +104,7 @@ func (c *Cluster) Start(ctx context.Context) (<-chan struct{}, error) {
 					}
 
 					if !c.config.EtcdDisableSnapshots {
-						if err := c.managedDB.StoreSnapshotData(ctx); err != nil {
+						if err := c.managedDB.ReconcileSnapshotData(ctx); err != nil {
 							logrus.Errorf("Failed to record snapshots for cluster: %v", err)
 						}
 					}

--- a/pkg/cluster/managed/drivers.go
+++ b/pkg/cluster/managed/drivers.go
@@ -22,7 +22,7 @@ type Driver interface {
 	Restore(ctx context.Context) error
 	EndpointName() string
 	Snapshot(ctx context.Context, config *config.Control) error
-	StoreSnapshotData(ctx context.Context) error
+	ReconcileSnapshotData(ctx context.Context) error
 	GetMembersClientURLs(ctx context.Context) ([]string, error)
 	RemoveSelf(ctx context.Context) error
 }

--- a/pkg/etcd/etcd_int_test.go
+++ b/pkg/etcd/etcd_int_test.go
@@ -36,7 +36,7 @@ var _ = Describe("etcd snapshots", func() {
 		})
 		It("saves an etcd snapshot", func() {
 			Expect(testutil.K3sCmd("etcd-snapshot", "save")).
-				To(ContainSubstring("Saving current etcd snapshot set to k3s-etcd-snapshots"))
+				To(ContainSubstring("saved"))
 		})
 		It("list snapshots", func() {
 			Expect(testutil.K3sCmd("etcd-snapshot", "ls")).
@@ -70,13 +70,13 @@ var _ = Describe("etcd snapshots", func() {
 	When("using etcd snapshot prune", func() {
 		It("saves 3 different snapshots", func() {
 			Expect(testutil.K3sCmd("etcd-snapshot", "save", "-name", "PRUNE_TEST")).
-				To(ContainSubstring("Saving current etcd snapshot set to k3s-etcd-snapshots"))
+				To(ContainSubstring("saved"))
 			time.Sleep(1 * time.Second)
 			Expect(testutil.K3sCmd("etcd-snapshot", "save", "-name", "PRUNE_TEST")).
-				To(ContainSubstring("Saving current etcd snapshot set to k3s-etcd-snapshots"))
+				To(ContainSubstring("saved"))
 			time.Sleep(1 * time.Second)
 			Expect(testutil.K3sCmd("etcd-snapshot", "save", "-name", "PRUNE_TEST")).
-				To(ContainSubstring("Saving current etcd snapshot set to k3s-etcd-snapshots"))
+				To(ContainSubstring("saved"))
 			time.Sleep(1 * time.Second)
 		})
 		It("lists all 3 snapshots", func() {
@@ -89,7 +89,7 @@ var _ = Describe("etcd snapshots", func() {
 		})
 		It("prunes snapshots down to 2", func() {
 			Expect(testutil.K3sCmd("etcd-snapshot", "prune", "--snapshot-retention", "2", "--name", "PRUNE_TEST")).
-				To(BeEmpty())
+				To(ContainSubstring("Removing local snapshot"))
 			lsResult, err := testutil.K3sCmd("etcd-snapshot", "ls")
 			Expect(err).ToNot(HaveOccurred())
 			reg, err := regexp.Compile(`:///var/lib/rancher/k3s/server/db/snapshots/PRUNE_TEST`)

--- a/pkg/etcd/s3.go
+++ b/pkg/etcd/s3.go
@@ -14,12 +14,14 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/pkg/errors"
 	"github.com/rancher/k3s/pkg/daemons/config"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // S3 maintains state for S3 functionality.
@@ -32,6 +34,9 @@ type S3 struct {
 // copy of the config.Control pointer and initializes
 // a new Minio client.
 func NewS3(ctx context.Context, config *config.Control) (*S3, error) {
+	if config.EtcdS3BucketName == "" {
+		return nil, errors.New("s3 bucket name was not set")
+	}
 	tr := http.DefaultTransport
 
 	switch {
@@ -88,9 +93,11 @@ func NewS3(ctx context.Context, config *config.Control) (*S3, error) {
 
 // upload uploads the given snapshot to the configured S3
 // compatible backend.
-func (s *S3) upload(ctx context.Context, snapshot string) error {
+func (s *S3) upload(ctx context.Context, snapshot, extraMetadata string, now time.Time) (*SnapshotFile, error) {
+	logrus.Infof("Uploading snapshot %s to S3", snapshot)
 	basename := filepath.Base(snapshot)
 	var snapshotFileName string
+	var snapshotFile SnapshotFile
 	if s.config.EtcdS3Folder != "" {
 		snapshotFileName = filepath.Join(s.config.EtcdS3Folder, basename)
 	} else {
@@ -103,11 +110,56 @@ func (s *S3) upload(ctx context.Context, snapshot string) error {
 		ContentType: "application/zip",
 		NumThreads:  2,
 	}
-	if _, err := s.client.FPutObject(toCtx, s.config.EtcdS3BucketName, snapshotFileName, snapshot, opts); err != nil {
-		logrus.Errorf("Error received in attempt to upload snapshot to S3: %s", err)
-	}
+	uploadInfo, err := s.client.FPutObject(toCtx, s.config.EtcdS3BucketName, snapshotFileName, snapshot, opts)
+	if err != nil {
+		snapshotFile = SnapshotFile{
+			Name:     filepath.Base(uploadInfo.Key),
+			Metadata: extraMetadata,
+			NodeName: "s3",
+			CreatedAt: &metav1.Time{
+				Time: now,
+			},
+			Message: base64.StdEncoding.EncodeToString([]byte(err.Error())),
+			Size:    0,
+			Status:  FailedSnapshotStatus,
+			S3: &s3Config{
+				Endpoint:      s.config.EtcdS3Endpoint,
+				EndpointCA:    s.config.EtcdS3EndpointCA,
+				SkipSSLVerify: s.config.EtcdS3SkipSSLVerify,
+				Bucket:        s.config.EtcdS3BucketName,
+				Region:        s.config.EtcdS3Region,
+				Folder:        s.config.EtcdS3Folder,
+				Insecure:      s.config.EtcdS3Insecure,
+			},
+		}
+		logrus.Errorf("Error received during snapshot upload to S3: %s", err)
+	} else {
+		ca, err := time.Parse(time.RFC3339, uploadInfo.LastModified.Format(time.RFC3339))
+		if err != nil {
+			return nil, err
+		}
 
-	return nil
+		snapshotFile = SnapshotFile{
+			Name:     filepath.Base(uploadInfo.Key),
+			Metadata: extraMetadata,
+			NodeName: "s3",
+			CreatedAt: &metav1.Time{
+				Time: ca,
+			},
+			Size:   uploadInfo.Size,
+			Status: SuccessfulSnapshotStatus,
+			S3: &s3Config{
+				Endpoint:      s.config.EtcdS3Endpoint,
+				EndpointCA:    s.config.EtcdS3EndpointCA,
+				SkipSSLVerify: s.config.EtcdS3SkipSSLVerify,
+				Bucket:        s.config.EtcdS3BucketName,
+				Region:        s.config.EtcdS3Region,
+				Folder:        s.config.EtcdS3Folder,
+				Insecure:      s.config.EtcdS3Insecure,
+			},
+		}
+	}
+	return &snapshotFile, nil
 }
 
 // download downloads the given snapshot from the configured S3
@@ -170,9 +222,13 @@ func (s *S3) snapshotPrefix() string {
 	return prefix
 }
 
-// snapshotRetention deletes the given snapshot from the configured S3
-// compatible backend.
+// snapshotRetention prunes snapshots in the configured S3 compatible backend for this specific node.
 func (s *S3) snapshotRetention(ctx context.Context) error {
+	if s.config.EtcdSnapshotRetention < 1 {
+		return nil
+	}
+	logrus.Infof("Applying snapshot retention policy to snapshots stored in S3: retention: %d, snapshotPrefix: %s", s.config.EtcdSnapshotRetention, s.snapshotPrefix())
+
 	var snapshotFiles []minio.ObjectInfo
 
 	toCtx, cancel := context.WithTimeout(ctx, s.config.EtcdS3Timeout)
@@ -199,7 +255,7 @@ func (s *S3) snapshotRetention(ctx context.Context) error {
 
 	delCount := len(snapshotFiles) - s.config.EtcdSnapshotRetention
 	for _, df := range snapshotFiles[:delCount] {
-		logrus.Debugf("Removing snapshot: %s", df.Key)
+		logrus.Infof("Removing S3 snapshot: %s", df.Key)
 		if err := s.client.RemoveObject(ctx, s.config.EtcdS3BucketName, df.Key, minio.RemoveObjectOptions{}); err != nil {
 			return err
 		}


### PR DESCRIPTION
Backport https://github.com/k3s-io/k3s/pull/4453

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Enhance etcd snapshot functionality in K3s

This PR does a couple of things.

Global changes:
1. `etcd snapshot-save` will now attach data from the `k3s-etcd-snapshot-extra-metadata` ConfigMap into the `k3s-etcd-snapshots` configmap under the new key. It will base64 encode the snapshot metadata so as to prevent accidental unmarshaling when the `k3s-etcd-snapshots` configmap is processed by other programs.
2. `etcd snapshot-save` now modifies the `k3s-etcd-snapshots` configmap transactionally, rather than relying on down-the-line reconciliation to populate information. This allows partially-successful attempts to be recorded in the configmap. 
3. If an `etcd snapshot-save` attempt fails, the configmap will be updated with the metadata of the snapshot and the base64 encoded error message encountered when the snapshot failed.  
4. The `etcd snapshot-save` failed attempts in the configmap will be cleaned up during a `prune` with the same retention policy defined, if the retention policy is defined.
5. `etcd snapshot-save prune` will prune both local and s3 snapshots at the same time.
6. The `k3s-etcd-snapshots` configmap keys will now have an additional prefix i.e. `s3-` or `local-` so as to allow duplicate snapshot names in the same configmap.

S3-specific changes:
1. If S3 is enabled when taking a one-time snapshot, the one-time snapshot will remain on disk and populated into the `k3s-etcd-snapshots` configmap as well.
2. If S3 is enabled and uploading to S3 fails, the local snapshot will be retained and populated into the `k3s-etcd-snapshots` configmap.
3. If S3 is enabled and upload to S3 is successful, there will be unique entries in the `k3s-etcd-snapshots` configmap.

#### Types of Changes ####
Etcd snapshot/prune functionality enhancements

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/4380
https://github.com/k3s-io/k3s/issues/4603
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
etcd snapshotting has been enhanced to provide better feedback
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
