### PR TITLE
[Engine-1.21] Improved cleanup for etcd unit test

### DIFF
--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -14,6 +14,7 @@ import (
 	testutil "github.com/rancher/k3s/tests/util"
 	"github.com/robfig/cron/v3"
 	clientv3 "go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/etcdserver"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 )
 
@@ -222,8 +223,8 @@ func Test_UnitETCD_Start(t *testing.T) {
 		name     string
 		fields   fields
 		args     args
-		setup    func(cnf *config.Control, ctxInfo *contextInfo) error
-		teardown func(cnf *config.Control, ctxInfo *contextInfo) error
+		setup    func(e *ETCD, ctxInfo *contextInfo) error
+		teardown func(e *ETCD, ctxInfo *contextInfo) error
 		wantErr  bool
 	}{
 		{
@@ -236,15 +237,24 @@ func Test_UnitETCD_Start(t *testing.T) {
 			args: args{
 				clientAccessInfo: nil,
 			},
-			setup: func(cnf *config.Control, ctxInfo *contextInfo) error {
+			setup: func(e *ETCD, ctxInfo *contextInfo) error {
 				ctxInfo.ctx, ctxInfo.cancel = context.WithCancel(context.Background())
-				cnf.EtcdDisableSnapshots = true
-				return testutil.GenerateRuntime(cnf)
+				e.config.EtcdDisableSnapshots = true
+				testutil.GenerateRuntime(e.config)
+				e.runtime = e.config.Runtime
+				client, err := GetClient(ctxInfo.ctx, e.runtime, endpoint)
+				e.client = client
+
+				return err
 			},
-			teardown: func(cnf *config.Control, ctxInfo *contextInfo) error {
+			teardown: func(e *ETCD, ctxInfo *contextInfo) error {
+				// RemoveSelf will fail with a specific error, but it still does cleanup for testing purposes
+				if err := e.RemoveSelf(ctxInfo.ctx); err != nil && err.Error() != etcdserver.ErrNotEnoughStartedMembers.Error() {
+					return err
+				}
 				ctxInfo.cancel()
-				time.Sleep(5 * time.Second)
-				testutil.CleanupDataDir(cnf)
+				time.Sleep(10 * time.Second)
+				testutil.CleanupDataDir(e.config)
 				return nil
 			},
 		},
@@ -259,14 +269,23 @@ func Test_UnitETCD_Start(t *testing.T) {
 			args: args{
 				clientAccessInfo: nil,
 			},
-			setup: func(cnf *config.Control, ctxInfo *contextInfo) error {
+			setup: func(e *ETCD, ctxInfo *contextInfo) error {
 				ctxInfo.ctx, ctxInfo.cancel = context.WithCancel(context.Background())
-				return testutil.GenerateRuntime(cnf)
+				testutil.GenerateRuntime(e.config)
+				e.runtime = e.config.Runtime
+				client, err := GetClient(ctxInfo.ctx, e.runtime, endpoint)
+				e.client = client
+
+				return err
 			},
-			teardown: func(cnf *config.Control, ctxInfo *contextInfo) error {
+			teardown: func(e *ETCD, ctxInfo *contextInfo) error {
+				// RemoveSelf will fail with a specific error, but it still does cleanup for testing purposes
+				if err := e.RemoveSelf(ctxInfo.ctx); err != nil && err.Error() != etcdserver.ErrNotEnoughStartedMembers.Error() {
+					return err
+				}
 				ctxInfo.cancel()
 				time.Sleep(5 * time.Second)
-				testutil.CleanupDataDir(cnf)
+				testutil.CleanupDataDir(e.config)
 				return nil
 			},
 		},
@@ -281,18 +300,28 @@ func Test_UnitETCD_Start(t *testing.T) {
 			args: args{
 				clientAccessInfo: nil,
 			},
-			setup: func(cnf *config.Control, ctxInfo *contextInfo) error {
+			setup: func(e *ETCD, ctxInfo *contextInfo) error {
 				ctxInfo.ctx, ctxInfo.cancel = context.WithCancel(context.Background())
-				if err := testutil.GenerateRuntime(cnf); err != nil {
+				if err := testutil.GenerateRuntime(e.config); err != nil {
 					return err
 				}
-				return os.MkdirAll(walDir(cnf), 0700)
+				e.runtime = e.config.Runtime
+				client, err := GetClient(ctxInfo.ctx, e.runtime, endpoint)
+				if err != nil {
+					return err
+				}
+				e.client = client
+				return os.MkdirAll(walDir(e.config), 0700)
 			},
-			teardown: func(cnf *config.Control, ctxInfo *contextInfo) error {
+			teardown: func(e *ETCD, ctxInfo *contextInfo) error {
+				// RemoveSelf will fail with a specific error, but it still does cleanup for testing purposes
+				if err := e.RemoveSelf(ctxInfo.ctx); err != nil && err.Error() != etcdserver.ErrNotEnoughStartedMembers.Error() {
+					return err
+				}
 				ctxInfo.cancel()
 				time.Sleep(5 * time.Second)
-				testutil.CleanupDataDir(cnf)
-				os.Remove(walDir(cnf))
+				testutil.CleanupDataDir(e.config)
+				os.Remove(walDir(e.config))
 				return nil
 			},
 		},
@@ -308,13 +337,17 @@ func Test_UnitETCD_Start(t *testing.T) {
 				cron:    tt.fields.cron,
 				s3:      tt.fields.s3,
 			}
-			defer tt.teardown(e.config, &tt.fields.context)
-			if err := tt.setup(e.config, &tt.fields.context); err != nil {
+
+			if err := tt.setup(e, &tt.fields.context); err != nil {
 				t.Errorf("Setup for ETCD.Start() failed = %v", err)
 				return
 			}
 			if err := e.Start(tt.fields.context.ctx, tt.args.clientAccessInfo); (err != nil) != tt.wantErr {
 				t.Errorf("ETCD.Start() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err := tt.teardown(e, &tt.fields.context); err != nil {
+				t.Errorf("Teardown for ETCD.Start() failed = %v", err)
+				return
 			}
 		})
 	}


### PR DESCRIPTION
Backport of https://github.com/k3s-io/k3s/pull/4537
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Improved the cleanup of etcd after test end, Previously several go routines would continue to run for the life of the testing process.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Flaky Test Fix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Stress tested by running the test on a 90% CPU utilization to slow things down. Was able to get the test to fail consistently before the patch.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
Test-only changes, no Issue to track/QA to verify
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
