### PR TITLE
Populate EtcdConfig in runtime from datastore when etcd is disabled

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -63,6 +63,9 @@ func (c *Cluster) Start(ctx context.Context) (<-chan struct{}, error) {
 			logrus.Warnf("Failed to remove this node from etcd members")
 		}
 
+		c.config.Runtime.EtcdConfig.Endpoints = strings.Split(c.config.Datastore.Endpoint, ",")
+		c.config.Runtime.EtcdConfig.TLSConfig = c.config.Datastore.BackendTLSConfig
+
 		return ready, nil
 	}
 


### PR DESCRIPTION
#### Proposed Changes ####

Fixes issue with secrets-encrypt rotate not having any etcd endpoints available on nodes without a local etcd server.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5225

#### User-Facing Change ####
```release-note
`k3s secrets-encrypt prepare` can now be used on control-plane only nodes
```

#### Further Comments ####

Thanks @dereknola for the pairing!
