### PR TITLE
Add http/2 support to API server

### DIFF
--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -53,6 +53,7 @@ func (c *Cluster) newListener(ctx context.Context) (net.Listener, http.Handler, 
 			ClientAuth:   tls.RequestClientCert,
 			MinVersion:   c.config.TLSMinVersion,
 			CipherSuites: c.config.TLSCipherSuites,
+			NextProtos:   []string{"h2", "http/1.1"},
 		},
 		RegenerateCerts: func() bool {
 			const regenerateDynamicListenerFile = "dynamic-cert-regenerate"


### PR DESCRIPTION
fix issue #5148

Signed-off-by: Kamil Madac <kamil.madac@gmail.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

There are projects which communicates with kube api server via http/2 protocol only, like https://github.com/gardener/gardener. 
But such projects are not working with k3s, because k3s does not have http/2 enabled unlike minikube or original kube-apiserver. This change enables http/2 on k3s-server to be on par with other k8s distributions.

#### Types of Changes ####

Enhancement

#### Verification ####

```
kubectl run tmp-shell --rm -i --tty --image nicolaka/netshoot -- /bin/bash
bash-5.1# curl --http2-prior-knowledge -sSk "https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/" -v
*   Trying 10.43.0.1:443...
* Connected to 10.43.0.1 (10.43.0.1) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Request CERT (13):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Certificate (11):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: O=k3s; CN=k3s
*  start date: Feb 22 08:49:36 2022 GMT
*  expire date: Feb 22 08:49:36 2023 GMT
*  issuer: CN=k3s-server-ca@1645519776
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fce8bed8a90)
> GET / HTTP/2
> Host: 10.43.0.1
> user-agent: curl/7.80.0
> accept: */*
> 
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* Connection state changed (MAX_CONCURRENT_STREAMS == 250)!
< HTTP/2 401 
< audit-id: 03bc7352-7234-411c-9cb3-d76b01f5be9d
< cache-control: no-cache, private
< content-type: application/json
< content-length: 157
< date: Tue, 22 Feb 2022 14:36:17 GMT
< 
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "Unauthorized",
  "reason": "Unauthorized",
  "code": 401
* Connection #0 to host 10.43.0.1 left intact
}
```
 We can see that http/2 is used and k3s api returned valid json.


#### Linked Issues ####

#5148 

#### User-Facing Change ####
NONE

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
