### PR TITLE
Fix cold boot and reconcilation on secondary servers

### DIFF
--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -53,6 +53,8 @@ func (c *Cluster) Bootstrap(ctx context.Context, snapshot bool) error {
 				if err := c.httpBootstrap(ctx); err == nil {
 					logrus.Info("Successfully reconciled with datastore")
 					return nil
+				} else {
+					logrus.Warn("Attempt to httpBootstrap failed: ", err.Error())
 				}
 			}
 			// In the case of etcd, if the database has been initialized, it doesn't

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -54,7 +54,7 @@ func (c *Cluster) Bootstrap(ctx context.Context, snapshot bool) error {
 					logrus.Info("Successfully reconciled with datastore")
 					return nil
 				} else {
-					logrus.Warn("Attempt to httpBootstrap failed: ", err.Error())
+					logrus.Warnf("Unable to reconcile with datastore: %v", err)
 				}
 			}
 			// In the case of etcd, if the database has been initialized, it doesn't

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -53,9 +53,8 @@ func (c *Cluster) Bootstrap(ctx context.Context, snapshot bool) error {
 				if err := c.httpBootstrap(ctx); err == nil {
 					logrus.Info("Successfully reconciled with datastore")
 					return nil
-				} else {
-					logrus.Warnf("Unable to reconcile with datastore: %v", err)
 				}
+				logrus.Warnf("Unable to reconcile with datastore: %v", err)
 			}
 			// In the case of etcd, if the database has been initialized, it doesn't
 			// need to be bootstrapped however we still need to check the database

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -52,7 +52,6 @@ func (c *Cluster) Bootstrap(ctx context.Context, snapshot bool) error {
 			// instance of etcd in the event that etcd certificates are unavailable,
 			// reading the data, and comparing that to the data on disk, all the while
 			// starting normal etcd.
-			// isHTTP := c.config.JoinURL != "" && c.config.Token != ""
 			if isInitialized {
 				logrus.Info("Only reconciling with datastore")
 				tmpDataDir := filepath.Join(c.config.DataDir, "db", "tmp-etcd")

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -52,8 +52,9 @@ func (c *Cluster) Bootstrap(ctx context.Context, snapshot bool) error {
 			// instance of etcd in the event that etcd certificates are unavailable,
 			// reading the data, and comparing that to the data on disk, all the while
 			// starting normal etcd.
-			isHTTP := c.config.JoinURL != "" && c.config.Token != ""
-			if isInitialized && !isHTTP {
+			// isHTTP := c.config.JoinURL != "" && c.config.Token != ""
+			if isInitialized {
+				logrus.Info("Only reconciling with datastore")
 				tmpDataDir := filepath.Join(c.config.DataDir, "db", "tmp-etcd")
 				os.RemoveAll(tmpDataDir)
 				if err := os.Mkdir(tmpDataDir, 0700); err != nil {
@@ -193,17 +194,15 @@ func (c *Cluster) shouldBootstrapLoad(ctx context.Context) (bool, bool, error) {
 			return false, false, err
 		}
 		if isInitialized {
+			// If the database is initialized we skip bootstrapping; if the user wants to rejoin a
+			// cluster they need to delete the database.
+			logrus.Infof("Managed %s cluster bootstrap already complete and initialized", c.managedDB.EndpointName())
 			// This is a workaround for an issue that can be caused by terminating the cluster bootstrap before
 			// etcd is promoted from learner. Odds are we won't need this info, and we don't want to fail startup
 			// due to failure to retrieve it as this will break cold cluster restart, so we ignore any errors.
 			if c.config.JoinURL != "" && c.config.Token != "" {
 				c.clientAccessInfo, _ = clientaccess.ParseAndValidateTokenForUser(c.config.JoinURL, c.config.Token, "server")
-				logrus.Infof("Joining %s cluster already initialized, forcing reconciliation", c.managedDB.EndpointName())
-				return true, true, nil
 			}
-			// If the database is initialized we skip bootstrapping; if the user wants to rejoin a
-			// cluster they need to delete the database.
-			logrus.Infof("Managed %s cluster bootstrap already complete and initialized", c.managedDB.EndpointName())
 			return false, true, nil
 		} else if c.config.JoinURL == "" {
 			// Not initialized, not joining - must be initializing (cluster-init)


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Fix to enable cold restarts again, while also making all server nodes perform reconciliation on restart.
This reverts changes made in https://github.com/k3s-io/k3s/commit/1055837e4f292087c0e5b38d4ab20f82d521275e#diff-4dcc46ade478259007245d87cf4eedb63ec9ebf0945746803e724cf1e8ee21a2R197-R198, in favor of a simpler and more correct fix.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- Start 3 k3s servers (1 cluster-init, 2 --server)
- On server 2 run `k3s secrets-encrypt prepare`
- Check that the status has updated only on server 2 `k3s secrets-encrypt status`
- Kill all 3 servers
- Restart only servers 2 and 3. 
- Check that server 3 now has the same status as server 2 `k3s secrets-encrypt status`

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/4746
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
