### PR TITLE
Don't print password conversion rate

### DIFF
--- a/pkg/nodepassword/nodepassword.go
+++ b/pkg/nodepassword/nodepassword.go
@@ -110,7 +110,6 @@ func MigrateFile(secretClient coreclient.SecretClient, nodeClient coreclient.Nod
 			}
 		}
 	}
-	ms := time.Since(start).Milliseconds()
-	logrus.Infof("Migrated %d node password entries in %d milliseconds, average %d ms", ensured, ms, ms/ensured)
+	logrus.Infof("Migrated %d node password entries in %s", ensured, time.Since(start))
 	return os.Remove(passwordFile)
 }


### PR DESCRIPTION
#### Proposed Changes ####

Don't print password conversion rate

Avoids divide-by-zero when the password file is empty

#### Types of Changes ####

bugfix

#### Verification ####

* See linked issue
* Convert node from agent to server:
    1. Start server with `k3s server --cluster-init --token=token`
    2. Start agent with `k3s agent --server=https://server:6443 --token=token`
    3. Stop agent
    4. Restart agent with `k3s server --server=https://server:6443 --token-token`
    5. Note that agent successfully starts, joins cluster, and has correct roles


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5190 

#### User-Facing Change ####
```release-note
K3s will no longer panic on startup if the legacy node password file exists but does not contain any valid password entries.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
