### PR TITLE
E2E secrets encryption test

### DIFF
--- a/tests/e2e/amd64_resource_files/secrets.yaml
+++ b/tests/e2e/amd64_resource_files/secrets.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: e2e-secret1
+type: Opaque
+stringData:
+  config.yaml: |
+    key: "hello"
+    val: "world"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: e2e-secret2
+type: Opaque
+stringData:
+  config.yaml: |
+    key: "good"
+    val: "day"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: e2e-secret3
+type: Opaque
+stringData:
+  config.yaml: |
+    key: "top-secret"
+    val: "information"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: e2e-secret4
+type: Opaque
+stringData:
+  config.yaml: |
+    key: "lock"
+    val: "key"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: e2e-secret5
+type: Opaque
+stringData:
+  config.yaml: |
+    key: "last"
+    val: "call"

--- a/tests/e2e/secretsencryption/Vagrantfile
+++ b/tests/e2e/secretsencryption/Vagrantfile
@@ -1,0 +1,88 @@
+ENV['VAGRANT_NO_PARALLEL'] = 'no'
+NODE_ROLES = (ENV['NODE_ROLES'] ||
+  ["server-0", "server-1", "server-2"])
+NODE_BOXES = (ENV['NODE_BOXES'] ||
+  ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
+GITHUB_BRANCH = (ENV['GITHUB_BRANCH'] || "master")
+RELEASE_VERSION = (ENV['RELEASE_VERSION'] || "")
+NODE_CPUS = (ENV['NODE_CPUS'] || 2).to_i
+NODE_MEMORY = (ENV['NODE_MEMORY'] || 1024).to_i
+# Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks 
+NETWORK_PREFIX = "10.10.10"
+install_type = ""
+
+def provision(vm, roles, role_num, node_num)
+  vm.box = NODE_BOXES[node_num]
+  vm.hostname = "#{roles[0]}-#{role_num}"
+  # An expanded netmask is required to allow VM<-->VM communication, virtualbox defaults to /32
+  vm.network "private_network", ip: "#{NETWORK_PREFIX}.#{100+node_num}", netmask: "255.255.255.0"
+
+  vagrant_defaults = '../vagrantdefaults.rb'
+  load vagrant_defaults if File.exists?(vagrant_defaults)
+  
+  defaultOSConfigure(vm)
+  
+  if !RELEASE_VERSION.empty?
+    install_type = "INSTALL_K3S_VERSION=#{RELEASE_VERSION}"
+  else
+    # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
+    vm.provision "shell", path: "../scripts/latest_commit.sh", args: [GITHUB_BRANCH, "/tmp/k3s_commits"]
+    install_type = "INSTALL_K3S_COMMIT=$(head\ -n\ 1\ /tmp/k3s_commits)"
+  end
+  vm.provision "shell", inline: "ping -c 2 k3s.io"
+  
+  if roles.include?("server") && role_num == 0
+    vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+      k3s.args = %W[server --cluster-init --node-external-ip=#{NETWORK_PREFIX}.100 --flannel-iface=eth1 --secrets-encryption]
+      k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+  elsif roles.include?("server") && role_num != 0
+    vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+      k3s.args = %W[server --server https://#{NETWORK_PREFIX}.100:6443 --flannel-iface=eth1 --secrets-encryption]
+      k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+  end
+  if roles.include?("agent")
+    vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+      k3s.args = %W[agent --server https://#{NETWORK_PREFIX}.100:6443 --flannel-iface=eth1 --secrets-encryption]
+      k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+  end
+  if vm.box.include?("microos")
+    vm.provision 'k3s-reload', type: 'reload', run: 'once'
+  end
+end
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = ["vagrant-k3s", "vagrant-reload"]
+  # Default provider is libvirt, virtualbox is only provided as a backup
+  config.vm.provider "libvirt" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+  
+  if NODE_ROLES.kind_of?(String)
+    NODE_ROLES = NODE_ROLES.split(" ", -1)
+  end
+  if NODE_BOXES.kind_of?(String)
+    NODE_BOXES = NODE_BOXES.split(" ", -1)
+  end
+
+  # Must iterate on the index, vagrant does not understand iterating 
+  # over the node roles themselves
+  NODE_ROLES.length.times do |i|
+    name = NODE_ROLES[i]
+    config.vm.define name do |node|
+      roles = name.split("-", -1)
+      role_num = roles.pop.to_i
+      provision(node.vm, roles, role_num, i)
+    end
+  end
+end

--- a/tests/e2e/secretsencryption/Vagrantfile
+++ b/tests/e2e/secretsencryption/Vagrantfile
@@ -44,13 +44,6 @@ def provision(vm, roles, role_num, node_num)
       k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
     end
   end
-  if roles.include?("agent")
-    vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
-      k3s.args = %W[agent --server https://#{NETWORK_PREFIX}.100:6443 --flannel-iface=eth1 --secrets-encryption]
-      k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
-      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
-    end
-  end
   if vm.box.include?("microos")
     vm.provision 'k3s-reload', type: 'reload', run: 'once'
   end

--- a/tests/e2e/secretsencryption/secretsencryption_test.go
+++ b/tests/e2e/secretsencryption/secretsencryption_test.go
@@ -1,0 +1,93 @@
+package secretsencryption
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/k3s/tests/e2e"
+)
+
+// Valid nodeOS: generic/ubuntu2004, opensuse/Leap-15.3.x86_64, dweomer/microos.amd64
+var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
+var serverCount = flag.Int("serverCount", 3, "number of server nodes")
+
+//valid format: RELEASE_VERSION=v1.23.1+k3s2 or nil for latest commit from master
+var installType = flag.String("installType", "", "version or nil to use latest commit")
+
+func Test_E2EClusterValidation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	flag.Parse()
+	RunSpecs(t, "Create Cluster Test Suite")
+}
+
+var (
+	kubeConfigFile  string
+	serverNodenames []string
+)
+
+var _ = Describe("Verify Create", func() {
+	Context("Cluster :", func() {
+		It("Starts up with no issues", func() {
+			var err error
+			serverNodenames, _, err = e2e.CreateCluster(*nodeOS, *serverCount, 0, *installType)
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog)
+			fmt.Println("CLUSTER CONFIG")
+			fmt.Println("OS:", *nodeOS)
+			fmt.Println("Server Nodes:", serverNodenames)
+			kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodenames[0])
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Checks Node and Pod Status", func() {
+			fmt.Printf("\nFetching node status\n")
+			Eventually(func(g Gomega) {
+				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, node := range nodes {
+					g.Expect(node.Status).Should(Equal("Ready"))
+				}
+			}, "420s", "5s").Should(Succeed())
+			_, _ = e2e.ParseNodes(kubeConfigFile, true)
+
+			fmt.Printf("\nFetching Pods status\n")
+			Eventually(func(g Gomega) {
+				pods, err := e2e.ParsePods(kubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, pod := range pods {
+					if strings.Contains(pod.Name, "helm-install") {
+						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
+					} else {
+						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
+					}
+				}
+			}, "420s", "5s").Should(Succeed())
+			_, _ = e2e.ParsePods(kubeConfigFile, true)
+		})
+
+		It("Verifies Encryption Status", func() {
+			cmd := "k3s secrets-encrypt status"
+			for _, nodeName := range serverNodenames {
+				Expect(e2e.RunCmdOnNode(cmd, nodeName)).Should(ContainSubstring("Current Rotation Stage: prepare"))
+			}
+		})
+	})
+})
+
+var failed = false
+var _ = AfterEach(func() {
+	failed = failed || CurrentGinkgoTestDescription().Failed
+})
+
+var _ = AfterSuite(func() {
+	if failed {
+		fmt.Println("FAILED!")
+	} else {
+		Expect(e2e.DestroyCluster()).To(Succeed())
+		Expect(os.Remove(kubeConfigFile)).To(Succeed())
+	}
+})

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -40,15 +40,15 @@ func CountOfStringInSlice(str string, pods []Pod) int {
 }
 
 func CreateCluster(nodeOS string, serverCount int, agentCount int, installType string) ([]string, []string, error) {
-	serverNodeNames := make([]string, serverCount)
+	serverNodenames := make([]string, serverCount)
 	for i := 0; i < serverCount; i++ {
-		serverNodeNames[i] = "server-" + strconv.Itoa(i)
+		serverNodenames[i] = "server-" + strconv.Itoa(i)
 	}
-	agentNodeNames := make([]string, agentCount)
+	agentNodenames := make([]string, agentCount)
 	for i := 0; i < agentCount; i++ {
-		agentNodeNames[i] = "agent-" + strconv.Itoa(i)
+		agentNodenames[i] = "agent-" + strconv.Itoa(i)
 	}
-	nodeRoles := strings.Join(serverNodeNames, " ") + " " + strings.Join(agentNodeNames, " ")
+	nodeRoles := strings.Join(serverNodenames, " ") + " " + strings.Join(agentNodenames, " ")
 
 	nodeRoles = strings.TrimSpace(nodeRoles)
 	nodeBoxes := strings.Repeat(nodeOS+" ", serverCount+agentCount)
@@ -59,7 +59,7 @@ func CreateCluster(nodeOS string, serverCount int, agentCount int, installType s
 		fmt.Println("Error Creating Cluster", err)
 		return nil, nil, err
 	}
-	return serverNodeNames, agentNodeNames, nil
+	return serverNodenames, agentNodenames, nil
 }
 
 func DeployWorkload(workload, kubeconfig string, arch bool) (string, error) {
@@ -206,6 +206,17 @@ func ParsePods(kubeconfig string, print bool) ([]Pod, error) {
 		fmt.Println(podList)
 	}
 	return pods, nil
+}
+
+// RestartCluster restarts the k3s service on each node given
+func RestartCluster(nodeNames []string) error {
+	for _, nodeName := range nodeNames {
+		cmd := "sudo systemctl k3s restart"
+		if _, err := RunCmdOnNode(cmd, nodeName); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // RunCmdOnNode executes a command from within the given node

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -211,7 +210,7 @@ func ParsePods(kubeconfig string, print bool) ([]Pod, error) {
 // RestartCluster restarts the k3s service on each node given
 func RestartCluster(nodeNames []string) error {
 	for _, nodeName := range nodeNames {
-		cmd := "sudo systemctl k3s restart"
+		cmd := "sudo systemctl restart k3s"
 		if _, err := RunCmdOnNode(cmd, nodeName); err != nil {
 			return err
 		}
@@ -221,19 +220,15 @@ func RestartCluster(nodeNames []string) error {
 
 // RunCmdOnNode executes a command from within the given node
 func RunCmdOnNode(cmd string, nodename string) (string, error) {
-	runcmd := "vagrant ssh -c " + cmd + " " + nodename
+	runcmd := "vagrant ssh -c \"" + cmd + "\" " + nodename
 	return RunCommand(runcmd)
 }
 
 // RunCommand executes a command on the host
 func RunCommand(cmd string) (string, error) {
 	c := exec.Command("bash", "-c", cmd)
-	var out bytes.Buffer
-	c.Stdout = &out
-	if err := c.Run(); err != nil {
-		return "", err
-	}
-	return out.String(), nil
+	out, err := c.CombinedOutput()
+	return string(out), err
 }
 
 func UpgradeCluster(serverNodenames []string, agentNodenames []string) error {

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -136,6 +136,18 @@ func GenKubeConfigFile(serverName string) (string, error) {
 	return kubeConfigFile, nil
 }
 
+func GetVagrantLog() string {
+	log, err := os.Open("vagrant.log")
+	if err != nil {
+		return err.Error()
+	}
+	bytes, err := ioutil.ReadAll(log)
+	if err != nil {
+		return err.Error()
+	}
+	return string(bytes)
+}
+
 func ParseNodes(kubeConfig string, print bool) ([]Node, error) {
 	nodes := make([]Node, 0, 10)
 	nodeList := ""

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Verify Upgrade", func() {
 			}, "240s", "5s").Should(ContainSubstring("test-clusterip"), "failed cmd: "+cmd)
 
 			clusterip, _ := e2e.FetchClusterIP(kubeConfigFile, "nginx-clusterip-svc")
-			cmd = "\"curl -L --insecure http://" + clusterip + "/name.html\""
+			cmd = "curl -L --insecure http://" + clusterip + "/name.html"
 			for _, nodeName := range serverNodenames {
 				Eventually(func() (string, error) {
 					return e2e.RunCmdOnNode(cmd, nodeName)
@@ -279,7 +279,7 @@ var _ = Describe("Verify Upgrade", func() {
 			}, "420s", "5s").Should(ContainSubstring("test-clusterip"))
 
 			clusterip, _ := e2e.FetchClusterIP(kubeConfigFile, "nginx-clusterip-svc")
-			cmd := "\"curl -L --insecure http://" + clusterip + "/name.html\""
+			cmd := "curl -L --insecure http://" + clusterip + "/name.html"
 			fmt.Println(cmd)
 			for _, nodeName := range serverNodenames {
 				Eventually(func() (string, error) {

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Verify Upgrade", func() {
 		It("Starts up with no issues", func() {
 			var err error
 			serverNodenames, agentNodenames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount, *installType)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Server Nodes:", serverNodenames)

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Verify Create", func() {
 			}, "240s", "5s").Should(Succeed())
 
 			clusterip, _ := e2e.FetchClusterIP(kubeConfigFile, "nginx-clusterip-svc")
-			cmd := "\"curl -L --insecure http://" + clusterip + "/name.html\""
+			cmd := "curl -L --insecure http://" + clusterip + "/name.html"
 			fmt.Println(cmd)
 			for _, nodeName := range serverNodenames {
 				Eventually(func(g Gomega) {

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Verify Create", func() {
 		It("Starts up with no issues", func() {
 			var err error
 			serverNodenames, agentNodenames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount, *installType)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog)
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Server Nodes:", serverNodenames)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
New E2E test for secrets-encryption rotation on a multinode cluster
Cleanup of testutils helper functions. You can now see the std error output when a command fails.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
New Test
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
`go test -v --timeout=15m ./tests/e2e/secretsencryption/... -run E2E`
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
N/A Internal testing only
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
