### PR TITLE
[1.21] Wrap containerd.New, split config files

### DIFF
--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -1,0 +1,125 @@
+//go:build linux
+// +build linux
+
+package containerd
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/containerd/containerd"
+	"github.com/opencontainers/runc/libcontainer/userns"
+	"github.com/pkg/errors"
+	"github.com/rancher/k3s/pkg/agent/templates"
+	util2 "github.com/rancher/k3s/pkg/agent/util"
+	"github.com/rancher/k3s/pkg/daemons/agent"
+	"github.com/rancher/k3s/pkg/daemons/config"
+	"github.com/rancher/k3s/pkg/version"
+	"github.com/rancher/wharfie/pkg/registries"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	"k8s.io/kubernetes/pkg/kubelet/util"
+)
+
+func getContainerdArgs(cfg *config.Node) []string {
+	args := []string{
+		"containerd",
+		"-c", cfg.Containerd.Config,
+		"-a", cfg.Containerd.Address,
+		"--state", cfg.Containerd.State,
+		"--root", cfg.Containerd.Root,
+	}
+	return args
+}
+
+// setupContainerdConfig generates the containerd.toml, using a template combined with various
+// runtime configurations and registry mirror settings provided by the administrator.
+// setupContainerdConfig generates the containerd.toml, using a template combined with various
+// runtime configurations and registry mirror settings provided by the administrator.
+func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
+	privRegistries, err := registries.GetPrivateRegistries(cfg.AgentConfig.PrivateRegistry)
+	if err != nil {
+		return err
+	}
+
+	isRunningInUserNS := userns.RunningInUserNS()
+	_, _, hasCFS, hasPIDs := agent.CheckCgroups()
+	// "/sys/fs/cgroup" is namespaced
+	cgroupfsWritable := unix.Access("/sys/fs/cgroup", unix.W_OK) == nil
+	disableCgroup := isRunningInUserNS && (!hasCFS || !hasPIDs || !cgroupfsWritable)
+	if disableCgroup {
+		logrus.Warn("cgroup v2 controllers are not delegated for rootless. Disabling cgroup.")
+	}
+
+	var containerdTemplate string
+	containerdConfig := templates.ContainerdConfig{
+		NodeConfig:            cfg,
+		DisableCgroup:         disableCgroup,
+		IsRunningInUserNS:     isRunningInUserNS,
+		PrivateRegistryConfig: privRegistries.Registry,
+	}
+
+	selEnabled, selConfigured, err := selinuxStatus()
+	if err != nil {
+		return errors.Wrap(err, "failed to detect selinux")
+	}
+	switch {
+	case !cfg.SELinux && selEnabled:
+		logrus.Warn("SELinux is enabled on this host, but " + version.Program + " has not been started with --selinux - containerd SELinux support is disabled")
+	case cfg.SELinux && !selConfigured:
+		logrus.Warnf("SELinux is enabled for "+version.Program+" but process is not running in context '%s', "+version.Program+"-selinux policy may need to be applied", SELinuxContextType)
+	}
+
+	containerdTemplateBytes, err := ioutil.ReadFile(cfg.Containerd.Template)
+	if err == nil {
+		logrus.Infof("Using containerd template at %s", cfg.Containerd.Template)
+		containerdTemplate = string(containerdTemplateBytes)
+	} else if os.IsNotExist(err) {
+		containerdTemplate = templates.ContainerdConfigTemplate
+	} else {
+		return err
+	}
+	parsedTemplate, err := templates.ParseTemplateFromConfig(containerdTemplate, containerdConfig)
+	if err != nil {
+		return err
+	}
+
+	return util2.WriteFile(cfg.Containerd.Config, parsedTemplate)
+}
+
+// criConnection connects to a CRI socket at the given path.
+func CriConnection(ctx context.Context, address string) (*grpc.ClientConn, error) {
+	addr, dialer, err := util.GetAddressAndDialer("unix://" + address)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(3*time.Second), grpc.WithContextDialer(dialer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
+	if err != nil {
+		return nil, err
+	}
+
+	c := runtimeapi.NewRuntimeServiceClient(conn)
+	_, err = c.Version(ctx, &runtimeapi.VersionRequest{
+		Version: "0.1.0",
+	})
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func Client(address string) (*containerd.Client, error) {
+	addr, _, err := util.GetAddressAndDialer("unix://" + address)
+	if err != nil {
+		return nil, err
+	}
+
+	return containerd.New(addr)
+}

--- a/pkg/agent/containerd/config_windows.go
+++ b/pkg/agent/containerd/config_windows.go
@@ -1,0 +1,100 @@
+//go:build windows
+// +build windows
+
+package containerd
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/containerd/containerd"
+	"github.com/rancher/k3s/pkg/agent/templates"
+	util2 "github.com/rancher/k3s/pkg/agent/util"
+	"github.com/rancher/k3s/pkg/daemons/config"
+	"github.com/rancher/wharfie/pkg/registries"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	"k8s.io/kubernetes/pkg/kubelet/util"
+)
+
+func getContainerdArgs(cfg *config.Node) []string {
+	args := []string{
+		"containerd",
+		"-c", cfg.Containerd.Config,
+	}
+	return args
+}
+
+// setupContainerdConfig generates the containerd.toml, using a template combined with various
+// runtime configurations and registry mirror settings provided by the administrator.
+func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
+	privRegistries, err := registries.GetPrivateRegistries(cfg.AgentConfig.PrivateRegistry)
+	if err != nil {
+		return err
+	}
+
+	if cfg.SELinux {
+		logrus.Warn("SELinux isn't supported on windows")
+	}
+
+	var containerdTemplate string
+
+	containerdConfig := templates.ContainerdConfig{
+		NodeConfig:            cfg,
+		DisableCgroup:         true,
+		IsRunningInUserNS:     false,
+		PrivateRegistryConfig: privRegistries.Registry,
+	}
+
+	containerdTemplateBytes, err := ioutil.ReadFile(cfg.Containerd.Template)
+	if err == nil {
+		logrus.Infof("Using containerd template at %s", cfg.Containerd.Template)
+		containerdTemplate = string(containerdTemplateBytes)
+	} else if os.IsNotExist(err) {
+		containerdTemplate = templates.ContainerdConfigTemplate
+	} else {
+		return err
+	}
+	parsedTemplate, err := templates.ParseTemplateFromConfig(containerdTemplate, containerdConfig)
+	if err != nil {
+		return err
+	}
+
+	return util2.WriteFile(cfg.Containerd.Config, parsedTemplate)
+}
+
+// criConnection connects to a CRI socket at the given path.
+func CriConnection(ctx context.Context, address string) (*grpc.ClientConn, error) {
+	addr, dialer, err := util.GetAddressAndDialer(address)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(3*time.Second), grpc.WithContextDialer(dialer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
+	if err != nil {
+		return nil, err
+	}
+
+	c := runtimeapi.NewRuntimeServiceClient(conn)
+	_, err = c.Version(ctx, &runtimeapi.VersionRequest{
+		Version: "0.1.0",
+	})
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func Client(address string) (*containerd.Client, error) {
+	addr, _, err := util.GetAddressAndDialer(address)
+	if err != nil {
+		return nil, err
+	}
+
+	return containerd.New(addr)
+}


### PR DESCRIPTION
problem: While setting up containerd we make a client and the name of the npipe for windows is `npipe://./pipe/containerd-containerd` but at some point between windows server patches and the winio dialer we got to a place where it's expecting `\\.\pipe\containerd-containerd` and the npipe:// needed to be dropped. This was fixed CriConnection as the address was wrapped with `utils.GetAddressAndDialer` but the second call to containerd.New for a client didn't have this.

Fix: wrap the containerd.New call with a func that parses the address properly and pass that down

https://github.com/rancher/rke2/issues/2161
https://github.com/rancher/windows/issues/72