### PR TITLE
Introduce --enable-pprof flag to optionally run pprof server

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	KubeConfigMode           string
 	TLSSan                   cli.StringSlice
 	BindAddress              string
+	EnablePProf              bool
 	ExtraAPIArgs             cli.StringSlice
 	ExtraEtcdArgs            cli.StringSlice
 	ExtraSchedulerArgs       cli.StringSlice
@@ -238,6 +239,11 @@ var ServerFlags = []cli.Flag{
 		Usage:       "(client) Write kubeconfig with this mode",
 		Destination: &ServerConfig.KubeConfigMode,
 		EnvVar:      version.ProgramUpper + "_KUBECONFIG_MODE",
+	},
+	cli.BoolFlag{
+		Name:        "enable-pprof",
+		Usage:       "(experimental) Enable pprof endpoint on supervisor port",
+		Destination: &ServerConfig.EnablePProf,
 	},
 	ExtraAPIArgs,
 	ExtraEtcdArgs,

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -121,6 +121,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.HTTPSPort = cfg.HTTPSPort
 	serverConfig.ControlConfig.APIServerPort = cfg.APIServerPort
 	serverConfig.ControlConfig.APIServerBindAddress = cfg.APIServerBindAddress
+	serverConfig.ControlConfig.EnablePProf = cfg.EnablePProf
 	serverConfig.ControlConfig.ExtraAPIArgs = cfg.ExtraAPIArgs
 	serverConfig.ControlConfig.ExtraControllerArgs = cfg.ExtraControllerArgs
 	serverConfig.ControlConfig.ExtraEtcdArgs = cfg.ExtraEtcdArgs

--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -9,9 +9,11 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"path/filepath"
 
+	"github.com/gorilla/mux"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/etcd"
 	"github.com/k3s-io/k3s/pkg/version"
@@ -92,6 +94,17 @@ func (c *Cluster) initClusterAndHTTPS(ctx context.Context) error {
 	handler, err = c.initClusterDB(ctx, handler)
 	if err != nil {
 		return err
+	}
+
+	if c.config.EnablePProf {
+		mux := mux.NewRouter()
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		mux.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
+		mux.NotFoundHandler = handler
+		handler = mux
 	}
 
 	// Create a HTTP server with the registered request handlers, using logrus for logging

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -157,6 +157,7 @@ type Control struct {
 	DisableETCD              bool
 	DisableKubeProxy         bool
 	DisableScheduler         bool
+	EnablePProf              bool
 	ExtraAPIArgs             []string
 	ExtraControllerArgs      []string
 	ExtraCloudControllerArgs []string


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

This patch introduces the ability to start a [pprof](https://pkg.go.dev/net/http/pprof) server as part of k3s. This enables various types of profiling, including CPU and memory profiling.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Example usage:

```shell
igor@k3s:~$ sudo cat /etc/rancher/k3s/config.yaml

enable-pprof: true

igor@k3s:~$ curl --insecure https://localhost:6443/debug/pprof/profile > cpu.pprof

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 26163    0 26163    0     0    870      0 --:--:--  0:00:30 --:--:--  6822

igor@k3s:~$ go tool pprof cpu.pprof

File: containerd
Type: cpu
Time: May 1, 2022 at 2:20pm (UTC)
Duration: 30.02s, Total samples = 1.84s ( 6.13%)
Entering interactive mode (type "help" for commands, "o" for options)

(pprof) top
Showing nodes accounting for 960ms, 52.17% of 1840ms total
Showing top 10 nodes out of 534
      flat  flat%   sum%        cum   cum%
     320ms 17.39% 17.39%      320ms 17.39%  runtime.futex
     150ms  8.15% 25.54%      150ms  8.15%  runtime.epollwait
     100ms  5.43% 30.98%      100ms  5.43%  syscall.Syscall6
      90ms  4.89% 35.87%       90ms  4.89%  syscall.Syscall
      80ms  4.35% 40.22%       80ms  4.35%  runtime.cgocall
      50ms  2.72% 42.93%       50ms  2.72%  github.com/prometheus/client_golang/prometheus.hashAdd
      50ms  2.72% 45.65%       50ms  2.72%  runtime.siftdownTimer
      40ms  2.17% 47.83%       40ms  2.17%  runtime.findObject
      40ms  2.17% 50.00%      510ms 27.72%  runtime.findrunnable
      40ms  2.17% 52.17%      190ms 10.33%  runtime.netpoll

(pprof) png
Generating report in profile001.png
```

Generated png:

![profile001](https://user-images.githubusercontent.com/11158255/166150271-51aac925-c984-4a6b-bd5a-60262734d472.png)

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

This feature was previously discussed in https://github.com/k3s-io/k3s/issues/1635.

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduce --enable-pprof flag to optionally run pprof server
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

This can be useful to identify sources of CPU resource usage, and perhaps reduce the baseline CPU utilization.

Another tool that can be useful for this kind of diagnosis (and account for system time and more) is [perf](https://www.brendangregg.com/perf.html). However, it requires unstripped binaries which k3s does not currently ship. Having unstripped binaries optionally available would be really useful to be able to capture more complete profiles.