### PR TITLE
Enable debug logging on all k3s subcommands with debug flag

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -214,7 +214,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 		Name:      "agent",
 		Usage:     "Run node agent",
 		UsageText: appName + " agent [OPTIONS]",
-		Before:    SetupDebug(CheckSELinuxFlags),
+		Before:    CheckSELinuxFlags,
 		Action:    action,
 		Flags: []cli.Flag{
 			ConfigFlag,

--- a/pkg/cli/cmds/log.go
+++ b/pkg/cli/cmds/log.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -76,4 +77,7 @@ func setupLogging() {
 	flag.Set("vmodule", LogConfig.VModule)
 	flag.Set("alsologtostderr", strconv.FormatBool(Debug))
 	flag.Set("logtostderr", strconv.FormatBool(!Debug))
+	if Debug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
 }

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 
 	"github.com/rancher/k3s/pkg/version"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -43,19 +42,6 @@ func NewApp() *cli.App {
 			Usage: "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
 		},
 	}
-	app.Before = SetupDebug(nil)
 
 	return app
-}
-
-func SetupDebug(next func(ctx *cli.Context) error) func(ctx *cli.Context) error {
-	return func(ctx *cli.Context) error {
-		if Debug {
-			logrus.SetLevel(logrus.DebugLevel)
-		}
-		if next != nil {
-			return next(ctx)
-		}
-		return nil
-	}
 }

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -514,7 +514,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 		Name:      "server",
 		Usage:     "Run management server",
 		UsageText: appName + " server [OPTIONS]",
-		Before:    SetupDebug(CheckSELinuxFlags),
+		Before:    CheckSELinuxFlags,
 		Action:    action,
 		Flags:     ServerFlags,
 	}


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Current the `--debug` only works for k3s agent and k3s server. This fixes debugging so that the command works on additional subcommands: `etcd-snapshot, certificate, and secrets-encrypt`. 
- Debug check is moved into the `InitLogging()` function, not attached to the `app.before` call. All relevant subcommands call InitLogging.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- start k3s with `--cluster-init`
- Run `k3s etcd-snapshot save --debug` and not that debug logs now appear.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/4920
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
