### PR TITLE
[engine-1.21] Move ClusterResetRestore handling after ControlConfig setup

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -165,43 +165,6 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		return errors.New("invalid flag use; --cluster-reset required with --cluster-reset-restore-path")
 	}
 
-	// make sure components are disabled so we only perform a restore
-	// and bail out
-	if cfg.ClusterResetRestorePath != "" && cfg.ClusterReset {
-		serverConfig.ControlConfig.ClusterInit = true
-		serverConfig.ControlConfig.DisableAPIServer = true
-		serverConfig.ControlConfig.DisableControllerManager = true
-		serverConfig.ControlConfig.DisableScheduler = true
-		serverConfig.ControlConfig.DisableCCM = true
-
-		// only close the agentReady channel in case of k3s restoration, because k3s does not start
-		// the agent until server returns successfully, unlike rke2's agent which starts in parallel
-		// with the server
-		if serverConfig.ControlConfig.SupervisorPort == serverConfig.ControlConfig.HTTPSPort {
-			close(agentReady)
-		}
-
-		dataDir, err := datadir.LocalHome(cfg.DataDir, false)
-		if err != nil {
-			return err
-		}
-		// delete local loadbalancers state for apiserver and supervisor servers
-		loadbalancer.ResetLoadBalancer(filepath.Join(dataDir, "agent"), loadbalancer.SupervisorServiceName)
-		loadbalancer.ResetLoadBalancer(filepath.Join(dataDir, "agent"), loadbalancer.APIServerServiceName)
-
-		// at this point we're doing a restore. Check to see if we've
-		// passed in a token and if not, check if the token file exists.
-		// If it doesn't, return an error indicating the token is necessary.
-		if cfg.Token == "" {
-			tokenFile := filepath.Join(dataDir, "server", "token")
-			if _, err := os.Stat(tokenFile); err != nil {
-				if os.IsNotExist(err) {
-					return errors.New(tokenFile + " does not exist, please pass --token to complete the restoration")
-				}
-			}
-		}
-	}
-
 	serverConfig.ControlConfig.ClusterReset = cfg.ClusterReset
 	serverConfig.ControlConfig.ClusterResetRestorePath = cfg.ClusterResetRestorePath
 	serverConfig.ControlConfig.SystemDefaultRegistry = cfg.SystemDefaultRegistry
@@ -415,6 +378,43 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.TLSCipherSuites, err = kubeapiserverflag.TLSCipherSuites(tlsCipherSuites)
 	if err != nil {
 		return errors.Wrap(err, "invalid tls-cipher-suites")
+	}
+
+	// make sure components are disabled so we only perform a restore
+	// and bail out
+	if cfg.ClusterResetRestorePath != "" && cfg.ClusterReset {
+		serverConfig.ControlConfig.ClusterInit = true
+		serverConfig.ControlConfig.DisableAPIServer = true
+		serverConfig.ControlConfig.DisableControllerManager = true
+		serverConfig.ControlConfig.DisableScheduler = true
+		serverConfig.ControlConfig.DisableCCM = true
+
+		// only close the agentReady channel in case of k3s restoration, because k3s does not start
+		// the agent until server returns successfully, unlike rke2's agent which starts in parallel
+		// with the server
+		if serverConfig.ControlConfig.SupervisorPort == serverConfig.ControlConfig.HTTPSPort {
+			close(agentReady)
+		}
+
+		dataDir, err := datadir.LocalHome(cfg.DataDir, false)
+		if err != nil {
+			return err
+		}
+		// delete local loadbalancers state for apiserver and supervisor servers
+		loadbalancer.ResetLoadBalancer(filepath.Join(dataDir, "agent"), loadbalancer.SupervisorServiceName)
+		loadbalancer.ResetLoadBalancer(filepath.Join(dataDir, "agent"), loadbalancer.APIServerServiceName)
+
+		// at this point we're doing a restore. Check to see if we've
+		// passed in a token and if not, check if the token file exists.
+		// If it doesn't, return an error indicating the token is necessary.
+		if cfg.Token == "" {
+			tokenFile := filepath.Join(dataDir, "server", "token")
+			if _, err := os.Stat(tokenFile); err != nil {
+				if os.IsNotExist(err) {
+					return errors.New(tokenFile + " does not exist, please pass --token to complete the restoration")
+				}
+			}
+		}
 	}
 
 	logrus.Info("Starting " + version.Program + " " + app.App.Version)


### PR DESCRIPTION
#### Proposed Changes ####

Fix cluster-reset not closing the agentReady channel on K3s so the LB never comes up.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/4914

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an issue that prevented cluster-reset restore from working on some nodes in a multi-node etcd cluster.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
