### PR TITLE
[release-1.20] Fix use of agent creds for config validate

### DIFF
--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 
+	"github.com/pkg/errors"
 	"github.com/rancher/k3s/pkg/bootstrap"
 	"github.com/rancher/k3s/pkg/clientaccess"
 	"github.com/rancher/k3s/pkg/daemons/config"
@@ -138,7 +138,7 @@ func (c *Cluster) bootstrap(ctx context.Context) error {
 	if c.runtime.HTTPBootstrap {
 		// Assuming we should just compare on managed databases
 		if err := c.compareConfig(); err != nil {
-			return err
+			return errors.Wrap(err, "failed to validate server configuration")
 		}
 		return c.httpBootstrap()
 	}
@@ -165,7 +165,11 @@ func (c *Cluster) Snapshot(ctx context.Context, config *config.Control) error {
 
 // compareConfig verifies that the config of the joining control plane node coincides with the cluster's config
 func (c *Cluster) compareConfig() error {
-	agentClientAccessInfo, err := clientaccess.ParseAndValidateTokenForUser(c.config.JoinURL, c.config.AgentToken, "node")
+	token := c.config.AgentToken
+	if token == "" {
+		token = c.config.Token
+	}
+	agentClientAccessInfo, err := clientaccess.ParseAndValidateTokenForUser(c.config.JoinURL, token, "node")
 	if err != nil {
 		return err
 	}
@@ -186,7 +190,7 @@ func (c *Cluster) compareConfig() error {
 	if !reflect.DeepEqual(clusterControl.CriticalControlArgs, c.config.CriticalControlArgs) {
 		logrus.Debugf("This is the server CriticalControlArgs: %#v", clusterControl.CriticalControlArgs)
 		logrus.Debugf("This is the local CriticalControlArgs: %#v", c.config.CriticalControlArgs)
-		return errors.New("Unable to join cluster due to critical configuration value mismatch")
+		return errors.New("critical configuration value mismatch")
 	}
 	return nil
 }

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -165,7 +165,7 @@ func (c *Cluster) Snapshot(ctx context.Context, config *config.Control) error {
 
 // compareConfig verifies that the config of the joining control plane node coincides with the cluster's config
 func (c *Cluster) compareConfig() error {
-	agentClientAccessInfo, err := clientaccess.ParseAndValidateTokenForUser(c.config.JoinURL, c.config.Token, "node")
+	agentClientAccessInfo, err := clientaccess.ParseAndValidateTokenForUser(c.config.JoinURL, c.config.AgentToken, "node")
 	if err != nil {
 		return err
 	}

--- a/scripts/test
+++ b/scripts/test
@@ -21,6 +21,9 @@ echo "Did test-run-basics $?"
 . ./scripts/test-run-compat
 echo "Did test-run-compat $?"
 
+. ./scripts/test-run-etcd
+echo "Did test-run-etcd $?"
+
 # ---
 
 [ "$ARCH" != 'amd64' ] && \

--- a/scripts/test
+++ b/scripts/test
@@ -35,6 +35,7 @@ echo "Did test-run-sonobuoy $?"
 
 # ---
 
+test-run-sonobuoy etcd
 test-run-sonobuoy mysql
 test-run-sonobuoy postgres
 

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -321,9 +321,6 @@ test-setup() {
         exit 0
     fi
 
-    local setupFile=./scripts/test-setup-${TEST_TYPE}
-    [ -f $setupFile ] && source $setupFile
-
     echo ${RANDOM}${RANDOM}${RANDOM} >$TEST_DIR/metadata/secret
 }
 export -f test-setup
@@ -422,7 +419,6 @@ provision-server() {
     local count=$(inc-count servers)
     local testID=$(basename $TEST_DIR)
     local name=$(echo "k3s-server-$count-$testID" | tee $TEST_DIR/servers/$count/metadata/name)
-    #local args=$(cat $TEST_DIR/args $TEST_DIR/servers/args $TEST_DIR/servers/$count/args 2>/dev/null)
     local port=$(timeout --foreground 5s bash -c get-port | tee $TEST_DIR/servers/$count/metadata/port)
     local SERVER_INSTANCE_ARGS="SERVER_${count}_ARGS"
 
@@ -454,7 +450,6 @@ provision-agent() {
     local count=$(inc-count agents)
     local testID=$(basename $TEST_DIR)
     local name=$(echo "k3s-agent-$count-$testID" | tee $TEST_DIR/agents/$count/metadata/name)
-    #local args=$(cat $TEST_DIR/args $TEST_DIR/agents/args $TEST_DIR/agents/$count/args 2>/dev/null)
     local AGENT_INSTANCE_ARGS="AGENT_${count}_ARGS"
 
     run-function agent-pre-hook $count
@@ -571,6 +566,35 @@ export -f run-test
 
 # ---
 
+cleanup-test-env(){
+      export NUM_SERVERS=1
+      export NUM_AGENTS=1
+      export AGENT_ARGS=''
+      export SERVER_ARGS=''
+      export WAIT_SERVICES="${all_services[@]}"
+
+      unset AGENT_1_ARGS AGENT_2_ARGS AGENT_3_ARGS
+      unset SERVER_1_ARGS SERVER_2_ARGS SERVER_3_ARGS
+
+      unset -f server-pre-hook server-post-hook agent-pre-hook agent-post-hook cluster-pre-hook cluster-post-hook test-post-hook
+}
+
+# ---
+
+count-running-tests(){
+      local count=0
+      for pid in ${pids[@]}; do
+          if [ $(pgrep -c -P $pid) -gt 0 ]; then
+            ((count++))
+          fi
+      done
+      echo "Currently running ${count} tests" 1>&2
+      echo ${count}
+}
+export -f count-running-tests
+
+# ---
+
 e2e-test() {
     local label=$label
     if [ -n "$LABEL_SUFFIX" ]; then
@@ -607,6 +631,7 @@ test-run-sonobuoy() {
         export LABEL_SUFFIX=$1
     fi
 
+    cleanup-test-env
     . ./scripts/test-setup-sonobuoy$suffix
     run-e2e-tests
 }

--- a/scripts/test-run-basics
+++ b/scripts/test-run-basics
@@ -46,3 +46,5 @@ export -f use-local-storage-volume
 
 # --- create a basic cluster and check for valid versions
 LABEL=BASICS run-test
+
+cleanup-test-env

--- a/scripts/test-run-compat
+++ b/scripts/test-run-compat
@@ -44,3 +44,5 @@ K3S_IMAGE_AGENT=${REPO}/${IMAGE_NAME}:${STABLE_VERSION} LABEL=STABLE-AGENT run-t
 # --- create a basic cluster to test for compat with the latest version of the server and agent
 K3S_IMAGE_SERVER=${REPO}/${IMAGE_NAME}:${LATEST_VERSION} LABEL=LATEST-SERVER run-test
 K3S_IMAGE_AGENT=${REPO}/${IMAGE_NAME}:${LATEST_VERSION} LABEL=LATEST-AGENT run-test
+
+cleanup-test-env

--- a/scripts/test-run-etcd
+++ b/scripts/test-run-etcd
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+all_services=(
+    coredns
+    local-path-provisioner
+    metrics-server
+    traefik
+)
+
+export NUM_SERVERS=2
+export NUM_AGENTS=0
+export WAIT_SERVICES="${all_services[@]}"
+export SERVER_1_ARGS="--cluster-init"
+
+server-post-hook() {
+  if [ $1 -eq 1 ]; then
+    local url=$(cat $TEST_DIR/servers/1/metadata/url)
+    export SERVER_ARGS="${SERVER_ARGS} --server $url"
+  fi
+}
+export -f server-post-hook
+
+export -f server-post-hook
+start-test() {
+  echo "Cluster is up"
+}
+export -f start-test
+
+# --- create a basic cluster to test joining managed etcd
+LABEL="ETCD-JOIN-BASIC" SERVER_ARGS="" run-test
+
+# --- create a basic cluster to test joining a managed etcd cluster with --agent-token set
+LABEL="ETCD-JOIN-AGENTTOKEN" SERVER_ARGS="--agent-token ${RANDOM}${RANDOM}${RANDOM}" run-test
+
+# --- test joining a managed etcd cluster with incompatible configuration
+test-post-hook() {
+  if [[ $1 -eq 0 ]]; then
+    return
+  fi
+  grep -sqF 'critical configuration value mismatch' $TEST_DIR/servers/2/logs/system.log
+}
+export -f test-post-hook
+LABEL="ETCD-JOIN-MISMATCH" SERVER_2_ARGS="--cluster-cidr 10.0.0.0/16" run-test
+
+cleanup-test-env

--- a/scripts/test-setup-sonobuoy-etcd
+++ b/scripts/test-setup-sonobuoy-etcd
@@ -4,10 +4,7 @@
 
 export NUM_SERVERS=2
 export NUM_AGENTS=0
-
-export SERVER_1_ARGS=--cluster-init
-
-# ---
+export SERVER_1_ARGS="--cluster-init"
 
 server-post-hook() {
   if [ $1 -eq 1 ]; then


### PR DESCRIPTION
#### Proposed Changes ####

Fix use of agent creds for config validate

Also backports some tests that hadn't been pulled back to 1.20 to catch this going forward.

#### Types of Changes ####

bugfix

#### Verification ####

* Start k3s server with `k3s server --token=token --agent-token=agent-token --cluster-init`
* Join a second server; note that it succeeds.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/4881

#### User-Facing Change ####
```release-note
Fixed an issue that prevented joining additional servers when `--agent-token` is set.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
