### PR TITLE
Replace DefaultProxyDialerFn dialer injection with EgressSelector support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,6 +115,7 @@ require (
 	github.com/tchap/go-patricia v2.3.0+incompatible // indirect
 	github.com/urfave/cli v1.22.4
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
+	github.com/yl2chen/cidranger v1.0.2
 	go.etcd.io/etcd/api/v3 v3.5.4
 	go.etcd.io/etcd/client/pkg/v3 v3.5.4
 	go.etcd.io/etcd/client/v3 v3.5.4

--- a/go.sum
+++ b/go.sum
@@ -1262,6 +1262,8 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca h1:1CFlNzQhALwjS9mBAUkycX616GzgsuYUOCHA5+HSlXI=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yl2chen/cidranger v1.0.2 h1:lbOWZVCG1tCRX4u24kuM1Tb4nHqWkDxwLdoS+SevawU=
+github.com/yl2chen/cidranger v1.0.2/go.mod h1:9U1yz7WPYDwf0vpNWFaeRh0bjwz5RVgRy/9UEQfHl0g=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -319,15 +319,21 @@ func configureNode(ctx context.Context, agentConfig *daemonconfig.Agent, nodes t
 			updateNode = true
 		}
 
+		if changed, err := nodeconfig.SetNodeConfigLabels(node); err != nil {
+			return false, err
+		} else if changed {
+			updateNode = true
+		}
+
 		if updateNode {
 			if _, err := nodes.Update(ctx, node, metav1.UpdateOptions{}); err != nil {
-				logrus.Infof("Failed to update node %s: %v", agentConfig.NodeName, err)
+				logrus.Infof("Failed to set annotations and labels on node %s: %v", agentConfig.NodeName, err)
 				return false, nil
 			}
-			logrus.Infof("labels have been set successfully on node: %s", agentConfig.NodeName)
+			logrus.Infof("Annotations and labels have been set successfully on node: %s", agentConfig.NodeName)
 			return true, nil
 		}
-		logrus.Infof("labels have already set on node: %s", agentConfig.NodeName)
+		logrus.Infof("Annotations and labels have already set on node: %s", agentConfig.NodeName)
 		return true, nil
 	}
 

--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -50,7 +50,7 @@ func (c *Cluster) newListener(ctx context.Context) (net.Listener, http.Handler, 
 		return nil, nil, err
 	}
 	storage := tlsStorage(ctx, c.config.DataDir, c.config.Runtime)
-	return dynamiclistener.NewListener(tcp, storage, cert, key, dynamiclistener.Config{
+	return wrapHandler(dynamiclistener.NewListener(tcp, storage, cert, key, dynamiclistener.Config{
 		ExpirationDaysCheck: config.CertificateRenewDays,
 		Organization:        []string{version.Program},
 		SANs:                append(c.config.SANs, "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc."+c.config.ClusterDomain),
@@ -70,7 +70,7 @@ func (c *Cluster) newListener(ctx context.Context) (net.Listener, http.Handler, 
 			}
 			return false
 		},
-	})
+	}))
 }
 
 // initClusterAndHTTPS sets up the dynamic tls listener, request router,
