### PR TITLE
Fix issue with RKE2 server hanging on startup when listing apiserver addresses

### DIFF
--- a/pkg/agent/proxy/apiproxy.go
+++ b/pkg/agent/proxy/apiproxy.go
@@ -16,6 +16,7 @@ type Proxy interface {
 	Update(addresses []string)
 	SetAPIServerPort(ctx context.Context, port int, isIPv6 bool) error
 	SetSupervisorDefault(address string)
+	IsSupervisorLBEnabled() bool
 	SupervisorURL() string
 	SupervisorAddresses() []string
 	APIServerURL() string
@@ -156,6 +157,10 @@ func (p *proxy) SetSupervisorDefault(address string) {
 	} else {
 		p.supervisorLB.SetDefault(address)
 	}
+}
+
+func (p *proxy) IsSupervisorLBEnabled() bool {
+	return p.supervisorLB != nil
 }
 
 func (p *proxy) SupervisorURL() string {

--- a/pkg/agent/tunnel/tunnel.go
+++ b/pkg/agent/tunnel/tunnel.go
@@ -54,17 +54,23 @@ func Setup(ctx context.Context, config *config.Node, proxy proxy.Proxy) error {
 		return err
 	}
 
-	// Try to get a list of apiservers from the server we're connecting to. If that fails, fall back to
-	// querying the endpoints list from Kubernetes. This fallback requires that the server we're joining be
-	// running an apiserver, but is the only safe thing to do if its supervisor is down-level and can't provide us
-	// with an endpoint list.
-	if addresses := agentconfig.APIServers(ctx, config, proxy); len(addresses) > 0 {
-		proxy.SetSupervisorDefault(addresses[0])
-		proxy.Update(addresses)
-	} else {
-		if endpoint, _ := client.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{}); endpoint != nil {
-			if addresses := util.GetAddresses(endpoint); len(addresses) > 0 {
-				proxy.Update(addresses)
+	// The loadbalancer is only disabled when there is a local apiserver.  Servers without a local
+	// apiserver load-balance to themselves initially, then switch over to an apiserver node as soon
+	// as we get some addresses from the code below.
+	if proxy.IsSupervisorLBEnabled() && proxy.SupervisorURL() != "" {
+		logrus.Info("Getting list of apiserver endpoints from server")
+		// If not running an apiserver locally, try to get a list of apiservers from the server we're
+		// connecting to. If that fails, fall back to querying the endpoints list from Kubernetes. This
+		// fallback requires that the server we're joining be running an apiserver, but is the only safe
+		// thing to do if its supervisor is down-level and can't provide us with an endpoint list.
+		if addresses := agentconfig.APIServers(ctx, config, proxy); len(addresses) > 0 {
+			proxy.SetSupervisorDefault(addresses[0])
+			proxy.Update(addresses)
+		} else {
+			if endpoint, _ := client.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{}); endpoint != nil {
+				if addresses := util.GetAddresses(endpoint); len(addresses) > 0 {
+					proxy.Update(addresses)
+				}
 			}
 		}
 	}

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -456,18 +456,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		}
 	}()
 
