### PR TITLE
Add service-cluster-ip-range to controller-manager args

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -469,7 +469,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		systemd.SdNotify(true, "READY=1\n")
 	}()
 
-	url := fmt.Sprintf("https://%s:%d", serverConfig.ControlConfig.BindAddressOrLoopback(false), serverConfig.ControlConfig.SupervisorPort)
+	url := fmt.Sprintf("https://%s:%d", serverConfig.ControlConfig.BindAddressOrLoopback(false, true), serverConfig.ControlConfig.SupervisorPort)
 	token, err := clientaccess.FormatToken(serverConfig.ControlConfig.Runtime.AgentToken, serverConfig.ControlConfig.Runtime.ServerCA)
 	if err != nil {
 		return err

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -314,7 +314,7 @@ func genClientCerts(config *config.Control) error {
 
 	var certGen bool
 
-	apiEndpoint := fmt.Sprintf("https://%s:%d", config.Loopback(), config.APIServerPort)
+	apiEndpoint := fmt.Sprintf("https://%s:%d", config.Loopback(true), config.APIServerPort)
 
 	certGen, err = factory("system:admin", []string{user.SystemPrivilegedGroup}, runtime.ClientAdminCert, runtime.ClientAdminKey)
 	if err != nil {
@@ -734,7 +734,7 @@ func genEgressSelectorConfig(controlConfig *config.Control) error {
 			ProxyProtocol: apiserver.ProtocolHTTPConnect,
 			Transport: &apiserver.Transport{
 				TCP: &apiserver.TCPTransport{
-					URL: fmt.Sprintf("https://%s:%d", controlConfig.BindAddressOrLoopback(false), controlConfig.SupervisorPort),
+					URL: fmt.Sprintf("https://%s:%d", controlConfig.BindAddressOrLoopback(false, true), controlConfig.SupervisorPort),
 					TLSConfig: &apiserver.TLSConfig{
 						CABundle:   controlConfig.Runtime.ServerCA,
 						ClientKey:  controlConfig.Runtime.ClientKubeAPIKey,

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -107,6 +107,7 @@ func controllerManager(ctx context.Context, cfg *config.Control) error {
 		"authentication-kubeconfig":        runtime.KubeConfigController,
 		"service-account-private-key-file": runtime.ServiceKey,
 		"allocate-node-cidrs":              "true",
+		"service-cluster-ip-range":         util.JoinIPNets(cfg.ServiceIPRanges),
 		"cluster-cidr":                     util.JoinIPNets(cfg.ClusterIPRanges),
 		"root-ca-file":                     runtime.ServerCA,
 		"profiling":                        "false",

--- a/pkg/daemons/control/tunnel.go
+++ b/pkg/daemons/control/tunnel.go
@@ -210,7 +210,7 @@ func (t *TunnelServer) dialBackend(ctx context.Context, addr string) (net.Conn, 
 	if err != nil {
 		return nil, err
 	}
-	loopback := t.config.Loopback()
+	loopback := t.config.Loopback(true)
 
 	var nodeName string
 	var toKubelet, useTunnel bool

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -653,7 +653,7 @@ func getEndpoints(control *config.Control) []string {
 	if len(runtime.EtcdConfig.Endpoints) > 0 {
 		return runtime.EtcdConfig.Endpoints
 	}
-	return []string{fmt.Sprintf("https://%s:2379", control.Loopback())}
+	return []string{fmt.Sprintf("https://%s:2379", control.Loopback(true))}
 }
 
 // toTLSConfig converts the ControlRuntime configuration to TLS configuration suitable
@@ -769,7 +769,7 @@ func (e *ETCD) peerURL() string {
 // During cluster reset/restore, we only listen on loopback to avoid having peers
 // connect mid-process.
 func (e *ETCD) listenPeerURLs(reset bool) string {
-	peerURLs := fmt.Sprintf("https://%s:2380", e.config.Loopback())
+	peerURLs := fmt.Sprintf("https://%s:2380", e.config.Loopback(true))
 	if !reset {
 		peerURLs += "," + e.peerURL()
 	}
@@ -785,7 +785,7 @@ func (e *ETCD) clientURL() string {
 // During cluster reset/restore, we only listen on loopback to avoid having the apiserver
 // connect mid-process.
 func (e *ETCD) listenClientURLs(reset bool) string {
-	clientURLs := fmt.Sprintf("https://%s:2379", e.config.Loopback())
+	clientURLs := fmt.Sprintf("https://%s:2379", e.config.Loopback(true))
 	if !reset {
 		clientURLs += "," + e.clientURL()
 	}
@@ -794,7 +794,7 @@ func (e *ETCD) listenClientURLs(reset bool) string {
 
 // listenMetricsURLs returns a list of URLs to bind to for metrics connections.
 func (e *ETCD) listenMetricsURLs(reset bool) string {
-	metricsURLs := fmt.Sprintf("http://%s:2381", e.config.Loopback())
+	metricsURLs := fmt.Sprintf("http://%s:2381", e.config.Loopback(true))
 	if !reset && e.config.EtcdExposeMetrics {
 		metricsURLs += "," + fmt.Sprintf("http://%s", net.JoinHostPort(e.address, "2381"))
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -337,18 +337,18 @@ func printTokens(config *config.Control) error {
 	}
 
 	if len(nodeFile) > 0 {
-		printToken(config.SupervisorPort, config.BindAddressOrLoopback(true), "To join node to cluster:", "agent")
+		printToken(config.SupervisorPort, config.BindAddressOrLoopback(true, true), "To join node to cluster:", "agent")
 	}
 
 	return nil
 }
 
 func writeKubeConfig(certs string, config *Config) error {
-	ip := config.ControlConfig.BindAddressOrLoopback(false)
+	ip := config.ControlConfig.BindAddressOrLoopback(false, true)
 	port := config.ControlConfig.HTTPSPort
 	// on servers without a local apiserver, tunnel access via the loadbalancer
 	if config.ControlConfig.DisableAPIServer {
-		ip = config.ControlConfig.Loopback()
+		ip = config.ControlConfig.Loopback(true)
 		port = config.ControlConfig.APIServerPort
 	}
 	url := fmt.Sprintf("https://%s:%d", ip, port)


### PR DESCRIPTION

#### Proposed Changes ####

Add service-cluster-ip-range to controller-manager args.

Also replace getLocalhostIP with Loopback helper method.

**note**: This does not absolve users from having to manually correct the node-cidr-mask values if they reduce the cluster cidrs below the default sizes. This only addresses the argument being missing from the controller-manager.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3175

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The configured service CIDR is now passed to the Kubernetes controller-manager via the `--service-cluster-ip-range` flag. Previously this value was only passed to the apiserver.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
