### PR TITLE
[Release-1.21] Create encryption hash file if it doesn't exist 

### DIFF
--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -8,6 +8,7 @@ import (
 	b64 "encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -661,6 +662,16 @@ func genEncryptionConfigAndState(controlConfig *config.Control, runtime *config.
 		return nil
 	}
 	if s, err := os.Stat(runtime.EncryptionConfig); err == nil && s.Size() > 0 {
+		// On upgrade from older versions, the encryption hash may not exist, create it
+		if _, err := os.Stat(runtime.EncryptionHash); errors.Is(err, os.ErrNotExist) {
+			curEncryptionByte, err := ioutil.ReadFile(runtime.EncryptionConfig)
+			if err != nil {
+				return err
+			}
+			encryptionConfigHash := sha256.Sum256(curEncryptionByte)
+			ann := "start-" + hex.EncodeToString(encryptionConfigHash[:])
+			return ioutil.WriteFile(controlConfig.Runtime.EncryptionHash, []byte(ann), 0600)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Backport of https://github.com/k3s-io/k3s/pull/5140
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Check and make sure the `encryption-hash.json` file exists when generating secrets-encryption files.
This was breaking upgrades because previously we only had one relevant encryption-config.json file.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- Install pre encryptions rotation version of K3s: v1.21.1+k3s1
- Start K3s `k3s server --secrets-encryption`
- Stop K3s
- Upgrade to this PR
- Start K3s `k3s server --secrets-encryption`
- Run `k3s secrets-encrypt status` and note that it does not fail with 500 Internal Server Error
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/5167
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a bug that prevented users from using k3s secrets-encryption rotation after upgrading from older K3s versions.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
