### PR TITLE
Track upstream changes to kubectl command execution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,6 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rootless-containers/rootlesskit v0.14.5
 	github.com/sirupsen/logrus v1.8.1
-	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/tchap/go-patricia v2.3.0+incompatible // indirect
 	github.com/urfave/cli v1.22.4

--- a/pkg/kubectl/main.go
+++ b/pkg/kubectl/main.go
@@ -1,7 +1,6 @@
 package kubectl
 
 import (
-	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
@@ -10,10 +9,9 @@ import (
 
 	"github.com/k3s-io/k3s/pkg/server"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
-	utilflag "k8s.io/component-base/cli/flag"
-	"k8s.io/component-base/logs"
+	"k8s.io/component-base/cli"
 	"k8s.io/kubectl/pkg/cmd"
+	"k8s.io/kubectl/pkg/cmd/util"
 )
 
 func Main() {
@@ -42,19 +40,8 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 
 	command := cmd.NewDefaultKubectlCommand()
-
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	// utilflag.InitFlags()
-	logs.InitLogs()
-	defer logs.FlushLogs()
-
-	if err := command.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+	if err := cli.RunNoErrOutput(command); err != nil {
+		util.CheckErr(err)
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes ####

Fix `kubectl` common flag parsing

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/4981

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a regression present in 1.23 that prevented the embedded kubectl binary from parsing common CLI flags, such as `-v=0 to set verbosity`
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
