### PR TITLE
[release-1.22] Remove control-plane egress context and fix agent mode

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -218,7 +218,7 @@ var ServerFlags = []cli.Flag{
 		Name:        "egress-selector-mode",
 		Usage:       "(networking) One of 'agent', cluster', 'pod', 'disabled'",
 		Destination: &ServerConfig.EgressSelectorMode,
-		Value:       "pod",
+		Value:       "agent",
 	},
 	ServerToken,
 	cli.StringFlag{

--- a/pkg/daemons/control/tunnel.go
+++ b/pkg/daemons/control/tunnel.go
@@ -245,19 +245,14 @@ func (t *TunnelServer) dialBackend(addr string) (net.Conn, error) {
 		useTunnel = false
 	}
 
-	if t.server.HasSession(nodeName) {
-		if useTunnel {
-			// Have a session and it is safe to use for this destination, do so.
-			logrus.Debugf("Tunnel server egress proxy dialing %s via session to %s", addr, nodeName)
-			return t.server.Dial(nodeName, 15*time.Second, "tcp", addr)
-		}
-		// Have a session but the agent doesn't support tunneling to this destination or
-		// the destination is local; fall back to direct connection.
-		logrus.Debugf("Tunnel server egress proxy dialing %s directly", addr)
-		return net.Dial("tcp", addr)
+	if useTunnel && t.server.HasSession(nodeName) {
+		// Have a session and it is safe to use for this destination, do so.
+		logrus.Debugf("Tunnel server egress proxy dialing %s via session to %s", addr, nodeName)
+		return t.server.Dial(nodeName, 15*time.Second, "tcp", addr)
 	}
 
-	// don't provide a proxy connection for anything else
-	logrus.Debugf("Tunnel server egress proxy rejecting connection to %s", addr)
-	return nil, fmt.Errorf("no sessions available for host %s", host)
+	// Don't have a session, the agent doesn't support tunneling to this destination, or
+	// the destination is local; fall back to direct connection.
+	logrus.Debugf("Tunnel server egress proxy dialing %s directly", addr)
+	return net.Dial("tcp", addr)
 }


### PR DESCRIPTION
#### Proposed Changes ####

The control-plane context handles requests outside the cluster and
should not be sent to the proxy.

In agent mode, we don't watch pods and just direct-dial any request for
a non-node address, which is the original behavior.

#### Types of Changes ####

bugfix

#### Verification ####

QA checks on CIS-hardened cluster

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5637

#### User-Facing Change ####
```release-note
The embedded apiserver network proxy no longer attempts to handle requests destined outside the cluster.
The embedded apiserver network proxy now functions properly in legacy `agent` mode.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
