### PR TITLE
[Engine-1.21] Close agentReady channel only in k3s

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -174,7 +174,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		serverConfig.ControlConfig.DisableScheduler = true
 		serverConfig.ControlConfig.DisableCCM = true
 
-		// only close the agentReady channel in case of k3s restoration, because k3s doesnt start
+		// only close the agentReady channel in case of k3s restoration, because k3s does not start
 		// the agent until server returns successfully, unlike rke2's agent which starts in parallel
 		// with the server
 		if serverConfig.ControlConfig.SupervisorPort == serverConfig.ControlConfig.HTTPSPort {

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -174,7 +174,13 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		serverConfig.ControlConfig.DisableScheduler = true
 		serverConfig.ControlConfig.DisableCCM = true
 
-		close(agentReady)
+		// only close the agentReady channel in case of k3s restoration, because k3s doesnt start
+		// the agent until server returns successfully, unlike rke2's agent which starts in parallel
+		// with the server
+		if serverConfig.ControlConfig.SupervisorPort == serverConfig.ControlConfig.HTTPSPort {
+			close(agentReady)
+		}
+
 		dataDir, err := datadir.LocalHome(cfg.DataDir, false)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: galal-hussein <hussein.galal.ahmed.11@gmail.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Close the agentready channel only in k3s cluster restore
#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

- snapshot restoration on fresh nodes

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####


#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
