### PR TITLE
Refactor egress-selector pods mode to watch pods on the local node

### DIFF
--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -30,7 +30,16 @@ const (
 	EgressSelectorModeDisabled    = "disabled"
 	EgressSelectorModePod         = "pod"
 	CertificateRenewDays          = 90
+	StreamServerPort              = "10010"
+	KubeletPort                   = "10250"
 )
+
+// These ports can always be accessed via the tunnel server, at the loopback address.
+// Other addresses and ports are only accessible via the tunnel on newer agents, when used by a pod.
+var KubeletReservedPorts = map[string]bool{
+	StreamServerPort: true,
+	KubeletPort:      true,
+}
 
 type Node struct {
 	ContainerRuntimeEndpoint string

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -256,3 +256,26 @@ func IsIPv6OnlyCIDRs(cidrs []*net.IPNet) (bool, error) {
 
 	return !v4Found && v6Found, nil
 }
+
+// IPToIPNet converts an IP to an IPNet, using a fully filled mask appropriate for the address family.
+func IPToIPNet(ip net.IP) (*net.IPNet, error) {
+	address := ip.String()
+	if strings.Contains(address, ":") {
+		address += "/128"
+	} else {
+		address += "/32"
+	}
+	_, cidr, err := net.ParseCIDR(address)
+	return cidr, err
+}
+
+// IPStringToIPNet converts an IP string to an IPNet, using a fully filled mask appropriate for the address family.
+func IPStringToIPNet(address string) (*net.IPNet, error) {
+	if strings.Contains(address, ":") {
+		address += "/128"
+	} else {
+		address += "/32"
+	}
+	_, cidr, err := net.ParseCIDR(address)
+	return cidr, err
+}


### PR DESCRIPTION
#### Proposed Changes ####

* Refactor egress-selector pods mode to watch pods on the local node
* Only redirect to localhost ports reserved for use by the kubelet and container runtime.
* Maintain a list of hostNetwork ports that can be connected to on the Node, while continuing to allow all ports on other Pods. Should also address issues with CNIs that don't respect the Node's PodCIDR, since we now look at the actual IPs assigned to Pods.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5637

#### User-Facing Change ####
```release-note
Fixed issue with the `pod` and `cluster` egress selector modes that caused connections from the apiserver to hostNetwork pods to be rejected.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
