### PR TITLE
[release-1.22] Fix use of agent creds for secrets-encrypt and config validate

### DIFF
--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -25,7 +25,7 @@ func commandPrep(app *cli.Context, cfg *cmds.Server) (config.Control, *clientacc
 	var err error
 	// hide process arguments from ps output, since they may contain
 	// database credentials or other secrets.
-	gspt.SetProcTitle(os.Args[0] + " encrypt")
+	gspt.SetProcTitle(os.Args[0] + " secrets-encrypt")
 
 	controlConfig.DataDir, err = server.ResolveDataDir(cfg.DataDir)
 	if err != nil {
@@ -47,7 +47,7 @@ func commandPrep(app *cli.Context, cfg *cmds.Server) (config.Control, *clientacc
 	}
 	controlConfig.EncryptForce = cfg.EncryptForce
 	controlConfig.EncryptSkip = cfg.EncryptSkip
-	info, err := clientaccess.ParseAndValidateTokenForUser(cmds.ServerConfig.ServerURL, controlConfig.Token, "node")
+	info, err := clientaccess.ParseAndValidateTokenForUser(cmds.ServerConfig.ServerURL, controlConfig.Token, "server")
 	if err != nil {
 		return controlConfig, nil, err
 	}

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -635,7 +635,7 @@ func (c *Cluster) Snapshot(ctx context.Context, config *config.Control) error {
 
 // compareConfig verifies that the config of the joining control plane node coincides with the cluster's config
 func (c *Cluster) compareConfig() error {
-	agentClientAccessInfo, err := clientaccess.ParseAndValidateTokenForUser(c.config.JoinURL, c.config.Token, "node")
+	agentClientAccessInfo, err := clientaccess.ParseAndValidateTokenForUser(c.config.JoinURL, c.config.AgentToken, "node")
 	if err != nil {
 		return err
 	}

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -48,8 +48,6 @@ func router(ctx context.Context, config *Config, cfg *cmds.Server) http.Handler 
 	authed.Path(prefix + "/server-ca.crt").Handler(fileHandler(serverConfig.Runtime.ServerCA))
 	authed.Path(prefix + "/config").Handler(configHandler(serverConfig, cfg))
 	authed.Path(prefix + "/readyz").Handler(readyzHandler(serverConfig))
-	authed.Path(prefix + "/encrypt/status").Handler(encryptionStatusHandler(serverConfig))
-	authed.Path(prefix + "/encrypt/config").Handler(encryptionConfigHandler(ctx, serverConfig))
 
 	nodeAuthed := mux.NewRouter()
 	nodeAuthed.Use(authMiddleware(serverConfig, "system:nodes"))
@@ -59,6 +57,8 @@ func router(ctx context.Context, config *Config, cfg *cmds.Server) http.Handler 
 	serverAuthed := mux.NewRouter()
 	serverAuthed.Use(authMiddleware(serverConfig, version.Program+":server"))
 	serverAuthed.NotFoundHandler = nodeAuthed
+	serverAuthed.Path(prefix + "/encrypt/status").Handler(encryptionStatusHandler(serverConfig))
+	serverAuthed.Path(prefix + "/encrypt/config").Handler(encryptionConfigHandler(ctx, serverConfig))
 	serverAuthed.Path("/db/info").Handler(nodeAuthed)
 	if serverConfig.Runtime.HTTPBootstrap {
 		serverAuthed.Path(prefix + "/server-bootstrap").Handler(bootstrap.Handler(&serverConfig.Runtime.ControlRuntimeBootstrap))


### PR DESCRIPTION
#### Proposed Changes ####

Fix use of agent creds for secrets-encrypt and config validate

#### Types of Changes ####

bugfix

#### Verification ####

* Start k3s server with `k3s server --token=token --agent-token=agent-token --cluster-init`
* Join a second server; note that it succeeds.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/4881

#### User-Facing Change ####
```release-note
Fixed an issue that prevented joining additional servers when `--agent-token` is set.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
