### PR TITLE
Fix default ipv6 cidr

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -238,7 +238,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	if len(cmds.ServerConfig.ClusterCIDR) == 0 {
 		clusterCIDR := "10.42.0.0/16"
 		if IPv6only {
-			clusterCIDR = "fd:42::/56"
+			clusterCIDR = "fd00:42::/56"
 		}
 		cmds.ServerConfig.ClusterCIDR.Set(clusterCIDR)
 	}
@@ -264,7 +264,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	if len(cmds.ServerConfig.ServiceCIDR) == 0 {
 		serviceCIDR := "10.43.0.0/16"
 		if IPv6only {
-			serviceCIDR = "fd:43::/112"
+			serviceCIDR = "fd00:43::/112"
 		}
 		cmds.ServerConfig.ServiceCIDR.Set(serviceCIDR)
 	}


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
The default ipv6-only cidr is wrong and the cluster never starts correctly

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Deploy with config:
```
write-kubeconfig-mode: 644
token: "secret"
disable-network-policy: true
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/5466

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix wrong default ipv6 cidr
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
