### PR TITLE
[engine-1.21] Update helm-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
-	github.com/k3s-io/helm-controller v0.11.7
+	github.com/k3s-io/helm-controller v0.12.0
 	github.com/k3s-io/kine v0.6.5
 	github.com/klauspost/compress v1.13.6
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/k3s-io/cri-tools v1.21.0-k3s1 h1:MWQtAsx4HCNXenqU/B4V9eU6HMyafkd1PnW6
 github.com/k3s-io/cri-tools v1.21.0-k3s1/go.mod h1:Qsz54zxINPR+WVWX9Kc3CTmuDFB1dNLCNV8jE8lUbtU=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20220113195313-6c2233a709e8 h1:EEZ7gWyQ3xOR4vL5j067MJmDy/kOKmShIW277mYQB+E=
 github.com/k3s-io/etcd v0.5.0-alpha.5.0.20220113195313-6c2233a709e8/go.mod h1:t1cqOhpjW3SEYhH7Wzlg51xzyIM2c5HMB9kvPO5k4gY=
-github.com/k3s-io/helm-controller v0.11.7 h1:fNpBImB3h5aHvPf3zwU9sFWmeVQh0nTG1sLCoBhEeUg=
-github.com/k3s-io/helm-controller v0.11.7/go.mod h1:z0ExsRRIkTO/QC//3/Esn5ItTD6AiQSluwzMaS7RI/4=
+github.com/k3s-io/helm-controller v0.12.0 h1:OIi43oEqIggVdc1z4BRzGPpNzvr5xV5EcG+RldJrIag=
+github.com/k3s-io/helm-controller v0.12.0/go.mod h1:yBS3F5emwVjyzUUi3VWAuj9+Ogoq84Mf7CBXbAnKI1U=
 github.com/k3s-io/kine v0.6.5 h1:gYjkuVUUhuIMthIAQSecb2APSx+JZLFO/GWHbDp2NFI=
 github.com/k3s-io/kine v0.6.5/go.mod h1:+QI+2dFYzFaFEdhXz3jFcY5HoD0SNXtMI22SxYhD7jk=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -206,6 +206,7 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 
 	if !config.ControlConfig.DisableHelmController {
 		helm.Register(ctx,
+			sc.K8s,
 			sc.Apply,
 			sc.Helm.Helm().V1().HelmChart(),
 			sc.Helm.Helm().V1().HelmChartConfig(),

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,4 +1,4 @@
-docker.io/rancher/klipper-helm:v0.6.6-build20211022
+docker.io/rancher/klipper-helm:v0.7.0-build20220315
 docker.io/rancher/klipper-lb:v0.3.4
 docker.io/rancher/local-path-provisioner:v0.0.21
 docker.io/rancher/mirrored-coredns-coredns:1.8.6


### PR DESCRIPTION
#### Proposed Changes ####

Update helm-controller

#### Types of Changes ####

* Add repoCA to helmChart.spec
* Add failurePolicy to helmChart.spec
* Add support for `helmcharts.helm.cattle.io/unmanaged` annotation to unmanage a chart

#### Verification ####

See https://github.com/k3s-io/helm-controller/pull/137

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5288

#### User-Facing Change ####
```release-note
The embedded Helm controller can now cease management of existing HelmChart releases, supports setting a failure policy for  install/update operations, and allows trusting custom CA certs for remote chart repositories.
```

#### Further Comments ####
