### PR TITLE
Add `--kubelet-preferred-address-types` argument for Kube APIServer

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -39,62 +39,63 @@ type Server struct {
 	// The port which custom k3s API runs on
 	SupervisorPort int
 	// The port which kube-apiserver runs on
-	APIServerPort            int
-	APIServerBindAddress     string
-	DataDir                  string
-	DisableAgent             bool
-	KubeConfigOutput         string
-	KubeConfigMode           string
-	TLSSan                   cli.StringSlice
-	BindAddress              string
-	ExtraAPIArgs             cli.StringSlice
-	ExtraEtcdArgs            cli.StringSlice
-	ExtraSchedulerArgs       cli.StringSlice
-	ExtraControllerArgs      cli.StringSlice
-	ExtraCloudControllerArgs cli.StringSlice
-	Rootless                 bool
-	DatastoreEndpoint        string
-	DatastoreCAFile          string
-	DatastoreCertFile        string
-	DatastoreKeyFile         string
-	AdvertiseIP              string
-	AdvertisePort            int
-	DisableScheduler         bool
-	ServerURL                string
-	FlannelBackend           string
-	DefaultLocalStoragePath  string
-	DisableCCM               bool
-	DisableNPC               bool
-	DisableHelmController    bool
-	DisableKubeProxy         bool
-	DisableAPIServer         bool
-	DisableControllerManager bool
-	DisableETCD              bool
-	ClusterInit              bool
-	ClusterReset             bool
-	ClusterResetRestorePath  string
-	EncryptSecrets           bool
-	EncryptForce             bool
-	EncryptSkip              bool
-	SystemDefaultRegistry    string
-	StartupHooks             []StartupHook
-	EtcdSnapshotName         string
-	EtcdDisableSnapshots     bool
-	EtcdExposeMetrics        bool
-	EtcdSnapshotDir          string
-	EtcdSnapshotCron         string
-	EtcdSnapshotRetention    int
-	EtcdS3                   bool
-	EtcdS3Endpoint           string
-	EtcdS3EndpointCA         string
-	EtcdS3SkipSSLVerify      bool
-	EtcdS3AccessKey          string
-	EtcdS3SecretKey          string
-	EtcdS3BucketName         string
-	EtcdS3Region             string
-	EtcdS3Folder             string
-	EtcdS3Timeout            time.Duration
-	EtcdS3Insecure           bool
+	APIServerPort                int
+	APIServerBindAddress         string
+	DataDir                      string
+	DisableAgent                 bool
+	KubeConfigOutput             string
+	KubeConfigMode               string
+	TLSSan                       cli.StringSlice
+	BindAddress                  string
+	ExtraAPIArgs                 cli.StringSlice
+	ExtraEtcdArgs                cli.StringSlice
+	ExtraSchedulerArgs           cli.StringSlice
+	ExtraControllerArgs          cli.StringSlice
+	ExtraCloudControllerArgs     cli.StringSlice
+	KubeletPreferredAddressTypes string
+	Rootless                     bool
+	DatastoreEndpoint            string
+	DatastoreCAFile              string
+	DatastoreCertFile            string
+	DatastoreKeyFile             string
+	AdvertiseIP                  string
+	AdvertisePort                int
+	DisableScheduler             bool
+	ServerURL                    string
+	FlannelBackend               string
+	DefaultLocalStoragePath      string
+	DisableCCM                   bool
+	DisableNPC                   bool
+	DisableHelmController        bool
+	DisableKubeProxy             bool
+	DisableAPIServer             bool
+	DisableControllerManager     bool
+	DisableETCD                  bool
+	ClusterInit                  bool
+	ClusterReset                 bool
+	ClusterResetRestorePath      string
+	EncryptSecrets               bool
+	EncryptForce                 bool
+	EncryptSkip                  bool
+	SystemDefaultRegistry        string
+	StartupHooks                 []StartupHook
+	EtcdSnapshotName             string
+	EtcdDisableSnapshots         bool
+	EtcdExposeMetrics            bool
+	EtcdSnapshotDir              string
+	EtcdSnapshotCron             string
+	EtcdSnapshotRetention        int
+	EtcdS3                       bool
+	EtcdS3Endpoint               string
+	EtcdS3EndpointCA             string
+	EtcdS3SkipSSLVerify          bool
+	EtcdS3AccessKey              string
+	EtcdS3SecretKey              string
+	EtcdS3BucketName             string
+	EtcdS3Region                 string
+	EtcdS3Folder                 string
+	EtcdS3Timeout                time.Duration
+	EtcdS3Insecure               bool
 }
 
 var (
@@ -231,6 +232,12 @@ var ServerFlags = []cli.Flag{
 		Name:  "kube-cloud-controller-manager-arg",
 		Usage: "(flags) Customized flag for kube-cloud-controller-manager process",
 		Value: &ServerConfig.ExtraCloudControllerArgs,
+	},
+	cli.StringFlag{
+		Name:        "kubelet-preferred-address-types",
+		Usage:       "(flags) Specify the preferred address to use to communicate with Kubelet API",
+		Destination: &ServerConfig.KubeletPreferredAddressTypes,
+		EnvVar:      version.ProgramUpper + "_KUBELET_PREFERRED_ADDRESS_TYPES",
 	},
 	cli.StringFlag{
 		Name:        "datastore-endpoint",

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -119,6 +119,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.ExtraControllerArgs = cfg.ExtraControllerArgs
 	serverConfig.ControlConfig.ExtraEtcdArgs = cfg.ExtraEtcdArgs
 	serverConfig.ControlConfig.ExtraSchedulerAPIArgs = cfg.ExtraSchedulerArgs
+	serverConfig.ControlConfig.KubeletPreferredAddressTypes = cfg.KubeletPreferredAddressTypes
 	serverConfig.ControlConfig.ClusterDomain = cfg.ClusterDomain
 	serverConfig.ControlConfig.Datastore.Endpoint = cfg.DatastoreEndpoint
 	serverConfig.ControlConfig.Datastore.BackendTLSConfig.CAFile = cfg.DatastoreCAFile

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -133,55 +133,56 @@ type Control struct {
 	// The port which custom k3s API runs on
 	SupervisorPort int
 	// The port which kube-apiserver runs on
-	APIServerPort            int
-	APIServerBindAddress     string
-	AgentToken               string `json:"-"`
-	Token                    string `json:"-"`
-	ServiceNodePortRange     *utilnet.PortRange
-	KubeConfigOutput         string
-	KubeConfigMode           string
-	DataDir                  string
-	Datastore                endpoint.Config
-	DisableAPIServer         bool
-	DisableControllerManager bool
-	DisableETCD              bool
-	DisableScheduler         bool
-	ExtraAPIArgs             []string
-	ExtraControllerArgs      []string
-	ExtraCloudControllerArgs []string
-	ExtraEtcdArgs            []string
-	ExtraSchedulerAPIArgs    []string
-	NoLeaderElect            bool
-	JoinURL                  string
-	IPSECPSK                 string
-	DefaultLocalStoragePath  string
-	SystemDefaultRegistry    string
-	ClusterInit              bool
-	ClusterReset             bool
-	ClusterResetRestorePath  string
-	EncryptSecrets           bool
-	EncryptForce             bool
-	EncryptSkip              bool
-	TLSMinVersion            uint16
-	TLSCipherSuites          []uint16
-	EtcdSnapshotName         string
-	EtcdDisableSnapshots     bool
-	EtcdExposeMetrics        bool
-	EtcdSnapshotDir          string
-	EtcdSnapshotCron         string
-	EtcdSnapshotRetention    int
-	EtcdS3                   bool
-	EtcdS3Endpoint           string
-	EtcdS3EndpointCA         string
-	EtcdS3SkipSSLVerify      bool
-	EtcdS3AccessKey          string
-	EtcdS3SecretKey          string
-	EtcdS3BucketName         string
-	EtcdS3Region             string
-	EtcdS3Folder             string
-	EtcdS3Timeout            time.Duration
-	EtcdS3Insecure           bool
-	ServerNodeName           string
+	APIServerPort                int
+	APIServerBindAddress         string
+	AgentToken                   string `json:"-"`
+	Token                        string `json:"-"`
+	ServiceNodePortRange         *utilnet.PortRange
+	KubeConfigOutput             string
+	KubeConfigMode               string
+	DataDir                      string
+	Datastore                    endpoint.Config
+	DisableAPIServer             bool
+	DisableControllerManager     bool
+	DisableETCD                  bool
+	DisableScheduler             bool
+	ExtraAPIArgs                 []string
+	ExtraControllerArgs          []string
+	ExtraCloudControllerArgs     []string
+	ExtraEtcdArgs                []string
+	ExtraSchedulerAPIArgs        []string
+	KubeletPreferredAddressTypes string
+	NoLeaderElect                bool
+	JoinURL                      string
+	IPSECPSK                     string
+	DefaultLocalStoragePath      string
+	SystemDefaultRegistry        string
+	ClusterInit                  bool
+	ClusterReset                 bool
+	ClusterResetRestorePath      string
+	EncryptSecrets               bool
+	EncryptForce                 bool
+	EncryptSkip                  bool
+	TLSMinVersion                uint16
+	TLSCipherSuites              []uint16
+	EtcdSnapshotName             string
+	EtcdDisableSnapshots         bool
+	EtcdExposeMetrics            bool
+	EtcdSnapshotDir              string
+	EtcdSnapshotCron             string
+	EtcdSnapshotRetention        int
+	EtcdS3                       bool
+	EtcdS3Endpoint               string
+	EtcdS3EndpointCA             string
+	EtcdS3SkipSSLVerify          bool
+	EtcdS3AccessKey              string
+	EtcdS3SecretKey              string
+	EtcdS3BucketName             string
+	EtcdS3Region                 string
+	EtcdS3Folder                 string
+	EtcdS3Timeout                time.Duration
+	EtcdS3Insecure               bool
+	ServerNodeName               string
 
 	BindAddress string
 	SANs        []string

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -172,6 +172,7 @@ func apiServer(ctx context.Context, cfg *config.Control, runtime *config.Control
 	argsMap["kubelet-certificate-authority"] = runtime.ServerCA
 	argsMap["kubelet-client-certificate"] = runtime.ClientKubeAPICert
 	argsMap["kubelet-client-key"] = runtime.ClientKubeAPIKey
+	argsMap["kubelet-preferred-address-types"] = cfg.KubeletPreferredAddressTypes
 	argsMap["requestheader-client-ca-file"] = runtime.RequestHeaderCA
 	argsMap["requestheader-allowed-names"] = deps.RequestHeaderCN
 	argsMap["proxy-client-cert-file"] = runtime.ClientAuthProxyCert


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Add `--kubelet-preferred-address-types` argument for `k3s server` to pass that into Kube APIServer.
I did this PR to be able to get rid of hardcoded value in [rke2 api-server static pod configuration](https://github.com/rancher/rke2/blob/master/pkg/podexecutor/staticpod.go#L229) and add this argument to `rke2 server` with the default value:
```go
args = append([]string{"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"}, args...)
```
In our setup kube-apiserver needs to communicate to Kubelet API via ExternalIP and as far as I can tell adding `--kubelet-preferred-address-types` in `--kube-apiserver-arg` doesn't override the argument specified earlier in the list (via hardcode).

This follows the #4620 to make sure the kube-apiserver can talk to kubelet over ExternalIP.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

New Feature

#### Verification ####

* Deploy 2 machines (control-panel and worker) in 2 separate VPCs
* Run `k3s server` with `--kubelet-preferred-address-types ExternalIP` on one
* Run `k3s agent` with `--node-external-ip ...` on another
* kubectl logs ... and kubectl exec ... should works
* tcpdump must show that the traffic goes to external ip of the worker port 10250/tcp

Opposite should is verifiable too, if `k3s server` restarted with `--kubelet-preferred-address-types InternalIP` the traffic will go to internal ip of the worker: in the 2 VPC setup the communication won't work, in a single VPC with properly set up firewall it does.

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Flag --kubelet-preferred-address-type for k3s server added to set the address for kube-apiserver to communicate with the kubelets on the nodes
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
