### PR TITLE
[Release 1.23] Remove kube-ipvs0 interface when cleaning up

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -675,6 +675,7 @@ done
 ip link delete cni0
 ip link delete flannel.1
 ip link delete flannel-v6.1
+ip link delete kube-ipvs0
 rm -rf /var/lib/cni/
 iptables-save | grep -v KUBE- | grep -v CNI- | grep -v flannel | iptables-restore
 ip6tables-save | grep -v KUBE- | grep -v CNI- | grep -v flannel | ip6tables-restore

--- a/package/rpm/install.sh
+++ b/package/rpm/install.sh
@@ -566,6 +566,7 @@ done
 ip link delete cni0
 ip link delete flannel.1
 ip link delete flannel-v6.1
+ip link delete kube-ipvs0
 rm -rf /var/lib/cni/
 iptables-save | grep -v KUBE- | grep -v CNI- | grep -v flannel | iptables-restore
 ip6tables-save | grep -v KUBE- | grep -v CNI- | grep -v flannel | ip6tables-restore


### PR DESCRIPTION
Backport: https://github.com/k3s-io/k3s/pull/5644
Issue: https://github.com/k3s-io/k3s/issues/5676