### PR TITLE
[release-1.22] Defragment etcd datastore before clearing alarms; don't delete temp etcd db while reconciling

### DIFF
--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -570,7 +570,9 @@ func (c *Cluster) reconcileEtcd(ctx context.Context) error {
 	if err := e.SetControlConfig(reconcileCtx, c.config); err != nil {
 		return err
 	}
-	e.StartEmbeddedTemporary(reconcileCtx)
+	if err := e.StartEmbeddedTemporary(reconcileCtx); err != nil {
+		return err
+	}
 
 	for {
 		if err := e.Test(reconcileCtx); err != nil && !errors.Is(err, etcd.ErrNotMember) {


### PR DESCRIPTION
#### Proposed Changes ####

Defragment etcd datastore before clearing alarms.

This also fixes an issue wherein we were deleting the temporary etcd directory while the reconcile etcd was still running. This doesn't seem to be currently causing any problems, as etcd seems to be able to open the files and read them into memory before they are unlinked, but it could possibly cause problems reconciling larger datastores, and it was definitely breaking the defragmentation and clearing of alarms on the reconciliation datastore.

#### Types of Changes ####

bugfix

#### Verification ####

Not sure how to reproduce this one, since it requires a datastore that is not just over quota but also defragmented. It would probably require setting up a long-running cluster with lots of datastore churn.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5331
* https://github.com/rancher/rke2/issues/2682

#### User-Facing Change ####
```release-note
The embedded etcd database is now defragmented on startup.
Fixed an issue that could cause restart of managed etcd nodes to occasionally fail while reconciling bootstrap data.
```

#### Further Comments ####
