### PR TITLE
Move all klipper-lb daemonset to common namespace for PodSecurity

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -101,6 +101,7 @@ type Server struct {
 	EtcdS3Folder             string
 	EtcdS3Timeout            time.Duration
 	EtcdS3Insecure           bool
+	ServiceLBNamespace       string
 }
 
 var (
@@ -220,6 +221,12 @@ var ServerFlags = []cli.Flag{
 		Usage:       "(networking) One of 'agent', cluster', 'pod', 'disabled'",
 		Destination: &ServerConfig.EgressSelectorMode,
 		Value:       "agent",
+	},
+	cli.StringFlag{
+		Name:        "servicelb-namespace",
+		Usage:       "(networking) Namespace of the pods for the servicelb component",
+		Destination: &ServerConfig.ServiceLBNamespace,
+		Value:       "kube-system",
 	},
 	ServerToken,
 	cli.StringFlag{

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -115,6 +115,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.KubeConfigOutput = cfg.KubeConfigOutput
 	serverConfig.ControlConfig.KubeConfigMode = cfg.KubeConfigMode
 	serverConfig.Rootless = cfg.Rootless
+	serverConfig.ServiceLBNamespace = cfg.ServiceLBNamespace
 	serverConfig.ControlConfig.SANs = cfg.TLSSan
 	serverConfig.ControlConfig.BindAddress = cfg.BindAddress
 	serverConfig.ControlConfig.SupervisorPort = cfg.SupervisorPort

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -212,6 +212,7 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 		sc.Core.Core().V1().Pod(),
 		sc.Core.Core().V1().Service(),
 		sc.Core.Core().V1().Endpoints(),
+		config.ServiceLBNamespace,
 		!config.DisableServiceLB,
 		config.Rootless); err != nil {
 		return err

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -8,14 +8,15 @@ import (
 )
 
 type Config struct {
-	DisableAgent      bool
-	DisableServiceLB  bool
-	ControlConfig     config.Control
-	Rootless          bool
-	SupervisorPort    int
-	StartupHooks      []cmds.StartupHook
-	LeaderControllers CustomControllers
-	Controllers       CustomControllers
+	DisableAgent       bool
+	DisableServiceLB   bool
+	ControlConfig      config.Control
+	Rootless           bool
+	ServiceLBNamespace string
+	SupervisorPort     int
+	StartupHooks       []cmds.StartupHook
+	LeaderControllers  CustomControllers
+	Controllers        CustomControllers
 }
 
 type CustomControllers []func(ctx context.Context, sc *Context) error


### PR DESCRIPTION
The baseline PodSecurity profile will reject klipper-lb pods from running.
Since klipper-lb pods are put in the same namespace as the Service this
means users can not use PodSecurity baseline profile in combination with
the k3s servicelb.

The solution is to move all klipper-lb pods to a klipper-lb-system where
the security policy of the klipper-lb pods can be different an uniformly
managed.

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Move all klipper-lb pods to klipper-lb-system namespace

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

On upgrade the existing klipper-lb daemonsets will be removed and moved to the klipper-lb-system namespace

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

Ensure that servicelb still works and the IPs of Services are still populated

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/5631

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####

klipper-lb-system will be a namespace now. Previously k3s created no new namespaces, now it will.  Maybe we should default to kube-system and then make it a configuration to pick a different namespace?

Also on upgrade the users load balancers will go down as long as it takes to deploy new daemonsets.

<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
