### PR TITLE
Revert "Give kubelet the node-ip value (#5579)"

### DIFF
--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -121,11 +121,9 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 	if cfg.NodeName != "" {
 		argsMap["hostname-override"] = cfg.NodeName
 	}
-	if nodeIPs := util.JoinIPs(cfg.NodeIPs); nodeIPs != "" {
-		defaultIP, err := net.ChooseHostInterface()
-		if err != nil || defaultIP.String() != nodeIPs {
-			argsMap["node-ip"] = nodeIPs
-		}
+	defaultIP, err := net.ChooseHostInterface()
+	if err != nil || defaultIP.String() != cfg.NodeIP {
+		argsMap["node-ip"] = cfg.NodeIP
 	}
 	kubeletRoot, runtimeRoot, controllers := cgroups.CheckCgroups()
 	if !controllers["cpu"] {


### PR DESCRIPTION
#### Proposed Changes ####

This reverts commit aa9065749c9479e7ec4914f73e6c5c0e86cf01bf.

Setting dual-stack node-ip does not work when --cloud-provider is set
to anything, including 'external'. Just set node-ip to the first IP, and
let the cloud provider add the other address.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5638

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
