### PR TITLE
update trivy to 0.25.3

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -18,16 +18,16 @@ RUN apk -U --no-cache add bash git gcc musl-dev docker vim less file curl wget c
     fi
 
 RUN if [ "$(go env GOARCH)" = "arm64" ]; then                                                               \
-    wget https://github.com/aquasecurity/trivy/releases/download/v0.16.0/trivy_0.16.0_Linux-ARM64.tar.gz && \
-    tar -zxvf trivy_0.16.0_Linux-ARM64.tar.gz                                                            && \
+    wget https://github.com/aquasecurity/trivy/releases/download/v0.25.3/trivy_0.25.3_Linux-ARM64.tar.gz && \
+    tar -zxvf trivy_0.25.3_Linux-ARM64.tar.gz                                                            && \
     mv trivy /usr/local/bin;                                                                                \
     elif [ "$(go env GOARCH)" = "arm" ]; then                                                               \
-    wget https://github.com/aquasecurity/trivy/releases/download/v0.16.0/trivy_0.16.0_Linux-ARM.tar.gz   && \
-    tar -zxvf trivy_0.16.0_Linux-ARM.tar.gz                                                              && \
+    wget https://github.com/aquasecurity/trivy/releases/download/v0.25.3/trivy_0.25.3_Linux-ARM.tar.gz   && \
+    tar -zxvf trivy_0.25.3_Linux-ARM.tar.gz                                                              && \
     mv trivy /usr/local/bin;                                                                                \
     else                                                                                                    \
-    wget https://github.com/aquasecurity/trivy/releases/download/v0.16.0/trivy_0.16.0_Linux-64bit.tar.gz && \
-    tar -zxvf trivy_0.16.0_Linux-64bit.tar.gz                                                            && \
+    wget https://github.com/aquasecurity/trivy/releases/download/v0.25.3/trivy_0.25.3_Linux-64bit.tar.gz && \
+    tar -zxvf trivy_0.25.3_Linux-64bit.tar.gz                                                            && \
     mv trivy /usr/local/bin;                                                                                \
     fi
 # this works for both go 1.15 and 1.16


### PR DESCRIPTION
#### Proposed Changes ####

Update trivy to latest version, which includes since 0.20 support for SLE BCI scanning.

#### Types of Changes ####

Bugfix

#### Verification ####

CI verifies it. 

#### Linked Issues ####

none

#### User-Facing Change ####

```release-note
NONE
```
