### PR TITLE
[Release-1.22] Check for `--kubeconfig` flag with embedded `kubectl` (#5064)

### DIFF
--- a/pkg/kubectl/main.go
+++ b/pkg/kubectl/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/rancher/k3s/pkg/server"
@@ -17,6 +18,13 @@ import (
 
 func Main() {
 	kubenv := os.Getenv("KUBECONFIG")
+	for i, arg := range os.Args {
+		if strings.HasPrefix(arg, "--kubeconfig=") {
+			kubenv = strings.Split(arg, "=")[1]
+		} else if strings.HasPrefix(arg, "--kubeconfig") && i+1 < len(os.Args) {
+			kubenv = os.Args[i+1]
+		}
+	}
 	if kubenv == "" {
 		config, err := server.HomeKubeConfig(false, false)
 		if _, serr := os.Stat(config); err == nil && serr == nil {


### PR DESCRIPTION
* Check for kubeconfig flag

Signed-off-by: Derek Nola <derek.nola@suse.com>
Backport of https://github.com/k3s-io/k3s/pull/5064

#### Proposed Changes ####
Seeks to address parts of the issue with #1541, by checking for a `--kubeconfig` flag argument. This prevent incorrect [Warning] logs from happening. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- Start up k3s
- Copy out the `/etc/rancher/k3s/k3s.yaml` into another location ( `/tmp/tempconfig` in this example)
- Check that `k3s kubectl get pods -A --kubeconfig /tmp//tempconfig` executes without warnings
- Check that `k3s kubectl get pods -A --kubeconfig=/tmp/tempconfig` executes without warnings
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/5073
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
K3s kubectl now no longer outputs a [WARN] log when using the `--kubeconfig` flag
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
