### PR TITLE
Add wireguard native flannel backend

### DIFF
--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -204,7 +204,8 @@ func createFlannelConf(nodeConfig *config.Node) error {
 		}
 	case config.FlannelBackendWireguard:
 		backendConf = strings.ReplaceAll(wireguardBackend, "%flannelConfDir%", filepath.Dir(nodeConfig.FlannelConfFile))
-	case config.FlannelBackendNativeWireguard:
+		logrus.Warnf("The wireguard backend is deprecated and will be removed in k3s v1.26, please switch to wireguard-native. Check our docs for information about how to migrate")
+	case config.FlannelBackendWireguardNative:
 		backendConf = wireguardNativeBackend
 	default:
 		return fmt.Errorf("Cannot configure unknown flannel backend '%s'", nodeConfig.FlannelBackend)

--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -75,6 +75,11 @@ const (
 	"SubnetRemoveCommand": "read PUBLICKEY; wg set flannel.1 peer $PUBLICKEY remove"
 }`
 
+	wireguardNativeBackend = `{
+	"Type": "wireguard",
+	"PersistentKeepaliveInterval": 25
+}`
+
 	emptyIPv6Network = "::/0"
 
 	ipv4 = iota
@@ -199,6 +204,8 @@ func createFlannelConf(nodeConfig *config.Node) error {
 		}
 	case config.FlannelBackendWireguard:
 		backendConf = strings.ReplaceAll(wireguardBackend, "%flannelConfDir%", filepath.Dir(nodeConfig.FlannelConfFile))
+	case config.FlannelBackendNativeWireguard:
+		backendConf = wireguardNativeBackend
 	default:
 		return fmt.Errorf("Cannot configure unknown flannel backend '%s'", nodeConfig.FlannelBackend)
 	}

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -204,7 +204,7 @@ var ServerFlags = []cli.Flag{
 	ClusterDomain,
 	cli.StringFlag{
 		Name:        "flannel-backend",
-		Usage:       "(networking) One of 'none', 'vxlan', 'ipsec', 'host-gw', or 'wireguard'",
+		Usage:       "(networking) One of 'none', 'vxlan', 'ipsec', 'host-gw', 'wireguard'(deprecated), or 'wireguard-native' (default: vxlan)",
 		Destination: &ServerConfig.FlannelBackend,
 		Value:       "vxlan",
 	},

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -17,12 +17,13 @@ import (
 )
 
 const (
-	FlannelBackendNone      = "none"
-	FlannelBackendVXLAN     = "vxlan"
-	FlannelBackendHostGW    = "host-gw"
-	FlannelBackendIPSEC     = "ipsec"
-	FlannelBackendWireguard = "wireguard"
-	CertificateRenewDays    = 90
+	FlannelBackendNone            = "none"
+	FlannelBackendVXLAN           = "vxlan"
+	FlannelBackendHostGW          = "host-gw"
+	FlannelBackendIPSEC           = "ipsec"
+	FlannelBackendWireguard       = "wireguard"
+	FlannelBackendNativeWireguard = "native-wireguard"
+	CertificateRenewDays          = 90
 )
 
 type Node struct {

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -22,7 +22,7 @@ const (
 	FlannelBackendHostGW          = "host-gw"
 	FlannelBackendIPSEC           = "ipsec"
 	FlannelBackendWireguard       = "wireguard"
-	FlannelBackendNativeWireguard = "native-wireguard"
+	FlannelBackendWireguardNative = "wireguard-native"
 	CertificateRenewDays          = 90
 )
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Added wireguard-native flannel backend to use the wireguard backend included in flannel.
The older wireguard backend will remain as it is for backward compatibility (#5011)

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
New Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Use the option `--flannel-backend=wireguard-native` to set up a cluster that uses wireguard as backend
On the node `flannel-wg` interface should be there and in case of dual-stack `flannel-wg-v6`

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
 #4364 #5216 #5101

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
