### PR TITLE
[Release-1.21] Secrets Encryption: Add RetryOnConflict around updating nodes

### DIFF
--- a/pkg/secretsencrypt/controller.go
+++ b/pkg/secretsencrypt/controller.go
@@ -132,7 +132,14 @@ func (h *handler) onChangeNode(nodeName string, node *corev1.Node) (*corev1.Node
 		h.recorder.Event(node, corev1.EventTypeWarning, secretsUpdateErrorEvent, err.Error())
 		return node, err
 	}
-	if err := WriteEncryptionHashAnnotation(h.controlConfig.Runtime, node, EncryptionReencryptFinished); err != nil {
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err = h.nodes.Get(nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		return WriteEncryptionHashAnnotation(h.controlConfig.Runtime, node, EncryptionReencryptFinished)
+	})
+	if err != nil {
 		h.recorder.Event(node, corev1.EventTypeWarning, secretsUpdateErrorEvent, err.Error())
 		return node, err
 	}

--- a/pkg/secretsencrypt/controller.go
+++ b/pkg/secretsencrypt/controller.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/pager"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -80,8 +81,17 @@ func (h *handler) onChangeNode(key string, node *corev1.Node) (*corev1.Node, err
 		return node, err
 	}
 	ann = EncryptionReencryptActive + "-" + reencryptHash
-	node.Annotations[EncryptionHashAnnotation] = ann
-	node, err = h.nodes.Update(node)
+
+	nodeName := node.Name
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := h.nodes.Get(nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		node.Annotations[EncryptionHashAnnotation] = ann
+		_, err = h.nodes.Update(node)
+		return err
+	})
 	if err != nil {
 		h.recorder.Event(node, corev1.EventTypeWarning, secretsUpdateErrorEvent, err.Error())
 		return node, err
@@ -94,11 +104,16 @@ func (h *handler) onChangeNode(key string, node *corev1.Node) (*corev1.Node, err
 
 	// If skipping, revert back to the previous stage
 	if h.controlConfig.EncryptSkip {
-		BootstrapEncryptionHashAnnotation(node, h.controlConfig.Runtime)
-		if node, err := h.nodes.Update(node); err != nil {
-			return node, err
-		}
-		return node, nil
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			node, err := h.nodes.Get(nodeName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			BootstrapEncryptionHashAnnotation(node, h.controlConfig.Runtime)
+			_, err = h.nodes.Update(node)
+			return err
+		})
+		return node, err
 	}
 
 	// Remove last key

--- a/pkg/secretsencrypt/controller.go
+++ b/pkg/secretsencrypt/controller.go
@@ -58,7 +58,7 @@ func Register(
 }
 
 // onChangeNode handles changes to Nodes. We are looking for a specific annotation change
-func (h *handler) onChangeNode(key string, node *corev1.Node) (*corev1.Node, error) {
+func (h *handler) onChangeNode(nodeName string, node *corev1.Node) (*corev1.Node, error) {
 	if node == nil {
 		return nil, nil
 	}
@@ -82,9 +82,8 @@ func (h *handler) onChangeNode(key string, node *corev1.Node) (*corev1.Node, err
 	}
 	ann = EncryptionReencryptActive + "-" + reencryptHash
 
-	nodeName := node.Name
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		node, err := h.nodes.Get(nodeName, metav1.GetOptions{})
+		node, err = h.nodes.Get(nodeName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -105,7 +104,7 @@ func (h *handler) onChangeNode(key string, node *corev1.Node) (*corev1.Node, err
 	// If skipping, revert back to the previous stage
 	if h.controlConfig.EncryptSkip {
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			node, err := h.nodes.Get(nodeName, metav1.GetOptions{})
+			node, err = h.nodes.Get(nodeName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Backport of https://github.com/k3s-io/k3s/pull/5495
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/5499
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
