### PR TITLE
Add systemd cgroup controller support

### DIFF
--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -45,18 +45,22 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 	}
 
 	isRunningInUserNS := userns.RunningInUserNS()
-	_, _, hasCFS, hasPIDs := cgroups.CheckCgroups()
+	_, _, controllers := cgroups.CheckCgroups()
 	// "/sys/fs/cgroup" is namespaced
 	cgroupfsWritable := unix.Access("/sys/fs/cgroup", unix.W_OK) == nil
-	disableCgroup := isRunningInUserNS && (!hasCFS || !hasPIDs || !cgroupfsWritable)
+	disableCgroup := isRunningInUserNS && (!controllers["cpu"] || !controllers["pids"] || !cgroupfsWritable)
 	if disableCgroup {
 		logrus.Warn("cgroup v2 controllers are not delegated for rootless. Disabling cgroup.")
 	}
+
+	systemdCgroup := controllers["cpuset"] && os.Getenv("NOTIFY_SOCKET") != ""
+	cfg.AgentConfig.Systemd = systemdCgroup
 
 	var containerdTemplate string
 	containerdConfig := templates.ContainerdConfig{
 		NodeConfig:            cfg,
 		DisableCgroup:         disableCgroup,
+		SystemdCgroup:         systemdCgroup,
 		IsRunningInUserNS:     isRunningInUserNS,
 		PrivateRegistryConfig: privRegistries.Registry,
 		ExtraRuntimes:         findNvidiaContainerRuntimes(os.DirFS(string(os.PathSeparator))),

--- a/pkg/agent/containerd/config_windows.go
+++ b/pkg/agent/containerd/config_windows.go
@@ -45,6 +45,7 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 	containerdConfig := templates.ContainerdConfig{
 		NodeConfig:            cfg,
 		DisableCgroup:         true,
+		SystemdCgroup:         false,
 		IsRunningInUserNS:     false,
 		PrivateRegistryConfig: privRegistries.Registry,
 	}

--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -14,6 +14,7 @@ type ContainerdRuntimeConfig struct {
 type ContainerdConfig struct {
 	NodeConfig            *config.Node
 	DisableCgroup         bool
+	SystemdCgroup         bool
 	IsRunningInUserNS     bool
 	PrivateRegistryConfig *registries.Registry
 	ExtraRuntimes         map[string]ContainerdRuntimeConfig

--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -81,6 +81,9 @@ enable_keychain = true
 [plugins.cri.containerd.runtimes.runc]
   runtime_type = "io.containerd.runc.v2"
 
+[plugins.cri.containerd.runtimes.runc.options]
+	SystemdCgroup = {{ .SystemdCgroup }}
+
 {{ if .PrivateRegistryConfig }}
 {{ if .PrivateRegistryConfig.Mirrors }}
 [plugins.cri.registry.mirrors]{{end}}

--- a/pkg/cgroups/cgroups_windows.go
+++ b/pkg/cgroups/cgroups_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package cgroups
@@ -6,6 +7,6 @@ func Validate() error {
 	return nil
 }
 
-func CheckCgroups() (kubeletRoot, runtimeRoot string, hasCFS, hasPIDs bool) {
-	return "", "", false, false
+func CheckCgroups() (kubeletRoot, runtimeRoot string, controllers map[string]bool) {
+	return
 }

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -90,6 +90,7 @@ type Agent struct {
 	ExtraKubeProxyArgs      []string
 	PauseImage              string
 	Snapshotter             string
+	Systemd                 bool
 	CNIPlugin               bool
 	NodeTaints              []string
 	NodeLabels              []string


### PR DESCRIPTION
#### Proposed Changes ####

Use the systemd cgroup controller when possible. This controller has been recommended over the legacy driver for several releases.

#### Types of Changes ####

enhancement

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5454

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
K3s now configures the systemd cgroup driver instead of cgroupfs, when running under a sufficiently new version of systemd.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
