### PR TITLE
Update golangci-lint to 1.45.2

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -35,7 +35,7 @@ RUN GOPROXY=direct go get golang.org/x/tools/cmd/goimports@gopls/v0.7.0
 RUN rm -rf /go/src /go/pkg
 
 RUN if [ "$(go env GOARCH)" = "amd64" ]; then \
-    curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.41.1; \
+    curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.45.2; \
     fi
 
 ENV YQ_URL=https://github.com/mikefarah/yq/releases/download/v4.6.2/yq_linux

--- a/pkg/agent/containerd/command.go
+++ b/pkg/agent/containerd/command.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 package containerd
 

--- a/pkg/agent/loadbalancer/utlity_linux.go
+++ b/pkg/agent/loadbalancer/utlity_linux.go
@@ -1,4 +1,4 @@
-// +build linux
+//go:build linux
 
 package loadbalancer
 

--- a/pkg/agent/syssetup/setup.go
+++ b/pkg/agent/syssetup/setup.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 package syssetup
 

--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -1,4 +1,4 @@
-// +build linux
+//go:build linux
 
 package templates
 

--- a/pkg/cli/cmds/const_linux.go
+++ b/pkg/cli/cmds/const_linux.go
@@ -1,4 +1,4 @@
-// +build linux
+//go:build linux
 
 package cmds
 

--- a/pkg/cli/cmds/init_linux.go
+++ b/pkg/cli/cmds/init_linux.go
@@ -1,4 +1,4 @@
-// +build linux,cgo
+//go:build linux && cgo
 
 package cmds
 

--- a/pkg/cli/cmds/stage.go
+++ b/pkg/cli/cmds/stage.go
@@ -1,4 +1,4 @@
-// +build !no_stage
+//go:build !no_stage
 
 package cmds
 

--- a/pkg/containerd/none.go
+++ b/pkg/containerd/none.go
@@ -1,4 +1,4 @@
-// +build !ctrd
+//go:build !ctrd
 
 package containerd
 

--- a/pkg/containerd/utility_linux.go
+++ b/pkg/containerd/utility_linux.go
@@ -1,4 +1,4 @@
-// +build linux
+//go:build linux
 
 package containerd
 

--- a/pkg/deploy/stage.go
+++ b/pkg/deploy/stage.go
@@ -1,4 +1,4 @@
-// +build !no_stage
+//go:build !no_stage
 
 package deploy
 

--- a/pkg/flock/flock_unix.go
+++ b/pkg/flock/flock_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd openbsd netbsd dragonfly
+//go:build linux || darwin || freebsd || openbsd || netbsd || dragonfly
 
 /*
 Copyright 2016 The Kubernetes Authors.

--- a/pkg/flock/flock_unix_test.go
+++ b/pkg/flock/flock_unix_test.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || freebsd || openbsd || netbsd || dragonfly
-// +build linux darwin freebsd openbsd netbsd dragonfly
 
 /*
 Copyright 2016 The Kubernetes Authors.

--- a/pkg/rootless/mounts.go
+++ b/pkg/rootless/mounts.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 package rootless
 

--- a/pkg/static/stage.go
+++ b/pkg/static/stage.go
@@ -1,4 +1,4 @@
-// +build !no_stage
+//go:build !no_stage
 
 package static
 

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 package util
 


### PR DESCRIPTION
#### Proposed Changes ####

This requires a further set of gofmt -s improvements to the
code, but nothing major. golangci-lint 1.45.2 brings golang 1.18
support which might be needed in the future.


#### Types of Changes ####

Bugfix

#### Verification ####

CI verifies it


#### Linked Issues ####

NONE

#### User-Facing Change ####
```release-note
* golang-ci has been upgraded to 1.45.2
```
