### PR TITLE
[release-1.21] Bump cgroup2 fedora version

### DIFF
--- a/tests/cgroup2/Vagrantfile
+++ b/tests/cgroup2/Vagrantfile
@@ -8,7 +8,7 @@
 # - k3s
 # - k3s.service
 Vagrant.configure("2") do |config|
-  config.vm.box = "fedora/33-cloud-base"
+  config.vm.box = "fedora/36-cloud-base"
   memory = 2048
   cpus = 2
   config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
#### Proposed Changes ####

Bump cgroup2 fedora version. Fedora 33 artifacts have been moved to the archive and can no longer be used.

https://app.vagrantup.com/fedora/boxes/33-cloud-base/versions/33.20201019.0/providers/fetch/virtualbox.box redirects to 
https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-33-1.2.x86_64.vagrant-virtualbox.box which returns a 404.

https://download.fedoraproject.org/pub/fedora/linux/releases/33/README says:
```
ATTENTION
======================================
The contents of this directory have been moved to our archives available at:

http://archives.fedoraproject.org/pub/archive/fedora/
```

#### Types of Changes ####

CI bugfix

#### Verification ####

See linked CI run

#### Testing ####

this is a test

#### Linked Issues ####

* https://github.com/k3s-io/k3s/runs/6890076843?check_suite_focus=true

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
