### PR TITLE
Update bootstrap logic to output all changed files on disk

### DIFF
--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -575,8 +575,10 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 	}
 
 	if len(newerOnDisk) > 0 {
-		files := strings.Join(newerOnDisk, ", ")
-		logrus.Fatal(files + " newer than datastore and could cause cluster outage. Remove the file from disk and restart to be recreated from datastore.")
+		if len(newerOnDisk) == 1 {
+			logrus.Fatal(newerOnDisk[0] + " newer than datastore and could cause a cluster outage. Remove the file from disk and restart to be recreated from datastore.")
+		}
+		logrus.Fatal(strings.Join(newerOnDisk, ", ") + " newer than datastore and could cause a cluster outage. Remove the files from disk and restart to be recreated from datastore.")
 	}
 
 	if updateDisk {

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -575,10 +575,7 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 	}
 
 	if len(newerOnDisk) > 0 {
-		if len(newerOnDisk) == 1 {
-			logrus.Fatal(newerOnDisk[0] + " newer than datastore and could cause a cluster outage. Remove the file from disk and restart to be recreated from datastore.")
-		}
-		logrus.Fatal(strings.Join(newerOnDisk, ", ") + " newer than datastore and could cause a cluster outage. Remove the files from disk and restart to be recreated from datastore.")
+		logrus.Fatal(strings.Join(newerOnDisk, ", ") + " newer than datastore and could cause a cluster outage. Remove the file(s) from disk and restart to be recreated from datastore.")
 	}
 
 	if updateDisk {


### PR DESCRIPTION
Signed-off-by: Brian Downs <brian.downs@gmail.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Adds additional logic to capture all changed files on disk and output them as part of the error message.

Update bootstrap logic to print out all changed files on disk before exiting rather than the first one found in the loop.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Change more than one file on disk that's part of the bootstrap data. E.g. client-ca.crt and client-ca.key

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#4797 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
