### PR TITLE
Don't crash when service IPFamiliyPolicy is not set

### DIFF
--- a/pkg/servicelb/controller.go
+++ b/pkg/servicelb/controller.go
@@ -189,7 +189,7 @@ func (h *handler) onChangeNode(key string, node *core.Node) (*core.Node, error) 
 // updateService ensures that the Service ingress IP address list is in sync
 // with the Nodes actually running pods for this service.
 func (h *handler) updateService(svc *core.Service) (runtime.Object, error) {
-	if !h.enabled {
+	if !h.enabled || svc.Spec.Type != core.ServiceTypeLoadBalancer {
 		return svc, nil
 	}
 
@@ -301,7 +301,7 @@ func (h *handler) podIPs(pods []*core.Pod, svc *core.Service) ([]string, error) 
 
 // filterByIPFamily filters ips based on dual-stack parameters of the service
 func filterByIPFamily(ips []string, svc *core.Service) ([]string, error) {
-
+	var ipFamilyPolicy core.IPFamilyPolicyType
 	var ipv4Addresses []string
 	var ipv6Addresses []string
 
@@ -314,7 +314,11 @@ func filterByIPFamily(ips []string, svc *core.Service) ([]string, error) {
 		}
 	}
 
-	switch *svc.Spec.IPFamilyPolicy {
+	if svc.Spec.IPFamilyPolicy != nil {
+		ipFamilyPolicy = *svc.Spec.IPFamilyPolicy
+	}
+
+	switch ipFamilyPolicy {
 	case core.IPFamilyPolicySingleStack:
 		if svc.Spec.IPFamilies[0] == core.IPv4Protocol {
 			return ipv4Addresses, nil


### PR DESCRIPTION
#### Proposed Changes ####

Don't crash when service IPFamiliyPolicy is not set. Service.Spec.IPFamilyPolicy may be a nil pointer on freshly upgraded clusters, coming from older releases where this field doesn't exist.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

See linked issue.

May be hard to trigger on demand - may be able to figure out what version the user was upgrading from? I suspect it would only be triggered when coming from a version prior to the introduction of the `Service.Spec.IPFamilyPolicy` field.

Another user provided a comment that may be useful in reproducing:
> appears to be triggered because I have Service w/ `type: ExternalName` which cannot have a ipFamilyPolicy.


#### Testing ####

N/A

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5762

#### User-Facing Change ####
```release-note
K3s will no longer crash after upgrading directly from much older Kubernetes releases, or when deploying services with `type: ExternalName`.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
