### PR TITLE
docs: adrs: Dual-stack in network policy agent

### DIFF
--- a/docs/adrs/002-add-dual-stack-support-to-netpol-agent.md
+++ b/docs/adrs/002-add-dual-stack-support-to-netpol-agent.md
@@ -1,0 +1,57 @@
+# 1. Add dual stack support to netpol agent
+
+Date: 2021-12-13
+
+## Status
+
+Accepted
+
+## Context
+
+Currently the network policy agent included in k3s is in fact a copied code of
+[kube-router's](https://github.com/cloudnativelabs/kube-router) network policy
+controller, which can be found [here](https://github.com/k3s-io/k3s/tree/master/pkg/agent/netpol).
+
+The first and the most important issue is that kube-router lacks support for
+dual-stack (and even IPv6 in general in the most of its components). However,
+implementing such support is a non-trivial task.
+
+The second issue is that we include a copy of kube-router code in k3s, which
+makes it hard to consume updates. Even if we need some changes on top of
+upstream code, we should rather use a fork which is easy to rebase with
+upstream.
+
+## Decision
+
+We implement a feature of supporting dual stack Kubernetes clusters in network
+policy controller in kube-router. We start from network policy controller, as
+we don't consume any other kube-router components in k3s.
+
+Once it's done and working, we submit a pull request:
+
+* to [our fork of kube-router](https://github.com/k3s-io/kube-router)
+* [upstream](https://github.com/cloudnativelabs/kube-router)
+
+The motivation behind keeping a fork is that:
+
+* upstream might ask for implementing dual-stack in all kube-router
+  components (which would be understandable)
+* acceepting a solution upstream might take long time
+
+Our fork of kube-router is going to be used as a vendored library inside k3s
+code. And the currently copied code in k3s in `pkg/agent/netpol` is going to
+be removed in favor of using kube-router as a library.
+
+As soon as dual-stack becomes an upstream feature - k3s is going to use
+upstream kube-router as a vendored library.
+
+## Consequences
+
+It will increase k3s product portfolio by fully supporting dual-stack
+networking.
+
+However, it might also introduce significant amount of work for developers
+which could be related to:
+
+* agreeing with proper solution upstream
+* maintaining a fork until that happens (rebasing with upstream releases)


### PR DESCRIPTION
Proposal about implementing dual stack in k3s network policy agent,
kube-router and the procedure of that implementation.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Proposal about implementing dual stack in k3s network policy agent,
kube-router and the procedure of that implementation.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
ADR

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
