### PR TITLE
fix checkError in terraform/testutils

### DIFF
--- a/tests/terraform/testutils.go
+++ b/tests/terraform/testutils.go
@@ -39,8 +39,7 @@ var err error
 
 func checkError(e error) {
 	if e != nil {
-		log.Fatal(err)
-		panic(e)
+		log.Fatal(e)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
`log.Fatal` https://cs.opensource.google/go/go/+/refs/tags/go1.18.4:src/log/log.go;l=364-367;drc=2580d0e08d5e9f979b943758d3c49877fb2324cb is equivalent to Print() followed by a call to os.Exit(1). So no `panic` needed.

Also I think this function wants to output the error in the function parameter to the log

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix
#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
