### PR TITLE
[release-1.22] backport fixes for egress proxy, servicelb, and kine issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/k3s-io/helm-controller v0.12.3
-	github.com/k3s-io/kine v0.9.1
+	github.com/k3s-io/kine v0.9.3
 	github.com/klauspost/compress v1.15.1
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -641,8 +641,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1 h1:swbvfSDpl7QsYO6Vh+EBgxZCMyG4N1tU
 github.com/k3s-io/etcd/server/v3 v3.5.4-k3s1/go.mod h1:S5/YTU15KxymM5l3T6b09sNOHPXqGYIZStpuuGbb65c=
 github.com/k3s-io/helm-controller v0.12.3 h1:jXEl/QBMrdGuZof//brZfb7CDep9H77iNIevAe2Hzbs=
 github.com/k3s-io/helm-controller v0.12.3/go.mod h1:yBS3F5emwVjyzUUi3VWAuj9+Ogoq84Mf7CBXbAnKI1U=
-github.com/k3s-io/kine v0.9.1 h1:HDT89cI7+xVYYFVC/LWK6mcA5dFwu1BUGffRvt/SXeU=
-github.com/k3s-io/kine v0.9.1/go.mod h1:Yqg5cVgu11yV16JzAS9gnjM+Ny5kiey9surO/AaF//U=
+github.com/k3s-io/kine v0.9.3 h1:VAjsljVuD2l20oByCsy7+LafAgwY9Y7hrksUTiuLq3E=
+github.com/k3s-io/kine v0.9.3/go.mod h1:IiaUJx32GOhR4N5zUevjz3cpU9JT0q9cQzXSZmznHKE=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 github.com/k3s-io/klog/v2 v2.9.0-k3s2 h1:8Dzu3wGPFMo1mPEobSEpkHWH+HXqgFXp8R7FbcdgE8k=

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -734,7 +734,7 @@ func genEgressSelectorConfig(controlConfig *config.Control) error {
 			ProxyProtocol: apiserver.ProtocolHTTPConnect,
 			Transport: &apiserver.Transport{
 				TCP: &apiserver.TCPTransport{
-					URL: fmt.Sprintf("https://%s:%d", controlConfig.Loopback(), controlConfig.SupervisorPort),
+					URL: fmt.Sprintf("https://%s:%d", controlConfig.BindAddressOrLoopback(false), controlConfig.SupervisorPort),
 					TLSConfig: &apiserver.TLSConfig{
 						CABundle:   controlConfig.Runtime.ServerCA,
 						ClientKey:  controlConfig.Runtime.ClientKubeAPIKey,

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -193,6 +193,7 @@ func apiServer(ctx context.Context, cfg *config.Control) error {
 	argsMap["kubelet-certificate-authority"] = runtime.ServerCA
 	argsMap["kubelet-client-certificate"] = runtime.ClientKubeAPICert
 	argsMap["kubelet-client-key"] = runtime.ClientKubeAPIKey
+	argsMap["kubelet-preferred-address-types"] = "InternalIP,ExternalIP,Hostname"
 	argsMap["requestheader-client-ca-file"] = runtime.RequestHeaderCA
 	argsMap["requestheader-allowed-names"] = deps.RequestHeaderCN
 	argsMap["proxy-client-cert-file"] = runtime.ClientAuthProxyCert

--- a/pkg/servicelb/controller.go
+++ b/pkg/servicelb/controller.go
@@ -170,7 +170,7 @@ func (h *handler) onChangeNode(key string, node *core.Node) (*core.Node, error) 
 // updateService ensures that the Service ingress IP address list is in sync
 // with the Nodes actually running pods for this service.
 func (h *handler) updateService(svc *core.Service) (runtime.Object, error) {
-	if !h.enabled {
+	if !h.enabled || svc.Spec.Type != core.ServiceTypeLoadBalancer {
 		return svc, nil
 	}
 
@@ -281,7 +281,7 @@ func (h *handler) podIPs(pods []*core.Pod, svc *core.Service) ([]string, error) 
 
 // filterByIPFamily filters ips based on dual-stack parameters of the service
 func filterByIPFamily(ips []string, svc *core.Service) ([]string, error) {
-
+	var ipFamilyPolicy core.IPFamilyPolicyType
 	var ipv4Addresses []string
 	var ipv6Addresses []string
 
@@ -294,7 +294,11 @@ func filterByIPFamily(ips []string, svc *core.Service) ([]string, error) {
 		}
 	}
 
-	switch *svc.Spec.IPFamilyPolicy {
+	if svc.Spec.IPFamilyPolicy != nil {
+		ipFamilyPolicy = *svc.Spec.IPFamilyPolicy
+	}
+
+	switch ipFamilyPolicy {
 	case core.IPFamilyPolicySingleStack:
 		if svc.Spec.IPFamilies[0] == core.IPv4Protocol {
 			return ipv4Addresses, nil


### PR DESCRIPTION
#### Proposed Changes ####

Backports:
* https://github.com/k3s-io/k3s/pull/5780
* https://github.com/k3s-io/k3s/pull/5771
* https://github.com/k3s-io/k3s/pull/5795

#### Types of Changes ####

bugfix / backport

#### Verification ####

See linked issues

#### Testing ####

n/a

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5802
* https://github.com/k3s-io/k3s/issues/5803
* https://github.com/k3s-io/k3s/issues/5804

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an issue that prevented `kubectl logs` and other functionality that requires a connection to the agent from working correctly when the server's `--bind-address` flag was used, or when K3s is used behind a HTTP proxy.
K3s will no longer log panics after upgrading directly from much older Kubernetes releases, or when deploying services with `type: ExternalName`.
Bumped kine to v0.9.3
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
