### PR TITLE
Add function to clear local alarms on etcd startup

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -122,6 +122,7 @@ func (e *ETCD) SetControlConfig(config *config.Control) {
 
 // Test ensures that the local node is a voting member of the target cluster.
 // If it is still a learner or not a part of the cluster, an error is raised.
+// If it has any alarms that cannot be disarmed, an error is raised.
 func (e *ETCD) Test(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, testTimeout)
 	defer cancel()
@@ -133,6 +134,10 @@ func (e *ETCD) Test(ctx context.Context) error {
 
 	if status.IsLearner {
 		return errors.New("this server has not yet been promoted from learner to voting member")
+	}
+
+	if err := e.clearAlarms(ctx); err != nil {
+		return errors.Wrap(err, "failed to report and disarm etcd alarms")
 	}
 
 	members, err := e.client.MemberList(ctx)
@@ -730,7 +735,7 @@ func (e *ETCD) RemovePeer(ctx context.Context, name, address string, allowSelfRe
 // manageLearners monitors the etcd cluster to ensure that learners are making progress towards
 // being promoted to full voting member. The checks only run on the cluster member that is
 // the etcd leader.
-func (e *ETCD) manageLearners(ctx context.Context) error {
+func (e *ETCD) manageLearners(ctx context.Context) {
 	<-e.config.Runtime.AgentReady
 	t := time.NewTicker(manageTickerTime)
 	defer t.Stop()
@@ -741,7 +746,7 @@ func (e *ETCD) manageLearners(ctx context.Context) error {
 
 		// Check to see if the local node is the leader. Only the leader should do learner management.
 		if e.client == nil {
-			logrus.Error("Etcd client was nil")
+			logrus.Debug("Etcd client was nil")
 			continue
 		}
 		if status, err := e.client.Status(ctx, endpoint); err != nil {
@@ -772,7 +777,7 @@ func (e *ETCD) manageLearners(ctx context.Context) error {
 			}
 		}
 	}
-	return nil
+	return
 }
 
 // trackLearnerProcess attempts to promote a learner. If it cannot be promoted, progress through the raft index is tracked.
@@ -860,6 +865,41 @@ func (e *ETCD) setLearnerProgress(ctx context.Context, status *learnerProgress) 
 
 	_, err := e.client.Put(ctx, learnerProgressKey, w.String())
 	return err
+}
+
+// clearAlarms checks for any alarms on the local etcd member. If found, they are
+// reported and the alarm state is cleared.
+func (e *ETCD) clearAlarms(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, testTimeout)
+	defer cancel()
+
+	if e.client == nil {
+		return errors.New("etcd client was nil")
+	}
+
+	alarmList, err := e.client.AlarmList(ctx)
+	if err != nil {
+		return fmt.Errorf("etcd alarm list failed: %v", err)
+	}
+	if len(alarmList.Alarms) == 0 {
+		return nil
+	}
+
+	var hasAlarm bool
+	for _, alarm := range alarmList.Alarms {
+		if alarmList.Header.MemberId != alarm.MemberID {
+			continue
+		}
+		logrus.Warnf("Alarm on etcd server: %s", alarm.Alarm)
+		hasAlarm = true
+	}
+	if hasAlarm {
+		if _, err := e.client.AlarmDisarm(ctx, &clientv3.AlarmMember{}); err != nil {
+			return fmt.Errorf("etcd alarm disarm failed: %v", err)
+		}
+		logrus.Infof("Alarms disarmed on etcd server")
+	}
+	return nil
 }
 
 // clientURLs returns a list of all non-learner etcd cluster member client access URLs


### PR DESCRIPTION
#### Proposed Changes ####

Clear alarms on the local etcd member at startup. If any errors reoccur after startup (such as continuing to exceed the disk quota) the alarm will be reasserted.

This is necessary because we don't currently have a good way to clear alarms on the embedded etcd cluster - if the quota was previously exceeded, and then raised by the user, the etcd datastore will remain read-only until the alarm is cleared. Unfortunately if the datastore is read-only, the apiserver will quickly fail to write to etcd and exit, taking the whole service (including etcd) down before the user can do anything about it.

#### Types of Changes ####

bugfix

#### Verification ####

* Start a multi-node cluster with `k3s server --cluster-init --etcd-arg=quota-backend-bytes=$((1*1024*1024))` to set a 1mb storage limit
* Wait for k3s to fail due to: `etcdserver: mvcc: database space exceeded`
* Start `k3s server --cluster-init --etcd-arg=quota-backend-bytes=$((1024*1024*1024))` to set a 1gb storage limit
* Note that the error is reported and cleared, and K3s starts up successfully

Prior to this fix, the final step will fail, as the "database space exceeded" alarm remains despite the quota being raised.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/4787

#### User-Facing Change ####
```release-note
Any alarms present on the embedded etcd datastore are now reported and cleared at startup. This should allow for graceful recovery after exceeding and subsequently raising the etcd quota size.
```

#### Further Comments ####

