### PR TITLE
Use ListWatch helpers instead of bare List/Watch

### DIFF
--- a/pkg/daemons/executor/embed.go
+++ b/pkg/daemons/executor/embed.go
@@ -5,22 +5,24 @@ package executor
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"net/http"
 	"runtime"
 
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	toolswatch "k8s.io/client-go/tools/watch"
 	ccm "k8s.io/cloud-provider"
 	cloudprovider "k8s.io/cloud-provider"
 	cloudproviderapi "k8s.io/cloud-provider/api"
@@ -205,43 +207,33 @@ func waitForUntaintedNode(ctx context.Context, kubeConfig string) error {
 	if err != nil {
 		return err
 	}
+	nodes := coreClient.Nodes()
 
-	// List first, to see if there's an existing node that will do
-	nodes, err := coreClient.Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (object k8sruntime.Object, e error) {
+			return nodes.List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
+			return nodes.Watch(ctx, options)
+		},
 	}
-	for _, node := range nodes.Items {
-		if taint := getCloudTaint(node.Spec.Taints); taint == nil {
-			return nil
+
+	condition := func(ev watch.Event) (bool, error) {
+		if node, ok := ev.Object.(*v1.Node); ok {
+			return getCloudTaint(node.Spec.Taints) == nil, nil
 		}
+		return false, errors.New("event object not of type v1.Node")
 	}
 
-	// List didn't give us an existing node, start watching at whatever ResourceVersion the list left off at.
-	watcher, err := coreClient.Nodes().Watch(ctx, metav1.ListOptions{ResourceVersion: nodes.ListMeta.ResourceVersion})
-	if err != nil {
-		return err
+	if _, err := toolswatch.UntilWithSync(ctx, lw, &v1.Node{}, nil, condition); err != nil {
+		return errors.Wrap(err, "failed to wait for untainted node")
 	}
-	defer watcher.Stop()
-
-	for ev := range watcher.ResultChan() {
-		if ev.Type == watch.Added || ev.Type == watch.Modified {
-			node, ok := ev.Object.(*corev1.Node)
-			if !ok {
-				return fmt.Errorf("could not convert event object to node: %v", ev)
-			}
-			if taint := getCloudTaint(node.Spec.Taints); taint == nil {
-				return nil
-			}
-		}
-	}
-
-	return errors.New("watch channel closed")
+	return nil
 }
 
 // getCloudTaint returns the external cloud provider taint, if present.
 // Cribbed from k8s.io/cloud-provider/controllers/node/node_controller.go
-func getCloudTaint(taints []corev1.Taint) *corev1.Taint {
+func getCloudTaint(taints []v1.Taint) *v1.Taint {
 	for _, taint := range taints {
 		if taint.Key == cloudproviderapi.TaintExternalCloudProvider {
 			return &taint


### PR DESCRIPTION
Reduces code complexity a bit and ensures we don't have to handle closed watch channels on our own. Failure to handle watch channel closure is the root cause of https://github.com/k3s-io/k3s/issues/5482.

#### Types of Changes ####

bugfix; code cleanup

#### Verification ####

Normal CI and QA checks to ensure no regressions

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5485

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####
