### PR TITLE
[release-1.21] Fix panic checking name of uninitialized etcd member

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -355,31 +355,42 @@ func (e *ETCD) join(ctx context.Context, clientAccessInfo *clientaccess.Info) er
 	}
 
 	for _, member := range members.Members {
-		lastHyphen := strings.LastIndex(member.Name, "-")
-		memberNodeName := member.Name[:lastHyphen]
-		if memberNodeName == e.config.ServerNodeName {
-			// make sure to remove the name file if a duplicate node name is used
-			nameFile := nameFile(e.config)
-			if err := os.Remove(nameFile); err != nil {
-				logrus.Errorf("Failed to remove etcd name file %s: %v", nameFile, err)
-			}
-			return errors.New("duplicate node name found, please use a unique name for this node")
-		}
 		for _, peer := range member.PeerURLs {
 			u, err := url.Parse(peer)
 			if err != nil {
 				return err
 			}
-			// An uninitialized member won't have a name
-			if u.Hostname() == e.address && (member.Name == e.name || member.Name == "") {
-				add = false
-			}
+			// An uninitialized joining member won't have a name; if it has our
+			// address it must be us.
 			if member.Name == "" && u.Hostname() == e.address {
 				member.Name = e.name
 			}
+
+			// If we're already in the cluster, don't try to add ourselves.
+			if member.Name == e.name && u.Hostname() == e.address {
+				add = false
+			}
+
 			if len(member.PeerURLs) > 0 {
 				cluster = append(cluster, fmt.Sprintf("%s=%s", member.Name, member.PeerURLs[0]))
 			}
+		}
+
+		// Try to get the node name from the member name
+		memberNodeName := member.Name
+		if lastHyphen := strings.LastIndex(member.Name, "-"); lastHyphen > 1 {
+			memberNodeName = member.Name[:lastHyphen]
+		}
+
+		// Make sure there's not already a member in the cluster with a duplicate node name
+		if member.Name != e.name && memberNodeName == e.config.ServerNodeName {
+			// make sure to remove the name file if a duplicate node name is used, so that we
+			// generate a new member name when our node name is fixed.
+			nameFile := nameFile(e.config)
+			if err := os.Remove(nameFile); err != nil {
+				logrus.Errorf("Failed to remove etcd name file %s: %v", nameFile, err)
+			}
+			return errors.New("duplicate node name found, please use a unique name for this node")
 		}
 	}
 


### PR DESCRIPTION

#### Proposed Changes ####

Fix panic checking name of uninitialized etcd member.

#### Types of Changes ####

bugfix

#### Verification ####

Not sure how to reproduce; see linked issue.

#### Linked Issues ####

* #4785 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
