### PR TITLE
[release-1.23] Disable urfave markdown/man docs generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tchap/go-patricia v2.3.0+incompatible // indirect
-	github.com/urfave/cli v1.22.4
+	github.com/urfave/cli v1.22.9
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
 	github.com/yl2chen/cidranger v1.0.2
 	go.etcd.io/etcd/api/v3 v3.5.4

--- a/go.sum
+++ b/go.sum
@@ -1232,8 +1232,9 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.9 h1:cv3/KhXGBGjEXLC4bH0sLuJ9BewaAbpk5oyMOveu4pw=
+github.com/urfave/cli v1.22.9/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=

--- a/scripts/build
+++ b/scripts/build
@@ -48,7 +48,7 @@ LDFLAGS="
 STATIC="
     -extldflags '-static -lm -ldl -lz -lpthread'
 "
-TAGS="apparmor seccomp netcgo osusergo providerless"
+TAGS="apparmor seccomp netcgo osusergo providerless urfave_cli_no_docs"
 RUNC_TAGS="apparmor seccomp"
 RUNC_STATIC="static"
 

--- a/scripts/package-cli
+++ b/scripts/package-cli
@@ -58,8 +58,9 @@ LDFLAGS="
     -X github.com/k3s-io/k3s/pkg/version.GitCommit=${COMMIT:0:8}
     -w -s
 "
+TAGS="urfave_cli_no_docs"
 STATIC="-extldflags '-static'"
-CGO_ENABLED=0 "${GO}" build -ldflags "$LDFLAGS $STATIC" -o ${CMD_NAME} ./cmd/k3s/main.go
+CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -ldflags "$LDFLAGS $STATIC" -o ${CMD_NAME} ./cmd/k3s/main.go
 
 stat ${CMD_NAME}
 


### PR DESCRIPTION
#### Proposed Changes ####

Disable urfave markdown/man docs generation. We're not using either of these, so it's just bloat.

From https://github.com/urfave/cli/pull/1383 :
> This removes the resulting binary dependency on cpuguy83/md2man and
> russross/blackfriday (and a few more packages imported by those),
> which saves more than 400 KB (more than 300 KB
> once stripped) from the resulting binary.

A/B comparison of builds without/with this commit:
```
k3s binary dist/artifacts/k3s size 66265088 is less than max acceptable size of 67108864 bytes (64 MiB)
k3s binary dist/artifacts/k3s size 65044480 is less than max acceptable size of 67108864 bytes (64 MiB)
```

This is a savings of 1192 Kb - just shy of 1MiB.

#### Types of Changes ####

size reduction

#### Verification ####

Check size of resulting K3s binary

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5698

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
