### PR TITLE
Bump Reencryption Test timeout, improve comments

### DIFF
--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -181,6 +181,8 @@ func K3sKillServer(server *K3sServer) error {
 }
 
 // K3sCleanup attempts to cleanup networking and files leftover from an integration test
+// this is similar to the k3s-killall.sh script, but we dynamically generate that on
+// install, so we don't have accces to it in testing.
 func K3sCleanup(k3sTestLock int, dataDir string) error {
 	if cni0Link, err := netlink.LinkByName("cni0"); err == nil {
 		links, _ := netlink.LinkList()
@@ -207,7 +209,7 @@ func K3sCleanup(k3sTestLock int, dataDir string) error {
 	return flock.Release(k3sTestLock)
 }
 
-// RunCommand Runs command on the cluster accessing the cluster through kubeconfig file
+// RunCommand Runs command on the host
 func RunCommand(cmd string) (string, error) {
 	c := exec.Command("bash", "-c", cmd)
 	var out bytes.Buffer

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -182,7 +182,7 @@ func K3sKillServer(server *K3sServer) error {
 
 // K3sCleanup attempts to cleanup networking and files leftover from an integration test
 // this is similar to the k3s-killall.sh script, but we dynamically generate that on
-// install, so we don't have accces to it in testing.
+// install, so we don't have access to it in testing.
 func K3sCleanup(k3sTestLock int, dataDir string) error {
 	if cni0Link, err := netlink.LinkByName("cni0"); err == nil {
 		links, _ := netlink.LinkList()

--- a/tests/integration/secretsencryption/secretsencryption_int_test.go
+++ b/tests/integration/secretsencryption/secretsencryption_int_test.go
@@ -99,7 +99,7 @@ var _ = Describe("secrets encryption rotation", func() {
 				To(ContainSubstring("reencryption started"))
 			Eventually(func() (string, error) {
 				return testutil.K3sCmd("secrets-encrypt status -d", secretsEncryptionDataDir)
-			}, "30s", "2s").Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
+			}, "45s", "2s").Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
 			result, err := testutil.K3sCmd("secrets-encrypt status -d", secretsEncryptionDataDir)
 			Expect(err).NotTo(HaveOccurred())
 			reg, err := regexp.Compile(`AES-CBC.+aescbckey.*`)


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Bump timeout (30s to 45s) when waiting for reencyrption to finish, was slightly to low when running on Github Action runners.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Flaky test
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
`go test -v ./tests/integration/... -run Integration`
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
TBD
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
