### PR TITLE
[release-1.21] Bump containerd to v1.4.13-k3s1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace (
 	github.com/containerd/btrfs => github.com/containerd/btrfs v1.0.0
 	github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
 	github.com/containerd/console => github.com/containerd/console v1.0.2
-	github.com/containerd/containerd => github.com/k3s-io/containerd v1.4.12-k3s1 // k3s-release/1.4
+	github.com/containerd/containerd => github.com/k3s-io/containerd v1.4.13-k3s1 // k3s-release/1.4
 	github.com/containerd/continuity => github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1
 	github.com/containerd/cri => github.com/k3s-io/cri v1.4.0-k3s.7 // k3s-release/1.4
 	github.com/containerd/fifo => github.com/containerd/fifo v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -589,8 +589,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/k-sone/critbitgo v1.3.1-0.20191024122315-48c9e1530131/go.mod h1:7E6pyoyADnFxlUBEKcnfS49b7SUAQGMK+OAp/UQvo0s=
-github.com/k3s-io/containerd v1.4.12-k3s1 h1:WVr0W45uXTIDujMtqsfEigIVuEwhW9E8WjV/06/j03w=
-github.com/k3s-io/containerd v1.4.12-k3s1/go.mod h1:g3v4rA/cI6WVYoSAYfUfAnrUSzEgbSZnu7uF1ZzkTmY=
+github.com/k3s-io/containerd v1.4.13-k3s1 h1:rntjGoRMe6muakSBheKVLDWV1ZODWlAqyuIOoCwtiR8=
+github.com/k3s-io/containerd v1.4.13-k3s1/go.mod h1:g3v4rA/cI6WVYoSAYfUfAnrUSzEgbSZnu7uF1ZzkTmY=
 github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1 h1:KEz2rd9IDbrQT8w6RibEYlwfTXiu0P6hQDE+6O4IJdI=
 github.com/k3s-io/continuity v0.0.0-20210309170710-f93269e0d5c1/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
 github.com/k3s-io/cri v1.4.0-k3s.7 h1:1ycdF3dMDJMW/k/UxDC6eMsyGSMZ/p0AoUBVdJvNGQs=


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd for:
* https://github.com/containerd/containerd/security/advisories/GHSA-crp2-qrr5-8pq7

#### Types of Changes ####

version bump

#### Verification ####

`kubectl get nodes -o wide`

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5204

#### User-Facing Change ####
```release-note
The embedded containerd has been bumped to v1.4.13-k3s1
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
