### PR TITLE
[engine-1.21] Ensure that apiserver ready channel checks re-dial every time

### DIFF
--- a/pkg/util/api.go
+++ b/pkg/util/api.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	coregetter "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -57,10 +56,6 @@ func WaitForAPIServerReady(ctx context.Context, client clientset.Interface, time
 
 	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		healthStatus := 0
-		// Idle connections to the apiserver are returned to a global pool between requests. Explicitly
-		// close these idle connections so that we re-connect through the loadbalancer in case the endpoints
-		// have changed.
-		restClient.(*rest.RESTClient).Client.CloseIdleConnections()
 		result := restClient.Get().AbsPath("/readyz").Do(ctx).StatusCode(&healthStatus)
 		if rerr := result.Error(); rerr != nil {
 			if errors.Is(rerr, context.Canceled) {


### PR DESCRIPTION
#### Proposed Changes ####

Closing idle connections isn't guaranteed to close out a pooled connection to a
loadbalancer endpoint that has been removed. Instead, ensure that requests used
to wait for the apiserver to become ready aren't reused.

While this seemed to work reliably on 1.23, it did not on 1.22 and 1.21 - possibly due to differences in golang version.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5318

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####
