### PR TITLE
Sign CSRs for legacy-unknown with the server CA

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -102,8 +102,8 @@ func controllerManager(ctx context.Context, cfg *config.Control, runtime *config
 		"cluster-signing-kubelet-client-key-file":         runtime.ClientCAKey,
 		"cluster-signing-kubelet-serving-cert-file":       runtime.ServerCA,
 		"cluster-signing-kubelet-serving-key-file":        runtime.ServerCAKey,
-		"cluster-signing-legacy-unknown-cert-file":        runtime.ClientCA,
-		"cluster-signing-legacy-unknown-key-file":         runtime.ClientCAKey,
+		"cluster-signing-legacy-unknown-cert-file":        runtime.ServerCA,
+		"cluster-signing-legacy-unknown-key-file":         runtime.ServerCAKey,
 	}
 	if cfg.NoLeaderElect {
 		argsMap["leader-elect"] = "false"


### PR DESCRIPTION
Problem:

CSR using signer as `kubernetes.io/legacy-unknown` are signed with the client CA. Serving certificates must be signed with the server CA otherwise we get error "x509: certificate signed by unknown authority".

Solution:
Updated
"cluster-signing-legacy-unknown-cert-file" &  "cluster-signing-legacy-unknown-key-file"  to ServerCA and ServerCAKey respectively.

#### Linked Issues ####

Issue with Minio Operator and proposed [workaround](https://github.com/minio/operator/issues/860#issuecomment-937898193)