### PR TITLE
Fix snapshot restoration on fresh nodes

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -174,6 +174,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		serverConfig.ControlConfig.DisableScheduler = true
 		serverConfig.ControlConfig.DisableCCM = true
 
+		close(agentReady)
 		dataDir, err := datadir.LocalHome(cfg.DataDir, false)
 		if err != nil {
 			return err

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -311,12 +311,11 @@ const systemTimeSkew = int64(3)
 
 // isMigrated checks to see if the given bootstrap data
 // is in the latest format.
-func isMigrated(buf io.ReadSeeker) bool {
+func isMigrated(buf io.ReadSeeker, files *bootstrap.PathsDataformat) bool {
 	buf.Seek(0, 0)
 	defer buf.Seek(0, 0)
 
-	files := make(bootstrap.PathsDataformat)
-	if err := json.NewDecoder(buf).Decode(&files); err != nil {
+	if err := json.NewDecoder(buf).Decode(files); err != nil {
 		// This will fail if data is being pulled from old an cluster since
 		// older clusters used a map[string][]byte for the data structure.
 		// Therefore, we need to perform a migration to the newer bootstrap
@@ -342,7 +341,7 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 		// from an older version of k3s. That version might not have the new data format
 		// and we should write the correct format.
 		files := make(bootstrap.PathsDataformat)
-		if !isMigrated(buf) {
+		if !isMigrated(buf, &files) {
 			if err := migrateBootstrapData(ctx, buf, files); err != nil {
 				return err
 			}
@@ -423,7 +422,7 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 	}
 
 	files := make(bootstrap.PathsDataformat)
-	if !isMigrated(buf) {
+	if !isMigrated(buf, &files) {
 		if err := migrateBootstrapData(ctx, buf, files); err != nil {
 			return err
 		}

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -198,6 +198,11 @@ func (e *ETCD) Reset(ctx context.Context, rebootstrap func() error) error {
 		t := time.NewTicker(5 * time.Second)
 		defer t.Stop()
 		for range t.C {
+			// resetting the apiaddresses to nil since we are doing a restoration
+			if _, err := e.client.Put(ctx, AddressKey, ""); err != nil {
+				logrus.Warnf("failed to reset api addresses key in etcd: %v", err)
+				continue
+			}
 			if err := e.Test(ctx); err == nil {
 				members, err := e.client.MemberList(ctx)
 				if err != nil {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

- Resetting the api address key in case of cluster restoration
- Closing the agent ready channel in cluster restoration as well
- Fixing an issue with unmigrated bootstrap data 

#### Types of Changes ####

Bugfix

#### Verification ####

- test restoration of etcd snapshot on a fresh new node

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
