### PR TITLE
[Release-1.22] Integration tests: move to a global test lock 

### DIFF
--- a/tests/integration/custometcdargs/custometcdargs_int_test.go
+++ b/tests/integration/custometcdargs/custometcdargs_int_test.go
@@ -16,9 +16,13 @@ var customEtcdArgsServerArgs = []string{
 	"--cluster-init",
 	"--etcd-arg quota-backend-bytes=858993459",
 }
+var testLock int
+
 var _ = BeforeSuite(func() {
 	if !testutil.IsExistingServer() {
 		var err error
+		testLock, err = testutil.K3sTestLock()
+		Expect(err).ToNot(HaveOccurred())
 		customEtcdArgsServer, err = testutil.K3sStartServer(customEtcdArgsServerArgs...)
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -51,8 +55,8 @@ var _ = Describe("custom etcd args", func() {
 
 var _ = AfterSuite(func() {
 	if !testutil.IsExistingServer() {
-		Expect(testutil.K3sKillServer(customEtcdArgsServer, false)).To(Succeed())
-		Expect(testutil.K3sCleanup(customEtcdArgsServer, true, "")).To(Succeed())
+		Expect(testutil.K3sKillServer(customEtcdArgsServer)).To(Succeed())
+		Expect(testutil.K3sCleanup(testLock, "")).To(Succeed())
 	}
 })
 

--- a/tests/integration/dualstack/dualstack_int_test.go
+++ b/tests/integration/dualstack/dualstack_int_test.go
@@ -18,9 +18,13 @@ var dualStackServerArgs = []string{
 	"--service-cidr 10.43.0.0/16,2001:cafe:42:1::/112",
 	"--disable-network-policy",
 }
+var testLock int
+
 var _ = BeforeSuite(func() {
 	if !testutil.IsExistingServer() && os.Getenv("CI") != "true" {
 		var err error
+		testLock, err = testutil.K3sTestLock()
+		Expect(err).ToNot(HaveOccurred())
 		dualStackServer, err = testutil.K3sStartServer(dualStackServerArgs...)
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -52,8 +56,8 @@ var _ = Describe("dual stack", func() {
 
 var _ = AfterSuite(func() {
 	if !testutil.IsExistingServer() && os.Getenv("CI") != "true" {
-		Expect(testutil.K3sKillServer(dualStackServer, false)).To(Succeed())
-		Expect(testutil.K3sCleanup(dualStackServer, true, "")).To(Succeed())
+		Expect(testutil.K3sKillServer(dualStackServer)).To(Succeed())
+		Expect(testutil.K3sCleanup(testLock, "")).To(Succeed())
 	}
 })
 

--- a/tests/integration/etcdrestore/etcd_restore_int_test.go
+++ b/tests/integration/etcdrestore/etcd_restore_int_test.go
@@ -13,10 +13,13 @@ import (
 var server1, server2 *testutil.K3sServer
 var tmpdDataDir = "/tmp/restoredatadir"
 var clientCACertHash string
+var testLock int
 var restoreServerArgs = []string{"--cluster-init", "-t", "test", "-d", tmpdDataDir}
 var _ = BeforeSuite(func() {
 	if !testutil.IsExistingServer() {
 		var err error
+		testLock, err = testutil.K3sTestLock()
+		Expect(err).ToNot(HaveOccurred())
 		server1, err = testutil.K3sStartServer(restoreServerArgs...)
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -60,7 +63,7 @@ var _ = Describe("etcd snapshot restore", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("stop k3s", func() {
-			Expect(testutil.K3sKillServer(server1, true)).To(Succeed())
+			Expect(testutil.K3sKillServer(server1)).To(Succeed())
 		})
 		It("restore the snapshot", func() {
 			// get snapshot file
@@ -99,17 +102,16 @@ var _ = Describe("etcd snapshot restore", func() {
 			Expect(clientCACertHash2).To(Equal(clientCACertHash))
 		})
 		It("stop k3s", func() {
-			Expect(testutil.K3sKillServer(server2, false)).To(Succeed())
+			Expect(testutil.K3sKillServer(server2)).To(Succeed())
 		})
 	})
 })
 
 var _ = AfterSuite(func() {
 	if !testutil.IsExistingServer() {
-		Expect(testutil.K3sKillServer(server1, false)).To(Succeed())
-		Expect(testutil.K3sCleanup(server1, true, tmpdDataDir)).To(Succeed())
-		Expect(testutil.K3sKillServer(server2, false)).To(Succeed())
-		Expect(testutil.K3sCleanup(server2, true, tmpdDataDir)).To(Succeed())
+		Expect(testutil.K3sKillServer(server1)).To(Succeed())
+		Expect(testutil.K3sKillServer(server2)).To(Succeed())
+		Expect(testutil.K3sCleanup(testLock, tmpdDataDir)).To(Succeed())
 	}
 })
 

--- a/tests/integration/etcdsnapshot/etcdsnapshot_int_test.go
+++ b/tests/integration/etcdsnapshot/etcdsnapshot_int_test.go
@@ -14,9 +14,13 @@ import (
 
 var server *testutil.K3sServer
 var serverArgs = []string{"--cluster-init"}
+var testLock int
+
 var _ = BeforeSuite(func() {
 	if !testutil.IsExistingServer() {
 		var err error
+		testLock, err = testutil.K3sTestLock()
+		Expect(err).ToNot(HaveOccurred())
 		server, err = testutil.K3sStartServer(serverArgs...)
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -112,8 +116,8 @@ var _ = Describe("etcd snapshots", func() {
 
 var _ = AfterSuite(func() {
 	if !testutil.IsExistingServer() {
-		Expect(testutil.K3sKillServer(server, false)).To(Succeed())
-		Expect(testutil.K3sCleanup(server, true, "")).To(Succeed())
+		Expect(testutil.K3sKillServer(server)).To(Succeed())
+		Expect(testutil.K3sCleanup(testLock, "")).To(Succeed())
 	}
 })
 

--- a/tests/integration/localstorage/localstorage_int_test.go
+++ b/tests/integration/localstorage/localstorage_int_test.go
@@ -15,9 +15,13 @@ import (
 
 var localStorageServer *testutil.K3sServer
 var localStorageServerArgs = []string{"--cluster-init"}
+var testLock int
+
 var _ = BeforeSuite(func() {
 	if !testutil.IsExistingServer() {
 		var err error
+		testLock, err = testutil.K3sTestLock()
+		Expect(err).ToNot(HaveOccurred())
 		localStorageServer, err = testutil.K3sStartServer(localStorageServerArgs...)
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -81,8 +85,8 @@ var _ = Describe("local storage", func() {
 
 var _ = AfterSuite(func() {
 	if !testutil.IsExistingServer() {
-		Expect(testutil.K3sKillServer(localStorageServer, false)).To(Succeed())
-		Expect(testutil.K3sCleanup(localStorageServer, true, "")).To(Succeed())
+		Expect(testutil.K3sKillServer(localStorageServer)).To(Succeed())
+		Expect(testutil.K3sCleanup(testLock, "")).To(Succeed())
 	}
 })
 

--- a/tests/integration/secretsencryption/secretsencryption_int_test.go
+++ b/tests/integration/secretsencryption/secretsencryption_int_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -15,12 +14,14 @@ import (
 
 var secretsEncryptionServer *testutil.K3sServer
 var secretsEncryptionDataDir = "/tmp/k3sse"
-
 var secretsEncryptionServerArgs = []string{"--secrets-encryption", "-d", secretsEncryptionDataDir}
+var testLock int
+
 var _ = BeforeSuite(func() {
 	if !testutil.IsExistingServer() {
 		var err error
-		Expect(os.MkdirAll(secretsEncryptionDataDir, 0777)).To(Succeed())
+		testLock, err = testutil.K3sTestLock()
+		Expect(err).ToNot(HaveOccurred())
 		secretsEncryptionServer, err = testutil.K3sStartServer(secretsEncryptionServerArgs...)
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -62,7 +63,7 @@ var _ = Describe("secrets encryption rotation", func() {
 		})
 		It("restarts the server", func() {
 			var err error
-			Expect(testutil.K3sKillServer(secretsEncryptionServer, true)).To(Succeed())
+			Expect(testutil.K3sKillServer(secretsEncryptionServer)).To(Succeed())
 			secretsEncryptionServer, err = testutil.K3sStartServer(secretsEncryptionServerArgs...)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() (string, error) {
@@ -86,7 +87,7 @@ var _ = Describe("secrets encryption rotation", func() {
 		})
 		It("restarts the server", func() {
 			var err error
-			Expect(testutil.K3sKillServer(secretsEncryptionServer, true)).To(Succeed())
+			Expect(testutil.K3sKillServer(secretsEncryptionServer)).To(Succeed())
 			secretsEncryptionServer, err = testutil.K3sStartServer(secretsEncryptionServerArgs...)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() (string, error) {
@@ -120,7 +121,7 @@ var _ = Describe("secrets encryption rotation", func() {
 		})
 		It("restarts the server", func() {
 			var err error
-			Expect(testutil.K3sKillServer(secretsEncryptionServer, true)).To(Succeed())
+			Expect(testutil.K3sKillServer(secretsEncryptionServer)).To(Succeed())
 			secretsEncryptionServer, err = testutil.K3sStartServer(secretsEncryptionServerArgs...)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() (string, error) {
@@ -142,8 +143,8 @@ var _ = Describe("secrets encryption rotation", func() {
 
 var _ = AfterSuite(func() {
 	if !testutil.IsExistingServer() {
-		Expect(testutil.K3sKillServer(secretsEncryptionServer, false)).To(Succeed())
-		Expect(testutil.K3sCleanup(secretsEncryptionServer, true, secretsEncryptionDataDir)).To(Succeed())
+		Expect(testutil.K3sKillServer(secretsEncryptionServer)).To(Succeed())
+		Expect(testutil.K3sCleanup(testLock, secretsEncryptionDataDir)).To(Succeed())
 	}
 })
 


### PR DESCRIPTION
Backport https://github.com/k3s-io/k3s/pull/5155
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Linked Issues ####
N/A internal testing change.
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
