### PR TITLE
[release-1.23] Address issues with etcd snapshots

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,7 @@ require (
 	go.uber.org/zap v1.19.0
 	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
 	google.golang.org/grpc v1.45.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -95,7 +95,7 @@ var EtcdSnapshotFlags = []cli.Flag{
 		Name:        "s3-timeout,etcd-s3-timeout",
 		Usage:       "(db) S3 timeout",
 		Destination: &ServerConfig.EtcdS3Timeout,
-		Value:       30 * time.Second,
+		Value:       5 * time.Minute,
 	},
 }
 

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -381,7 +381,7 @@ var ServerFlags = []cli.Flag{
 		Name:        "etcd-s3-timeout",
 		Usage:       "(db) S3 timeout",
 		Destination: &ServerConfig.EtcdS3Timeout,
-		Value:       30 * time.Second,
+		Value:       5 * time.Minute,
 	},
 	cli.StringFlag{
 		Name:        "default-local-storage-path",

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -152,6 +152,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.EtcdDisableSnapshots = cfg.EtcdDisableSnapshots
 
 	if !cfg.EtcdDisableSnapshots {
+		serverConfig.ControlConfig.EtcdSnapshotCompress = cfg.EtcdSnapshotCompress
 		serverConfig.ControlConfig.EtcdSnapshotName = cfg.EtcdSnapshotName
 		serverConfig.ControlConfig.EtcdSnapshotCron = cfg.EtcdSnapshotCron
 		serverConfig.ControlConfig.EtcdSnapshotDir = cfg.EtcdSnapshotDir

--- a/pkg/etcd/s3.go
+++ b/pkg/etcd/s3.go
@@ -106,9 +106,11 @@ func (s *S3) upload(ctx context.Context, snapshot, extraMetadata string, now tim
 
 	toCtx, cancel := context.WithTimeout(ctx, s.config.EtcdS3Timeout)
 	defer cancel()
-	opts := minio.PutObjectOptions{
-		ContentType: "application/zip",
-		NumThreads:  2,
+	opts := minio.PutObjectOptions{NumThreads: 2}
+	if strings.HasSuffix(snapshot, compressedExtension) {
+		opts.ContentType = "application/zip"
+	} else {
+		opts.ContentType = "application/octet-stream"
 	}
 	uploadInfo, err := s.client.FPutObject(toCtx, s.config.EtcdS3BucketName, snapshotFileName, snapshot, opts)
 	if err != nil {


### PR DESCRIPTION
#### Proposed Changes ####

* Increase the default snapshot timeout. The timeout is not currently
  configurable from Rancher, and larger clusters are frequently seeing
  uploads fail at 30 seconds.
* Enable compression for scheduled snapshots if enabled on the
  command-line. The CLI flag was not being passed into the etcd config.
* Only set the S3 content-type to application/zip if the file is zipped.
* Don't run more than one snapshot at once, to prevent misconfigured
  etcd snapshot cron schedules from stacking up.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issues

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5840

#### User-Facing Change ####
```release-note
Scheduled etcd snapshots are now compressed when snapshot compression is enabled.
The default etcd snapshot timeout has been raised to 5 minutes.
Only one scheduled etcd snapshot will run at a time. If another snapshot would occur while the previous snapshot is still in progress, an error will be logged and the second scheduled snapshot will be skipped.
S3 objects for etcd snapshots are now labeled with the correct content-type when compression is not enabled.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
