### PR TITLE
[release-1.23] Fix fatal error when reconciling bootstrap data

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -75,7 +75,7 @@ func WriteToDiskFromStorage(files PathsDataformat, bootstrap *config.ControlRunt
 
 	for pathKey, bsf := range files {
 		path, ok := paths[pathKey]
-		if !ok {
+		if !ok || path == "" {
 			continue
 		}
 

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -363,7 +363,7 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 
 				for pk := range files {
 					p, ok := paths[pk]
-					if !ok {
+					if !ok || p == "" {
 						continue
 					}
 
@@ -393,7 +393,7 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 
 				for pk := range files {
 					p, ok := paths[pk]
-					if !ok {
+					if !ok || p == "" {
 						continue
 					}
 

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -316,13 +316,11 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 		buf.Seek(0, 0)
 	}
 
-	type update struct {
-		db, disk, conflict bool
-	}
-
+	// Compare on-disk content to the datastore.
+	// If the files differ and the timestamp in the datastore is newer, data on disk will be updated.
+	// If the files differ and the timestamp on disk is newer, an error will be raised listing the conflicting files.
 	var updateDisk bool
-
-	results := make(map[string]update)
+	var newerOnDisk []string
 	for pathKey, fileData := range files {
 		path, ok := paths[pathKey]
 		if !ok || path == "" {
@@ -338,123 +336,44 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 				updateDisk = true
 				continue
 			}
-			return err
+			return errors.Wrapf(err, "reconcile failed to open %s", pathKey)
 		}
 		defer f.Close()
 
 		fData, err := ioutil.ReadAll(f)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "reconcile failed to read %s", pathKey)
 		}
 
 		if !bytes.Equal(fileData.Content, fData) {
-			info, err := os.Stat(path)
+			updateDisk = true
+			info, err := f.Stat()
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "reconcile failed to stat %s", pathKey)
 			}
 
-			switch {
-			case info.ModTime().Unix()-files[pathKey].Timestamp.Unix() >= systemTimeSkew:
-				if _, ok := results[path]; !ok {
-					results[path] = update{
-						db: true,
-					}
-				}
-
-				for pk := range files {
-					p, ok := paths[pk]
-					if !ok || p == "" {
-						continue
-					}
-
-					if filepath.Base(p) == info.Name() {
-						continue
-					}
-
-					i, err := os.Stat(p)
-					if err != nil {
-						return err
-					}
-
-					if i.ModTime().Unix()-files[pk].Timestamp.Unix() >= systemTimeSkew {
-						if _, ok := results[path]; !ok {
-							results[path] = update{
-								conflict: true,
-							}
-						}
-					}
-				}
-			case info.ModTime().Unix()-files[pathKey].Timestamp.Unix() <= systemTimeSkew:
-				if _, ok := results[info.Name()]; !ok {
-					results[path] = update{
-						disk: true,
-					}
-				}
-
-				for pk := range files {
-					p, ok := paths[pk]
-					if !ok || p == "" {
-						continue
-					}
-
-					if filepath.Base(p) == info.Name() {
-						continue
-					}
-
-					i, err := os.Stat(p)
-					if err != nil {
-						return err
-					}
-
-					if i.ModTime().Unix()-files[pk].Timestamp.Unix() <= systemTimeSkew {
-						if _, ok := results[path]; !ok {
-							results[path] = update{
-								conflict: true,
-							}
-						}
-					}
-				}
-			default:
-				if _, ok := results[path]; ok {
-					results[path] = update{}
-				}
+			if info.ModTime().Unix()-fileData.Timestamp.Unix() >= systemTimeSkew {
+				newerOnDisk = append(newerOnDisk, path)
+			} else {
+				logrus.Warn(path + " will be updated from the datastore.")
 			}
 		}
 	}
 
 	if c.config.ClusterReset {
+		updateDisk = true
 		serverTLSDir := filepath.Join(c.config.DataDir, "tls")
 		tlsBackupDir := filepath.Join(c.config.DataDir, "tls-"+strconv.Itoa(int(time.Now().Unix())))
 
 		logrus.Infof("Cluster reset: backing up certificates directory to " + tlsBackupDir)
 
 		if _, err := os.Stat(serverTLSDir); err != nil {
-			return err
+			return errors.Wrap(err, "cluster reset failed to stat server TLS dir")
 		}
 		if err := copy.Copy(serverTLSDir, tlsBackupDir); err != nil {
-			return err
+			return errors.Wrap(err, "cluster reset failed to back up server TLS dir")
 		}
-	}
-
-	var newerOnDisk []string
-	for path, res := range results {
-		switch {
-		case res.disk:
-			updateDisk = true
-			logrus.Warn("Datastore newer than " + path)
-		case res.db:
-			if c.config.ClusterReset {
-				logrus.Infof("Cluster reset: replacing file on disk: " + path)
-				updateDisk = true
-				continue
-			}
-			newerOnDisk = append(newerOnDisk, path)
-		case res.conflict:
-			logrus.Warnf("Datastore / disk conflict: %s newer than in the datastore", path)
-		}
-	}
-
-	if len(newerOnDisk) > 0 {
+	} else if len(newerOnDisk) > 0 {
 		logrus.Fatal(strings.Join(newerOnDisk, ", ") + " newer than datastore and could cause a cluster outage. Remove the file(s) from disk and restart to be recreated from datastore.")
 	}
 


### PR DESCRIPTION
#### Proposed Changes ####

* Fix fatal error when reconciling bootstrap data
* Remove legacy bidirectional datastore sync code
   Since #4438 removed 2-way sync and treats any changed+newer files on disk as an error, we no longer need to determine if files are newer on disk/db or if there is a conflicting mix of both. Any changed+newer file found on disk is treated an error, unless we're reconciling as part of a cluster-reset, in which case everything is unconditionally replaced.

#### Types of Changes ####

bugfix / cleanup

#### Verification ####

See linked issue/comment

#### Testing ####

#### Linked Issues ####

* 

#### User-Facing Change ####
```release-note
Fixed an issue that would cause etcd restore to fail when restoring a snapshot made with secrets encryption enabled if the --secrets-encryption command was not included in the config file or restore command.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
