### PR TITLE
[release-1.22] Update helm-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/k3s-io/helm-controller v0.11.7
+	github.com/k3s-io/helm-controller v0.12.0
 	github.com/k3s-io/kine v0.8.1
 	github.com/klauspost/compress v1.14.2
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,8 @@ github.com/k3s-io/etcd/etcdutl/v3 v3.5.1-k3s1 h1:FK0fnJI8kvP3P2yjxypkFVnokeQwXgA
 github.com/k3s-io/etcd/etcdutl/v3 v3.5.1-k3s1/go.mod h1:fDeCOsFfxdcMIbjSoKLJQDCFRv0ixQY+tyOuPF7uEQU=
 github.com/k3s-io/etcd/server/v3 v3.5.1-k3s1 h1:B9DDdjIwQo2UXIflhSinSEDrihQOKJwEYjUejPpH6Js=
 github.com/k3s-io/etcd/server/v3 v3.5.1-k3s1/go.mod h1:yBKYw++NWu6ciuWoKuL7UXgGKDP7ICBCuVQrIcYbPdw=
-github.com/k3s-io/helm-controller v0.11.7 h1:fNpBImB3h5aHvPf3zwU9sFWmeVQh0nTG1sLCoBhEeUg=
-github.com/k3s-io/helm-controller v0.11.7/go.mod h1:z0ExsRRIkTO/QC//3/Esn5ItTD6AiQSluwzMaS7RI/4=
+github.com/k3s-io/helm-controller v0.12.0 h1:OIi43oEqIggVdc1z4BRzGPpNzvr5xV5EcG+RldJrIag=
+github.com/k3s-io/helm-controller v0.12.0/go.mod h1:yBS3F5emwVjyzUUi3VWAuj9+Ogoq84Mf7CBXbAnKI1U=
 github.com/k3s-io/kine v0.8.1 h1:cuxZmENBUL5lvJORWGBjn87kKtIo8GK7o8H1hu+vd98=
 github.com/k3s-io/kine v0.8.1/go.mod h1:gaezUQ9c8iw8vxDV/DI8vc93h2rCpTvY37kMdYPMsyc=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -206,6 +206,7 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 
 	if !config.ControlConfig.DisableHelmController {
 		helm.Register(ctx,
+			sc.K8s,
 			sc.Apply,
 			sc.Helm.Helm().V1().HelmChart(),
 			sc.Helm.Helm().V1().HelmChartConfig(),

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,4 +1,4 @@
-docker.io/rancher/klipper-helm:v0.6.6-build20211022
+docker.io/rancher/klipper-helm:v0.7.0-build20220315
 docker.io/rancher/klipper-lb:v0.3.4
 docker.io/rancher/local-path-provisioner:v0.0.21
 docker.io/rancher/mirrored-coredns-coredns:1.8.6


### PR DESCRIPTION
#### Proposed Changes ####

Update helm-controller

#### Types of Changes ####

* Add repoCA to helmChart.spec
* Add failurePolicy to helmChart.spec
* Add support for `helmcharts.helm.cattle.io/unmanaged` annotation to unmanage a chart

#### Verification ####

See https://github.com/k3s-io/helm-controller/pull/137

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5288

#### User-Facing Change ####
```release-note
The embedded Helm controller can now cease management of existing HelmChart releases, supports setting a failure policy for  install/update operations, and allows trusting custom CA certs for remote chart repositories.
```

#### Further Comments ####