### PR TITLE
Sanitize filenames for use in configmap keys

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -82,6 +83,8 @@ var (
 
 	ErrAddressNotSet = errors.New("apiserver addresses not yet set")
 	ErrNotMember     = errNotMember()
+
+	invalidKeyChars = regexp.MustCompile(`[^-._a-zA-Z0-9]`)
 )
 
 type NodeControllerGetter func() controllerv1.NodeController
@@ -1682,6 +1685,7 @@ func (e *ETCD) addSnapshotData(sf snapshotFile) error {
 		}
 		snapshotConfigMap, getErr := e.config.Runtime.Core.Core().V1().ConfigMap().Get(metav1.NamespaceSystem, snapshotConfigMapName, metav1.GetOptions{})
 
+		sfKey := generateSnapshotConfigMapKey(sf)
 		marshalledSnapshotFile, err := json.Marshal(sf)
 		if err != nil {
 			return err
@@ -1692,7 +1696,7 @@ func (e *ETCD) addSnapshotData(sf snapshotFile) error {
 					Name:      snapshotConfigMapName,
 					Namespace: metav1.NamespaceSystem,
 				},
-				Data: map[string]string{sf.Name: string(marshalledSnapshotFile)},
+				Data: map[string]string{sfKey: string(marshalledSnapshotFile)},
 			}
 			_, err := e.config.Runtime.Core.Core().V1().ConfigMap().Create(&cm)
 			return err
@@ -1702,7 +1706,6 @@ func (e *ETCD) addSnapshotData(sf snapshotFile) error {
 			snapshotConfigMap.Data = make(map[string]string)
 		}
 
-		sfKey := generateSnapshotConfigMapKey(sf)
 		snapshotConfigMap.Data[sfKey] = string(marshalledSnapshotFile)
 
 		_, err = e.config.Runtime.Core.Core().V1().ConfigMap().Update(snapshotConfigMap)
@@ -1711,13 +1714,11 @@ func (e *ETCD) addSnapshotData(sf snapshotFile) error {
 }
 
 func generateSnapshotConfigMapKey(sf snapshotFile) string {
-	var sfKey string
+	name := invalidKeyChars.ReplaceAllString(sf.Name, "_")
 	if sf.NodeName == "s3" {
-		sfKey = "s3-" + sf.Name
-	} else {
-		sfKey = "local-" + sf.Name
+		return "s3-" + name
 	}
-	return sfKey
+	return "local-" + name
 }
 
 // ReconcileSnapshotData reconciles snapshot data in the snapshot ConfigMap.


### PR DESCRIPTION
#### Proposed Changes ####

If the user points S3 backups at a bucket containing other files, those
file names may not be valid configmap keys.

For example, RKE1 generates backup files with names like
`s3-c-zrjnb-rs-6hxpk_2022-05-05T12:05:15Z.zip`; the semicolons in the
timestamp portion of the name are not allowed for use in configmap keys.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

n/a

#### Linked Issues ####

* https://github.com/rancher/rancher/issues/37904#issuecomment-1155731449

#### User-Facing Change ####
```release-note
The embedded etcd snapshot controller will no longer fail to process snapshot files containing characters that are invalid for use in ConfigMap keys.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
