### PR TITLE
Skip setting up client tls when etcd server does not have tls enabled

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -614,18 +614,20 @@ func getClientConfig(ctx context.Context, runtime *config.ControlRuntime, endpoi
 	if len(endpoints) == 0 {
 		endpoints = getEndpoints(runtime)
 	}
-	tlsConfig, err := toTLSConfig(runtime)
-	if err != nil {
-		return nil, err
-	}
-	return &clientv3.Config{
+
+	config := &clientv3.Config{
 		Endpoints:            endpoints,
-		TLS:                  tlsConfig,
 		Context:              ctx,
 		DialTimeout:          defaultDialTimeout,
 		DialKeepAliveTime:    defaultKeepAliveTime,
 		DialKeepAliveTimeout: defaultKeepAliveTimeout,
-	}, nil
+	}
+
+	var err error
+	if strings.HasPrefix(endpoints[0], "https://") {
+		config.TLS, err = toTLSConfig(runtime)
+	}
+	return config, err
 }
 
 // getEndpoints returns the endpoints from the runtime config if set, otherwise the default endpoint.


### PR DESCRIPTION
#### Proposed Changes ####

Fixes an issue where startup would fail while reconciling etcd data following a `k3s certificate rotate` due to client certs not being recreated yet.

#### Types of Changes ####

bugfix

#### Verification ####

* Start K3s with embedded etcd
* Stop k3s and run `k3s certificate rotate`
* Start K3s

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2683

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

Really need some CI tests for cert rotation