### PR TITLE
Added support for repeated extra arguments

### DIFF
--- a/pkg/daemons/config/types_test.go
+++ b/pkg/daemons/config/types_test.go
@@ -79,6 +79,67 @@ func Test_UnitGetArgs(t *testing.T) {
 				"--iii=II",
 			},
 		},
+		{
+			name: "Multiple args with defaults Test",
+			args: args{
+				argsMap: map[string]string{
+					"aaa": "A",
+					"bbb": "B",
+				},
+				extraArgs: []string{
+					"--ccc=C",
+					"--bbb=DD",
+					"--bbb=AA",
+				},
+			},
+
+			want: []string{
+				"--aaa=A",
+				"--bbb=DD",
+				"--bbb=AA",
+				"--ccc=C",
+			},
+		},
+		{
+			name: "Multiple args with defaults and prefix",
+			args: args{
+				argsMap: map[string]string{
+					"aaa": "A",
+					"bbb": "B",
+				},
+				extraArgs: []string{
+					"--ccc=C",
+					"--bbb-=DD",
+				},
+			},
+
+			want: []string{
+				"--aaa=A",
+				"--bbb=DD",
+				"--bbb=B",
+				"--ccc=C",
+			},
+		},
+		{
+			name: "Multiple args with defaults and suffix",
+			args: args{
+				argsMap: map[string]string{
+					"aaa": "A",
+					"bbb": "B",
+				},
+				extraArgs: []string{
+					"--ccc=C",
+					"--bbb+=DD",
+				},
+			},
+
+			want: []string{
+				"--aaa=A",
+				"--bbb=B",
+				"--bbb=DD",
+				"--ccc=C",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
When providing extra arguments i.e `--kube-apiserver-arg`, arguments that can be repeated multiple times are not retained when passed through to the daemon. This is because the arguments are stored in a map which would mean only the last of the repeated arguments is retained.

#### Proposed Changes ####

Store the arguments in a map which can have multiple values. The extra arguments are removed from the defaults map so that the defaults can simply be added to the multivalue map.

The `--service-account-issuer ` flag [here](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) has some logic applied around the order of the repeated values, therefore simply sorting the resultant list of arguments could result in arguments not ending up in the order they were specified. This is solved by getting a list of argument names, sorting them and then adding the arguments to a list in order of their name but not their value.

The GetArgs function will be updated to support specifying -= and += when declaring extra arguments with the effect of prefixing or suffixing the default values with the extra values. E.g.

Default value:
```
service-account-issuer: https://kubernetes.default.svc.cluster.local
```
Arg:
```
--kube-apiserver-arg=service-account-issuer-=https://s3-eu-west-2.amazonaws.com/somebucket
```
Resultant args:
```
--service-account-issuer=https://s3-eu-west-2.amazonaws.com/somebucket
--service-account-issuer=https://kubernetes.default.svc.cluster.local
```

#### Types of Changes ####

`pkg/daemons/config/types.go - GetArgs - Bugfix/Update`

#### Verification ####

An additional unit test for the `GetArgs` function was added to verify both the sorting of repeated arguments and the retention of repeated arguments. Also added unit tests to verify the logic of prepending/appending values including default values

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/5374

#### User-Facing Change ####

```release-note
NONE
```
Not sure if the release-note should be none, would prefer someone else's opinion on that.
