### PR TITLE
[release-1.22] Move containerd wait into exported function

### DIFF
--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -94,9 +94,20 @@ func Run(ctx context.Context, cfg *config.Node) error {
 		os.Exit(1)
 	}()
 
+	if err := WaitForContainerd(ctx, cfg.Containerd.Address); err != nil {
+		return err
+	}
+
+	return preloadImages(ctx, cfg)
+}
+
+// WaitForContainerd blocks in a retry loop until the Containerd CRI service
+// is functional at the provided socket address. It will return only on success,
+// or when the context is cancelled.
+func WaitForContainerd(ctx context.Context, address string) error {
 	first := true
 	for {
-		conn, err := CriConnection(ctx, cfg.Containerd.Address)
+		conn, err := CriConnection(ctx, address)
 		if err == nil {
 			conn.Close()
 			break
@@ -113,8 +124,7 @@ func Run(ctx context.Context, cfg *config.Node) error {
 		}
 	}
 	logrus.Info("Containerd is now running")
-
-	return preloadImages(ctx, cfg)
+	return nil
 }
 
 // preloadImages reads the contents of the agent images directory, and attempts to


### PR DESCRIPTION
#### Proposed Changes ####

Move containerd wait into exported function

RKE2 needs to do the same thing when starting up the temporary kubelet and containerd; make this code reusable so that we don't have to copypasta it over there.

#### Types of Changes ####

D.R.Y.

#### Verification ####

No change to K3s - existing code just moved into a function

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2083#issuecomment-977563685
* https://github.com/rancher/rke2/pull/2391

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
