### PR TITLE
[Engine-1.21] Add `--json` flag for `k3s secrets-encrypt status`

### DIFF
--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -38,7 +38,11 @@ func NewSecretsEncryptSubcommands(status, enable, disable, prepare, rotate, reen
 			SkipFlagParsing: false,
 			SkipArgReorder:  true,
 			Action:          status,
-			Flags:           EncryptFlags,
+			Flags: append(EncryptFlags, &cli.StringFlag{
+				Name:        "output,o",
+				Usage:       "Status format. Default: text. Optional: json",
+				Destination: &ServerConfig.EncryptOutput,
+			}),
 		},
 		{
 			Name:            "enable",

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -75,6 +75,7 @@ type Server struct {
 	ClusterResetRestorePath  string
 	EncryptSecrets           bool
 	EncryptForce             bool
+	EncryptOutput            string
 	EncryptSkip              bool
 	SystemDefaultRegistry    string
 	StartupHooks             []StartupHook


### PR DESCRIPTION
Backport https://github.com/k3s-io/k3s/pull/5127
* Add json flag for secrets-encrypt status

Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
