### PR TITLE
Make supervisor errors parsable by Kubernetes client libs

### DIFF
--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -5,7 +5,12 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/k3s-io/k3s/pkg/generated/clientset/versioned/scheme"
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
@@ -24,23 +29,23 @@ func doAuth(roles []string, serverConfig *config.Control, next http.Handler, rw 
 	switch {
 	case serverConfig == nil:
 		logrus.Errorf("Authenticate not initialized: serverConfig is nil")
-		rw.WriteHeader(http.StatusUnauthorized)
+		unauthorized(rw, req)
 		return
 	case serverConfig.Runtime.Authenticator == nil:
 		logrus.Errorf("Authenticate not initialized: serverConfig.Runtime.Authenticator is nil")
-		rw.WriteHeader(http.StatusUnauthorized)
+		unauthorized(rw, req)
 		return
 	}
 
 	resp, ok, err := serverConfig.Runtime.Authenticator.AuthenticateRequest(req)
 	if err != nil {
 		logrus.Errorf("Failed to authenticate request from %s: %v", req.RemoteAddr, err)
-		rw.WriteHeader(http.StatusUnauthorized)
+		unauthorized(rw, req)
 		return
 	}
 
 	if !ok || !hasRole(roles, resp.User.GetGroups()) {
-		rw.WriteHeader(http.StatusForbidden)
+		forbidden(rw, req)
 		return
 	}
 
@@ -55,4 +60,28 @@ func authMiddleware(serverConfig *config.Control, roles ...string) mux.Middlewar
 			doAuth(roles, serverConfig, next, rw, req)
 		})
 	}
+}
+
+func unauthorized(resp http.ResponseWriter, req *http.Request) {
+	responsewriters.ErrorNegotiated(
+		&apierrors.StatusError{ErrStatus: metav1.Status{
+			Status:  metav1.StatusFailure,
+			Code:    http.StatusUnauthorized,
+			Reason:  metav1.StatusReasonUnauthorized,
+			Message: "not authorized",
+		}},
+		scheme.Codecs.WithoutConversion(), schema.GroupVersion{}, resp, req,
+	)
+}
+
+func forbidden(resp http.ResponseWriter, req *http.Request) {
+	responsewriters.ErrorNegotiated(
+		&apierrors.StatusError{ErrStatus: metav1.Status{
+			Status:  metav1.StatusFailure,
+			Code:    http.StatusForbidden,
+			Reason:  metav1.StatusReasonForbidden,
+			Message: "forbidden",
+		}},
+		scheme.Codecs.WithoutConversion(), schema.GroupVersion{}, resp, req,
+	)
 }


### PR DESCRIPTION
#### Proposed Changes ####

Make supervisor errors parsable by Kubernetes client libs

This gives nicer errors from Kubernetes components during startup, and
reduces code complexity a bit by using the upstream responsewriters module instead
of writing the headers and body by hand.

#### Types of Changes ####

enhancement

#### Verification ####

See linked issue

#### Linked Issues ####

* TBD

#### User-Facing Change ####
<!--
-->
```release-note
K3s supervisor status errors are now wrapped in Kubernetes API error types, for improved compatibility with Kubernetes client libraries.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
