### PR TITLE
Update flaky tests for v1.24

### DIFF
--- a/scripts/flaky-tests
+++ b/scripts/flaky-tests
@@ -1,0 +1,4 @@
+[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]
+[Fail] [sig-node] KubeletManagedEtcHosts [It] should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance] [Conformance]
+[Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] should be able to deny pod and configmap creation [Conformance]
+[Fail] [sig-apps] Deployment [It] should run the lifecycle of a Deployment [Conformance]

--- a/scripts/flaky-tests
+++ b/scripts/flaky-tests
@@ -2,3 +2,4 @@
 [Fail] [sig-node] KubeletManagedEtcHosts [It] should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance] [Conformance]
 [Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] should be able to deny pod and configmap creation [Conformance]
 [Fail] [sig-apps] Deployment [It] should run the lifecycle of a Deployment [Conformance]
+[Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] listing validating webhooks should work [Conformance]

--- a/scripts/test-setup-sonobuoy
+++ b/scripts/test-setup-sonobuoy
@@ -19,11 +19,7 @@ test-post-hook() {
   fi
   local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
   # Ignore sonobuoy failures if only these flaky tests have failed
-  local flakyTest1='[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
-  local flakyTest2='[Fail] [sig-node] KubeletManagedEtcHosts [It] should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance] [Conformance]'
-  local flakyTest3='[Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] should be able to deny pod and configmap creation [Conformance]'
-  local flakyTest4='[Fail] [sig-apps] Deployment [It] should run the lifecycle of a Deployment [Conformance]'
-  flakyFails=$( grep -scF -e "$flakyTest1" -e "$flakyTest2" -e "$flakyTest3"  -e "$flakyTest4" <<< "$failures" )
+  flakyFails=$( grep -scF -f flaky-tests <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )
   [ "$totalFails" -le "$flakyFails" ]
 }

--- a/scripts/test-setup-sonobuoy
+++ b/scripts/test-setup-sonobuoy
@@ -19,7 +19,7 @@ test-post-hook() {
   fi
   local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
   # Ignore sonobuoy failures if only these flaky tests have failed
-  flakyFails=$( grep -scF -f flaky-tests <<< "$failures" )
+  flakyFails=$( grep -scF -f ./scripts/flaky-tests <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )
   [ "$totalFails" -le "$flakyFails" ]
 }

