### PR TITLE
Enable separate node pools for servicelb

### DIFF
--- a/pkg/servicelb/controller.go
+++ b/pkg/servicelb/controller.go
@@ -32,10 +32,11 @@ import (
 )
 
 var (
-	svcNameLabel       = "svccontroller." + version.Program + ".cattle.io/svcname"
-	daemonsetNodeLabel = "svccontroller." + version.Program + ".cattle.io/enablelb"
-	nodeSelectorLabel  = "svccontroller." + version.Program + ".cattle.io/nodeselector"
-	DefaultLBImage     = "rancher/klipper-lb:v0.3.4"
+	svcNameLabel           = "svccontroller." + version.Program + ".cattle.io/svcname"
+	daemonsetNodeLabel     = "svccontroller." + version.Program + ".cattle.io/enablelb"
+	daemonsetNodePoolLabel = "svccontroller." + version.Program + ".cattle.io/lbpool"
+	nodeSelectorLabel      = "svccontroller." + version.Program + ".cattle.io/nodeselector"
+	DefaultLBImage         = "rancher/klipper-lb:v0.3.4"
 )
 
 const (
@@ -498,6 +499,10 @@ func (h *handler) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 	if len(nodesWithLabel) > 0 {
 		ds.Spec.Template.Spec.NodeSelector = map[string]string{
 			daemonsetNodeLabel: "true",
+		}
+		// Add node selector for "svccontroller.k3s.cattle.io/lbpool=<pool>" if service has lbpool label
+		if svc.Labels[daemonsetNodePoolLabel] != "" {
+			ds.Spec.Template.Spec.NodeSelector[daemonsetNodePoolLabel] = svc.Labels[daemonsetNodePoolLabel]
 		}
 		ds.Labels[nodeSelectorLabel] = "true"
 	}


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

adds a new optional node label
"svccontroller.k3s.cattle.io/lbpool=<pool>" that can be set on nodes.
ServiceType: LoadBalancer services can then specify a matching label,
which will schedule the DaemonSet only on specified nodes. This allows
operators to specify different pools of nodes that can serve different
LoadBalancer services on the same ports.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

New Feature

#### Verification ####

- Label nodes with `svccontroller.k3s.cattle.io/enablelb=true`
- Label `Node A` and `Node B` with `svccontroller.k3s.cattle.io/lbpool=pool_1`
- Label `Node C` and `Node D` with `svccontroller.k3s.cattle.io/lbpool=pool_2`
- Create one `ServiceType: LoadBalancer` service on port 443 with label `svccontroller.k3s.cattle.io/lbpool=pool_1`. The `DaemonSet` should only deploy to `Node A` and `Node B`.
- Create another `ServiceType: LoadBalancer` service on port 443 with label `svccontroller.k3s.cattle.io/lbpool=pool_2`. The `DaemonSet` should only deploy to `Node C` and `Node D`.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/k3s-io/k3s/issues/1969


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
