### PR TITLE
Bump k3s-root to v0.10.1

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 . ./scripts/version.sh
 
 RUNC_VERSION=v1.0.3
-ROOT_VERSION=v0.9.1
+ROOT_VERSION=v0.10.1
 TRAEFIK_CHART_VERSION=$(yq e '.spec.chart' manifests/traefik.yaml | awk 'match($0, /([0-9.]+)([0-9]{2})/, m) { print m[1]; exit; }')
 TRAEFIK_PACKAGE_VERSION=$(yq e '.spec.chart' manifests/traefik.yaml | awk 'match($0, /([0-9.]+)([0-9]{2})/, m) { print m[2]; exit; }')
 TRAEFIK_FILE=traefik-${TRAEFIK_CHART_VERSION}${TRAEFIK_PACKAGE_VERSION}.tgz
@@ -24,7 +24,7 @@ rm -rf ${RUNC_DIR}
 mkdir -p ${CHARTS_DIR}
 mkdir -p ${DATA_DIR}
 
-curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${ROOT_VERSION}/k3s-root-${ARCH}.tar | tar xf -
+curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${ROOT_VERSION}/k3s-root-${ARCH}.tar | tar xf - --exclude=bin/socat
 
 git clone --depth=1 https://github.com/opencontainers/runc ${RUNC_DIR} || true
 pushd ${RUNC_DIR}


### PR DESCRIPTION
#### Proposed Changes ####

Bump k3s-root to v0.10.1. Doing this helps offset the increase in size from https://github.com/k3s-io/k3s/pull/4757 as the binaries in this release are a fair bit smaller due to recent improvements made by @dweomer.

#### Types of Changes ####

packaged userspace

#### Verification ####

run `/var/lib/rancher/k3s/data/current/bin/busybox`

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/4689

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The embedded userspace binaries have been updated to k3s-root v0.10.1.
```

#### Further Comments ####

