### PR TITLE
containerd: Enable enable_unprivileged_ports and enable_unprivileged_…

### DIFF
--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -15,6 +15,8 @@ const ContainerdConfigTemplate = `
   stream_server_address = "127.0.0.1"
   stream_server_port = "10010"
   enable_selinux = {{ .NodeConfig.SELinux }}
+  enable_unprivileged_ports = true
+  enable_unprivileged_icmp = true
 
 {{- if .DisableCgroup}}
   disable_cgroup = true


### PR DESCRIPTION
#### Proposed Changes ####
Make using hardened containers a bit easier by:
* Allowing non-root containers to listen ports < 1024
* Allowing ICMP on containers without any capabilities

#### Types of Changes ####
Containerd configuration change.

#### Verification ####
Create test deployment based on standard NGINX image which wants to listen port **80** and would fail as non-root before this change:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: test
  name: test
spec:
  selector:
    matchLabels:
      app: test
  template:
    metadata:
      labels:
        app: test
    spec:
      containers:
      - name: test
        image: nginx
        ports:
        - containerPort: 80
          protocol: TCP
        volumeMounts:
        - name: nginx-cache
          mountPath: /var/cache/nginx/
        - name: nginx-run
          mountPath: /var/run/
        securityContext:
          capabilities:
            drop:
            - ALL
      securityContext:
        runAsNonRoot: true
        runAsUser: 65534
        runAsGroup: 65534
      volumes:
      - name: nginx-cache
        emptyDir: {}
      - name: nginx-run
        emptyDir: {}
```
Check that NGINX is running and listening port 80

Start debug session inside of same pod and test that ping works.
```bash
kubectl debug -it <pod name> --image=ollijanatuinen/debug:v2 --target=test
ping -c 1 k3s.io
```

#### Linked Issues ####
Closes #4545


#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####
~containerd 1.6.x is needed so waiting for #4761 to be merged first. PR which added those flags and discussion related to it can be found from https://github.com/containerd/containerd/pull/6170~