### PR TITLE
Added ipv6 only support with flannel

### DIFF
--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -45,7 +45,7 @@ const (
 
 	flannelConf = `{
 	"Network": "%CIDR%",
-	"EnableIPv6": %DUALSTACK%,
+	"EnableIPv6": %IPV6_ENABLED%,
 	"EnableIPv4": %IPV4_ENABLED%,
 	"IPv6Network": "%CIDR_IPV6%",
 	"Backend": %backend%
@@ -163,11 +163,11 @@ func createFlannelConf(nodeConfig *config.Node) error {
 	confJSON := strings.ReplaceAll(flannelConf, "%IPV4_ENABLED%", ipv4Enabled)
 	if netMode == ipv4 {
 		confJSON = strings.ReplaceAll(confJSON, "%CIDR%", nodeConfig.AgentConfig.ClusterCIDR.String())
-		confJSON = strings.ReplaceAll(confJSON, "%DUALSTACK%", "false")
+		confJSON = strings.ReplaceAll(confJSON, "%IPV6_ENABLED%", "false")
 		confJSON = strings.ReplaceAll(confJSON, "%CIDR_IPV6%", emptyIPv6Network)
 	} else if netMode == (ipv4 + ipv6) {
 		confJSON = strings.ReplaceAll(confJSON, "%CIDR%", nodeConfig.AgentConfig.ClusterCIDR.String())
-		confJSON = strings.ReplaceAll(confJSON, "%DUALSTACK%", "true")
+		confJSON = strings.ReplaceAll(confJSON, "%IPV6_ENABLED%", "true")
 		for _, cidr := range nodeConfig.AgentConfig.ClusterCIDRs {
 			if utilsnet.IsIPv6(cidr.IP) {
 				// Only one ipv6 range available. This might change in future: https://github.com/kubernetes/enhancements/issues/2593
@@ -176,7 +176,7 @@ func createFlannelConf(nodeConfig *config.Node) error {
 		}
 	} else {
 		confJSON = strings.ReplaceAll(confJSON, "%CIDR%", "0.0.0.0/0")
-		confJSON = strings.ReplaceAll(confJSON, "%DUALSTACK%", "true")
+		confJSON = strings.ReplaceAll(confJSON, "%IPV6_ENABLED%", "true")
 		for _, cidr := range nodeConfig.AgentConfig.ClusterCIDRs {
 			if utilsnet.IsIPv6(cidr.IP) {
 				// Only one ipv6 range available. This might change in future: https://github.com/kubernetes/enhancements/issues/2593

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -534,9 +534,6 @@ func validateNetworkConfiguration(serverConfig server.Config) error {
 		if serverConfig.ControlConfig.DisableNPC == false {
 			return errors.New("network policy enforcement is not compatible with IPv6 only operation; server must be restarted with --disable-network-policy")
 		}
-		if serverConfig.ControlConfig.FlannelBackend != config.FlannelBackendNone {
-			return errors.New("Flannel is not compatible with IPv6 only operation; server must be restarted with --flannel-backend=none")
-		}
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Roberto Bonafiglia <roberto.bonafiglia@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Added support for IPv6 only setup using flannel

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Setup multiple nodes with IPv6 and configure the IPv6 addresses on the config file
```
node-ip: 2001:cafe:42::1c8 # use the node IPv6 address
cluster-cidr: 2001:cafe:43:0::/56
service-cidr: 2001:cafe:43:1::/112
disable-network-policy: true
flannel-ipv6-masq: true
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
#5237 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
