### PR TITLE
Add FlannelCNIConf flag

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -533,6 +533,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		}
 		nodeConfig.AgentConfig.CNIBinDir = filepath.Dir(hostLocal)
 		nodeConfig.AgentConfig.CNIConfDir = filepath.Join(envInfo.DataDir, "agent", "etc", "cni", "net.d")
+		nodeConfig.AgentConfig.FlannelCniConfFile = envInfo.FlannelCniConfFile
 	}
 
 	if nodeConfig.ContainerRuntimeEndpoint == "" {

--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -91,7 +91,7 @@ const (
 )
 
 func Prepare(ctx context.Context, nodeConfig *config.Node) error {
-	if err := createCNIConf(nodeConfig.AgentConfig.CNIConfDir); err != nil {
+	if err := createCNIConf(nodeConfig.AgentConfig.CNIConfDir, nodeConfig); err != nil {
 		return err
 	}
 
@@ -146,12 +146,17 @@ func waitForPodCIDR(ctx context.Context, nodeName string, nodes typedcorev1.Node
 	return nil
 }
 
-func createCNIConf(dir string) error {
+func createCNIConf(dir string, nodeConfig *config.Node) error {
 	logrus.Debugf("Creating the CNI conf in directory %s", dir)
 	if dir == "" {
 		return nil
 	}
 	p := filepath.Join(dir, "10-flannel.conflist")
+
+	if nodeConfig.AgentConfig.FlannelCniConfFile != "" {
+		logrus.Debugf("Using %s as the flannel CNI conf", nodeConfig.AgentConfig.FlannelCniConfFile)
+		return util.CopyFile(nodeConfig.AgentConfig.FlannelCniConfFile, p)
+	}
 	return util.WriteFile(p, cniConf)
 }
 

--- a/pkg/agent/util/file.go
+++ b/pkg/agent/util/file.go
@@ -16,3 +16,16 @@ func WriteFile(name string, content string) error {
 	}
 	return nil
 }
+
+func CopyFile(sourceFile string, destinationFile string) error {
+	os.MkdirAll(filepath.Dir(destinationFile), 0755)
+	input, err := ioutil.ReadFile(sourceFile)
+	if err != nil {
+		return errors.Wrapf(err, "copying %s to %s", sourceFile, destinationFile)
+	}
+	err = ioutil.WriteFile(destinationFile, input, 0644)
+	if err != nil {
+		return errors.Wrapf(err, "copying %s to %s", sourceFile, destinationFile)
+	}
+	return nil
+}

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -31,6 +31,7 @@ type Agent struct {
 	NoFlannel                bool
 	FlannelIface             string
 	FlannelConf              string
+	FlannelCniConfFile       string
 	Debug                    bool
 	Rootless                 bool
 	RootlessAlreadyUnshared  bool
@@ -134,6 +135,11 @@ var (
 		Name:        "flannel-conf",
 		Usage:       "(agent/networking) Override default flannel config file",
 		Destination: &AgentConfig.FlannelConf,
+	}
+	FlannelCniConfFileFlag = cli.StringFlag{
+		Name:        "flannel-cni-conf",
+		Usage:       "(agent/networking) Override default flannel cni config file",
+		Destination: &AgentConfig.FlannelCniConfFile,
 	}
 	ResolvConfFlag = cli.StringFlag{
 		Name:        "resolv-conf",
@@ -258,6 +264,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			ResolvConfFlag,
 			FlannelIfaceFlag,
 			FlannelConfFlag,
+			FlannelCniConfFileFlag,
 			ExtraKubeletArgs,
 			ExtraKubeProxyArgs,
 			ProtectKernelDefaultsFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -439,6 +439,7 @@ var ServerFlags = []cli.Flag{
 	ResolvConfFlag,
 	FlannelIfaceFlag,
 	FlannelConfFlag,
+	FlannelCniConfFileFlag,
 	ExtraKubeletArgs,
 	ExtraKubeProxyArgs,
 	ProtectKernelDefaultsFlag,

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -101,6 +101,7 @@ type Agent struct {
 	ImageCredProvBinDir     string
 	ImageCredProvConfig     string
 	IPSECPSK                string
+	FlannelCniConfFile      string
 	StrongSwanDir           string
 	PrivateRegistry         string
 	SystemDefaultRegistry   string


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This PR introduces the FlannelCNIConf which points to a file that contains the desired flannel cni conf file, i.e. what is written in /var/lib/rancher/k3s/agent/etc/cni/net.d/10-flannel.conflist and controls the behaviour of the flannel binary. This would allow users to change that config, e.g. to use other CNI plugins on top of flannel (e.g. bandwidth)

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
New feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Create a flannel cni config file and deploy with that flag. Check that the content of `/var/lib/rancher/k3s/agent/etc/cni/net.d/10-flannel.conflist ` is not the hardcoded one but a new one

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/5655

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduce the flannelcniconf flag to set the desired flannel cni configuration
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
