### PR TITLE
Update CentOS 8 smoke vm's with vault repositories

### DIFF
--- a/tests/vagrant/install/centos-8/Vagrantfile
+++ b/tests/vagrant/install/centos-8/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define 'install-centos-8', primary: true do |test|
     test.vm.hostname = 'smoke'
-    test.vm.provision 'centos8-repos-point2vault', type: 'shell' run: 'once' do |sh|
+    test.vm.provision 'centos8-repos-point2vault', type: 'shell', run: 'once' do |sh|
       sh.env = { :PATH => '/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin' }
       sh.inline = <<~'SHELL'
         #!/bin/sh

--- a/tests/vagrant/install/centos-8/Vagrantfile
+++ b/tests/vagrant/install/centos-8/Vagrantfile
@@ -14,6 +14,14 @@ Vagrant.configure("2") do |config|
 
   config.vm.define 'install-centos-8', primary: true do |test|
     test.vm.hostname = 'smoke'
+    test.vm.provision 'centos8-repos-point2vault', type: 'shell' run: 'once' do |sh|
+      sh.env = { :PATH => '/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin' }
+      sh.inline = <<~'SHELL'
+        #!/bin/sh
+        find /etc/yum.repos.d -type f -name '*.repo' -exec \
+          sed -i -e '/mirrorlist.*/d' -e 's%#baseurl=http://mirror.centos.org%baseurl=http://vault.centos.org%g' {} \;
+      SHELL
+    end
     test.vm.provision 'k3s-upload', type: 'file', run: 'always', source: ENV['TEST_INSTALL_SH'], destination: 'install.sh'
     test.vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
       k3s.installer_url = 'file:///home/vagrant/install.sh'


### PR DESCRIPTION
Problem: CentOS 8 reached its EOL alongside its public mirrors, making
all the smoke test fail at provisioning time.

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Update all CentOS repositories to point [vault.centos.org](https://vault.centos.org/).

#### Types of Changes ####

CI / Smoke tests fix

#### Verification ####

CI Passing on smoke test stage for CentOS 8 vm's

#### Linked Issues ####

#5091 

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

This is a quick fix to unblock CI builds. The long standing one should be either:

1.  Update [dweomer/centos-8.4-amd64](https://github.com/dweomer/vagrantry/tree/main/distro/centos) vagrant images with the same patch
2. Migrate CentOS 8 builds to [CentOS Stream 9](https://www.centos.org/centos-stream/)

Both approaches will require to create and publish new vagrant images for each hypervisor we want to support (currently: vbox, vmware, libvrt).