### PR TITLE
Add cross-compilation as sanity check

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,6 +22,14 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 
+- name: validate-cross-compilation
+  image: rancher/dapper:v0.5.0
+  commands:
+  - dapper validate-cross-compilation
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+
 - name: fossa
   image: rancher/drone-fossa:latest
   failure: ignore

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -11,7 +11,12 @@ ENV no_proxy=$no_proxy
 RUN apk -U --no-cache add bash git gcc musl-dev docker vim less file curl wget ca-certificates jq linux-headers \
     zlib-dev tar zip squashfs-tools npm coreutils python3 openssl-dev libffi-dev libseccomp libseccomp-dev \
     libseccomp-static make libuv-static sqlite-dev sqlite-static libselinux libselinux-dev zlib-dev zlib-static \
-    zstd pigz alpine-sdk binutils-gold btrfs-progs-dev btrfs-progs-static gawk
+    zstd pigz alpine-sdk binutils-gold btrfs-progs-dev btrfs-progs-static gawk \
+    && \
+    if [ "$(go env GOARCH)" = "amd64" ]; then \
+    apk -U --no-cache add mingw-w64-gcc; \
+    fi
+
 RUN if [ "$(go env GOARCH)" = "arm64" ]; then                                                               \
     wget https://github.com/aquasecurity/trivy/releases/download/v0.16.0/trivy_0.16.0_Linux-ARM64.tar.gz && \
     tar -zxvf trivy_0.16.0_Linux-ARM64.tar.gz                                                            && \

--- a/scripts/validate-cross-compilation
+++ b/scripts/validate-cross-compilation
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e -x
+
+cd $(dirname $0)/..
+
+. ./scripts/version.sh
+
+GO=${GO-go}
+
+PKG="github.com/k3s-io/k3s"
+PKG_CONTAINERD="github.com/containerd/containerd"
+PKG_K3S_CONTAINERD="github.com/k3s-io/containerd"
+PKG_CRICTL="github.com/kubernetes-sigs/cri-tools/pkg"
+PKG_K8S_BASE="k8s.io/component-base"
+PKG_K8S_CLIENT="k8s.io/client-go/pkg"
+
+buildDate=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+VERSIONFLAGS="
+    -X ${PKG}/pkg/version.Version=${VERSION}
+    -X ${PKG}/pkg/version.GitCommit=${COMMIT:0:8}
+
+    -X ${PKG_K8S_CLIENT}/version.gitVersion=${VERSION}
+    -X ${PKG_K8S_CLIENT}/version.gitCommit=${COMMIT}
+    -X ${PKG_K8S_CLIENT}/version.gitTreeState=${TREE_STATE}
+    -X ${PKG_K8S_CLIENT}/version.buildDate=${buildDate}
+
+    -X ${PKG_K8S_BASE}/version.gitVersion=${VERSION}
+    -X ${PKG_K8S_BASE}/version.gitCommit=${COMMIT}
+    -X ${PKG_K8S_BASE}/version.gitTreeState=${TREE_STATE}
+    -X ${PKG_K8S_BASE}/version.buildDate=${buildDate}
+
+    -X ${PKG_CRICTL}/version.Version=${VERSION_CRICTL}
+
+    -X ${PKG_CONTAINERD}/version.Version=${VERSION_CONTAINERD}
+    -X ${PKG_CONTAINERD}/version.Package=${PKG_K3S_CONTAINERD}
+
+    -X ${PKG_CONTAINERD}/version.Version=${VERSION_CONTAINERD}
+    -X ${PKG_CONTAINERD}/version.Package=${PKG_K3S_CONTAINERD}
+"
+
+LDFLAGS="
+    -w -s"
+
+STATIC=""
+
+TAGS="netcgo osusergo providerless"
+
+mkdir -p bin
+
+# Sanity check for downstream dependencies
+echo 'Validate K3s cross-compilation on Windows x86_64' 
+GOOS=windows CGO_ENABLED=1 CXX=x86_64-w64-mingw32-g++ CC=x86_64-w64-mingw32-gcc \
+    "${GO}" build -tags "${TAGS}" -ldflags "${VERSIONFLAGS} ${LDFLAGS} ${STATIC}" -o bin/k3s.exe ./cmd/server/main.go
+
+if [ "${KEEP_WINDOWS_BIN}" != 'true' ]; then
+    rm -rf bin/k3s.exe
+fi


### PR DESCRIPTION
K3s downstream dependencies have support for Windows agents, making the need for windows specific minimal verifications. 

#### Proposed Changes ####

Add an extra CI cross-compiling K3s as a minimal verification. 

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Build and CI

#### Verification ####

Successfully cross-compile K3s for windows x86_64 using `scripts/validate-cross-compilation`

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#5243 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

I have a couple questions that I'd like to address before moving on:

- I added build-windows as a separate drone step in the `amd64` pipeline. Is this the way we would tackle it or should I add it into the `scripts/ci` list? If so, when do you prefer build-windows to be executed after `build` or `package` (so we don't  package it without noticing it)?
- Based on RKE2 windows build I removed all the linker flags for static linking. Is this alright with the team? Otherwise we would need to install the required headers for `x86_64-w64-mingw32`