### PR TITLE
feat: override CoreDNS config

### DIFF
--- a/manifests/coredns.yaml
+++ b/manifests/coredns.yaml
@@ -57,6 +57,7 @@ data:
         errors
         health
         ready
+        import /etc/coredns/custom/*.override.start
         kubernetes %{CLUSTER_DOMAIN}% in-addr.arpa ip6.arpa {
           pods insecure
           fallthrough in-addr.arpa ip6.arpa
@@ -66,12 +67,14 @@ data:
           reload 15s
           fallthrough
         }
+        import /etc/coredns/custom/*.override.fallthrough
         prometheus :9153
         forward . /etc/resolv.conf
         cache 30
         loop
         reload
         loadbalance
+        import /etc/coredns/custom/*.override.end
     }
     import /etc/coredns/custom/*.server
 ---


### PR DESCRIPTION
#### Proposed Changes ####

Fixes: https://github.com/k3s-io/k3s/pull/4397#issuecomment-1002788409

Problem:
The coredns-custom configmap does not support overriding an existing server to add custom rules.

Solution:
Import overrides from the coredns-custom ConfigMap.

#### Types of Changes ####

New Feature (non-breaking change).

#### Verification ####

- deploy this ConfigMap:

    ```
    apiVersion: v1
    kind: ConfigMap
    metadata:
      name: coredns-custom
      namespace: kube-system
    data:
      rewrite.override.start: |
        rewrite name example.com traefik.kube-system.svc.cluster.local
    ```

- verify Traefik's ClusterIP is returned from: `kubectl run -it --rm --image=azukiapp/dig dig -- dig example.com`

#### Linked Issues ####

- https://github.com/k3s-io/k3s/pull/4397
- https://github.com/k3s-io/k3s/issues/462
- https://github.com/rancher/k3d/issues/816

#### User-Facing Change ####

```release-note
Allow optional customizations to existing CoreDNS servers via `coredns-custom` ConfigMap
```