### PR TITLE
Close additional leaked GPRC clients

### DIFF
--- a/pkg/apiaddresses/controller.go
+++ b/pkg/apiaddresses/controller.go
@@ -28,8 +28,12 @@ func Register(ctx context.Context, runtime *config.ControlRuntime, endpoints con
 	if err != nil {
 		return err
 	}
-
 	h.etcdClient = cl
+
+	go func() {
+		<-ctx.Done()
+		h.etcdClient.Close()
+	}()
 
 	return nil
 }

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -148,6 +148,11 @@ func (e *ETCD) SetControlConfig(ctx context.Context, config *config.Control) err
 	}
 	e.client = client
 
+	go func() {
+		<-ctx.Done()
+		e.client.Close()
+	}()
+
 	address, err := GetAdvertiseAddress(config.PrivateIP)
 	if err != nil {
 		return err
@@ -478,6 +483,11 @@ func (e *ETCD) Register(ctx context.Context, config *config.Control, handler htt
 		return nil, err
 	}
 	e.client = client
+
+	go func() {
+		<-ctx.Done()
+		e.client.Close()
+	}()
 
 	address, err := GetAdvertiseAddress(config.PrivateIP)
 	if err != nil {
@@ -1098,6 +1108,11 @@ func (e *ETCD) preSnapshotSetup(ctx context.Context, config *config.Control) err
 			return err
 		}
 		e.client = client
+
+		go func() {
+			<-ctx.Done()
+			e.client.Close()
+		}()
 	}
 	return nil
 }
@@ -1958,6 +1973,8 @@ func GetAPIServerURLsFromETCD(ctx context.Context, cfg *config.Control) ([]strin
 	if err != nil {
 		return nil, err
 	}
+	defer cl.Close()
+
 	etcdResp, err := cl.KV.Get(ctx, AddressKey)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### Proposed Changes ####

Close additional leaked GPRC clients

#### Types of Changes ####

bugfix

#### Verification ####

confirm that there are no messages in the logs: `failed to connect to {http://127.0.0.1:2399`

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/4728

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####
