### PR TITLE
Fix crash on early snapshot

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -1233,19 +1233,22 @@ func (e *ETCD) Snapshot(ctx context.Context, config *config.Control) error {
 		return err
 	}
 
-	logrus.Debugf("Attempting to retrieve extra metadata from %s ConfigMap", snapshotExtraMetadataConfigMapName)
+	// make sure the core.Factory is initialized before attempting to add snapshot metadata
 	var extraMetadata string
-	if snapshotExtraMetadataConfigMap, err := e.config.Runtime.Core.Core().V1().ConfigMap().Get(metav1.NamespaceSystem, snapshotExtraMetadataConfigMapName, metav1.GetOptions{}); err != nil {
-		logrus.Debugf("Error encountered attempting to retrieve extra metadata from %s ConfigMap, error: %v", snapshotExtraMetadataConfigMapName, err)
-		extraMetadata = ""
+	if e.config.Runtime.Core == nil {
+		logrus.Debugf("Cannot retrieve extra metadata from %s ConfigMap: runtime core not ready", snapshotExtraMetadataConfigMapName)
 	} else {
-		if m, err := json.Marshal(snapshotExtraMetadataConfigMap.Data); err != nil {
-			logrus.Debugf("Error attempting to marshal extra metadata contained in %s ConfigMap, error: %v", snapshotExtraMetadataConfigMapName, err)
-			extraMetadata = ""
+		logrus.Debugf("Attempting to retrieve extra metadata from %s ConfigMap", snapshotExtraMetadataConfigMapName)
+		if snapshotExtraMetadataConfigMap, err := e.config.Runtime.Core.Core().V1().ConfigMap().Get(metav1.NamespaceSystem, snapshotExtraMetadataConfigMapName, metav1.GetOptions{}); err != nil {
+			logrus.Debugf("Error encountered attempting to retrieve extra metadata from %s ConfigMap, error: %v", snapshotExtraMetadataConfigMapName, err)
 		} else {
-			logrus.Debugf("Setting extra metadata from %s ConfigMap", snapshotExtraMetadataConfigMapName)
-			logrus.Tracef("Marshalled extra metadata in %s ConfigMap was: %s", snapshotExtraMetadataConfigMapName, string(m))
-			extraMetadata = base64.StdEncoding.EncodeToString(m)
+			if m, err := json.Marshal(snapshotExtraMetadataConfigMap.Data); err != nil {
+				logrus.Debugf("Error attempting to marshal extra metadata contained in %s ConfigMap, error: %v", snapshotExtraMetadataConfigMapName, err)
+			} else {
+				logrus.Debugf("Setting extra metadata from %s ConfigMap", snapshotExtraMetadataConfigMapName)
+				logrus.Tracef("Marshalled extra metadata in %s ConfigMap was: %s", snapshotExtraMetadataConfigMapName, string(m))
+				extraMetadata = base64.StdEncoding.EncodeToString(m)
+			}
 		}
 	}
 


### PR DESCRIPTION

#### Proposed Changes ####

Don't attempt to retrieve snapshot metadata configmap if the apiserver
isn't available. This could be triggered if the cron expression caused a
snapshot to be triggered before the apiserver is up.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue. Probably requires some timing to reproduce - in particular a snapshot expression that triggers a snapshot while K3s is starting up. May be easier to reproduce on RKE2 where startup takes longer.

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/2716

#### User-Facing Change ####
```release-note
K3s will no longer crash on startup if the scheduled cron expression triggered a snapshot before the internal controllers are fully initialized.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
