### PR TITLE
[master] Wrap containerd.New

### DIFF
--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/containerd/containerd"
 	"github.com/k3s-io/k3s/pkg/agent/templates"
 	util2 "github.com/k3s-io/k3s/pkg/agent/util"
 	"github.com/k3s-io/k3s/pkg/cgroups"
@@ -111,4 +112,13 @@ func CriConnection(ctx context.Context, address string) (*grpc.ClientConn, error
 	}
 
 	return conn, nil
+}
+
+func Client(address string) (*containerd.Client, error) {
+	addr, _, err := util.GetAddressAndDialer("unix://" + address)
+	if err != nil {
+		return nil, err
+	}
+
+	return containerd.New(addr)
 }

--- a/pkg/agent/containerd/config_windows.go
+++ b/pkg/agent/containerd/config_windows.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/containerd/containerd"
 	"github.com/k3s-io/k3s/pkg/agent/templates"
 	util2 "github.com/k3s-io/k3s/pkg/agent/util"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
@@ -87,4 +88,13 @@ func CriConnection(ctx context.Context, address string) (*grpc.ClientConn, error
 	}
 
 	return conn, nil
+}
+
+func Client(address string) (*containerd.Client, error) {
+	addr, _, err := util.GetAddressAndDialer(address)
+	if err != nil {
+		return nil, err
+	}
+
+	return containerd.New(addr)
 }

--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -150,7 +150,7 @@ func preloadImages(ctx context.Context, cfg *config.Node) error {
 		return nil
 	}
 
-	client, err := containerd.New(cfg.Containerd.Address)
+	client, err := Client(cfg.Containerd.Address)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
problem: While setting up containerd we make a client and the name of the npipe for windows is `npipe://./pipe/containerd-containerd` but at some point between windows server patches and the winio dialer we got to a place where it's expecting `\\.\pipe\containerd-containerd` and the npipe:// needed to be dropped. This was fixed CriConnection as the address was wrapped with `utils.GetAddressAndDialer` but the second call to containerd.New for a client didn't have this.
Fix: wrap the containerd.New call with a func that parses the address properly and pass that down

https://github.com/rancher/rke2/issues/2161
https://github.com/rancher/windows/issues/72