### PR TITLE
[Engine-1.21] Expose default parser

### DIFF
--- a/pkg/configfilearg/defaultparser.go
+++ b/pkg/configfilearg/defaultparser.go
@@ -7,7 +7,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var defaultParser = &Parser{
+var DefaultParser = &Parser{
 	After:         []string{"server", "agent", "etcd-snapshot:1"},
 	FlagNames:     []string{"--config", "-c"},
 	EnvName:       version.ProgramUpper + "_CONFIG_FILE",
@@ -16,15 +16,11 @@ var defaultParser = &Parser{
 }
 
 func MustParse(args []string) []string {
-	result, err := defaultParser.Parse(args)
+	result, err := DefaultParser.Parse(args)
 	if err != nil {
 		logrus.Fatal(err)
 	}
 	return result
-}
-
-func AppendValidFlags(command string, flags []cli.Flag) {
-	defaultParser.ValidFlags[command] = append(defaultParser.ValidFlags[command], flags...)
 }
 
 func MustFindString(args []string, target string) string {

--- a/pkg/configfilearg/defaultparser.go
+++ b/pkg/configfilearg/defaultparser.go
@@ -23,6 +23,10 @@ func MustParse(args []string) []string {
 	return result
 }
 
+func AppendValidFlags(command string, flags []cli.Flag) {
+	defaultParser.ValidFlags[command] = append(defaultParser.ValidFlags[command], flags...)
+}
+
 func MustFindString(args []string, target string) string {
 	parser := &Parser{
 		After:         []string{},

--- a/pkg/configfilearg/defaultparser_test.go
+++ b/pkg/configfilearg/defaultparser_test.go
@@ -65,7 +65,7 @@ func Test_UnitMustParse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defaultParser.DefaultConfig = tt.config
+			DefaultParser.DefaultConfig = tt.config
 			if got := MustParse(tt.args); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("MustParse() = %+v\nWant = %+v", got, tt.want)
 			}


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Enable downstream programs to modify the default parser.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Local testing
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/rke2/issues/2130
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
