### PR TITLE
[Engine-1.21] Populate EtcdConfig in runtime from datastore when etcd is disabled

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -66,7 +66,7 @@ func (c *Cluster) Start(ctx context.Context) (<-chan struct{}, error) {
 		}
 
 		c.config.Runtime.EtcdConfig.Endpoints = strings.Split(c.config.Datastore.Endpoint, ",")
-		c.config.Runtime.EtcdConfig.TLSConfig = c.config.Datastore.BackendTLSConfig
+		c.config.Runtime.EtcdConfig.TLSConfig = c.config.Datastore.Config
 
 		return ready, nil
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -65,6 +65,9 @@ func (c *Cluster) Start(ctx context.Context) (<-chan struct{}, error) {
 			logrus.Warnf("Failed to remove this node from etcd members")
 		}
 
+		c.config.Runtime.EtcdConfig.Endpoints = strings.Split(c.config.Datastore.Endpoint, ",")
+		c.config.Runtime.EtcdConfig.TLSConfig = c.config.Datastore.BackendTLSConfig
+
 		return ready, nil
 	}
 


### PR DESCRIPTION
Backport of https://github.com/k3s-io/k3s/pull/5222

Fixes issue with secrets-encrypt rotate not having any etcd endpoints
available on nodes without a local etcd server.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`k3s secrets-encrypt prepare` can now be used on control-plane only nodes
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
