### PR TITLE
agent(netpol): Explicitly enable IPv4 when necessary

### DIFF
--- a/pkg/agent/netpol/netpol.go
+++ b/pkg/agent/netpol/netpol.go
@@ -55,7 +55,7 @@ func Run(ctx context.Context, nodeConfig *config.Node) error {
 
 	krConfig := options.NewKubeRouterConfig()
 	krConfig.ClusterIPCIDR = util.JoinIPNets(nodeConfig.AgentConfig.ServiceCIDRs)
-	krConfig.EnableIPv4 = true
+	krConfig.EnableIPv4 = nodeConfig.AgentConfig.EnableIPv4
 	krConfig.EnableIPv6 = nodeConfig.AgentConfig.EnableIPv6
 	krConfig.NodePortRange = strings.ReplaceAll(nodeConfig.AgentConfig.ServiceNodePortRange.String(), "-", ":")
 	krConfig.HostnameOverride = nodeConfig.AgentConfig.NodeName

--- a/pkg/agent/netpol/netpol.go
+++ b/pkg/agent/netpol/netpol.go
@@ -80,17 +80,19 @@ func Run(ctx context.Context, nodeConfig *config.Node) error {
 	iptablesCmdHandlers := make(map[v1core.IPFamily]utils.IPTablesHandler, 2)
 	ipSetHandlers := make(map[v1core.IPFamily]utils.IPSetHandler, 2)
 
-	iptHandler, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
-	if err != nil {
-		return errors.Wrap(err, "failed to create iptables handler")
-	}
-	iptablesCmdHandlers[v1core.IPv4Protocol] = iptHandler
+	if nodeConfig.AgentConfig.EnableIPv4 {
+		iptHandler, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+		if err != nil {
+			return errors.Wrap(err, "failed to create iptables handler")
+		}
+		iptablesCmdHandlers[v1core.IPv4Protocol] = iptHandler
 
-	ipset, err := utils.NewIPSet(false)
-	if err != nil {
-		return errors.Wrap(err, "failed to create ipset handler")
+		ipset, err := utils.NewIPSet(false)
+		if err != nil {
+			return errors.Wrap(err, "failed to create ipset handler")
+		}
+		ipSetHandlers[v1core.IPv4Protocol] = ipset
 	}
-	ipSetHandlers[v1core.IPv4Protocol] = ipset
 
 	if nodeConfig.AgentConfig.EnableIPv6 {
 		ipt6Handler, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -59,15 +59,19 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to validate node-ip")
 	}
+	serviceIPv4 := utilsnet.IsIPv4CIDR(nodeConfig.AgentConfig.ServiceCIDR)
+	clusterIPv4 := utilsnet.IsIPv4CIDR(nodeConfig.AgentConfig.ClusterCIDR)
 	serviceIPv6 := utilsnet.IsIPv6CIDR(nodeConfig.AgentConfig.ServiceCIDR)
 	clusterIPv6 := utilsnet.IsIPv6CIDR(nodeConfig.AgentConfig.ClusterCIDR)
 
+	enableIPv4 := dualCluster || dualService || dualNode || serviceIPv4 || clusterIPv4
 	enableIPv6 := dualCluster || dualService || dualNode || serviceIPv6 || clusterIPv6
 	conntrackConfig, err := getConntrackConfig(nodeConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to validate kube-proxy conntrack configuration")
 	}
 	syssetup.Configure(enableIPv6, conntrackConfig)
+	nodeConfig.AgentConfig.EnableIPv4 = enableIPv4
 	nodeConfig.AgentConfig.EnableIPv6 = enableIPv6
 
 	if err := setupCriCtlConfig(cfg, nodeConfig); err != nil {

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -520,13 +520,6 @@ func validateNetworkConfiguration(serverConfig server.Config) error {
 		return errors.New("dual-stack cluster-dns is not supported")
 	}
 
-	IPv6OnlyService, _ := util.IsIPv6OnlyCIDRs(serverConfig.ControlConfig.ServiceIPRanges)
-	if IPv6OnlyService {
-		if serverConfig.ControlConfig.DisableNPC == false {
-			return errors.New("network policy enforcement is not compatible with IPv6 only operation; server must be restarted with --disable-network-policy")
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -105,6 +105,7 @@ type Agent struct {
 	Rootless                bool
 	ProtectKernelDefaults   bool
 	DisableServiceLB        bool
+	EnableIPv4              bool
 	EnableIPv6              bool
 }
 


### PR DESCRIPTION
Before this change, kube-router was always assuming that IPv4 is
enabled, which is not the case in IPv6-only clusters. To enable network
policies in IPv6-only, we need to explicitly let kube-router know when
to disable IPv4.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>