-	ip := serverConfig.ControlConfig.BindAddress
-	if ip == "" {
-		ip = "127.0.0.1"
-		if IPv6only {
-			ip = "::1"
-		}
-	}
-	if utilsnet.IsIPv6String(ip) {
-		ip = fmt.Sprintf("[%s]", ip)
-	}
-
-	url := fmt.Sprintf("https://%s:%d", ip, serverConfig.ControlConfig.SupervisorPort)
+	url := fmt.Sprintf("https://%s:%d", serverConfig.ControlConfig.BindAddressOrLoopback(false), serverConfig.ControlConfig.SupervisorPort)
 	token, err := clientaccess.FormatToken(serverConfig.ControlConfig.Runtime.AgentToken, serverConfig.ControlConfig.Runtime.ServerCA)
 	if err != nil {
 		return err

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/k3s-io/k3s/pkg/util"
 	"github.com/k3s-io/kine/pkg/endpoint"
 	"github.com/rancher/wrangler/pkg/generated/controllers/core"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	utilsnet "k8s.io/utils/net"
 )
 
 const (
@@ -192,6 +194,36 @@ type Control struct {
 	SANs        []string
 	PrivateIP   string
 	Runtime     *ControlRuntime `json:"-"`
+}
+
+// BindAddressOrLoopback returns an IPv4 or IPv6 address suitable for embedding in server
+// URLs. If a bind address was configured, that is returned. If the chooseHostInterface
+// parameter is true, and a suitable default interface can be found, that interface's
+// address is returned.  If neither of the previous were used, the loopback address is
+// returned. IPv6 addresses are enclosed in square brackets, as per RFC2732.
+func (c *Control) BindAddressOrLoopback(chooseHostInterface bool) string {
+	ip := c.BindAddress
+	if ip == "" && chooseHostInterface {
+		if hostIP, _ := utilnet.ChooseHostInterface(); len(hostIP) > 0 {
+			ip = hostIP.String()
+		}
+	}
+	if utilsnet.IsIPv6String(ip) {
+		return fmt.Sprintf("[%s]", ip)
+	} else if ip != "" {
+		return ip
+	}
+	return c.Loopback()
+}
+
+// Loopback returns an IPv4 or IPv6 loopback address, depending on whether the cluster
+// service CIDRs indicate an IPv4/Dual-Stack or IPv6 only cluster.  IPv6 addresses are
+// enclosed in square brackets, as per RFC2732.
+func (c *Control) Loopback() string {
+	if IPv6OnlyService, _ := util.IsIPv6OnlyCIDRs(c.ServiceIPRanges); IPv6OnlyService {
+		return "[::1]"
+	}
+	return "127.0.0.1"
 }
 
 type ControlRuntimeBootstrap struct {

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -28,7 +28,6 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apiserver/pkg/apis/apiserver"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 )

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -28,7 +28,9 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/apis/apiserver"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 const (
@@ -314,7 +316,7 @@ func genClientCerts(config *config.Control) error {
 	}
 	apiEndpoint := fmt.Sprintf("https://%s:%d", ip, config.APIServerPort)
 
-	certGen, err = factory("system:admin", []string{"system:masters"}, runtime.ClientAdminCert, runtime.ClientAdminKey)
+	certGen, err = factory("system:admin", []string{user.SystemPrivilegedGroup}, runtime.ClientAdminCert, runtime.ClientAdminKey)
 	if err != nil {
 		return err
 	}
@@ -324,7 +326,7 @@ func genClientCerts(config *config.Control) error {
 		}
 	}
 
-	certGen, err = factory("system:kube-controller-manager", nil, runtime.ClientControllerCert, runtime.ClientControllerKey)
+	certGen, err = factory(user.KubeControllerManager, nil, runtime.ClientControllerCert, runtime.ClientControllerKey)
 	if err != nil {
 		return err
 	}
@@ -334,7 +336,7 @@ func genClientCerts(config *config.Control) error {
 		}
 	}
 
-	certGen, err = factory("system:kube-scheduler", nil, runtime.ClientSchedulerCert, runtime.ClientSchedulerKey)
+	certGen, err = factory(user.KubeScheduler, nil, runtime.ClientSchedulerCert, runtime.ClientSchedulerKey)
 	if err != nil {
 		return err
 	}
@@ -344,7 +346,7 @@ func genClientCerts(config *config.Control) error {
 		}
 	}
 
-	certGen, err = factory("kube-apiserver", nil, runtime.ClientKubeAPICert, runtime.ClientKubeAPIKey)
+	certGen, err = factory(user.APIServerUser, []string{user.SystemPrivilegedGroup}, runtime.ClientKubeAPICert, runtime.ClientKubeAPIKey)
 	if err != nil {
 		return err
 	}
@@ -354,7 +356,7 @@ func genClientCerts(config *config.Control) error {
 		}
 	}
 
-	if _, err = factory("system:kube-proxy", nil, runtime.ClientKubeProxyCert, runtime.ClientKubeProxyKey); err != nil {
+	if _, err = factory(user.KubeProxy, nil, runtime.ClientKubeProxyCert, runtime.ClientKubeProxyKey); err != nil {
 		return err
 	}
 	// This user (system:k3s-controller by default) must be bound to a role in rolebindings.yaml or the downstream equivalent
@@ -493,23 +495,22 @@ func addSANs(altNames *certutil.AltNames, sans []string) {
 	}
 }
 
