### PR TITLE
Add `--server` flag to `k3s secrets-encrypt` 

### DIFF
--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"github.com/rancher/k3s/pkg/version"
 	"github.com/urfave/cli"
 )
 
@@ -9,6 +10,13 @@ const SecretsEncryptCommand = "secrets-encrypt"
 var EncryptFlags = []cli.Flag{
 	DataDirFlag,
 	ServerToken,
+	cli.StringFlag{
+		Name:        "server, s",
+		Usage:       "(cluster) Server to connect to",
+		EnvVar:      version.ProgramUpper + "_URL",
+		Value:       "https://127.0.0.1:6443",
+		Destination: &ServerConfig.ServerURL,
+	},
 }
 
 func NewSecretsEncryptCommand(action func(*cli.Context) error, subcommands []cli.Command) cli.Command {

--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -31,9 +31,6 @@ func commandPrep(app *cli.Context, cfg *cmds.Server) (config.Control, *clientacc
 	if err != nil {
 		return controlConfig, nil, err
 	}
-	if cfg.ServerURL == "" {
-		cfg.ServerURL = "https://127.0.0.1:6443"
-	}
 
 	if cfg.Token == "" {
 		fp := filepath.Join(controlConfig.DataDir, "token")


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
This adds the `--server/-s` flag to `k3s secrets-encrypt` allowing the command to access non-local servers or non default server configuration. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- Start up k3s with a `--bind-address` assigned to a nonlocal interface
`k3s server --cluster-init --secrets-encryption --bind-address=192.168.1.117`

- Access the secrets encrypt status with --server
`k3s secrets-encrypt status --server=https://192.168.1.117:6443`
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/5006
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add `--server` flag to `k3s secrets-encrypt` subcommand to enable access non-local and non-default k3s servers.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
