### PR TITLE
[Engine-1.21]  Add `--server flag` to `k3s secrets-encrypt`

### DIFF
--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"github.com/rancher/k3s/pkg/version"
 	"github.com/urfave/cli"
 )
 
@@ -9,6 +10,13 @@ const SecretsEncryptCommand = "secrets-encrypt"
 var EncryptFlags = []cli.Flag{
 	DataDirFlag,
 	ServerToken,
+	cli.StringFlag{
+		Name:        "server, s",
+		Usage:       "(cluster) Server to connect to",
+		EnvVar:      version.ProgramUpper + "_URL",
+		Value:       "https://127.0.0.1:6443",
+		Destination: &ServerConfig.ServerURL,
+	},
 }
 
 func NewSecretsEncryptCommand(action func(*cli.Context) error, subcommands []cli.Command) cli.Command {

--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -31,9 +31,6 @@ func commandPrep(app *cli.Context, cfg *cmds.Server) (config.Control, *clientacc
 	if err != nil {
 		return controlConfig, nil, err
 	}
-	if cfg.ServerURL == "" {
-		cfg.ServerURL = "https://127.0.0.1:6443"
-	}
 
 	if cfg.Token == "" {
 		fp := filepath.Join(controlConfig.DataDir, "token")


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Backport of https://github.com/k3s-io/k3s/pull/5016 to `engine-1.21`
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bug fix 
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
