### PR TITLE
[k3s-engine] Remove Disables, Skips and DisableKubeProxy from the critical configs

### DIFF
--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -110,15 +110,12 @@ type CriticalControlArgs struct {
 	ClusterIPRange        *net.IPNet
 	DisableCCM            bool
 	DisableHelmController bool
-	DisableKubeProxy      bool
 	DisableNPC            bool
-	Disables              map[string]bool
 	DisableServiceLB      bool
 	FlannelBackend        string
 	NoCoreDNS             bool
 	ServiceIPRange        *net.IPNet
 	ServiceIPRanges       []*net.IPNet
-	Skips                 map[string]bool
 }
 
 type Control struct {
@@ -142,7 +139,9 @@ type Control struct {
 	DisableAPIServer         bool
 	DisableControllerManager bool
 	DisableETCD              bool
+	DisableKubeProxy         bool
 	DisableScheduler         bool
+	Disables                 map[string]bool
 	ExtraAPIArgs             []string
 	ExtraControllerArgs      []string
 	ExtraCloudControllerArgs []string
@@ -152,6 +151,7 @@ type Control struct {
 	JoinURL                  string
 	IPSECPSK                 string
 	DefaultLocalStoragePath  string
+	Skips                    map[string]bool
 	SystemDefaultRegistry    string
 	ClusterInit              bool
 	ClusterReset             bool


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Move Disables, Skips and DisableKubeProxy back to the Config struct. That means, those don't need to be the same in all server nodes joining an HA cluster. We need to do this because in rke2, we are changing the config at runtime and disabling `rke2-kube-proxy` module

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bug fix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/4773

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
