### PR TITLE
Skip CGroup v2 evac when agent is disabled

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -55,9 +55,13 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	// database credentials or other secrets.
 	gspt.SetProcTitle(os.Args[0] + " server")
 
-	// Evacuate cgroup v2 before doing anything else that may fork.
-	if err := cmds.EvacuateCgroup2(); err != nil {
-		return err
+	// If the agent is enabled, evacuate cgroup v2 before doing anything else that may fork.
+	// If the agent is disabled, we don't need to bother doing this as it is only the kubelet
+	// that cares about cgroups.
+	if !cfg.DisableAgent {
+		if err := cmds.EvacuateCgroup2(); err != nil {
+			return err
+		}
 	}
 
 	// Initialize logging, and subprocess reaping if necessary.


### PR DESCRIPTION
#### Proposed Changes ####

Skip CGroup v2 evac when agent is disabled

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/4873

#### User-Facing Change ####
```release-note
K3s servers no longer attempt to manage cgroup membership when the (unsupported, hidden) `--disable-agent` flag is used.
```

#### Further Comments ####