### PR TITLE
Fix issue with containerd stats missing from cadvisor metrics

### DIFF
--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -94,6 +94,7 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 		argsMap["resolv-conf"] = cfg.ResolvConf
 	}
 	if cfg.RuntimeSocket != "" {
+		argsMap["containerd"] = cfg.RuntimeSocket
 		argsMap["serialize-image-pulls"] = "false"
 		checkRuntimeEndpoint(cfg, argsMap)
 	}

--- a/pkg/daemons/agent/agent_windows.go
+++ b/pkg/daemons/agent/agent_windows.go
@@ -85,7 +85,7 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 		argsMap["resolv-conf"] = cfg.ResolvConf
 	}
 	if cfg.RuntimeSocket != "" {
-		argsMap["container-runtime"] = "remote"
+		argsMap["containerd"] = cfg.RuntimeSocket
 		argsMap["serialize-image-pulls"] = "false"
 		checkRuntimeEndpoint(cfg, argsMap)
 	}


### PR DESCRIPTION
#### Proposed Changes ####

Fix issue with containerd stats missing from cadvisor pod metrics

cadvisor still doesn't pull stats via CRI yet, so we have to continue to use the deprecated arg.

#### Types of Changes ####

bugfix

#### Verification ####

* `kubectl get --raw /api/v1/nodes/NODENAME/proxy/metrics/cadvisor | grep 'container_cpu_usage_seconds_total.*traefik'` - note that the container, image, and name labels are populated.

#### Testing ####

n/a

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5782

#### User-Facing Change ####

```release-note
Fixed a regression that caused some containerd labels to be empty in cadvisor pod metrics
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
