### PR TITLE
Give kubelet the node-ip value

### DIFF
--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -121,9 +121,18 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 	if cfg.NodeName != "" {
 		argsMap["hostname-override"] = cfg.NodeName
 	}
+	var nodeIPs string
+	switch len(cfg.NodeIPs) {
+	case 1:
+		nodeIPs = cfg.NodeIPs[0].String()
+	case 2:
+		nodeIPs = cfg.NodeIPs[0].String() + "," + cfg.NodeIPs[1].String()
+	default:
+		logrus.Errorf("node-ip value: %v is wrong. It must have one or two IPs", cfg.NodeIPs)
+	}
 	defaultIP, err := net.ChooseHostInterface()
-	if err != nil || defaultIP.String() != cfg.NodeIP {
-		argsMap["node-ip"] = cfg.NodeIP
+	if err != nil || defaultIP.String() != nodeIPs {
+		argsMap["node-ip"] = nodeIPs
 	}
 	kubeletRoot, runtimeRoot, controllers := cgroups.CheckCgroups()
 	if !controllers["cpu"] {

--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -121,18 +121,11 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 	if cfg.NodeName != "" {
 		argsMap["hostname-override"] = cfg.NodeName
 	}
-	var nodeIPs string
-	switch len(cfg.NodeIPs) {
-	case 1:
-		nodeIPs = cfg.NodeIPs[0].String()
-	case 2:
-		nodeIPs = cfg.NodeIPs[0].String() + "," + cfg.NodeIPs[1].String()
-	default:
-		logrus.Errorf("node-ip value: %v is wrong. It must have one or two IPs", cfg.NodeIPs)
-	}
-	defaultIP, err := net.ChooseHostInterface()
-	if err != nil || defaultIP.String() != nodeIPs {
-		argsMap["node-ip"] = nodeIPs
+	if nodeIPs := util.JoinIPs(cfg.NodeIPs); nodeIPs != "" {
+		defaultIP, err := net.ChooseHostInterface()
+		if err != nil || defaultIP.String() != nodeIPs {
+			argsMap["node-ip"] = nodeIPs
+		}
 	}
 	kubeletRoot, runtimeRoot, controllers := cgroups.CheckCgroups()
 	if !controllers["cpu"] {


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This PR passes the configured node-ip value to kubelet if its length is greater than 1 (dual-stack) or if the IP is not the one form the default interface (which kubelet derives anyway). This fixes the bug we are experiencing in kubernetes 1.24 when creating dual-stack services

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Deploy a k3s dual-stack env. Create dual-stack services of type LoadBalancer. They should get two external ip addresses

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/5575

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Pass the node-ip values to kubelet
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
