### PR TITLE
E2E Validation Improvements

### DIFF
--- a/tests/e2e/splitserver/Vagrantfile
+++ b/tests/e2e/splitserver/Vagrantfile
@@ -17,8 +17,8 @@ def provision(vm, role, role_num, node_num)
   # An expanded netmask is required to allow VM<-->VM communication, virtualbox defaults to /32
   vm.network "private_network", ip: "#{NETWORK_PREFIX}.#{100+node_num}", netmask: "255.255.255.0"
 
-  vagrant_defaults = '../vagrantdefaults.rb'
-  load vagrant_defaults if File.exists?(vagrant_defaults)
+  load './vagrantdefaults.rb' if File.exists?('./vagrantdefaults.rb')
+  load '../vagrantdefaults.rb' if File.exists?('../vagrantdefaults.rb')
   
   defaultOSConfigure(vm)
   

--- a/tests/e2e/splitserver/Vagrantfile
+++ b/tests/e2e/splitserver/Vagrantfile
@@ -17,9 +17,10 @@ def provision(vm, role, role_num, node_num)
   # An expanded netmask is required to allow VM<-->VM communication, virtualbox defaults to /32
   vm.network "private_network", ip: "#{NETWORK_PREFIX}.#{100+node_num}", netmask: "255.255.255.0"
 
-  load './vagrantdefaults.rb' if File.exists?('./vagrantdefaults.rb')
-  load '../vagrantdefaults.rb' if File.exists?('../vagrantdefaults.rb')
-  
+  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  load vagrant_defaults
+
   defaultOSConfigure(vm)
   
   if !RELEASE_VERSION.empty?
@@ -27,7 +28,7 @@ def provision(vm, role, role_num, node_num)
   else
     # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
     # MicroOS requires it not be in a /tmp/ or other root system folder
-    vm.provision "Acquire latest commit", type: "shell", path: "../scripts/latest_commit.sh", args: [GITHUB_BRANCH, "/home/vagrant/k3s_commits"]
+    vm.provision "Acquire latest commit", type: "shell", path: scripts_location + "/latest_commit.sh", args: [GITHUB_BRANCH, "/home/vagrant/k3s_commits"]
     install_type = "INSTALL_K3S_COMMIT=$(head\ -n\ 1\ /home/vagrant/k3s_commits)"
   end
   vm.provision "ping k3s.io", type: "shell", inline: "ping -c 2 k3s.io"

--- a/tests/e2e/splitserver/Vagrantfile
+++ b/tests/e2e/splitserver/Vagrantfile
@@ -47,7 +47,6 @@ def provision(vm, role, role_num, node_num)
         disable-controller-manager: true
         disable-scheduler: true
       YAML
-      k3s.args = "server --cluster-init --disable-apiserver --disable-controller-manager --disable-scheduler --node-external-ip=#{NETWORK_PREFIX}.100 --flannel-iface=eth1"
       k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
       k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
     end

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -2,7 +2,7 @@ ENV['VAGRANT_NO_PARALLEL'] = 'no'
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
   ["server-0", "server-1", "server-2", "agent-0", "agent-1"])
 NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
-  ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
+  ['opensuse/Leap-15.3.x86_64', 'opensuse/Leap-15.3.x86_64', 'opensuse/Leap-15.3.x86_64', 'opensuse/Leap-15.3.x86_64', 'opensuse/Leap-15.3.x86_64'])
 GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 EXTERNAL_DB = (ENV['E2E_EXTERNAL_DB'] || "etcd")
@@ -19,12 +19,12 @@ def provision(vm, role, role_num, node_num)
   vm.hostname = role
   # An expanded netmask is required to allow VM<-->VM communication, virtualbox defaults to /32
   node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
-  vm.network "private_network", ip: node_ip, netmask: "24"
+  vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
 
   scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
   vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
   load vagrant_defaults
-  
+
   defaultOSConfigure(vm)
   
   if !RELEASE_VERSION.empty?

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -21,8 +21,9 @@ def provision(vm, role, role_num, node_num)
   node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
   vm.network "private_network", ip: node_ip, netmask: "24"
 
-  load './vagrantdefaults.rb' if File.exists?('./vagrantdefaults.rb')
-  load '../vagrantdefaults.rb' if File.exists?('../vagrantdefaults.rb')
+  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  load vagrant_defaults
   
   defaultOSConfigure(vm)
   
@@ -31,7 +32,7 @@ def provision(vm, role, role_num, node_num)
   else
     # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
     # MicroOS requires it not be in a /tmp/ or other root system folder
-    vm.provision "Get latest commit", type: "shell", path: "../scripts/latest_commit.sh", args: [GITHUB_BRANCH, "/home/vagrant/k3s_commits"]
+    vm.provision "Get latest commit", type: "shell", path: scripts_location + "/latest_commit.sh", args: [GITHUB_BRANCH, "/home/vagrant/k3s_commits"]
     install_type = "INSTALL_K3S_COMMIT=$(head\ -n\ 1\ /home/vagrant/k3s_commits)"
   end
   vm.provision "shell", inline: "ping -c 2 k3s.io"
@@ -39,7 +40,7 @@ def provision(vm, role, role_num, node_num)
   db_type = getDBType(role, role_num, vm)
 
   if !HARDENED.empty?
-    vm.provision "Set kernel parameters", type: "shell", path: "../scripts/harden.sh"
+    vm.provision "Set kernel parameters", type: "shell", path: scripts_location + "/harden.sh"
     hardened_arg = "protect-kernel-defaults: true\nkube-apiserver-arg: \"enable-admission-plugins=NodeRestriction,PodSecurityPolicy,ServiceAccount\""
   end
 

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -123,7 +123,7 @@ def getDBType(role, role_num, vm)
       return "cluster-init: true"
     end
   elsif ( EXTERNAL_DB == "none" )
-    next
+    # Use internal sqlite
   else
     puts "Unknown EXTERNAL_DB: " + EXTERNAL_DB
     abort

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -21,8 +21,8 @@ def provision(vm, role, role_num, node_num)
   node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
   vm.network "private_network", ip: node_ip, netmask: "24"
 
-  vagrant_defaults = '../vagrantdefaults.rb'
-  load vagrant_defaults if File.exists?(vagrant_defaults)
+  load './vagrantdefaults.rb' if File.exists?('./vagrantdefaults.rb')
+  load '../vagrantdefaults.rb' if File.exists?('../vagrantdefaults.rb')
   
   defaultOSConfigure(vm)
   

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -122,6 +122,8 @@ def getDBType(role, role_num, vm)
     if role.include?("server") && role_num == 0
       return "cluster-init: true"
     end
+  elsif ( EXTERNAL_DB == "none" )
+    next
   else
     puts "Unknown EXTERNAL_DB: " + EXTERNAL_DB
     abort


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Added option for a "None" external_db, i.e. internal sqlite for single server
- Added support for upcoming "test-pad" script. 
- Moved to Leap 15.3 as the default OS, its images are ~1/5 the size of generic/ubuntu (250MB vs 1.2 GB)
- Fixed to Network Mask for libvirt (incorrectly changed in previous PR)
- Remove duplicate line in splitserver test
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Test Enhancements 
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
`vagrant up`
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/rancher/ecm-distro-tools/issues/89
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
