### PR TITLE
Fix server systemd detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -217,11 +217,7 @@ setup_env() {
     if [ -n "${INSTALL_K3S_TYPE}" ]; then
         SYSTEMD_TYPE=${INSTALL_K3S_TYPE}
     else
-        if [ "${CMD_K3S}" = server ]; then
-            SYSTEMD_TYPE=notify
-        else
-            SYSTEMD_TYPE=exec
-        fi
+        SYSTEMD_TYPE=notify
     fi
 
     # --- use binary install directory if defined or create default ---

--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -52,7 +52,10 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 	if disableCgroup {
 		logrus.Warn("cgroup v2 controllers are not delegated for rootless. Disabling cgroup.")
 	} else {
-		cfg.AgentConfig.Systemd = controllers["cpuset"] && os.Getenv("NOTIFY_SOCKET") != ""
+		// note: this mutatation of the passed agent.Config is later used to set the
+		// kubelet's cgroup-driver flag. This may merit moving to somewhere else in order
+		// to avoid mutating the configuration while setting up containerd.
+		cfg.AgentConfig.Systemd = !isRunningInUserNS && controllers["cpuset"] && os.Getenv("INVOCATION_ID") != ""
 	}
 
 	var containerdTemplate string


### PR DESCRIPTION
#### Proposed Changes ####

* Use INVOCATION_ID to detect execution under systemd, since as of a9b5a1933fbd773062be1433d056df07f138a7bd NOTIFY_SOCKET is now cleared by the server code.
  > The invocation ID is passed to the activated processes as environment variable. It is additionally stored as extended attribute on the cgroup of the unit.
* Set the unit type to notify by default for both server and agent, which is what Rancher-managed installs have done for a while.

Note that the systemd cgroup controller does NOT work with rootless due to the issue documented here:
* https://github.com/containerd/cgroups/issues/33

#### Types of Changes ####

bugfix

#### Verification ####

See test steps at https://github.com/k3s-io/k3s/issues/5454#issuecomment-1145343093

#### Testing ####

Needs a test...

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5850

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a regression that caused systemd cgroup driver autoconfiguration to fail on server nodes.
```

#### Further Comments ####

I would have preferred to use `SYSTEMD_EXEC_PID`, but that wasn't added until [v248-2](https://github.com/systemd/systemd/commit/dc4e2940e87f4f0969476b45a1d25322b5210643) in March of 2021.  `INVOCATION_ID` is more available, as it's been around since [232](https://github.com/systemd/systemd/commit/4b58153dd22172d817055d2a09a0cdf3f4bd9db3).