-func sansChanged(certFile string, sans *certutil.AltNames) bool {
+func fieldsChanged(certFile string, commonName string, organization []string, sans *certutil.AltNames, caCertFile string) bool {
 	if sans == nil {
+		sans = &certutil.AltNames{}
+	}
+
+	certificates, err := certutil.CertsFromFile(certFile)
+	if err != nil || len(certificates) == 0 {
 		return false
 	}
 
-	certBytes, err := ioutil.ReadFile(certFile)
-	if err != nil {
-		return false
+	if certificates[0].Subject.CommonName != commonName {
+		return true
 	}
 
-	certificates, err := certutil.ParseCertsPEM(certBytes)
-	if err != nil {
-		return false
-	}
-
-	if len(certificates) == 0 {
-		return false
+	if !sets.NewString(certificates[0].Subject.Organization...).Equal(sets.NewString(organization...)) {
+		return true
 	}
 
 	if !sets.NewString(certificates[0].DNSNames...).HasAll(sans.DNSNames...) {
@@ -527,26 +528,32 @@ func sansChanged(certFile string, sans *certutil.AltNames) bool {
 		}
 	}
 
+	caCertificates, err := certutil.CertsFromFile(caCertFile)
+	if err != nil || len(caCertificates) == 0 {
+		return false
+	}
+
+	verifyOpts := x509.VerifyOptions{
+		Roots: x509.NewCertPool(),
+		KeyUsages: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageAny,
+		},
+	}
+
+	for _, cert := range caCertificates {
+		verifyOpts.Roots.AddCert(cert)
+	}
+
+	if _, err := certificates[0].Verify(verifyOpts); err != nil {
+		return true
+	}
+
 	return false
 }
 
 func createClientCertKey(regen bool, commonName string, organization []string, altNames *certutil.AltNames, extKeyUsage []x509.ExtKeyUsage, caCertFile, caKeyFile, certFile, keyFile string) (bool, error) {
-	caBytes, err := ioutil.ReadFile(caCertFile)
-	if err != nil {
-		return false, err
-	}
-
-	pool := x509.NewCertPool()
-	pool.AppendCertsFromPEM(caBytes)
-
-	// check for certificate expiration
-	if !regen {
-		regen = expired(certFile, pool)
-	}
-
-	if !regen {
-		regen = sansChanged(certFile, altNames)
-	}
+	// check for reasons to renew the certificate even if not manually requested.
+	regen = regen || expired(certFile) || fieldsChanged(certFile, commonName, organization, altNames, caCertFile)
 
 	if !regen {
 		if exists(certFile, keyFile) {
@@ -554,17 +561,12 @@ func createClientCertKey(regen bool, commonName string, organization []string, a
 		}
 	}
 
-	caKeyBytes, err := ioutil.ReadFile(caKeyFile)
+	caKey, err := certutil.PrivateKeyFromFile(caKeyFile)
 	if err != nil {
 		return false, err
 	}
 
-	caKey, err := certutil.ParsePrivateKeyPEM(caKeyBytes)
-	if err != nil {
-		return false, err
-	}
-
-	caCert, err := certutil.ParseCertsPEM(caBytes)
+	caCert, err := certutil.CertsFromFile(caCertFile)
 	if err != nil {
 		return false, err
 	}
@@ -648,23 +650,10 @@ func createSigningCertKey(prefix, certFile, keyFile string) (bool, error) {
 	return true, nil
 }
 
-func expired(certFile string, pool *x509.CertPool) bool {
-	certBytes, err := ioutil.ReadFile(certFile)
+func expired(certFile string) bool {
+	certificates, err := certutil.CertsFromFile(certFile)
 	if err != nil {
 		return false
-	}
-	certificates, err := certutil.ParseCertsPEM(certBytes)
-	if err != nil {
-		return false
-	}
-	_, err = certificates[0].Verify(x509.VerifyOptions{
-		Roots: pool,
-		KeyUsages: []x509.ExtKeyUsage{
-			x509.ExtKeyUsageAny,
-		},
-	})
-	if err != nil {
-		return true
 	}
 	return certutil.IsCertExpired(certificates[0], config.CertificateRenewDays)
 }

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -45,12 +46,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/util/retry"
-	utilsnet "k8s.io/utils/net"
 )
 
 const (
-	defaultEndpoint      = "https://127.0.0.1:2379"
-	defaultEndpointv6    = "https://[::1]:2379"
 	testTimeout          = time.Second * 10
 	manageTickerTime     = time.Second * 15
 	learnerMaxStallTime  = time.Minute * 5
@@ -133,13 +131,6 @@ func NewETCD() *ETCD {
 	return &ETCD{
 		cron: cron.New(),
 	}
-}
-
-func getLocalhostAddress(address string) string {
-	if utilsnet.IsIPv6String(address) {
-		return "[::1]"
-	}
-	return "127.0.0.1"
 }
 
 // EndpointName returns the name of the endpoint.
@@ -648,10 +639,7 @@ func getEndpoints(control *config.Control) []string {
 	if len(runtime.EtcdConfig.Endpoints) > 0 {
 		return runtime.EtcdConfig.Endpoints
 	}
-	if utilsnet.IsIPv6String(control.PrivateIP) {
-		return []string{defaultEndpointv6}
-	}
-	return []string{defaultEndpoint}
+	return []string{fmt.Sprintf("https://%s:2379", control.Loopback())}
 }
 
 // toTLSConfig converts the ControlRuntime configuration to TLS configuration suitable
@@ -760,29 +748,19 @@ func (e *ETCD) migrateFromSQLite(ctx context.Context) error {
 
 // peerURL returns the peer access address for the local node
 func (e *ETCD) peerURL() string {
-	if utilsnet.IsIPv6String(e.address) {
-		return fmt.Sprintf("https://[%s]:2380", e.address)
-	}
-	return fmt.Sprintf("https://%s:2380", e.address)
+	return fmt.Sprintf("https://%s", net.JoinHostPort(e.address, "2380"))
 }
 
 // clientURL returns the client access address for the local node
 func (e *ETCD) clientURL() string {
-	if utilsnet.IsIPv6String(e.address) {
-		return fmt.Sprintf("https://[%s]:2379", e.address)
-	}
-	return fmt.Sprintf("https://%s:2379", e.address)
+	return fmt.Sprintf("https://%s", net.JoinHostPort(e.address, "2379"))
 }
 
 // metricsURL returns the metrics access address
 func (e *ETCD) metricsURL(expose bool) string {
-	address := fmt.Sprintf("http://%s:2381", getLocalhostAddress(e.address))
+	address := fmt.Sprintf("http://%s:2381", e.config.Loopback())
 	if expose {
-		if utilsnet.IsIPv6String(e.address) {
-			address = fmt.Sprintf("http://[%s]:2381,%s", e.address, address)
-		} else {
-			address = fmt.Sprintf("http://%s:2381,%s", e.address, address)
-		}
+		address = fmt.Sprintf("http://%s,%s", net.JoinHostPort(e.address, "2381"), address)
 	}
 	return address
 }
@@ -793,7 +771,7 @@ func (e *ETCD) cluster(ctx context.Context, forceNew bool, options executor.Init
 		Name:                e.name,
 		InitialOptions:      options,
 		ForceNewCluster:     forceNew,
-		ListenClientURLs:    e.clientURL() + "," + fmt.Sprintf("https://%s:2379", getLocalhostAddress(e.address)),
+		ListenClientURLs:    e.clientURL() + "," + fmt.Sprintf("https://%s:2379", e.config.Loopback()),
 		ListenMetricsURLs:   e.metricsURL(e.config.EtcdExposeMetrics),
 		ListenPeerURLs:      e.peerURL(),
 		AdvertiseClientURLs: e.clientURL(),

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 const (
@@ -58,7 +59,7 @@ func router(ctx context.Context, config *Config, cfg *cmds.Server) http.Handler 
 	}
 
 	nodeAuthed := mux.NewRouter()
-	nodeAuthed.Use(authMiddleware(serverConfig, "system:nodes"))
+	nodeAuthed.Use(authMiddleware(serverConfig, user.NodesGroup))
 	nodeAuthed.Path(prefix + "/connect").Handler(serverConfig.Runtime.Tunnel)
 	nodeAuthed.NotFoundHandler = authed
 
@@ -247,7 +248,7 @@ func clientKubeletCert(server *config.Control, keyFile string, auth nodePassBoot
 
 		cert, err := certutil.NewSignedCert(certutil.Config{
 			CommonName:   "system:node:" + nodeName,
-			Organization: []string{"system:nodes"},
+			Organization: []string{user.NodesGroup},
 			Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		}, key, caCert[0], caKey)
 		if err != nil {


### PR DESCRIPTION
#### Proposed Changes ####

* Fix issue with RKE2 servers hanging on listing apiserver addresses.
* Print a helpful error when trying to join additional servers but etcd is not in use.
* Move IPv4/v6 selection into helpers.
* Use upstream group constants.

#### Types of Changes ####

Bugfix/cleanup

#### Verification ####

* Verify that K3s starts up as usual.
* Verify that RKE2 starts up as usual, when this PR is pulled through.
* Try to join an additional server to the cluster when etcd is not in use; note the helpful warning on the first server.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5348
* https://github.com/k3s-io/k3s/issues/284

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
