### PR TITLE
EIO/1098 output gsutil logs

### DIFF
--- a/scripts/log-upload
+++ b/scripts/log-upload
@@ -45,6 +45,6 @@ PATH=$PATH:${HOME}/gsutil
 LOG_TGZ=k3s-log-$(date +%s)-$("${GO}" env GOARCH)-$(git rev-parse --short HEAD)-$(basename $1).tgz
 
 tar -cz -f ${TMPDIR}/${LOG_TGZ} -C $(dirname $1) $(basename $1)
-gsutil cp ${TMPDIR}/${LOG_TGZ} gs://k3s-ci-logs || exit 1
+gsutil cp -L cp.log ${TMPDIR}/${LOG_TGZ} gs://k3s-ci-logs || cat cp.log; exit 1
 echo "Logs uploaded" >&2
 echo "https://storage.googleapis.com/k3s-ci-logs/${LOG_TGZ}"


### PR DESCRIPTION
#### Proposed Changes ####

uploading build log are failing and additional details are needed to determine why the uploads are failing

#### Types of Changes ####

change modifies `scripts/log-upload` to output upload logs during build process

#### Verification ####

during the build process in the test step if build logs fail to upload the upload logs will be catted to stdout

#### Linked Issues ####

https://github.com/rancherlabs/eio/issues/1098

#### User-Facing Change ####

NONE

```release-note
NONE
```

