### PR TITLE
Add `--json` flag for `k3s secrets-encrypt status`

### DIFF
--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -38,7 +38,11 @@ func NewSecretsEncryptSubcommands(status, enable, disable, prepare, rotate, reen
 			SkipFlagParsing: false,
 			SkipArgReorder:  true,
 			Action:          status,
-			Flags:           EncryptFlags,
+			Flags: append(EncryptFlags, &cli.BoolFlag{
+				Name:        "json",
+				Usage:       "Output status as JSON.",
+				Destination: &ServerConfig.EncryptJson,
+			}),
 		},
 		{
 			Name:            "enable",

--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -40,7 +40,7 @@ func NewSecretsEncryptSubcommands(status, enable, disable, prepare, rotate, reen
 			Action:          status,
 			Flags: append(EncryptFlags, &cli.StringFlag{
 				Name:        "output,o",
-				Usage:       "Output status as (text|json).",
+				Usage:       "Status format. Default: text. Optional: json",
 				Destination: &ServerConfig.EncryptOutput,
 			}),
 		},

--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -41,7 +41,7 @@ func NewSecretsEncryptSubcommands(status, enable, disable, prepare, rotate, reen
 			Flags: append(EncryptFlags, &cli.BoolFlag{
 				Name:        "json",
 				Usage:       "Output status as JSON.",
-				Destination: &ServerConfig.EncryptJson,
+				Destination: &ServerConfig.EncryptJSON,
 			}),
 		},
 		{

--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -38,10 +38,10 @@ func NewSecretsEncryptSubcommands(status, enable, disable, prepare, rotate, reen
 			SkipFlagParsing: false,
 			SkipArgReorder:  true,
 			Action:          status,
-			Flags: append(EncryptFlags, &cli.BoolFlag{
-				Name:        "json",
-				Usage:       "Output status as JSON.",
-				Destination: &ServerConfig.EncryptJSON,
+			Flags: append(EncryptFlags, &cli.StringFlag{
+				Name:        "output,o",
+				Usage:       "Output status as (text|json).",
+				Destination: &ServerConfig.EncryptOutput,
 			}),
 		},
 		{

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -76,7 +76,7 @@ type Server struct {
 	ClusterResetRestorePath  string
 	EncryptSecrets           bool
 	EncryptForce             bool
-	EncryptJSON              bool
+	EncryptOutput            string
 	EncryptSkip              bool
 	SystemDefaultRegistry    string
 	StartupHooks             []StartupHook

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -76,6 +76,7 @@ type Server struct {
 	ClusterResetRestorePath  string
 	EncryptSecrets           bool
 	EncryptForce             bool
+	EncryptJson              bool
 	EncryptSkip              bool
 	SystemDefaultRegistry    string
 	StartupHooks             []StartupHook

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -76,7 +76,7 @@ type Server struct {
 	ClusterResetRestorePath  string
 	EncryptSecrets           bool
 	EncryptForce             bool
-	EncryptJson              bool
+	EncryptJSON              bool
 	EncryptSkip              bool
 	SystemDefaultRegistry    string
 	StartupHooks             []StartupHook

--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/erikdubbelboer/gspt"
@@ -97,7 +98,7 @@ func Status(app *cli.Context) error {
 		return err
 	}
 
-	if cmds.ServerConfig.EncryptJSON {
+	if strings.ToLower(cmds.ServerConfig.EncryptOutput) == "json" {
 		json, err := json.MarshalIndent(status, "", "\t")
 		if err != nil {
 			return err

--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -20,7 +20,6 @@ import (
 )
 
 func commandPrep(app *cli.Context, cfg *cmds.Server) (*clientaccess.Info, error) {
-	var err error
 	// hide process arguments from ps output, since they may contain
 	// database credentials or other secrets.
 	gspt.SetProcTitle(os.Args[0] + " secrets-encrypt")
@@ -38,11 +37,7 @@ func commandPrep(app *cli.Context, cfg *cmds.Server) (*clientaccess.Info, error)
 		}
 		cfg.Token = string(bytes.TrimRight(tokenByte, "\n"))
 	}
-	info, err := clientaccess.ParseAndValidateTokenForUser(cmds.ServerConfig.ServerURL, cfg.Token, "server")
-	if err != nil {
-		return nil, err
-	}
-	return info, nil
+	return clientaccess.ParseAndValidateTokenForUser(cmds.ServerConfig.ServerURL, cfg.Token, "server")
 }
 
 func Enable(app *cli.Context) error {

--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -97,7 +97,7 @@ func Status(app *cli.Context) error {
 		return err
 	}
 
-	if cmds.ServerConfig.EncryptJson {
+	if cmds.ServerConfig.EncryptJSON {
 		json, err := json.MarshalIndent(status, "", "\t")
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Adds a new --json optional flag that outputs the status in json format. This makes it easier to consume during automated testing.
Cleanup of `CommandPrep` function

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Feature Enhancement 
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
```
$ k3s secrets-encrypt status 
Encryption Status: Enabled
Current Rotation Stage: start
Server Encryption Hashes: All hashes match

Active  Key Type  Name
------  --------  ----
 *      AES-CBC   aescbckey
```
```
$ k3s secrets-encrypt status --json
{
	"stage": "start",
	"activekey": "aescbckey",
	"enable": true,
	"hashmatch": true
}
```
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/5138
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
