### PR TITLE
[release-1.22] Backport multiple CI fixes from master

### DIFF
--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -1,7 +1,7 @@
 ARG GOLANG=golang:1.16.10-alpine3.13
 FROM ${GOLANG}
 
-RUN apk -U --no-cache add bash git gcc musl-dev docker curl jq coreutils python3 openssl py3-pip
+RUN apk -U --no-cache add bash git gcc musl-dev docker curl jq coreutils python3 openssl py3-pip procps
 
 ENV SONOBUOY_VERSION 0.55.0
 

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -393,6 +393,7 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 		if err != nil {
 			return err
 		}
+		defer storageClient.Close()
 
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -48,6 +48,7 @@ func Save(ctx context.Context, config *config.Control, etcdConfig endpoint.ETCDC
 	if err != nil {
 		return err
 	}
+	defer storageClient.Close()
 
 	if _, _, err = getBootstrapKeyFromStorage(ctx, storageClient, normalizedToken, token); err != nil {
 		return err
@@ -102,6 +103,7 @@ func (c *Cluster) storageBootstrap(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer storageClient.Close()
 
 	token := c.config.Token
 	if token == "" {

--- a/scripts/build
+++ b/scripts/build
@@ -11,6 +11,8 @@ PKG="github.com/rancher/k3s"
 PKG_CONTAINERD="github.com/containerd/containerd"
 PKG_K3S_CONTAINERD="github.com/k3s-io/containerd"
 PKG_CRICTL="github.com/kubernetes-sigs/cri-tools"
+PKG_K8S_BASE="k8s.io/component-base"
+PKG_K8S_CLIENT="k8s.io/client-go/pkg"
 
 buildDate=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
@@ -19,15 +21,17 @@ VERSIONFLAGS="
     -X ${PKG}/pkg/version.Version=${VERSION}
     -X ${PKG}/pkg/version.GitCommit=${COMMIT:0:8}
 
-    -X ${VENDOR_PREFIX}k8s.io/client-go/pkg/version.gitVersion=${VERSION}
-    -X ${VENDOR_PREFIX}k8s.io/client-go/pkg/version.gitCommit=${COMMIT}
-    -X ${VENDOR_PREFIX}k8s.io/client-go/pkg/version.gitTreeState=${TREE_STATE}
-    -X ${VENDOR_PREFIX}k8s.io/client-go/pkg/version.buildDate=${buildDate}
+    -X ${VENDOR_PREFIX}${PKG_K8S_CLIENT}/version.gitVersion=${VERSION}
+    -X ${VENDOR_PREFIX}${PKG_K8S_CLIENT}/version.gitCommit=${COMMIT}
+    -X ${VENDOR_PREFIX}${PKG_K8S_CLIENT}/version.gitTreeState=${TREE_STATE}
+    -X ${VENDOR_PREFIX}${PKG_K8S_CLIENT}/version.buildDate=${buildDate}
 
-    -X ${VENDOR_PREFIX}k8s.io/component-base/version.gitVersion=${VERSION}
-    -X ${VENDOR_PREFIX}k8s.io/component-base/version.gitCommit=${COMMIT}
-    -X ${VENDOR_PREFIX}k8s.io/component-base/version.gitTreeState=${TREE_STATE}
-    -X ${VENDOR_PREFIX}k8s.io/component-base/version.buildDate=${buildDate}
+    -X ${VENDOR_PREFIX}${PKG_K8S_BASE}/version.gitVersion=${VERSION}
+    -X ${VENDOR_PREFIX}${PKG_K8S_BASE}/version.gitCommit=${COMMIT}
+    -X ${VENDOR_PREFIX}${PKG_K8S_BASE}/version.gitTreeState=${TREE_STATE}
+    -X ${VENDOR_PREFIX}${PKG_K8S_BASE}/version.buildDate=${buildDate}
+
+    -X ${VENDOR_PREFIX}${PKG_CRICTL}/version.Version=${VERSION_CRICTL}
 
     -X ${VENDOR_PREFIX}${PKG_CONTAINERD}/version.Version=${VERSION_CONTAINERD}
     -X ${VENDOR_PREFIX}${PKG_CONTAINERD}/version.Package=${PKG_K3S_CONTAINERD}
@@ -35,11 +39,8 @@ VERSIONFLAGS="
 "
 LDFLAGS="
     -w -s"
-STATIC="
-    -extldflags '-static'
-"
 
-STATIC_SQLITE="
+STATIC="
     -extldflags '-static -lm -ldl -lz -lpthread'
 "
 TAGS="ctrd apparmor seccomp no_btrfs netcgo osusergo providerless"
@@ -53,8 +54,6 @@ fi
 
 if [ "$STATIC_BUILD" != "true" ]; then
     STATIC="
-"
-    STATIC_SQLITE="
 "
     RUNC_STATIC=""
 else
@@ -70,19 +69,17 @@ fi
 
 rm -f \
     bin/k3s-agent \
-    bin/hyperkube \
-    bin/containerd \
-    bin/runc \
-    bin/containerd-shim \
-    bin/containerd-shim-runc-v1 \
-    bin/containerd-shim-runc-v2 \
     bin/k3s-server \
     bin/k3s-etcd-snapshot \
     bin/k3s-secrets-encrypt \
     bin/k3s-certificate \
     bin/kubectl \
     bin/crictl \
-    bin/ctr
+    bin/ctr \
+    bin/containerd \
+    bin/containerd-shim \
+    bin/containerd-shim-runc-v2 \
+    bin/runc
 
 cleanup() {
     exit_status=$?
@@ -102,10 +99,9 @@ if [ ! -x ${INSTALLBIN}/cni ]; then
     GOPATH=$TMPDIR CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -ldflags "$LDFLAGS $STATIC" -o $INSTALLBIN/cni
 )
 fi
-# echo Building agent
-# CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s-agent ./cmd/agent/main.go
-echo Building server
-CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC_SQLITE" -o bin/containerd ./cmd/server/main.go
+
+echo Building k3s
+CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/containerd ./cmd/server/main.go
 ln -s containerd ./bin/k3s-agent
 ln -s containerd ./bin/k3s-server
 ln -s containerd ./bin/k3s-etcd-snapshot
@@ -114,12 +110,7 @@ ln -s containerd ./bin/k3s-certificate
 ln -s containerd ./bin/kubectl
 ln -s containerd ./bin/crictl
 ln -s containerd ./bin/ctr
-#echo Building hyperkube
-#CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC_SQLITE" -o bin/hyperkube ./vendor/k8s.io/kubernetes/cmd/hyperkube/
-#echo Building ctr
-#CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC_SQLITE" -o bin/ctr ./cmd/ctr/main.go
-# echo Building containerd
-# CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/containerd ./cmd/containerd/
+
 echo Building runc
 rm -f ./build/src/github.com/opencontainers/runc/runc
 make GOPATH=$(pwd)/build EXTRA_LDFLAGS="-w -s" BUILDTAGS="$RUNC_TAGS" -C ./build/src/github.com/opencontainers/runc $RUNC_STATIC

--- a/scripts/codespell.sh
+++ b/scripts/codespell.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-set -e
 
 # Ignore vendor folder and check file names as well
 # Note: ignore "ba" in https://github.com/k3s-io/k3s/blob/4317a91/scripts/provision/vagrant#L54
-codespell --skip=.git,./vendor,./go.mod,./go.sum --check-filenames --ignore-words-list=ba
+codespell --skip=.git,./vendor,MAINTAINERS,go.mod,go.sum --check-filenames --ignore-words-list=ba
 
 code=$?
 if [ $code -ne 0 ]; then

--- a/scripts/download
+++ b/scripts/download
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 . ./scripts/version.sh
 
 RUNC_VERSION=v1.0.3
-ROOT_VERSION=v0.9.1
+ROOT_VERSION=v0.10.1
 TRAEFIK_CHART_VERSION=$(yq e '.spec.chart' manifests/traefik.yaml | awk 'match($0, /([0-9.]+)([0-9]{2})/, m) { print m[1]; exit; }')
 TRAEFIK_PACKAGE_VERSION=$(yq e '.spec.chart' manifests/traefik.yaml | awk 'match($0, /([0-9.]+)([0-9]{2})/, m) { print m[2]; exit; }')
 TRAEFIK_FILE=traefik-${TRAEFIK_CHART_VERSION}${TRAEFIK_PACKAGE_VERSION}.tgz
@@ -24,7 +24,7 @@ rm -rf ${RUNC_DIR}
 mkdir -p ${CHARTS_DIR}
 mkdir -p ${DATA_DIR}
 
-curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${ROOT_VERSION}/k3s-root-${ARCH}.tar | tar xf -
+curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${ROOT_VERSION}/k3s-root-${ARCH}.tar | tar xf - --exclude=bin/socat
 
 git clone --depth=1 https://github.com/opencontainers/runc ${RUNC_DIR} || true
 pushd ${RUNC_DIR}

--- a/scripts/download
+++ b/scripts/download
@@ -6,8 +6,6 @@ cd $(dirname $0)/..
 
 . ./scripts/version.sh
 
-RUNC_VERSION=v1.0.3
-ROOT_VERSION=v0.10.1
 TRAEFIK_CHART_VERSION=$(yq e '.spec.chart' manifests/traefik.yaml | awk 'match($0, /([0-9.]+)([0-9]{2})/, m) { print m[1]; exit; }')
 TRAEFIK_PACKAGE_VERSION=$(yq e '.spec.chart' manifests/traefik.yaml | awk 'match($0, /([0-9.]+)([0-9]{2})/, m) { print m[2]; exit; }')
 TRAEFIK_FILE=traefik-${TRAEFIK_CHART_VERSION}${TRAEFIK_PACKAGE_VERSION}.tgz
@@ -24,13 +22,9 @@ rm -rf ${RUNC_DIR}
 mkdir -p ${CHARTS_DIR}
 mkdir -p ${DATA_DIR}
 
-curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${ROOT_VERSION}/k3s-root-${ARCH}.tar | tar xf - --exclude=bin/socat
+curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${VERSION_ROOT}/k3s-root-${ARCH}.tar | tar xf - --exclude=bin/socat
 
-git clone --depth=1 https://github.com/opencontainers/runc ${RUNC_DIR} || true
-pushd ${RUNC_DIR}
-git fetch --all --tags
-git checkout ${RUNC_VERSION} -b k3s
-popd
+git clone --single-branch --branch=${VERSION_RUNC} --depth=1 https://github.com/opencontainers/runc ${RUNC_DIR}
 
 setup_tmp() {
     TMP_DIR=$(mktemp -d --tmpdir=${CHARTS_DIR})

--- a/scripts/package-cli
+++ b/scripts/package-cli
@@ -35,7 +35,7 @@ mkdir -p dist/artifacts
     set -x
 )
 
-tar cvf ./build/out/data.tar --exclude ./bin/hyperkube ./bin ./etc 
+tar cvf ./build/out/data.tar ./bin ./etc
 zstd --no-progress -T0 -16 -f --long=25 --rm ./build/out/data.tar -o ./build/out/data.tar.zst
 HASH=$(sha256sum ./build/out/data.tar.zst | awk '{print $1}')
 

--- a/scripts/test
+++ b/scripts/test
@@ -41,6 +41,7 @@ echo "Did test-run-sonobuoy $?"
 
 # ---
 
+test-run-sonobuoy etcd
 test-run-sonobuoy mysql
 test-run-sonobuoy postgres
 

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -321,9 +321,6 @@ test-setup() {
         exit 0
     fi
 
-    local setupFile=./scripts/test-setup-${TEST_TYPE}
-    [ -f $setupFile ] && source $setupFile
-
     echo ${RANDOM}${RANDOM}${RANDOM} >$TEST_DIR/metadata/secret
 }
 export -f test-setup
@@ -422,7 +419,6 @@ provision-server() {
     local count=$(inc-count servers)
     local testID=$(basename $TEST_DIR)
     local name=$(echo "k3s-server-$count-$testID" | tee $TEST_DIR/servers/$count/metadata/name)
-    #local args=$(cat $TEST_DIR/args $TEST_DIR/servers/args $TEST_DIR/servers/$count/args 2>/dev/null)
     local port=$(timeout --foreground 5s bash -c get-port | tee $TEST_DIR/servers/$count/metadata/port)
     local SERVER_INSTANCE_ARGS="SERVER_${count}_ARGS"
 
@@ -454,7 +450,6 @@ provision-agent() {
     local count=$(inc-count agents)
     local testID=$(basename $TEST_DIR)
     local name=$(echo "k3s-agent-$count-$testID" | tee $TEST_DIR/agents/$count/metadata/name)
-    #local args=$(cat $TEST_DIR/args $TEST_DIR/agents/args $TEST_DIR/agents/$count/args 2>/dev/null)
     local AGENT_INSTANCE_ARGS="AGENT_${count}_ARGS"
 
     run-function agent-pre-hook $count
@@ -581,6 +576,21 @@ export -f run-test
 
 # ---
 
+cleanup-test-env(){
+      export NUM_SERVERS=1
+      export NUM_AGENTS=1
+      export AGENT_ARGS=''
+      export SERVER_ARGS=''
+      export WAIT_SERVICES="${all_services[@]}"
+
+      unset AGENT_1_ARGS AGENT_2_ARGS AGENT_3_ARGS
+      unset SERVER_1_ARGS SERVER_2_ARGS SERVER_3_ARGS
+
+      unset -f server-pre-hook server-post-hook agent-pre-hook agent-post-hook cluster-pre-hook cluster-post-hook test-post-hook
+}
+
+# ---
+
 count-running-tests(){
       local count=0
       for pid in ${pids[@]}; do
@@ -631,6 +641,7 @@ test-run-sonobuoy() {
         export LABEL_SUFFIX=$1
     fi
 
+    cleanup-test-env
     . ./scripts/test-setup-sonobuoy$suffix
     run-e2e-tests
 }

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -492,12 +492,12 @@ provision-cluster() {
         done
     fi
 
+    [ -f "$PROVISION_LOCK" ] && rm $PROVISION_LOCK
+
     timeout --foreground 2m bash -c "wait-for-nodes $(( NUM_SERVERS + NUM_AGENTS ))"
     timeout --foreground 4m bash -c "wait-for-services $WAIT_SERVICES"
 
     run-function cluster-post-hook
-
-    [ -f "$PROVISION_LOCK" ] && rm $PROVISION_LOCK
 }
 export -f provision-cluster
 
@@ -556,18 +556,42 @@ export -f early-exit
 # ---
 
 run-test() {
+    local delay=15
+    (
+      set +x
+      while [ $(count-running-tests) -ge ${MAX_CONCURRENT_TESTS:-4} ]; do
+          sleep $delay
+      done
+    )
+
     export PROVISION_LOCK=$(mktemp)
     ./scripts/test-runner $@ &
     pids+=($!)
+
     (
         set +x
+        # busy-wait on the provisioning lock before imposing a final inter-test delay
         while [ -f "$PROVISION_LOCK" ]; do
             sleep 1
         done
-        sleep 5
+        sleep $delay
     )
 }
 export -f run-test
+
+# ---
+
+count-running-tests(){
+      local count=0
+      for pid in ${pids[@]}; do
+          if [ $(pgrep -c -P $pid) -gt 0 ]; then
+            ((count++))
+          fi
+      done
+      echo "Currently running ${count} tests" 1>&2
+      echo ${count}
+}
+export -f count-running-tests
 
 # ---
 

--- a/scripts/test-run-basics
+++ b/scripts/test-run-basics
@@ -46,3 +46,5 @@ export -f use-local-storage-volume
 
 # --- create a basic cluster and check for valid versions
 LABEL=BASICS run-test
+
+cleanup-test-env

--- a/scripts/test-run-compat
+++ b/scripts/test-run-compat
@@ -28,7 +28,7 @@ export -f test-post-hook
 
 REPO=${REPO:-rancher}
 IMAGE_NAME=${IMAGE_NAME:-k3s}
-PREVIOUS_CHANNEL=$(grep 'k8s.io/kubernetes v' go.mod | head -n1 | awk '{print $2}' | awk -F. '{print "v1." ($(NF - 1) - 1)}')
+PREVIOUS_CHANNEL=$(grep 'k8s.io/kubernetes v' go.mod | head -n1 | awk '{print $2}' | awk -F. '{print "v1." ($2 - 1)}')
 PREVIOUS_VERSION=$(curl -s https://update.k3s.io/v1-release/channels/${PREVIOUS_CHANNEL} -o /dev/null -w '%{redirect_url}' | awk -F/ '{print gensub(/\+/, "-", "g", $NF)}')
 STABLE_VERSION=$(curl -s https://update.k3s.io/v1-release/channels/stable -o /dev/null -w '%{redirect_url}' | awk -F/ '{print gensub(/\+/, "-", "g", $NF)}')
 LATEST_VERSION=$(curl -s https://update.k3s.io/v1-release/channels/latest -o /dev/null -w '%{redirect_url}' | awk -F/ '{print gensub(/\+/, "-", "g", $NF)}')

--- a/scripts/test-run-compat
+++ b/scripts/test-run-compat
@@ -44,3 +44,5 @@ K3S_IMAGE_AGENT=${REPO}/${IMAGE_NAME}:${STABLE_VERSION} LABEL=STABLE-AGENT run-t
 # --- create a basic cluster to test for compat with the latest version of the server and agent
 K3S_IMAGE_SERVER=${REPO}/${IMAGE_NAME}:${LATEST_VERSION} LABEL=LATEST-SERVER run-test
 K3S_IMAGE_AGENT=${REPO}/${IMAGE_NAME}:${LATEST_VERSION} LABEL=LATEST-AGENT run-test
+
+cleanup-test-env

--- a/scripts/test-run-lazypull
+++ b/scripts/test-run-lazypull
@@ -132,3 +132,5 @@ export -f get-topmost-layer
 
 # --- create a basic cluster and check for lazy pulling
 LABEL=LAZYPULL run-test
+
+cleanup-test-env

--- a/scripts/test-setup-sonobuoy-etcd
+++ b/scripts/test-setup-sonobuoy-etcd
@@ -4,10 +4,7 @@
 
 export NUM_SERVERS=2
 export NUM_AGENTS=0
-
-export SERVER_1_ARGS=--cluster-init
-
-# ---
+export SERVER_1_ARGS="--cluster-init"
 
 server-post-hook() {
   if [ $1 -eq 1 ]; then

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -37,7 +37,14 @@ if [ -z "$VERSION_K8S" ]; then
     VERSION_K8S="v0.0.0"
 fi
 
+VERSION_RUNC=$(grep github.com/opencontainers/runc go.mod | head -n1 | awk '{print $4}')
+if [ -z "$VERSION_RUNC" ]; then
+    VERSION_RUNC="v0.0.0"
+fi
+
 VERSION_CNIPLUGINS="v0.9.1-k3s1"
+
+VERSION_ROOT="v0.9.1"
 
 if [[ -n "$GIT_TAG" ]]; then
     if [[ ! "$GIT_TAG" =~ ^"$VERSION_K8S"[+-] ]]; then


### PR DESCRIPTION
#### Proposed Changes ####

* Add etcd sonobuoy tests
* Add variable to enforce max test concurrency
* Fix previous channel detection
* More codespell ignores
* Close etcd clients to avoid leaking GRPC connections
* Build script cleanups
* Bump k3s-root to v0.10.1

#### Types of Changes ####

CI; Bugfix

#### Verification ####

* Check for successful CI output
* See linked issues

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/4819

#### User-Facing Change ####
```release-note

```

#### Further Comments ####