### PR TITLE
Add new `k3s completion` command for shell completion

### DIFF
--- a/cmd/completion/main.go
+++ b/cmd/completion/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+func main() {
+	app := cmds.NewApp()
+	app.Commands = []cli.Command{
+		cmds.NewCompletionCommand(),
+	}
+
+	if err := app.Run(os.Args); err != nil && !errors.Is(err, context.Canceled) {
+		logrus.Fatal(err)
+	}
+}

--- a/cmd/completion/main.go
+++ b/cmd/completion/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/cli/completion"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -13,7 +14,7 @@ import (
 func main() {
 	app := cmds.NewApp()
 	app.Commands = []cli.Command{
-		cmds.NewCompletionCommand(),
+		cmds.NewCompletionCommand(completion.Run),
 	}
 
 	if err := app.Run(os.Args); err != nil && !errors.Is(err, context.Canceled) {

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -137,7 +137,7 @@ func externalCLI(cli, dataDir string, args []string) error {
 // internalCLIAction returns a function that will call a K3s internal command, be used as the Action of a cli.Command.
 func internalCLIAction(cmd, dataDir string, args []string) func(ctx *cli.Context) error {
 	return func(ctx *cli.Context) error {
-		// We don't wont the Info logs seen when printing the autocomplete script
+		// We don't want the Info logs seen when printing the autocomplete script
 		if cmd == "k3s-completion" {
 			logrus.SetLevel(logrus.ErrorLevel)
 		}

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -68,7 +68,7 @@ func main() {
 			cmds.NewCertSubcommands(
 				certCommand),
 		),
-		cmds.NewCompletionCommand(internalCLIAction(version.Version+"-completion", dataDir, os.Args)),
+		cmds.NewCompletionCommand(internalCLIAction(version.Program+"-completion", dataDir, os.Args)),
 	}
 
 	if err := app.Run(os.Args); err != nil && !errors.Is(err, context.Canceled) {

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -40,6 +40,7 @@ func main() {
 
 	// Handle subcommand invocation (k3s server, k3s crictl, etc)
 	app := cmds.NewApp()
+	app.EnableBashCompletion = true
 	app.Commands = []cli.Command{
 		cmds.NewServerCommand(internalCLIAction(version.Program+"-server", dataDir, os.Args)),
 		cmds.NewAgentCommand(internalCLIAction(version.Program+"-agent", dataDir, os.Args)),
@@ -67,6 +68,7 @@ func main() {
 			cmds.NewCertSubcommands(
 				certCommand),
 		),
+		cmds.NewCompletionCommand(),
 	}
 
 	if err := app.Run(os.Args); err != nil && !errors.Is(err, context.Canceled) {

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -137,6 +137,10 @@ func externalCLI(cli, dataDir string, args []string) error {
 // internalCLIAction returns a function that will call a K3s internal command, be used as the Action of a cli.Command.
 func internalCLIAction(cmd, dataDir string, args []string) func(ctx *cli.Context) error {
 	return func(ctx *cli.Context) error {
+		// We don't wont the Info logs seen when printing the autocomplete script
+		if cmd == "k3s-completion" {
+			logrus.SetLevel(logrus.ErrorLevel)
+		}
 		return stageAndRunCLI(ctx, cmd, dataDir, args)
 	}
 }
@@ -197,7 +201,7 @@ func extract(dataDir string) (string, error) {
 	// acquire a data directory lock
 	os.MkdirAll(filepath.Join(dataDir, "data"), 0755)
 	lockFile := filepath.Join(dataDir, "data", ".lock")
-	logrus.Debugf("Acquiring lock file %s", lockFile)
+	logrus.Infof("Acquiring lock file %s", lockFile)
 	lock, err := flock.Acquire(lockFile)
 	if err != nil {
 		return "", err
@@ -209,7 +213,7 @@ func extract(dataDir string) (string, error) {
 		return dir, nil
 	}
 
-	logrus.Debugf("Preparing data dir %s", dir)
+	logrus.Infof("Preparing data dir %s", dir)
 
 	content, err := data.Asset(asset)
 	if err != nil {

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -197,7 +197,7 @@ func extract(dataDir string) (string, error) {
 	// acquire a data directory lock
 	os.MkdirAll(filepath.Join(dataDir, "data"), 0755)
 	lockFile := filepath.Join(dataDir, "data", ".lock")
-	logrus.Infof("Acquiring lock file %s", lockFile)
+	logrus.Debugf("Acquiring lock file %s", lockFile)
 	lock, err := flock.Acquire(lockFile)
 	if err != nil {
 		return "", err
@@ -209,7 +209,7 @@ func extract(dataDir string) (string, error) {
 		return dir, nil
 	}
 
-	logrus.Infof("Preparing data dir %s", dir)
+	logrus.Debugf("Preparing data dir %s", dir)
 
 	content, err := data.Asset(asset)
 	if err != nil {

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -68,7 +68,7 @@ func main() {
 			cmds.NewCertSubcommands(
 				certCommand),
 		),
-		cmds.NewCompletionCommand(),
+		cmds.NewCompletionCommand(internalCLIAction(version.Version+"-completion", dataDir, os.Args)),
 	}
 
 	if err := app.Run(os.Args); err != nil && !errors.Is(err, context.Canceled) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/cli/agent"
 	"github.com/k3s-io/k3s/pkg/cli/cert"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/cli/completion"
 	"github.com/k3s-io/k3s/pkg/cli/crictl"
 	"github.com/k3s-io/k3s/pkg/cli/ctr"
 	"github.com/k3s-io/k3s/pkg/cli/etcdsnapshot"
@@ -67,6 +68,7 @@ func main() {
 			cmds.NewCertSubcommands(
 				cert.Run),
 		),
+		cmds.NewCompletionCommand(completion.Run),
 	}
 
 	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil && !errors.Is(err, context.Canceled) {

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/cli/agent"
 	"github.com/k3s-io/k3s/pkg/cli/cert"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/cli/completion"
 	"github.com/k3s-io/k3s/pkg/cli/crictl"
 	"github.com/k3s-io/k3s/pkg/cli/etcdsnapshot"
 	"github.com/k3s-io/k3s/pkg/cli/kubectl"
@@ -51,6 +52,7 @@ func main() {
 			cmds.NewCertSubcommands(
 				cert.Run),
 		),
+		cmds.NewCompletionCommand(completion.Run),
 	}
 
 	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil && !errors.Is(err, context.Canceled) {

--- a/pkg/cli/cmds/completion.go
+++ b/pkg/cli/cmds/completion.go
@@ -1,22 +1,14 @@
 package cmds
 
 import (
-	"fmt"
-
-	"github.com/k3s-io/k3s/pkg/cli/completion"
 	"github.com/urfave/cli"
 )
 
-func NewCompletionCommand() cli.Command {
+func NewCompletionCommand(action func(*cli.Context) error) cli.Command {
 	return cli.Command{
 		Name:      "completion",
 		Usage:     "Install shell completion script",
 		UsageText: appName + " completion [SHELL] (valid shells: bash, zsh)",
-		Action: func(ctx *cli.Context) error {
-			if ctx.NArg() < 1 {
-				return fmt.Errorf("must provide a valid SHELL argument")
-			}
-			return completion.ShellCompletionInstall(appName, ctx.Args()[0])
-		},
+		Action:    action,
 	}
 }

--- a/pkg/cli/cmds/completion.go
+++ b/pkg/cli/cmds/completion.go
@@ -1,0 +1,74 @@
+package cmds
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+func genShellCompletion(shell string) error {
+	var completionScript string
+	if shell == "bash" {
+		completionScript = fmt.Sprintf(`#! /bin/bash
+_cli_bash_autocomplete() {
+if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+	local cur opts base
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	if [[ "$cur" == "-"* ]]; then
+	opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+	else
+	opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+	fi
+	COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+	return 0
+fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete %s
+`, appName)
+	} else if shell == "zsh" {
+		completionScript = fmt.Sprintf(`#compdef %[1]s
+_cli_zsh_autocomplete() {
+
+	local -a opts
+	local cur
+	cur=${words[-1]}
+	if [[ "$cur" == "-"* ]]; then
+	opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+	else
+	opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+	fi
+
+	if [[ "${opts[1]}" != "" ]]; then
+	_describe 'values' opts
+	else
+	_files
+	fi
+
+	return
+}
+
+compdef _cli_zsh_autocomplete %[1]s`, appName)
+	} else {
+		return fmt.Errorf("unkown shell, ")
+	}
+
+	fmt.Println(completionScript)
+	return nil
+}
+
+func NewCompletionCommand() cli.Command {
+	return cli.Command{
+		Name:      "completion",
+		Usage:     "Generate shell completion script",
+		UsageText: appName + " completion [SHELL] (valid shells: bash, zsh)",
+		Action: func(ctx *cli.Context) error {
+			if ctx.NArg() < 1 {
+				return fmt.Errorf("must provide a valid SHELL argument")
+			}
+			genShellCompletion(ctx.Args()[0])
+			return nil
+		},
+	}
+}

--- a/pkg/cli/cmds/completion.go
+++ b/pkg/cli/cmds/completion.go
@@ -10,5 +10,11 @@ func NewCompletionCommand(action func(*cli.Context) error) cli.Command {
 		Usage:     "Install shell completion script",
 		UsageText: appName + " completion [SHELL] (valid shells: bash, zsh)",
 		Action:    action,
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "i",
+				Usage: "Install source line to rc file",
+			},
+		},
 	}
 }

--- a/pkg/cli/cmds/completion.go
+++ b/pkg/cli/cmds/completion.go
@@ -3,72 +3,20 @@ package cmds
 import (
 	"fmt"
 
+	"github.com/k3s-io/k3s/pkg/cli/completion"
 	"github.com/urfave/cli"
 )
-
-func genShellCompletion(shell string) error {
-	var completionScript string
-	if shell == "bash" {
-		completionScript = fmt.Sprintf(`#! /bin/bash
-_cli_bash_autocomplete() {
-if [[ "${COMP_WORDS[0]}" != "source" ]]; then
-	local cur opts base
-	COMPREPLY=()
-	cur="${COMP_WORDS[COMP_CWORD]}"
-	if [[ "$cur" == "-"* ]]; then
-	opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
-	else
-	opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
-	fi
-	COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
-	return 0
-fi
-}
-
-complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete %s
-`, appName)
-	} else if shell == "zsh" {
-		completionScript = fmt.Sprintf(`#compdef %[1]s
-_cli_zsh_autocomplete() {
-
-	local -a opts
-	local cur
-	cur=${words[-1]}
-	if [[ "$cur" == "-"* ]]; then
-	opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
-	else
-	opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
-	fi
-
-	if [[ "${opts[1]}" != "" ]]; then
-	_describe 'values' opts
-	else
-	_files
-	fi
-
-	return
-}
-
-compdef _cli_zsh_autocomplete %[1]s`, appName)
-	} else {
-		return fmt.Errorf("unkown shell, ")
-	}
-
-	fmt.Println(completionScript)
-	return nil
-}
 
 func NewCompletionCommand() cli.Command {
 	return cli.Command{
 		Name:      "completion",
-		Usage:     "Generate shell completion script",
+		Usage:     "Install shell completion script",
 		UsageText: appName + " completion [SHELL] (valid shells: bash, zsh)",
 		Action: func(ctx *cli.Context) error {
 			if ctx.NArg() < 1 {
 				return fmt.Errorf("must provide a valid SHELL argument")
 			}
-			genShellCompletion(ctx.Args()[0])
-			return nil
+			return completion.ShellCompletionInstall(appName, ctx.Args()[0])
 		},
 	}
 }

--- a/pkg/cli/completion/completion.go
+++ b/pkg/cli/completion/completion.go
@@ -18,11 +18,11 @@ func Run(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	autoFile := "/etc/rancher/" + version.Program + "/autocomplete"
-	if err := os.WriteFile(autoFile, []byte(completetionScript), 0644); err != nil {
-		return err
+	if ctx.Bool("i") {
+		return writeToRC(shell)
 	}
-	return writeToRC(shell)
+	fmt.Println(completetionScript)
+	return nil
 }
 
 func genCompletionScript(shell string) (string, error) {
@@ -94,10 +94,10 @@ func writeToRC(shell string) error {
 		return err
 	}
 	defer f.Close()
-	bashEntry := fmt.Sprintf("# >> %[1]s command completion (start)\n. /etc/rancher/%[1]s/autocomplete\n# >> %[1]s command completion (end)", version.Program)
+	bashEntry := fmt.Sprintf("# >> %[1]s command completion (start)\n. <(%[1]s completion %s)\n# >> %[1]s command completion (end)", version.Program, shell)
 	if _, err := f.WriteString(bashEntry); err != nil {
 		return err
 	}
-	fmt.Printf("Autocomplete for %s installed in: %s\n", shell, rcFileName)
+	fmt.Printf("Autocomplete for %s added to: %s\n", shell, rcFileName)
 	return nil
 }

--- a/pkg/cli/completion/completion.go
+++ b/pkg/cli/completion/completion.go
@@ -70,7 +70,7 @@ _cli_zsh_autocomplete() {
 
 compdef _cli_zsh_autocomplete %[1]s`, version.Program)
 	} else {
-		return "", fmt.Errorf("unkown shell: %s", shell)
+		return "", fmt.Errorf("unknown shell: %s", shell)
 	}
 
 	return completionScript, nil

--- a/pkg/cli/completion/completion.go
+++ b/pkg/cli/completion/completion.go
@@ -1,0 +1,95 @@
+package completion
+
+import (
+	"fmt"
+	"os"
+)
+
+func ShellCompletionInstall(appName, shell string) error {
+	completetionScript, err := genCompletionScript(appName, shell)
+	if err != nil {
+		return err
+	}
+	autoFile := "/etc/rancher/" + appName + "/autocomplete"
+	if err := os.WriteFile(autoFile, []byte(completetionScript), 0644); err != nil {
+		return err
+	}
+	return writeToRC(appName, shell)
+}
+
+func genCompletionScript(appName, shell string) (string, error) {
+	var completionScript string
+	if shell == "bash" {
+		completionScript = fmt.Sprintf(`#! /bin/bash
+_cli_bash_autocomplete() {
+if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+	local cur opts base
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	if [[ "$cur" == "-"* ]]; then
+	opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+	else
+	opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+	fi
+	COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+	return 0
+fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete %s
+`, appName)
+	} else if shell == "zsh" {
+		completionScript = fmt.Sprintf(`#compdef %[1]s
+_cli_zsh_autocomplete() {
+
+	local -a opts
+	local cur
+	cur=${words[-1]}
+	if [[ "$cur" == "-"* ]]; then
+	opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+	else
+	opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+	fi
+
+	if [[ "${opts[1]}" != "" ]]; then
+	_describe 'values' opts
+	else
+	_files
+	fi
+
+	return
+}
+
+compdef _cli_zsh_autocomplete %[1]s`, appName)
+	} else {
+		return "", fmt.Errorf("unkown shell: %s", shell)
+	}
+
+	return completionScript, nil
+}
+
+func writeToRC(appName, shell string) error {
+	rcFileName := ""
+	if shell == "bash" {
+		rcFileName = "/.bashrc"
+	} else if shell == "zsh" {
+		rcFileName = "/.zshrc"
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	rcFileName = home + rcFileName
+	f, err := os.OpenFile(rcFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	bashEntry := fmt.Sprintf("# >> %[1]s command completion (start)\n. /etc/rancher/%[1]s/autocomplete\n# >> %[1]s command completion (end)", appName)
+	if _, err := f.WriteString(bashEntry); err != nil {
+		return err
+	}
+	fmt.Println("Autocomplete installed in: ", rcFileName)
+	return nil
+}

--- a/scripts/build
+++ b/scripts/build
@@ -74,6 +74,7 @@ rm -f \
     bin/k3s-etcd-snapshot \
     bin/k3s-secrets-encrypt \
     bin/k3s-certificate \
+    bin/k3s-completion \
     bin/kubectl \
     bin/crictl \
     bin/ctr \
@@ -108,6 +109,7 @@ ln -s k3s ./bin/k3s-server
 ln -s k3s ./bin/k3s-etcd-snapshot
 ln -s k3s ./bin/k3s-secrets-encrypt
 ln -s k3s ./bin/k3s-certificate
+ln -s k3s ./bin/k3s-completion
 ln -s k3s ./bin/kubectl
 ln -s k3s ./bin/crictl
 ln -s k3s ./bin/ctr

--- a/scripts/package-cli
+++ b/scripts/package-cli
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 
 GO=${GO-go}
 
-for i in crictl kubectl k3s-agent k3s-server k3s-etcd-snapshot k3s-secrets-encrypt k3s-certificate; do
+for i in crictl kubectl k3s-agent k3s-server k3s-etcd-snapshot k3s-secrets-encrypt k3s-certificate k3s-completion; do
     rm -f bin/$i
     ln -s k3s bin/$i
 done


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Added a `k3s completion` command which generates auto-completion scripts for bash and zsh.
Can be activated via `source <(k3s completion bash)` or via the -i flag `k3s completion bash -i` which adds the source line into the bashrc/zshrc file.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
New CLI
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
**Help**
```
derek@degion:~/rancher/k3s$ ./dist/artifacts/k3s completion -h
NAME:
   k3s completion - Install shell completion script

USAGE:
   k3s completion [SHELL] (valid shells: bash, zsh)

OPTIONS:
   -i  Install source line to rc file
```
**Running as regular user** 
```
derek@degion:~/rancher/k3s$ ./dist/artifacts/k3s completion bash
#! /bin/bash
_cli_bash_autocomplete() {
if [[ "${COMP_WORDS[0]}" != "source" ]]; then
	local cur opts base
	COMPREPLY=()
	cur="${COMP_WORDS[COMP_CWORD]}"
	if [[ "$cur" == "-"* ]]; then
	opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
	else
	opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
	fi
	COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
	return 0
fi
}

complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete k3s

```
**Install option**
```
derek@degion:~/rancher/k3s$ ./dist/artifacts/k3s completion bash -i
Autocomplete for bash added to: /home/derek/.bashrc
derek@degion:~/rancher/k3s$ tail -n 3 ~/.bashrc
# >> k3s command completion (start)
. <(k3s completion bash)
# >> k3s command completion (end)
```
**Sudo Install option**
```
derek@degion:~/rancher/k3s$ sudo ./dist/artifacts/k3s completion bash -i
Autocomplete for bash added to: /root/.bashrc

```

**Regular Use**
```
derek@degion:~/rancher/k3s$ ./dist/artifacts/k3s se
secrets-encrypt  server  

derek@degion:~/rancher/k3s$ ./dist/artifacts/k3s agent --a
--airgap-extra-registry  --alsologtostderr        
```
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/5316
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users can now install auto-completion using the k3s completion command
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
