### PR TITLE
Clean up duplicated fields and parameters

### DIFF
--- a/pkg/cli/cert/cert.go
+++ b/pkg/cli/cert/cert.go
@@ -77,7 +77,7 @@ func rotate(app *cli.Context, cfg *cmds.Server) error {
 
 	serverConfig.ControlConfig.DataDir = serverDataDir
 	serverConfig.ControlConfig.Runtime = &config.ControlRuntime{}
-	deps.CreateRuntimeCertFiles(&serverConfig.ControlConfig, serverConfig.ControlConfig.Runtime)
+	deps.CreateRuntimeCertFiles(&serverConfig.ControlConfig)
 
 	if err := validateCertConfig(); err != nil {
 		return err

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -386,7 +386,7 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 		if ec != nil {
 			etcdConfig = *ec
 		} else {
-			etcdConfig = c.EtcdConfig
+			etcdConfig = c.config.Runtime.EtcdConfig
 		}
 
 		storageClient, err := client.New(etcdConfig)

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -196,7 +196,7 @@ func createTmpDataDir(src, dst string) error {
 func (c *Cluster) shouldBootstrapLoad(ctx context.Context) (bool, bool, error) {
 	// Non-nil managedDB indicates that the database is either initialized, initializing, or joining
 	if c.managedDB != nil {
-		c.runtime.HTTPBootstrap = true
+		c.config.Runtime.HTTPBootstrap = true
 
 		isInitialized, err := c.managedDB.IsInitialized(ctx, c.config)
 		if err != nil {
@@ -363,7 +363,7 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 	if c.managedDB != nil && !isHTTP {
 		token := c.config.Token
 		if token == "" {
-			tokenFromFile, err := readTokenFromFile(c.runtime.ServerToken, c.runtime.ServerCA, c.config.DataDir)
+			tokenFromFile, err := readTokenFromFile(c.config.Runtime.ServerToken, c.config.Runtime.ServerCA, c.config.DataDir)
 			if err != nil {
 				return err
 			}
@@ -600,7 +600,7 @@ func (c *Cluster) httpBootstrap(ctx context.Context) error {
 
 func (c *Cluster) retrieveInitializedDBdata(ctx context.Context) (*bytes.Buffer, error) {
 	var buf bytes.Buffer
-	if err := bootstrap.ReadFromDisk(&buf, &c.runtime.ControlRuntimeBootstrap); err != nil {
+	if err := bootstrap.ReadFromDisk(&buf, &c.config.Runtime.ControlRuntimeBootstrap); err != nil {
 		return nil, err
 	}
 
@@ -612,7 +612,7 @@ func (c *Cluster) bootstrap(ctx context.Context) error {
 	c.joining = true
 
 	// bootstrap managed database via HTTPS
-	if c.runtime.HTTPBootstrap {
+	if c.config.Runtime.HTTPBootstrap {
 		// Assuming we should just compare on managed databases
 		if err := c.compareConfig(); err != nil {
 			return errors.Wrap(err, "failed to validate server configuration")

--- a/pkg/cluster/bootstrap_test.go
+++ b/pkg/cluster/bootstrap_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/k3s-io/kine/pkg/endpoint"
 	"github.com/rancher/k3s/pkg/bootstrap"
 	"github.com/rancher/k3s/pkg/clientaccess"
 	"github.com/rancher/k3s/pkg/cluster/managed"
@@ -90,7 +89,6 @@ func TestCluster_certDirsExist(t *testing.T) {
 		clientAccessInfo *clientaccess.Info
 		config           *config.Control
 		managedDB        managed.Driver
-		etcdConfig       endpoint.ETCDConfig
 		shouldBootstrap  bool
 		storageStarted   bool
 		saveBootstrap    bool
@@ -131,7 +129,6 @@ func TestCluster_certDirsExist(t *testing.T) {
 				clientAccessInfo: tt.fields.clientAccessInfo,
 				config:           tt.fields.config,
 				managedDB:        tt.fields.managedDB,
-				EtcdConfig:       tt.fields.etcdConfig,
 				storageStarted:   tt.fields.storageStarted,
 				saveBootstrap:    tt.fields.saveBootstrap,
 			}
@@ -152,7 +149,6 @@ func TestCluster_migrateBootstrapData(t *testing.T) {
 		clientAccessInfo *clientaccess.Info
 		config           *config.Control
 		managedDB        managed.Driver
-		etcdConfig       endpoint.ETCDConfig
 		joining          bool
 		storageStarted   bool
 		saveBootstrap    bool
@@ -207,7 +203,6 @@ func TestCluster_Snapshot(t *testing.T) {
 		clientAccessInfo *clientaccess.Info
 		config           *config.Control
 		managedDB        managed.Driver
-		etcdConfig       endpoint.ETCDConfig
 		joining          bool
 		storageStarted   bool
 		saveBootstrap    bool
@@ -238,7 +233,6 @@ func TestCluster_Snapshot(t *testing.T) {
 				clientAccessInfo: tt.fields.clientAccessInfo,
 				config:           tt.fields.config,
 				managedDB:        tt.fields.managedDB,
-				EtcdConfig:       tt.fields.etcdConfig,
 				joining:          tt.fields.joining,
 				storageStarted:   tt.fields.storageStarted,
 				saveBootstrap:    tt.fields.saveBootstrap,

--- a/pkg/cluster/bootstrap_test.go
+++ b/pkg/cluster/bootstrap_test.go
@@ -82,13 +82,13 @@ func Test_isDirEmpty(t *testing.T) {
 func TestCluster_certDirsExist(t *testing.T) {
 	const testDataDir = "/tmp/k3s/"
 
+	testCredDir := filepath.Join(testDataDir, "server", "cred")
 	testTLSDir := filepath.Join(testDataDir, "server", "tls")
 	testTLSEtcdDir := filepath.Join(testDataDir, "server", "tls", "etcd")
 
 	type fields struct {
 		clientAccessInfo *clientaccess.Info
 		config           *config.Control
-		runtime          *config.ControlRuntime
 		managedDB        managed.Driver
 		etcdConfig       endpoint.ETCDConfig
 		shouldBootstrap  bool
@@ -110,8 +110,10 @@ func TestCluster_certDirsExist(t *testing.T) {
 				},
 			},
 			setup: func() error {
+				os.MkdirAll(testCredDir, 0700)
 				os.MkdirAll(testTLSEtcdDir, 0700)
 
+				_, _ = os.Create(filepath.Join(testCredDir, "test_file"))
 				_, _ = os.Create(filepath.Join(testTLSDir, "test_file"))
 				_, _ = os.Create(filepath.Join(testTLSEtcdDir, "test_file"))
 
@@ -128,7 +130,6 @@ func TestCluster_certDirsExist(t *testing.T) {
 			c := &Cluster{
 				clientAccessInfo: tt.fields.clientAccessInfo,
 				config:           tt.fields.config,
-				runtime:          tt.fields.runtime,
 				managedDB:        tt.fields.managedDB,
 				EtcdConfig:       tt.fields.etcdConfig,
 				storageStarted:   tt.fields.storageStarted,
@@ -150,7 +151,6 @@ func TestCluster_migrateBootstrapData(t *testing.T) {
 	type fields struct {
 		clientAccessInfo *clientaccess.Info
 		config           *config.Control
-		runtime          *config.ControlRuntime
 		managedDB        managed.Driver
 		etcdConfig       endpoint.ETCDConfig
 		joining          bool
@@ -206,7 +206,6 @@ func TestCluster_Snapshot(t *testing.T) {
 	type fields struct {
 		clientAccessInfo *clientaccess.Info
 		config           *config.Control
-		runtime          *config.ControlRuntime
 		managedDB        managed.Driver
 		etcdConfig       endpoint.ETCDConfig
 		joining          bool
@@ -238,7 +237,6 @@ func TestCluster_Snapshot(t *testing.T) {
 			c := &Cluster{
 				clientAccessInfo: tt.fields.clientAccessInfo,
 				config:           tt.fields.config,
-				runtime:          tt.fields.runtime,
 				managedDB:        tt.fields.managedDB,
 				EtcdConfig:       tt.fields.etcdConfig,
 				joining:          tt.fields.joining,

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -18,7 +18,6 @@ import (
 type Cluster struct {
 	clientAccessInfo *clientaccess.Info
 	config           *config.Control
-	runtime          *config.ControlRuntime
 	managedDB        managed.Driver
 	EtcdConfig       endpoint.ETCDConfig
 	joining          bool
@@ -149,7 +148,6 @@ func (c *Cluster) startStorage(ctx context.Context) error {
 // New creates an initial cluster using the provided configuration.
 func New(config *config.Control) *Cluster {
 	return &Cluster{
-		config:  config,
-		runtime: config.Runtime,
+		config: config,
 	}
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -19,7 +19,6 @@ type Cluster struct {
 	clientAccessInfo *clientaccess.Info
 	config           *config.Control
 	managedDB        managed.Driver
-	EtcdConfig       endpoint.ETCDConfig
 	joining          bool
 	storageStarted   bool
 	saveBootstrap    bool
@@ -84,7 +83,7 @@ func (c *Cluster) Start(ctx context.Context) (<-chan struct{}, error) {
 
 	// if necessary, store bootstrap data to datastore
 	if c.saveBootstrap {
-		if err := Save(ctx, c.config, c.EtcdConfig, false); err != nil {
+		if err := Save(ctx, c.config, false); err != nil {
 			return nil, err
 		}
 	}
@@ -98,7 +97,7 @@ func (c *Cluster) Start(ctx context.Context) (<-chan struct{}, error) {
 			for {
 				select {
 				case <-ready:
-					if err := Save(ctx, c.config, c.EtcdConfig, false); err != nil {
+					if err := Save(ctx, c.config, false); err != nil {
 						panic(err)
 					}
 
@@ -138,7 +137,7 @@ func (c *Cluster) startStorage(ctx context.Context) error {
 	// Persist the returned etcd configuration. We decide if we're doing leader election for embedded controllers
 	// based on what the kine wrapper tells us about the datastore. Single-node datastores like sqlite don't require
 	// leader election, while basically all others (etcd, external database, etc) do since they allow multiple servers.
-	c.EtcdConfig = etcdConfig
+	c.config.Runtime.EtcdConfig = etcdConfig
 	c.config.Datastore.BackendTLSConfig = etcdConfig.TLSConfig
 	c.config.Datastore.Endpoint = strings.Join(etcdConfig.Endpoints, ",")
 	c.config.NoLeaderElect = !etcdConfig.LeaderElect

--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -39,11 +39,11 @@ func (c *Cluster) newListener(ctx context.Context) (net.Listener, http.Handler, 
 	if err != nil {
 		return nil, nil, err
 	}
-	cert, key, err := factory.LoadCerts(c.runtime.ServerCA, c.runtime.ServerCAKey)
+	cert, key, err := factory.LoadCerts(c.config.Runtime.ServerCA, c.config.Runtime.ServerCAKey)
 	if err != nil {
 		return nil, nil, err
 	}
-	storage := tlsStorage(ctx, c.config.DataDir, c.runtime)
+	storage := tlsStorage(ctx, c.config.DataDir, c.config.Runtime)
 	return dynamiclistener.NewListener(tcp, storage, cert, key, dynamiclistener.Config{
 		ExpirationDaysCheck: config.CertificateRenewDays,
 		Organization:        []string{version.Program},

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -184,11 +184,11 @@ func (c *Cluster) deleteNodePasswdSecret(ctx context.Context) {
 		}
 		// the core factory may not yet be initialized so we
 		// want to wait until it is so not to evoke a panic.
-		if c.runtime.Core == nil {
+		if c.config.Runtime.Core == nil {
 			logrus.Infof("runtime is not yet initialized")
 			continue
 		}
-		secretsClient := c.runtime.Core.Core().V1().Secret()
+		secretsClient := c.config.Runtime.Core.Core().V1().Secret()
 		if err := nodepassword.Delete(secretsClient, nodeName); err != nil {
 			if apierrors.IsNotFound(err) {
 				logrus.Debugf("node password secret is not found for node %s", nodeName)

--- a/pkg/cluster/router.go
+++ b/pkg/cluster/router.go
@@ -19,11 +19,11 @@ func (c *Cluster) getHandler(handler http.Handler) (http.Handler, error) {
 // if no additional handlers are available.
 func (c *Cluster) router() http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if c.runtime.Handler == nil {
+		if c.config.Runtime.Handler == nil {
 			http.Error(rw, "starting", http.StatusServiceUnavailable)
 			return
 		}
 
-		c.runtime.Handler.ServeHTTP(rw, req)
+		c.config.Runtime.Handler.ServeHTTP(rw, req)
 	})
 }

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -107,7 +107,7 @@ func (c *Cluster) storageBootstrap(ctx context.Context) error {
 
 	token := c.config.Token
 	if token == "" {
-		tokenFromFile, err := readTokenFromFile(c.runtime.ServerToken, c.runtime.ServerCA, c.config.DataDir)
+		tokenFromFile, err := readTokenFromFile(c.config.Runtime.ServerToken, c.config.Runtime.ServerCA, c.config.DataDir)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/k3s-io/kine/pkg/client"
-	"github.com/k3s-io/kine/pkg/endpoint"
 	"github.com/rancher/k3s/pkg/bootstrap"
 	"github.com/rancher/k3s/pkg/clientaccess"
 	"github.com/rancher/k3s/pkg/daemons/config"
@@ -21,7 +20,7 @@ import (
 // snapshot of the cluster's CA certs and keys, encryption passphrases, etc - encrypted with the join token.
 // This is used when bootstrapping a cluster from a managed database or external etcd cluster.
 // This is NOT used with embedded etcd, which bootstraps over HTTP.
-func Save(ctx context.Context, config *config.Control, etcdConfig endpoint.ETCDConfig, override bool) error {
+func Save(ctx context.Context, config *config.Control, override bool) error {
 	buf := &bytes.Buffer{}
 	if err := bootstrap.ReadFromDisk(buf, &config.Runtime.ControlRuntimeBootstrap); err != nil {
 		return err
@@ -44,7 +43,7 @@ func Save(ctx context.Context, config *config.Control, etcdConfig endpoint.ETCDC
 		return err
 	}
 
-	storageClient, err := client.New(etcdConfig)
+	storageClient, err := client.New(config.Runtime.EtcdConfig)
 	if err != nil {
 		return err
 	}
@@ -99,7 +98,7 @@ func (c *Cluster) storageBootstrap(ctx context.Context) error {
 		return err
 	}
 
-	storageClient, err := client.New(c.EtcdConfig)
+	storageClient, err := client.New(c.config.Runtime.EtcdConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -93,7 +93,8 @@ func KubeConfig(dest, url, caCert, clientCert, clientKey string) error {
 
 // CreateRuntimeCertFiles is responsible for filling out all the
 // .crt and .key filenames for a ControlRuntime.
-func CreateRuntimeCertFiles(config *config.Control, runtime *config.ControlRuntime) {
+func CreateRuntimeCertFiles(config *config.Control) {
+	runtime := config.Runtime
 	runtime.ClientCA = filepath.Join(config.DataDir, "tls", "client-ca.crt")
 	runtime.ClientCAKey = filepath.Join(config.DataDir, "tls", "client-ca.key")
 	runtime.ServerCA = filepath.Join(config.DataDir, "tls", "server-ca.crt")
@@ -155,8 +156,9 @@ func CreateRuntimeCertFiles(config *config.Control, runtime *config.ControlRunti
 
 // GenServerDeps is responsible for generating the cluster dependencies
 // needed to successfully bootstrap a cluster.
-func GenServerDeps(config *config.Control, runtime *config.ControlRuntime) error {
-	if err := genCerts(config, runtime); err != nil {
+func GenServerDeps(config *config.Control) error {
+	runtime := config.Runtime
+	if err := genCerts(config); err != nil {
 		return err
 	}
 
@@ -164,15 +166,15 @@ func GenServerDeps(config *config.Control, runtime *config.ControlRuntime) error
 		return err
 	}
 
-	if err := genUsers(config, runtime); err != nil {
+	if err := genUsers(config); err != nil {
 		return err
 	}
 
-	if err := genEncryptedNetworkInfo(config, runtime); err != nil {
+	if err := genEncryptedNetworkInfo(config); err != nil {
 		return err
 	}
 
-	if err := genEncryptionConfigAndState(config, runtime); err != nil {
+	if err := genEncryptionConfigAndState(config); err != nil {
 		return err
 	}
 
@@ -205,7 +207,8 @@ func getNodePass(config *config.Control, serverPass string) string {
 	return config.AgentToken
 }
 
-func genUsers(config *config.Control, runtime *config.ControlRuntime) error {
+func genUsers(config *config.Control) error {
+	runtime := config.Runtime
 	passwd, err := passwd.Read(runtime.PasswdFile)
 	if err != nil {
 		return err
@@ -233,7 +236,8 @@ func genUsers(config *config.Control, runtime *config.ControlRuntime) error {
 	return passwd.Write(runtime.PasswdFile)
 }
 
-func genEncryptedNetworkInfo(controlConfig *config.Control, runtime *config.ControlRuntime) error {
+func genEncryptedNetworkInfo(controlConfig *config.Control) error {
+	runtime := controlConfig.Runtime
 	if s, err := os.Stat(runtime.IPSECKey); err == nil && s.Size() > 0 {
 		psk, err := ioutil.ReadFile(runtime.IPSECKey)
 		if err != nil {
@@ -271,17 +275,17 @@ func getServerPass(passwd *passwd.Passwd, config *config.Control) (string, error
 	return serverPass, nil
 }
 
-func genCerts(config *config.Control, runtime *config.ControlRuntime) error {
-	if err := genClientCerts(config, runtime); err != nil {
+func genCerts(config *config.Control) error {
+	if err := genClientCerts(config); err != nil {
 		return err
 	}
-	if err := genServerCerts(config, runtime); err != nil {
+	if err := genServerCerts(config); err != nil {
 		return err
 	}
-	if err := genRequestHeaderCerts(config, runtime); err != nil {
+	if err := genRequestHeaderCerts(config); err != nil {
 		return err
 	}
-	return genETCDCerts(config, runtime)
+	return genETCDCerts(config)
 }
 
 func getSigningCertFactory(regen bool, altNames *certutil.AltNames, extKeyUsage []x509.ExtKeyUsage, caCertFile, caKeyFile string) signedCertFactory {
@@ -290,7 +294,8 @@ func getSigningCertFactory(regen bool, altNames *certutil.AltNames, extKeyUsage 
 	}
 }
 
-func genClientCerts(config *config.Control, runtime *config.ControlRuntime) error {
+func genClientCerts(config *config.Control) error {
+	runtime := config.Runtime
 	regen, err := createSigningCertKey(version.Program+"-client", runtime.ClientCA, runtime.ClientCAKey)
 	if err != nil {
 		return err
@@ -366,8 +371,9 @@ func genClientCerts(config *config.Control, runtime *config.ControlRuntime) erro
 	return nil
 }
 
-func genServerCerts(config *config.Control, runtime *config.ControlRuntime) error {
-	regen, err := createServerSigningCertKey(config, runtime)
+func genServerCerts(config *config.Control) error {
+	runtime := config.Runtime
+	regen, err := createServerSigningCertKey(config)
 	if err != nil {
 		return err
 	}
@@ -392,7 +398,8 @@ func genServerCerts(config *config.Control, runtime *config.ControlRuntime) erro
 	return nil
 }
 
-func genETCDCerts(config *config.Control, runtime *config.ControlRuntime) error {
+func genETCDCerts(config *config.Control) error {
+	runtime := config.Runtime
 	regen, err := createSigningCertKey("etcd-server", runtime.ETCDServerCA, runtime.ETCDServerCAKey)
 	if err != nil {
 		return err
@@ -430,7 +437,8 @@ func genETCDCerts(config *config.Control, runtime *config.ControlRuntime) error 
 	return nil
 }
 
-func genRequestHeaderCerts(config *config.Control, runtime *config.ControlRuntime) error {
+func genRequestHeaderCerts(config *config.Control) error {
+	runtime := config.Runtime
 	regen, err := createSigningCertKey(version.Program+"-request-header", runtime.RequestHeaderCA, runtime.RequestHeaderCAKey)
 	if err != nil {
 		return err
@@ -448,7 +456,8 @@ func genRequestHeaderCerts(config *config.Control, runtime *config.ControlRuntim
 
 type signedCertFactory = func(commonName string, organization []string, certFile, keyFile string) (bool, error)
 
-func createServerSigningCertKey(config *config.Control, runtime *config.ControlRuntime) (bool, error) {
+func createServerSigningCertKey(config *config.Control) (bool, error) {
+	runtime := config.Runtime
 	TokenCA := filepath.Join(config.DataDir, "tls", "token-ca.crt")
 	TokenCAKey := filepath.Join(config.DataDir, "tls", "token-ca.key")
 
@@ -652,7 +661,8 @@ func expired(certFile string, pool *x509.CertPool) bool {
 	return certutil.IsCertExpired(certificates[0], config.CertificateRenewDays)
 }
 
-func genEncryptionConfigAndState(controlConfig *config.Control, runtime *config.ControlRuntime) error {
+func genEncryptionConfigAndState(controlConfig *config.Control) error {
+	runtime := controlConfig.Runtime
 	if !controlConfig.EncryptSecrets {
 		return nil
 	}

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -262,7 +262,6 @@ func prepare(ctx context.Context, config *config.Control) error {
 	}
 
 	config.Runtime.ETCDReady = ready
-	config.Runtime.EtcdConfig = cluster.EtcdConfig
 	return nil
 }
 

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -35,46 +35,45 @@ var localhostIP = net.ParseIP("127.0.0.1")
 
 func Server(ctx context.Context, cfg *config.Control) error {
 	rand.Seed(time.Now().UTC().UnixNano())
-	runtime := cfg.Runtime
 
-	if err := prepare(ctx, cfg, runtime); err != nil {
+	if err := prepare(ctx, cfg); err != nil {
 		return errors.Wrap(err, "preparing server")
 	}
 
 	cfg.Runtime.Tunnel = setupTunnel()
 	proxyutil.DisableProxyHostnameCheck = true
 
-	basicAuth, err := basicAuthenticator(runtime.PasswdFile)
+	basicAuth, err := basicAuthenticator(cfg.Runtime.PasswdFile)
 	if err != nil {
 		return err
 	}
-	runtime.Authenticator = basicAuth
+	cfg.Runtime.Authenticator = basicAuth
 
 	if !cfg.DisableAPIServer {
-		go waitForAPIServerHandlers(ctx, runtime)
+		go waitForAPIServerHandlers(ctx, cfg.Runtime)
 
-		if err := apiServer(ctx, cfg, runtime); err != nil {
+		if err := apiServer(ctx, cfg); err != nil {
 			return err
 		}
 
-		if err := waitForAPIServerInBackground(ctx, runtime); err != nil {
+		if err := waitForAPIServerInBackground(ctx, cfg.Runtime); err != nil {
 			return err
 		}
 	}
 
 	if !cfg.DisableScheduler {
-		if err := scheduler(ctx, cfg, runtime); err != nil {
+		if err := scheduler(ctx, cfg); err != nil {
 			return err
 		}
 	}
 	if !cfg.DisableControllerManager {
-		if err := controllerManager(ctx, cfg, runtime); err != nil {
+		if err := controllerManager(ctx, cfg); err != nil {
 			return err
 		}
 	}
 
 	if !cfg.DisableCCM {
-		if err := cloudControllerManager(ctx, cfg, runtime); err != nil {
+		if err := cloudControllerManager(ctx, cfg); err != nil {
 			return err
 		}
 	}
@@ -82,7 +81,8 @@ func Server(ctx context.Context, cfg *config.Control) error {
 	return nil
 }
 
-func controllerManager(ctx context.Context, cfg *config.Control, runtime *config.ControlRuntime) error {
+func controllerManager(ctx context.Context, cfg *config.Control) error {
+	runtime := cfg.Runtime
 	argsMap := map[string]string{
 		"feature-gates":                    "JobTrackingWithFinalizers=true",
 		"kubeconfig":                       runtime.KubeConfigController,
@@ -116,10 +116,11 @@ func controllerManager(ctx context.Context, cfg *config.Control, runtime *config
 	args := config.GetArgs(argsMap, cfg.ExtraControllerArgs)
 	logrus.Infof("Running kube-controller-manager %s", config.ArgString(args))
 
-	return executor.ControllerManager(ctx, runtime.APIServerReady, args)
+	return executor.ControllerManager(ctx, cfg.Runtime.APIServerReady, args)
 }
 
-func scheduler(ctx context.Context, cfg *config.Control, runtime *config.ControlRuntime) error {
+func scheduler(ctx context.Context, cfg *config.Control) error {
+	runtime := cfg.Runtime
 	argsMap := map[string]string{
 		"kubeconfig":                runtime.KubeConfigScheduler,
 		"authorization-kubeconfig":  runtime.KubeConfigScheduler,
@@ -134,10 +135,11 @@ func scheduler(ctx context.Context, cfg *config.Control, runtime *config.Control
 	args := config.GetArgs(argsMap, cfg.ExtraSchedulerAPIArgs)
 
 	logrus.Infof("Running kube-scheduler %s", config.ArgString(args))
-	return executor.Scheduler(ctx, runtime.APIServerReady, args)
+	return executor.Scheduler(ctx, cfg.Runtime.APIServerReady, args)
 }
 
-func apiServer(ctx context.Context, cfg *config.Control, runtime *config.ControlRuntime) error {
+func apiServer(ctx context.Context, cfg *config.Control) error {
+	runtime := cfg.Runtime
 	argsMap := map[string]string{
 		"feature-gates": "JobTrackingWithFinalizers=true",
 	}
@@ -225,7 +227,7 @@ func defaults(config *config.Control) {
 	}
 }
 
-func prepare(ctx context.Context, config *config.Control, runtime *config.ControlRuntime) error {
+func prepare(ctx context.Context, config *config.Control) error {
 	var err error
 
 	defaults(config)
@@ -242,7 +244,7 @@ func prepare(ctx context.Context, config *config.Control, runtime *config.Contro
 	os.MkdirAll(filepath.Join(config.DataDir, "tls"), 0700)
 	os.MkdirAll(filepath.Join(config.DataDir, "cred"), 0700)
 
-	deps.CreateRuntimeCertFiles(config, runtime)
+	deps.CreateRuntimeCertFiles(config)
 
 	cluster := cluster.New(config)
 
@@ -250,7 +252,7 @@ func prepare(ctx context.Context, config *config.Control, runtime *config.Contro
 		return err
 	}
 
-	if err := deps.GenServerDeps(config, runtime); err != nil {
+	if err := deps.GenServerDeps(config); err != nil {
 		return err
 	}
 
@@ -259,8 +261,8 @@ func prepare(ctx context.Context, config *config.Control, runtime *config.Contro
 		return err
 	}
 
-	runtime.ETCDReady = ready
-	runtime.EtcdConfig = cluster.EtcdConfig
+	config.Runtime.ETCDReady = ready
+	config.Runtime.EtcdConfig = cluster.EtcdConfig
 	return nil
 }
 
@@ -282,7 +284,8 @@ func setupStorageBackend(argsMap map[string]string, cfg *config.Control) {
 	}
 }
 
-func cloudControllerManager(ctx context.Context, cfg *config.Control, runtime *config.ControlRuntime) error {
+func cloudControllerManager(ctx context.Context, cfg *config.Control) error {
+	runtime := cfg.Runtime
 	argsMap := map[string]string{
 		"profiling":                    "false",
 		"allocate-node-cidrs":          "true",
@@ -313,7 +316,7 @@ func cloudControllerManager(ctx context.Context, cfg *config.Control, runtime *c
 			select {
 			case <-ctx.Done():
 				return
-			case <-runtime.APIServerReady:
+			case <-cfg.Runtime.APIServerReady:
 				break apiReadyLoop
 			case <-time.After(30 * time.Second):
 				logrus.Infof("Waiting for API server to become available")
@@ -325,7 +328,7 @@ func cloudControllerManager(ctx context.Context, cfg *config.Control, runtime *c
 			select {
 			case <-ctx.Done():
 				return
-			case err := <-promise(func() error { return checkForCloudControllerPrivileges(ctx, runtime, 5*time.Second) }):
+			case err := <-promise(func() error { return checkForCloudControllerPrivileges(ctx, cfg.Runtime, 5*time.Second) }):
 				if err != nil {
 					logrus.Infof("Waiting for cloud-controller-manager privileges to become available: %v", err)
 					continue

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -84,7 +84,6 @@ type ETCD struct {
 	client  *clientv3.Client
 	config  *config.Control
 	name    string
-	runtime *config.ControlRuntime
 	address string
 	cron    *cron.Cron
 	s3      *S3
@@ -196,7 +195,7 @@ func (e *ETCD) IsInitialized(ctx context.Context, config *config.Control) (bool,
 func (e *ETCD) Reset(ctx context.Context, rebootstrap func() error) error {
 	// Wait for etcd to come up as a new single-node cluster, then exit
 	go func() {
-		<-e.runtime.AgentReady
+		<-e.config.Runtime.AgentReady
 		t := time.NewTicker(5 * time.Second)
 		defer t.Stop()
 		for range t.C {
@@ -219,7 +218,7 @@ func (e *ETCD) Reset(ctx context.Context, rebootstrap func() error) error {
 				}
 
 				// call functions to rewrite them from daemons/control/server.go (prepare())
-				if err := deps.GenServerDeps(e.config, e.runtime); err != nil {
+				if err := deps.GenServerDeps(e.config); err != nil {
 					logrus.Fatal(err)
 				}
 
@@ -320,7 +319,7 @@ func (e *ETCD) Start(ctx context.Context, clientAccessInfo *clientaccess.Info) e
 	}
 
 	go func() {
-		<-e.runtime.AgentReady
+		<-e.config.Runtime.AgentReady
 		if err := e.join(ctx, clientAccessInfo); err != nil {
 			logrus.Fatalf("ETCD join failed: %v", err)
 		}
@@ -344,7 +343,7 @@ func (e *ETCD) join(ctx context.Context, clientAccessInfo *clientaccess.Info) er
 		return err
 	}
 
-	client, err := GetClient(clientCtx, e.runtime, clientURLs...)
+	client, err := GetClient(clientCtx, e.config.Runtime, clientURLs...)
 	if err != nil {
 		return err
 	}
@@ -420,9 +419,8 @@ func (e *ETCD) join(ctx context.Context, clientAccessInfo *clientaccess.Info) er
 // Register configures a new etcd client and adds db info routes for the http request handler.
 func (e *ETCD) Register(ctx context.Context, config *config.Control, handler http.Handler) (http.Handler, error) {
 	e.config = config
-	e.runtime = config.Runtime
 
-	client, err := GetClient(ctx, e.runtime, endpoint)
+	client, err := GetClient(ctx, e.config.Runtime, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -434,9 +432,9 @@ func (e *ETCD) Register(ctx context.Context, config *config.Control, handler htt
 	}
 	e.address = address
 	e.config.Datastore.Endpoint = endpoint
-	e.config.Datastore.BackendTLSConfig.CAFile = e.runtime.ETCDServerCA
-	e.config.Datastore.BackendTLSConfig.CertFile = e.runtime.ClientETCDCert
-	e.config.Datastore.BackendTLSConfig.KeyFile = e.runtime.ClientETCDKey
+	e.config.Datastore.BackendTLSConfig.CAFile = e.config.Runtime.ETCDServerCA
+	e.config.Datastore.BackendTLSConfig.CertFile = e.config.Runtime.ClientETCDCert
+	e.config.Datastore.BackendTLSConfig.KeyFile = e.config.Runtime.ClientETCDKey
 
 	tombstoneFile := filepath.Join(DBDir(e.config), "tombstone")
 	if _, err := os.Stat(tombstoneFile); err == nil {
@@ -623,7 +621,7 @@ func (e *ETCD) migrateFromSQLite(ctx context.Context) error {
 	}
 	defer sqliteClient.Close()
 
-	etcdClient, err := GetClient(ctx, e.runtime, "https://localhost:2379")
+	etcdClient, err := GetClient(ctx, e.config.Runtime, "https://localhost:2379")
 	if err != nil {
 		return err
 	}
@@ -733,7 +731,7 @@ func (e *ETCD) RemovePeer(ctx context.Context, name, address string, allowSelfRe
 // being promoted to full voting member. The checks only run on the cluster member that is
 // the etcd leader.
 func (e *ETCD) manageLearners(ctx context.Context) error {
-	<-e.runtime.AgentReady
+	<-e.config.Runtime.AgentReady
 	t := time.NewTicker(manageTickerTime)
 	defer t.Stop()
 
@@ -937,9 +935,6 @@ func (e *ETCD) preSnapshotSetup(ctx context.Context, config *config.Control) err
 		}
 		e.client = client
 	}
-	if e.runtime == nil {
-		e.runtime = config.Runtime
-	}
 	return nil
 }
 
@@ -1069,7 +1064,7 @@ func (e *ETCD) Snapshot(ctx context.Context, config *config.Control) error {
 		return errors.Wrap(err, "failed to get the snapshot dir")
 	}
 
-	cfg, err := getClientConfig(ctx, e.runtime, endpoint)
+	cfg, err := getClientConfig(ctx, e.config.Runtime, endpoint)
 	if err != nil {
 		return errors.Wrap(err, "failed to get config for etcd snapshot")
 	}

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -244,8 +244,7 @@ func Test_UnitETCD_Start(t *testing.T) {
 				ctxInfo.ctx, ctxInfo.cancel = context.WithCancel(context.Background())
 				e.config.EtcdDisableSnapshots = true
 				testutil.GenerateRuntime(e.config)
-				e.runtime = e.config.Runtime
-				client, err := GetClient(ctxInfo.ctx, e.runtime, endpoint)
+				client, err := GetClient(ctxInfo.ctx, e.config.Runtime, endpoint)
 				e.client = client
 
 				return err
@@ -275,8 +274,7 @@ func Test_UnitETCD_Start(t *testing.T) {
 			setup: func(e *ETCD, ctxInfo *contextInfo) error {
 				ctxInfo.ctx, ctxInfo.cancel = context.WithCancel(context.Background())
 				testutil.GenerateRuntime(e.config)
-				e.runtime = e.config.Runtime
-				client, err := GetClient(ctxInfo.ctx, e.runtime, endpoint)
+				client, err := GetClient(ctxInfo.ctx, e.config.Runtime, endpoint)
 				e.client = client
 
 				return err
@@ -308,8 +306,7 @@ func Test_UnitETCD_Start(t *testing.T) {
 				if err := testutil.GenerateRuntime(e.config); err != nil {
 					return err
 				}
-				e.runtime = e.config.Runtime
-				client, err := GetClient(ctxInfo.ctx, e.runtime, endpoint)
+				client, err := GetClient(ctxInfo.ctx, e.config.Runtime, endpoint)
 				if err != nil {
 					return err
 				}
@@ -335,7 +332,6 @@ func Test_UnitETCD_Start(t *testing.T) {
 				client:  tt.fields.client,
 				config:  tt.fields.config,
 				name:    tt.fields.name,
-				runtime: tt.fields.config.Runtime,
 				address: tt.fields.address,
 				cron:    tt.fields.cron,
 				s3:      tt.fields.s3,

--- a/pkg/secretsencrypt/controller.go
+++ b/pkg/secretsencrypt/controller.go
@@ -120,7 +120,7 @@ func (h *handler) onChangeNode(key string, node *corev1.Node) (*corev1.Node, err
 		h.recorder.Event(node, corev1.EventTypeWarning, secretsUpdateErrorEvent, err.Error())
 		return node, err
 	}
-	if err := cluster.Save(h.ctx, h.controlConfig, h.controlConfig.Runtime.EtcdConfig, true); err != nil {
+	if err := cluster.Save(h.ctx, h.controlConfig, true); err != nil {
 		h.recorder.Event(node, corev1.EventTypeWarning, secretsUpdateErrorEvent, err.Error())
 		return node, err
 	}

--- a/pkg/server/secrets-encrypt.go
+++ b/pkg/server/secrets-encrypt.go
@@ -148,7 +148,7 @@ func encryptionEnable(ctx context.Context, server *config.Control, enable bool) 
 	} else {
 		return fmt.Errorf("unable to enable/disable secrets encryption, unknown configuration")
 	}
-	return cluster.Save(ctx, server, server.Runtime.EtcdConfig, true)
+	return cluster.Save(ctx, server, true)
 }
 
 func encryptionConfigHandler(ctx context.Context, server *config.Control) http.Handler {
@@ -217,7 +217,7 @@ func encryptionPrepare(ctx context.Context, server *config.Control, force bool) 
 	if err = secretsencrypt.WriteEncryptionHashAnnotation(server.Runtime, node, secretsencrypt.EncryptionPrepare); err != nil {
 		return err
 	}
-	return cluster.Save(ctx, server, server.Runtime.EtcdConfig, true)
+	return cluster.Save(ctx, server, true)
 }
 
 func encryptionRotate(ctx context.Context, server *config.Control, force bool) error {
@@ -246,7 +246,7 @@ func encryptionRotate(ctx context.Context, server *config.Control, force bool) e
 	if err := secretsencrypt.WriteEncryptionHashAnnotation(server.Runtime, node, secretsencrypt.EncryptionRotate); err != nil {
 		return err
 	}
-	return cluster.Save(ctx, server, server.Runtime.EtcdConfig, true)
+	return cluster.Save(ctx, server, true)
 }
 
 func encryptionReencrypt(ctx context.Context, server *config.Control, force bool, skip bool) error {

--- a/tests/util/unit.go
+++ b/tests/util/unit.go
@@ -43,7 +43,7 @@ func CleanupDataDir(cnf *config.Control) {
 // GenerateRuntime creates a temporary data dir and configures
 // config.ControlRuntime with all the appropriate certificate keys.
 func GenerateRuntime(cnf *config.Control) error {
-	runtime := &config.ControlRuntime{}
+	cnf.Runtime = &config.ControlRuntime{}
 	if err := GenerateDataDir(cnf); err != nil {
 		return err
 	}
@@ -51,13 +51,9 @@ func GenerateRuntime(cnf *config.Control) error {
 	os.MkdirAll(filepath.Join(cnf.DataDir, "tls"), 0700)
 	os.MkdirAll(filepath.Join(cnf.DataDir, "cred"), 0700)
 
-	deps.CreateRuntimeCertFiles(cnf, runtime)
+	deps.CreateRuntimeCertFiles(cnf)
 
-	if err := deps.GenServerDeps(cnf, runtime); err != nil {
-		return err
-	}
-	cnf.Runtime = runtime
-	return nil
+	return deps.GenServerDeps(cnf)
 }
 
 func ClusterIPNet() *net.IPNet {


### PR DESCRIPTION
#### Proposed Changes ####

Several types contained redundant references to ControlRuntime data. Many functions passed in both config and config.Runtime (both a variable and a field on that same variable) as separate parameters to the same function. Switch to consistently accessing it via config.Runtime instead.

EtcdConfig had a similar issue; separate copies of it were being kept in the cluster type, as both cluster.EtcdConfig, and cluster.config.Runtime.EtcdConfig.

#### Types of Changes ####

cleanup

#### Verification ####

Run tests. No change for end-user.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5176

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
