### PR TITLE
Re-add `--cloud-provider=external` kubelet arg

### DIFF
--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -150,6 +150,10 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 		argsMap["register-with-taints"] = strings.Join(cfg.NodeTaints, ",")
 	}
 
+	if !cfg.DisableCCM {
+		argsMap["cloud-provider"] = "external"
+	}
+
 	if ImageCredProvAvailable(cfg) {
 		logrus.Infof("Kubelet image credential provider bin dir and configuration file found.")
 		argsMap["feature-gates"] = util.AddFeatureGate(argsMap["feature-gates"], "KubeletCredentialProviders=true")

--- a/pkg/daemons/agent/agent_windows.go
+++ b/pkg/daemons/agent/agent_windows.go
@@ -116,6 +116,10 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 		argsMap["register-with-taints"] = strings.Join(cfg.NodeTaints, ",")
 	}
 
+	if !cfg.DisableCCM {
+		argsMap["cloud-provider"] = "external"
+	}
+
 	if ImageCredProvAvailable(cfg) {
 		logrus.Infof("Kubelet image credential provider bin dir and configuration file found.")
 		argsMap["feature-gates"] = util.AddFeatureGate(argsMap["feature-gates"], "KubeletCredentialProviders=true")


### PR DESCRIPTION
#### Proposed Changes ####

Partial revert of 551f2fa00a81f6a0aee1be13c69d29b0d4ed1d7f

The cloud-provider arg is deprecated and cannot be set to anything other than external, but must still be used or node addresses are not set properly.

```console
brandond@dev01:~$ k3s server | grep 'has been deprecated'
Flag --cloud-provider has been deprecated, will be removed in 1.24 or later, in favor of removing cloud provider code from Kubelet.
Flag --pod-infra-container-image has been deprecated, will be removed in 1.27. Image garbage collector will get sandbox image information from CRI.
```

If there is no in-tree cloud-provider configured, but cloud-provider is not explicitly set to external, the kubelet replaces the node Address list with the --node-ip values every time it syncs:

https://github.com/kubernetes/kubernetes/blob/release-1.24/pkg/kubelet/nodestatus/setters.go#L158-L163

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3000

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
