### PR TITLE
Secrets Encryption: Add RetryOnConflict around updating nodes

### DIFF
--- a/pkg/secretsencrypt/controller.go
+++ b/pkg/secretsencrypt/controller.go
@@ -58,7 +58,7 @@ func Register(
 }
 
 // onChangeNode handles changes to Nodes. We are looking for a specific annotation change
-func (h *handler) onChangeNode(key string, node *corev1.Node) (*corev1.Node, error) {
+func (h *handler) onChangeNode(nodeName string, node *corev1.Node) (*corev1.Node, error) {
 	if node == nil {
 		return nil, nil
 	}
@@ -91,9 +91,8 @@ func (h *handler) onChangeNode(key string, node *corev1.Node) (*corev1.Node, err
 	}
 	ann = EncryptionReencryptActive + "-" + reencryptHash
 
-	nodeName := node.Name
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		node, err := h.nodes.Get(nodeName, metav1.GetOptions{})
+		node, err = h.nodes.Get(nodeName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -114,7 +113,7 @@ func (h *handler) onChangeNode(key string, node *corev1.Node) (*corev1.Node, err
 	// If skipping, revert back to the previous stage
 	if h.controlConfig.EncryptSkip {
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			node, err := h.nodes.Get(nodeName, metav1.GetOptions{})
+			node, err = h.nodes.Get(nodeName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Retry updating the nodes when reencrypting secrets
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
BugFix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- Run a k3s server with secrets-encryption
- Run `k3s secrets-encrypt reencrypt --force --skip` 
- While the reencryption is running, inject a new node annotation (shouldn't matter what it is, we just want the node to change)
- See that reencryption still finishes

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/5489
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
