### PR TITLE
Bootstrap the executor even when the agent is disabled

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -80,8 +80,10 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 			return err
 		}
 		cfg.DataDir = dataDir
-		if err := rootless.Rootless(dataDir); err != nil {
-			return err
+		if !cfg.DisableAgent {
+			if err := rootless.Rootless(dataDir); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -441,12 +443,6 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		}
 	}()
 
-	if cfg.DisableAgent {
-		close(agentReady)
-		<-ctx.Done()
-		return nil
-	}
-
 	ip := serverConfig.ControlConfig.BindAddress
 	if ip == "" {
 		ip = "127.0.0.1"
@@ -468,7 +464,6 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	agentConfig.DisableServiceLB = serverConfig.DisableServiceLB
 	agentConfig.ETCDAgent = serverConfig.ControlConfig.DisableAPIServer
 	agentConfig.ClusterReset = serverConfig.ControlConfig.ClusterReset
-
 	agentConfig.Rootless = cfg.Rootless
 
 	if agentConfig.Rootless {
@@ -484,6 +479,12 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		agentConfig.APIAddressCh = make(chan []string)
 		go getAPIAddressFromEtcd(ctx, serverConfig, agentConfig)
 	}
+
+	if cfg.DisableAgent {
+		agentConfig.ContainerRuntimeEndpoint = "/dev/null"
+		return agent.RunStandalone(ctx, agentConfig)
+	}
+
 	return agent.Run(ctx, agentConfig)
 }
 


### PR DESCRIPTION
#### Proposed Changes ####

Bootstrap the executor even when the agent is disabled.

The executor gets called on to start control-plane components even if the agent is disabled, so we need to at least do enough agent setup to call `executor.Bootstrap` even if we don't want the kubelet and containerd to run.

#### Types of Changes ####

bugfix

#### Verification ####

1. Start `k3s server --disable-agent`
2. Start `k3s agent` on another node
3. Notice that the kube-scheduler starts up after the agent is registered, and pods are successfully scheduled.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5118

#### User-Facing Change ####
```release-note
When using the unsupported `--disable-agent` flag, kube-scheduler will now be started when a node is available.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
