### PR TITLE
Close etcd clients to avoid leaking GRPC connections

### DIFF
--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -385,6 +385,7 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 		if err != nil {
 			return err
 		}
+		defer storageClient.Close()
 
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -48,6 +48,7 @@ func Save(ctx context.Context, config *config.Control, etcdConfig endpoint.ETCDC
 	if err != nil {
 		return err
 	}
+	defer storageClient.Close()
 
 	if _, _, err = getBootstrapKeyFromStorage(ctx, storageClient, normalizedToken, token); err != nil {
 		return err
@@ -102,6 +103,7 @@ func (c *Cluster) storageBootstrap(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer storageClient.Close()
 
 	token := c.config.Token
 	if token == "" {


### PR DESCRIPTION
#### Proposed Changes ####

If you don't explicitly close the etcd client when you're done with it,
the GRPC connection hangs around in the background. Normally this is
harmelss, but in the case of the temporary etcd we start up on 2399 to
reconcile bootstrap data, the client will start logging errors
afterwards when the server goes away.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* #4728

#### User-Facing Change ####
```release-note
K3s no longer leaks etcd client grpc connections
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
