### PR TITLE
Add CNI Plugins and Flannel version to build scripts

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -13,6 +13,7 @@ PKG_K3S_CONTAINERD="github.com/k3s-io/containerd"
 PKG_CRICTL="github.com/kubernetes-sigs/cri-tools/pkg"
 PKG_K8S_BASE="k8s.io/component-base"
 PKG_K8S_CLIENT="k8s.io/client-go/pkg"
+PKG_CNI_PLUGINS="github.com/containernetworking/plugins"
 
 buildDate=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
@@ -35,8 +36,11 @@ VERSIONFLAGS="
     -X ${PKG_CONTAINERD}/version.Version=${VERSION_CONTAINERD}
     -X ${PKG_CONTAINERD}/version.Package=${PKG_K3S_CONTAINERD}
 
-    -X ${PKG_CONTAINERD}/version.Version=${VERSION_CONTAINERD}
-    -X ${PKG_CONTAINERD}/version.Package=${PKG_K3S_CONTAINERD}
+    -X ${PKG_CNI_PLUGINS}/pkg/utils/buildversion.BuildVersion=${VERSION_CNIPLUGINS}
+    -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Program=flannel
+    -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Version=${VERSION_FLANNEL}
+    -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Commit=${COMMIT}
+    -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.buildDate=${buildDate}
 "
 LDFLAGS="
     -w -s"
@@ -101,7 +105,7 @@ if [ ! -x ${INSTALLBIN}/cni ]; then
     WORKDIR=$TMPDIR/src/github.com/containernetworking/plugins
     git clone -b $VERSION_CNIPLUGINS https://github.com/rancher/plugins.git $WORKDIR
     cd $WORKDIR
-    GO111MODULE=off GOPATH=$TMPDIR CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -ldflags "$LDFLAGS $STATIC" -o $INSTALLBIN/cni
+    GO111MODULE=off GOPATH=$TMPDIR CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o $INSTALLBIN/cni
 )
 fi
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -42,7 +42,12 @@ if [ -z "$VERSION_RUNC" ]; then
     VERSION_RUNC="v0.0.0"
 fi
 
-VERSION_CNIPLUGINS="v1.0.1-k3s1"
+VERSION_FLANNEL=$(grep github.com/flannel-io/flannel go.mod | head -n1 | awk '{print $2}')
+if [ -z "$VERSION_FLANNEL" ]; then
+  VERSION_FLANNEL="v0.0.0"
+fi
+
+VERSION_CNIPLUGINS="v1.1.1-k3s1"
 
 VERSION_ROOT="v0.11.0"
 


### PR DESCRIPTION
#### Proposed Changes ####

Add build constants to the CNI plugins so that the version strings output meaningful information

Bump CNI plugins: https://github.com/containernetworking/plugins/compare/v1.0.1...v1.1.1

#### Types of Changes ####

bugfix

#### Verification ####

```console
/ # flannel
CNI Plugin flannel version v0.17.0 (linux/amd64) commit 6def09c2b123be5f0d39aa1d65833cefad8a80ec built on 2022-04-19T22:23:17Z

/ # bridge
CNI bridge plugin v1.1.1-k3s1
/ #
```

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5329

#### User-Facing Change ####
```release-note
CNI plugins binaries now output the correct versions when queried on the command line
CNI plugins have been bumped to v1.1.1
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