--- a/scripts/test-setup-sonobuoy
+++ b/scripts/test-setup-sonobuoy
@@ -19,10 +19,10 @@ test-post-hook() {
   fi
   local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
   # Ignore sonobuoy failures if only these flaky tests have failed
-  local flakyTest1='[Fail] [sig-node] Probing container [It] should have monotonically increasing restart count [NodeConformance] [Conformance]'
-  local flakyTest2='[Fail] [sig-node] Pods [It] should delete a collection of pods [Conformance]'
-  local flakyTest3='[Fail] [sig-network] Proxy version v1 [It] A set of valid responses are returned for both pod and service ProxyWithPath [Conformance]'
-  local flakyTest4='[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
+  local flakyTest1='[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
+  local flakyTest2='[Fail] [sig-node] KubeletManagedEtcHosts [It] should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance] [Conformance]'
+  local flakyTest3='[Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] should be able to deny pod and configmap creation [Conformance]'
+  local flakyTest4='[Fail] [sig-apps] Deployment [It] should run the lifecycle of a Deployment [Conformance]'
   flakyFails=$( grep -scF -e "$flakyTest1" -e "$flakyTest2" -e "$flakyTest3"  -e "$flakyTest4" <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )
   [ "$totalFails" -le "$flakyFails" ]

--- a/scripts/test-setup-sonobuoy-etcd
+++ b/scripts/test-setup-sonobuoy-etcd
@@ -20,7 +20,7 @@ test-post-hook() {
   fi
   local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
   # Ignore sonobuoy failures if only these flaky tests have failed
-  flakyFails=$( grep -scF -f flaky-tests <<< "$failures" )
+  flakyFails=$( grep -scF -f ./scripts/flaky-tests <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )
   [ "$totalFails" -le "$flakyFails" ]
 }

--- a/scripts/test-setup-sonobuoy-etcd
+++ b/scripts/test-setup-sonobuoy-etcd
@@ -20,10 +20,10 @@ test-post-hook() {
   fi
   local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
   # Ignore sonobuoy failures if only these flaky tests have failed
-  local flakyTest1='[Fail] [sig-node] Probing container [It] should have monotonically increasing restart count [NodeConformance] [Conformance]'
-  local flakyTest2='[Fail] [sig-node] Pods [It] should delete a collection of pods [Conformance]'
-  local flakyTest3='[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
-  local flakyTest4='[Fail] [sig-network] Proxy version v1 [It] A set of valid responses are returned for both pod and service ProxyWithPath [Conformance]'
+  local flakyTest1='[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
+  local flakyTest2='[Fail] [sig-node] KubeletManagedEtcHosts [It] should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance] [Conformance]'
+  local flakyTest3='[Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] should be able to deny pod and configmap creation [Conformance]'
+  local flakyTest4='[Fail] [sig-apps] Deployment [It] should run the lifecycle of a Deployment [Conformance]'
   flakyFails=$( grep -scF -e "$flakyTest1" -e "$flakyTest2" -e "$flakyTest3" -e "$flakyTest4" <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )
   [ "$totalFails" -le "$flakyFails" ]

--- a/scripts/test-setup-sonobuoy-etcd
+++ b/scripts/test-setup-sonobuoy-etcd
@@ -20,11 +20,7 @@ test-post-hook() {
   fi
   local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
   # Ignore sonobuoy failures if only these flaky tests have failed
-  local flakyTest1='[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
-  local flakyTest2='[Fail] [sig-node] KubeletManagedEtcHosts [It] should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance] [Conformance]'
-  local flakyTest3='[Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] should be able to deny pod and configmap creation [Conformance]'
-  local flakyTest4='[Fail] [sig-apps] Deployment [It] should run the lifecycle of a Deployment [Conformance]'
-  flakyFails=$( grep -scF -e "$flakyTest1" -e "$flakyTest2" -e "$flakyTest3" -e "$flakyTest4" <<< "$failures" )
+  flakyFails=$( grep -scF -f flaky-tests <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )
   [ "$totalFails" -le "$flakyFails" ]
 }

--- a/scripts/test-setup-sonobuoy-mysql
+++ b/scripts/test-setup-sonobuoy-mysql
@@ -61,7 +61,7 @@ test-post-hook() {
   fi
   local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
   # Ignore sonobuoy failures if only these flaky tests have failed
-  flakyFails=$( grep -scF -f flaky-tests <<< "$failures" )
+  flakyFails=$( grep -scF -f ./scripts/flaky-tests <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )
   [ "$totalFails" -le "$flakyFails" ]
 }

--- a/scripts/test-setup-sonobuoy-mysql
+++ b/scripts/test-setup-sonobuoy-mysql
@@ -61,11 +61,7 @@ test-post-hook() {
   fi
   local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
   # Ignore sonobuoy failures if only these flaky tests have failed
-  local flakyTest1='[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
-  local flakyTest2='[Fail] [sig-node] KubeletManagedEtcHosts [It] should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance] [Conformance]'
-  local flakyTest3='[Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] should be able to deny pod and configmap creation [Conformance]'
-  local flakyTest4='[Fail] [sig-apps] Deployment [It] should run the lifecycle of a Deployment [Conformance]'
-  flakyFails=$( grep -scF -e "$flakyTest1" -e "$flakyTest2" -e "$flakyTest3" -e "$flakyTest4" <<< "$failures" )
+  flakyFails=$( grep -scF -f flaky-tests <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )
   [ "$totalFails" -le "$flakyFails" ]
 }

--- a/scripts/test-setup-sonobuoy-mysql
+++ b/scripts/test-setup-sonobuoy-mysql
@@ -61,10 +61,10 @@ test-post-hook() {
   fi
   local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
   # Ignore sonobuoy failures if only these flaky tests have failed
-  local flakyTest1='[Fail] [sig-node] Probing container [It] should have monotonically increasing restart count [NodeConformance] [Conformance]'
-  local flakyTest2='[Fail] [sig-node] Pods [It] should delete a collection of pods [Conformance]'
-  local flakyTest3='[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
-  local flakyTest4='[Fail] [sig-network] Proxy version v1 [It] A set of valid responses are returned for both pod and service ProxyWithPath [Conformance]'
+  local flakyTest1='[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
+  local flakyTest2='[Fail] [sig-node] KubeletManagedEtcHosts [It] should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance] [Conformance]'
+  local flakyTest3='[Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] should be able to deny pod and configmap creation [Conformance]'
+  local flakyTest4='[Fail] [sig-apps] Deployment [It] should run the lifecycle of a Deployment [Conformance]'
   flakyFails=$( grep -scF -e "$flakyTest1" -e "$flakyTest2" -e "$flakyTest3" -e "$flakyTest4" <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )
   [ "$totalFails" -le "$flakyFails" ]

--- a/scripts/test-setup-sonobuoy-postgres
+++ b/scripts/test-setup-sonobuoy-postgres
@@ -61,11 +61,7 @@ test-post-hook() {
   fi
   local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
   # Ignore sonobuoy failures if only these flaky tests have failed
-  local flakyTest1='[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
-  local flakyTest2='[Fail] [sig-node] KubeletManagedEtcHosts [It] should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance] [Conformance]'
-  local flakyTest3='[Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] should be able to deny pod and configmap creation [Conformance]'
-  local flakyTest4='[Fail] [sig-apps] Deployment [It] should run the lifecycle of a Deployment [Conformance]'
-  flakyFails=$( grep -scF -e "$flakyTest1" -e "$flakyTest2" -e "$flakyTest3" -e "$flakyTest4" <<< "$failures" )
+  flakyFails=$( grep -scF -f ./scripts/flaky-tests <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )
   [ "$totalFails" -le "$flakyFails" ]
 }

--- a/scripts/test-setup-sonobuoy-postgres
+++ b/scripts/test-setup-sonobuoy-postgres
@@ -61,10 +61,10 @@ test-post-hook() {
   fi
   local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
   # Ignore sonobuoy failures if only these flaky tests have failed
-  local flakyTest1='[Fail] [sig-node] Probing container [It] should have monotonically increasing restart count [NodeConformance] [Conformance]'
-  local flakyTest2='[Fail] [sig-node] Pods [It] should delete a collection of pods [Conformance]'
-  local flakyTest3='[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
-  local flakyTest4='[Fail] [sig-network] Proxy version v1 [It] A set of valid responses are returned for both pod and service ProxyWithPath [Conformance]'
+  local flakyTest1='[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
+  local flakyTest2='[Fail] [sig-node] KubeletManagedEtcHosts [It] should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance] [Conformance]'
+  local flakyTest3='[Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] should be able to deny pod and configmap creation [Conformance]'
+  local flakyTest4='[Fail] [sig-apps] Deployment [It] should run the lifecycle of a Deployment [Conformance]'
   flakyFails=$( grep -scF -e "$flakyTest1" -e "$flakyTest2" -e "$flakyTest3" -e "$flakyTest4" <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )
   [ "$totalFails" -le "$flakyFails" ]


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Update to which test we consider "flaky" for k3s.

The existing 4 flaky tests:
```
1) '[Fail] [sig-node] Probing container [It] should have monotonically increasing restart count [NodeConformance] [Conformance]'
2) '[Fail] [sig-node] Pods [It] should delete a collection of pods [Conformance]'
3) '[Fail] [sig-network] Proxy version v1 [It] A set of valid responses are returned for both pod and service ProxyWithPath [Conformance]'
4) '[Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]' 
```
1) Has been fixed by https://github.com/kubernetes/kubernetes/pull/108652
2) Has been fixed by https://github.com/kubernetes/kubernetes/pull/108813
3) Has been fixed by https://github.com/kubernetes/kubernetes/pull/109039
4) Remains our biggest failure, and is thus being moved to 1) slot

Additionally, over 1 week of Drone failures (42 separate CI runs) the following top test failures were identified: (# of Failures) (Test Name)
```
15 [Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] listing validating webhooks should work [Conformance]
16 [Fail] [sig-apps] Deployment [It] should run the lifecycle of a Deployment [Conformance] 
18 [Fail] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] [It] should be able to deny pod and configmap creation [Conformance] 
31 [Fail] [sig-node] KubeletManagedEtcHosts [It] should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance] [Conformance] 
43 [Fail] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance] 
```

As such, these tests will now become the new flaky tests.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
DRONE CI Improvements
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Drone Passes More often now
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/5624
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
