### PR TITLE
Adds the ability to compress etcd snapshots

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -33,6 +33,10 @@
 			{
 				"linters": "revive",
 				"text": "should have comment"
+			},
+			{
+				"linters": "revive",
+				"text": "exported",
 			}
 		]
 	}

--- a/.golangci.json
+++ b/.golangci.json
@@ -36,7 +36,7 @@
 			},
 			{
 				"linters": "revive",
-				"text": "exported",
+				"text": "exported"
 			}
 		]
 	}

--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -33,6 +33,11 @@ var EtcdSnapshotFlags = []cli.Flag{
 		Value:       "on-demand",
 	},
 	&cli.BoolFlag{
+		Name:        "snapshot-compress,etcd-snapshot-compress",
+		Usage:       "(db) Compress etcd snapshot",
+		Destination: &ServerConfig.EtcdSnapshotCompress,
+	},
+	&cli.BoolFlag{
 		Name:        "s3,etcd-s3",
 		Usage:       "(db) Enable backup to S3",
 		Destination: &ServerConfig.EtcdS3,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -84,6 +84,7 @@ type Server struct {
 	EtcdSnapshotDir          string
 	EtcdSnapshotCron         string
 	EtcdSnapshotRetention    int
+	EtcdSnapshotCompress     bool
 	EtcdS3                   bool
 	EtcdS3Endpoint           string
 	EtcdS3EndpointCA         string
@@ -288,6 +289,11 @@ var ServerFlags = []cli.Flag{
 		Name:        "etcd-snapshot-dir",
 		Usage:       "(db) Directory to save db snapshots. (Default location: ${data-dir}/db/snapshots)",
 		Destination: &ServerConfig.EtcdSnapshotDir,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-snapshot-compress",
+		Usage:       "(db) Compress etcd snapshot",
+		Destination: &ServerConfig.EtcdSnapshotCompress,
 	},
 	&cli.BoolFlag{
 		Name:        "etcd-s3",

--- a/pkg/cli/etcdsnapshot/etcd_snapshot.go
+++ b/pkg/cli/etcdsnapshot/etcd_snapshot.go
@@ -39,6 +39,7 @@ func commandSetup(app *cli.Context, cfg *cmds.Server, sc *server.Config) (string
 	sc.ControlConfig.DataDir = cfg.DataDir
 	sc.ControlConfig.EtcdSnapshotName = cfg.EtcdSnapshotName
 	sc.ControlConfig.EtcdSnapshotDir = cfg.EtcdSnapshotDir
+	sc.ControlConfig.EtcdSnapshotCompress = cfg.EtcdSnapshotCompress
 	sc.ControlConfig.EtcdS3 = cfg.EtcdS3
 	sc.ControlConfig.EtcdS3Endpoint = cfg.EtcdS3Endpoint
 	sc.ControlConfig.EtcdS3EndpointCA = cfg.EtcdS3EndpointCA

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -170,6 +170,7 @@ type Control struct {
 	EtcdSnapshotDir          string
 	EtcdSnapshotCron         string
 	EtcdSnapshotRetention    int
+	EtcdSnapshotCompress     bool
 	EtcdS3                   bool
 	EtcdS3Endpoint           string
 	EtcdS3EndpointCA         string

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -982,9 +982,9 @@ func (e *ETCD) compressSnapshot(snapshotDir, snapshotName, snapshotPath string) 
 		return "", err
 	}
 
-	header.Name = zipPath
+	header.Name = snapshotName
 	header.Method = zip.Deflate
-	header.Modified = time.Unix(0, 0)
+	header.Modified = time.Now()
 
 	writer, err := zipWriter.CreateHeader(header)
 	if err != nil {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Adds the ability to compress etcd snapshots using Go's zip package for feature parity with RKE1.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Scenario 1:

1. Create a new cluster.
2. Take a snapshot: `./k3s etcd-snapshot --snapshot-compress`.
3. Stop the cluster.
4. Perform a restore.

Scenario 2:

1. Create a new cluster.
2. Take a snapshot: `./k3s etcd-snapshot --snapshot-compress`.
3. Stop the cluster.
4. Remove the `${data-dir}`.
5. Perform a restore.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/rancher/rke2/issues/2151

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