@@ -130,4 +130,19 @@ func tlsStorage(ctx context.Context, dataDir string, runtime *config.ControlRunt
 	return kubernetes.New(ctx, func() *core.Factory {
 		return runtime.Core
 	}, metav1.NamespaceSystem, version.Program+"-serving", cache)
+}
+
+// wrapHandler wraps the dynamiclistener request handler, adding a User-Agent value to
+// CONNECT requests that will prevent DynamicListener from adding the request's Host
+// header to the SAN list.  CONNECT requests set the Host header to the target of the
+// proxy connection, so it is not correct to add this value to the certificate.  It would
+// be nice if we could do this with with the FilterCN callback, but unfortunately that
+// callback does not offer access to the request that triggered the change.
+func wrapHandler(listener net.Listener, handler http.Handler, err error) (net.Listener, http.Handler, error) {
+	return listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodConnect {
+			r.Header.Add("User-Agent", "mozilla")
+		}
+		handler.ServeHTTP(w, r)
+	}), err
 }

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -276,6 +276,8 @@ type ControlRuntime struct {
 	Tunnel             http.Handler
 	Authenticator      authenticator.Request
 
+	EgressSelectorConfig string
+
 	ClientAuthProxyCert string
 	ClientAuthProxyKey  string
 

--- a/pkg/daemons/control/proxy/proxy.go
+++ b/pkg/daemons/control/proxy/proxy.go
@@ -1,0 +1,57 @@
+package proxy
+
+import (
+	"io"
+	"net"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type proxy struct {
+	lconn, rconn io.ReadWriteCloser
+	done         bool
+	errc         chan error
+}
+
+func Proxy(lconn, rconn net.Conn) error {
+	p := &proxy{
+		lconn: lconn,
+		rconn: rconn,
+		errc:  make(chan error),
+	}
+
+	defer p.rconn.Close()
+	defer p.lconn.Close()
+	go p.pipe(p.lconn, p.rconn)
+	go p.pipe(p.rconn, p.lconn)
+	return <-p.errc
+}
+
+func (p *proxy) err(err error) {
+	if p.done {
+		return
+	}
+	if !errors.Is(err, io.EOF) {
+		logrus.Warnf("Proxy error: %v", err)
+	}
+	p.done = true
+	p.errc <- err
+}
+
+func (p *proxy) pipe(src, dst io.ReadWriter) {
+	buff := make([]byte, 1<<15)
+	for {
+		n, err := src.Read(buff)
+		if err != nil {
+			p.err(errors.Wrap(err, "read failed"))
+			return
+		}
+		_, err = dst.Write(buff[:n])
+		if err != nil {
+			p.err(errors.Wrap(err, "write failed"))
+			return
+		}
+	}
+
+}

--- a/pkg/daemons/control/tunnel.go
+++ b/pkg/daemons/control/tunnel.go
@@ -2,45 +2,38 @@ package control
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/k3s-io/k3s/pkg/daemons/control/proxy"
+	"github.com/k3s-io/k3s/pkg/nodeconfig"
+	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/rancher/remotedialer"
-	"github.com/rancher/wrangler/pkg/kv"
 	"github.com/sirupsen/logrus"
-	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"github.com/yl2chen/cidranger"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/kubernetes/cmd/kube-apiserver/app"
+	"k8s.io/client-go/kubernetes"
 )
 
 func loggingErrorWriter(rw http.ResponseWriter, req *http.Request, code int, err error) {
-	logrus.Debugf("remoteDialer error: %d %v", code, err)
+	logrus.Debugf("Tunnel server error: %d %v", code, err)
 	rw.WriteHeader(code)
 	rw.Write([]byte(err.Error()))
 }
 
-func setupTunnel() http.Handler {
-	tunnelServer := remotedialer.New(authorizer, loggingErrorWriter)
-	setupProxyDialer(tunnelServer)
-	return tunnelServer
-}
-
-func setupProxyDialer(tunnelServer *remotedialer.Server) {
-	app.DefaultProxyDialerFn = utilnet.DialFunc(func(ctx context.Context, network, address string) (net.Conn, error) {
-		_, port, _ := net.SplitHostPort(address)
-		addr := "127.0.0.1"
-		if port != "" {
-			addr += ":" + port
-		}
-		nodeName, _ := kv.Split(address, ":")
-		if tunnelServer.HasSession(nodeName) {
-			return tunnelServer.Dial(nodeName, 15*time.Second, "tcp", addr)
-		}
-		var d net.Dialer
-		return d.DialContext(ctx, network, address)
-	})
+func setupTunnel(ctx context.Context, cfg *config.Control) (http.Handler, error) {
+	tunnel := &TunnelServer{
+		cidrs:  cidranger.NewPCTrieRanger(),
+		config: cfg,
+		server: remotedialer.New(authorizer, loggingErrorWriter),
+	}
+	go tunnel.watchNodes(ctx)
+	return tunnel, nil
 }
 
 func authorizer(req *http.Request) (clientKey string, authed bool, err error) {
@@ -54,4 +47,186 @@ func authorizer(req *http.Request) (clientKey string, authed bool, err error) {
 	}
 
 	return "", false, nil
+}
+
+// explicit interface check
+var _ http.Handler = &TunnelServer{}
+
+type TunnelServer struct {
+	cidrs  cidranger.Ranger
+	client kubernetes.Interface
+	config *config.Control
+	server *remotedialer.Server
+}
+
+// explicit interface check
+var _ cidranger.RangerEntry = &nodeAddress{}
+var _ cidranger.RangerEntry = &nodeCIDR{}
+
+type nodeAddress struct {
+	cidr net.IPNet
+	node string
+}
+
+func (n *nodeAddress) Network() net.IPNet {
+	return n.cidr
+}
+
+type nodeCIDR struct {
+	cidr          net.IPNet
+	clusterEgress bool
+	node          string
+}
+
+func (n *nodeCIDR) Network() net.IPNet {
+	return n.cidr
+}
+
+// ServeHTTP handles either CONNECT requests, or websocket requests to the remotedialer server
+func (t *TunnelServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	logrus.Debugf("Tunnel server handing %s %s request for %s from %s", req.Proto, req.Method, req.URL, req.RemoteAddr)
+	if req.Method == http.MethodConnect {
+		t.serveConnect(resp, req)
+	} else {
+		t.server.ServeHTTP(resp, req)
+	}
+}
+
+// watchNodes waits for the runtime core to become available,
+// and registers an OnChange handler to observe PodCIDR changes.
+func (t *TunnelServer) watchNodes(ctx context.Context) {
+	for {
+		if t.config.Runtime.Core != nil {
+			t.config.Runtime.Core.Core().V1().Node().OnChange(ctx, version.Program+"-tunnel-server", t.onChangeNode)
+			return
+		}
+		logrus.Infof("Tunnel server waiting for runtime core to become available")
+		time.Sleep(5 * time.Second)
+	}
+}
+
+// onChangeNode updates the node address/CIDR mappings by observing changes to nodes.
+func (t *TunnelServer) onChangeNode(nodeName string, node *v1.Node) (*v1.Node, error) {
+	if node != nil {
+		logrus.Debugf("Tunnel server updating node %s", nodeName)
+		_, clusterEgress := node.Labels[nodeconfig.ClusterEgressLabel]
+		// Add all node IP addresses
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == v1.NodeInternalIP || addr.Type == v1.NodeExternalIP {
+				address := addr.Address
+				if strings.Contains(address, ":") {
+					address += "/128"
+				} else {
+					address += "/32"
+				}
+				if _, n, err := net.ParseCIDR(address); err == nil {
+					if node.DeletionTimestamp != nil {
+						t.cidrs.Remove(*n)
+					} else {
+						t.cidrs.Insert(&nodeAddress{cidr: *n, node: nodeName})
+					}
+				}
+			}
+		}
+		// Add all node PodCIDRs
+		for _, cidr := range node.Spec.PodCIDRs {
+			if _, n, err := net.ParseCIDR(cidr); err == nil {
+				if node.DeletionTimestamp != nil {
+					t.cidrs.Remove(*n)
+				} else {
+					t.cidrs.Insert(&nodeCIDR{cidr: *n, clusterEgress: clusterEgress, node: nodeName})
+				}
+			}
+		}
+	}
+	return node, nil
+}
+
+// serveConnect attempts to handle the HTTP CONNECT request by dialing
+// a connection, either locally or via the remotedialer tunnel.
+func (t *TunnelServer) serveConnect(resp http.ResponseWriter, req *http.Request) {
+	bconn, err := t.dialBackend(req.Host)
+	if err != nil {
+		http.Error(resp, fmt.Sprintf("no tunnels available: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	hijacker, ok := resp.(http.Hijacker)
+	if !ok {
+		http.Error(resp, "hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+	resp.WriteHeader(http.StatusOK)
+
+	rconn, _, err := hijacker.Hijack()
+	if err != nil {
+		http.Error(resp, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	proxy.Proxy(rconn, bconn)
+}
+
+// dialBackend determines where to route the connection request to, and returns
+// a dialed connection if possible. Note that in the case of a remotedialer
+// tunnel connection, the agent may return an error if the agent's authorizer
+// denies the connection, or if there is some other error in actually dialing
+// the requested endpoint.
+func (t *TunnelServer) dialBackend(addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	loopback := t.config.Loopback()
+
+	var node string
+	var toKubelet, useTunnel bool
+	if ip := net.ParseIP(host); ip != nil {
+		// Destination is an IP address, check to see if the target is a CIDR or node address.
+		// We can only use the tunnel for egress to pods if the agent supports it.
+		if nets, err := t.cidrs.ContainingNetworks(ip); err == nil && len(nets) > 0 {
+			switch n := nets[0].(type) {
+			case *nodeAddress:
+				node = n.node
+				toKubelet = true
+				useTunnel = true
+			case *nodeCIDR:
+				node = n.node
+				useTunnel = n.clusterEgress
+			default:
+				logrus.Debugf("Tunnel server CIDR lookup returned unknown type %T for address %s", nets[0], ip)
+			}
+		}
+	} else {
+		// Destination is a kubelet by name, it is safe to use the tunnel.
+		node = host
+		toKubelet = true
+		useTunnel = true
+	}
+
+	// Always dial kubelets via the loopback address.
+	if toKubelet {
+		addr = fmt.Sprintf("%s:%s", loopback, port)
+	}
+
+	// If connecting to something hosted by the local node, don't tunnel
+	if node == t.config.ServerNodeName {
+		useTunnel = false
+	}
+
+	if t.server.HasSession(node) {
+		if useTunnel {
+			// Have a session and it is safe to use for this destination, do so.
+			logrus.Debugf("Tunnel server dialing %s via session to %s", addr, node)
+			return t.server.Dial(node, 15*time.Second, "tcp", addr)
+		}
+		// Have a session but the agent doesn't support tunneling to this destination or
+		// the destination is local; fall back to direct connection.
+		logrus.Debugf("Tunnel server dialing %s directly", addr)
+		return net.Dial("tcp", addr)
+	}
+
+	// don't provide a proxy connection for anything else
+	logrus.Debugf("Tunnel server rejecting connection to %s", addr)
+	return nil, fmt.Errorf("no sessions available for host %s", host)
 }

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -570,7 +570,7 @@ func (e *ETCD) setName(force bool) error {
 
 // handler wraps the handler with routes for database info
 func (e *ETCD) handler(next http.Handler) http.Handler {
-	mux := mux.NewRouter()
+	mux := mux.NewRouter().SkipClean(true)
 	mux.Handle("/db/info", e.infoHandler())
 	mux.NotFoundHandler = next
 	return mux

--- a/tests/unit.go
+++ b/tests/unit.go
@@ -48,6 +48,7 @@ func GenerateRuntime(cnf *config.Control) error {
 		return err
 	}
 
+	os.MkdirAll(filepath.Join(cnf.DataDir, "etc"), 0700)
 	os.MkdirAll(filepath.Join(cnf.DataDir, "tls"), 0700)
 	os.MkdirAll(filepath.Join(cnf.DataDir, "cred"), 0700)
 


### PR DESCRIPTION
#### Proposed Changes ####

This PR drops use of our [custom dialer injection patch](https://github.com/k3s-io/kubernetes/commit/63140772e6855d034c43f5b34db4b5a8f01014e0), in favor of implementing the standard Egress Selector / Konnectivity Server functionality on top of the existing reversedialer agent tunnel. This has the added bonus of making it possible to tunnel connections to cluster endpoints (webhooks, metrics-server, etc) when the apiserver node is not running a kubelet (ie with --disable-agent). It will also allow RKE2 to make use of the agent tunnel for communication initiated by the apiserver, which it currently does not due to lack of the Kubernetes patch.

* ~This PR builds on top of the changes from https://github.com/k3s-io/k3s/pull/5367~

##### Background 

K3s currently carries a custom patch to Kubernetes that we use to replace the dialer that the apiserver uses to dial the kubelet when the administrator runs `kubectl logs` or `kubectl exec`. This was a workaround to the approach that upstream previously took, which saw the apiserver using ssh tunnels to log in to kubelet nodes in environments where the apiserver and kubelet were not directly accessible to each other.

Starting with Kubernetes 1.21, upstream has dropped the ssh tunnel support, and replaced it with EgressSelector configuration and the Konnectivity Service: 
* https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1281-network-proxy
* https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/
* https://github.com/kubernetes-sigs/apiserver-network-proxy

Egress Selector configuration and the Konnectivity Service work together to accomplish the same thing we were doing via our dialer injection, but via formal configuration API and a HTTP or GRPC client/server architecture to implement the proxy functionality.

#### Types of Changes ####

tech debt removal

#### Verification ####

See linked PR

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5330

#### User-Facing Change ####
```release-note
The K3s supervisor now implements a [KEP-1281](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1281-network-proxy) compliant apiserver network proxy.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
