### PR TITLE
[Release-1.22] Fix cgroup smoke test

### DIFF
--- a/.github/workflows/cgroup.yaml
+++ b/.github/workflows/cgroup.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with: { name: k3s, path: dist/artifacts/k3s }
   test:
-    name: "Smoke Test"
+    name: "Conformance Test"
     needs: prep
     # nested virtualization is only available on macOS hosts
     runs-on: macos-10.15
@@ -66,10 +66,14 @@ jobs:
         continue-on-error: true
       - name: "Vagrant Plugin(s)"
         run: vagrant plugin install vagrant-k3s
-      - name: "Vagrant Up ⏩ Install K3s"
+      - name: "Vagrant Up"
         run: vagrant up
-      - name: "K3s Start" # start k3s rootfull
-        run: vagrant ssh -- sudo systemctl start k3s-server
+      - name: "K3s Prepare"
+        run: vagrant provision --provision-with=k3s-prepare
+      - name: ⏬ "K3s Install"
+        run: vagrant provision --provision-with=k3s-install
+      - name: ⏩ "K3s Start"
+        run: vagrant provision --provision-with=k3s-start
       - name: "K3s Ready" # wait for k3s to be ready
         run: vagrant provision --provision-with=k3s-ready
       - name: "K3s Status" # kubectl get node,all -A -o wide

--- a/tests/vagrant/cgroup/unified/fedora-34/Vagrantfile
+++ b/tests/vagrant/cgroup/unified/fedora-34/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
     test.vm.hostname = 'smoke'
     test.vm.provision :file, run: 'always', source: ENV['TEST_UNITFILE_ROOTFULL'], destination: 'k3s-rootfull.service'
     test.vm.provision :file, run: 'always', source: ENV['TEST_UNITFILE_ROOTLESS'], destination: 'k3s-rootless.service'
-    test.vm.provision 'k3s-prepare', type: "shell", run: "once", privileged: true do |sh|
+    test.vm.provision 'k3s-prepare', type: "shell", run: ENV['CI'] == 'true' ? 'never' : 'once', privileged: true do |sh|
       sh.inline = <<~SHELL
         #!/usr/bin/env bash
         set -eux -o pipefail
@@ -58,7 +58,7 @@ EOF
         chown -R vagrant:vagrant /home/vagrant/.config
       SHELL
     end
-    test.vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+    test.vm.provision 'k3s-install', type: 'k3s', run: ENV['CI'] == 'true' ? 'never' : 'once' do |k3s|
       k3s.args = %w[server]
       k3s.env = %w[INSTALL_K3S_NAME=server INSTALL_K3S_SKIP_DOWNLOAD=true K3S_TOKEN=vagrant INSTALL_K3S_SKIP_ENABLE=true]
       k3s.config = {
@@ -68,6 +68,9 @@ EOF
         'write-kubeconfig-mode' => '0644',
       }
       k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+    test.vm.provision "k3s-start", type: "shell", run: ENV['CI'] == 'true' ? 'never' : 'once' do |sh|
+      sh.inline = "systemctl start k3s-server"
     end
     test.vm.provision "k3s-ready", type: "shell", run: ENV['CI'] == 'true' ? 'never' : 'once' do |sh|
       sh.env = {


### PR DESCRIPTION
Backport of **https://github.com/k3s-io/k3s/pull/4823**
* Fixed control group vagrantfile so running vagrant up doesn't fail locally

Signed-off-by: Derek Nola <derek.nola@suse.com>
