### PR TITLE
fix openrc startup script in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -828,8 +828,8 @@ respawn_delay=5
 respawn_max=0
 
 set -o allexport
-if [ -f /etc/environment ]; then source /etc/environment; fi
-if [ -f ${FILE_K3S_ENV} ]; then source ${FILE_K3S_ENV}; fi
+if [ -f /etc/environment ]; then . /etc/environment; fi
+if [ -f ${FILE_K3S_ENV} ]; then . ${FILE_K3S_ENV}; fi
 set +o allexport
 EOF
     $SUDO chmod 0755 ${FILE_K3S_SERVICE}


### PR DESCRIPTION
correct source of shell scripts compatible with openrc default shell

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Fix install.sh for OpenRC init

#### Types of Changes ####

Correct import of shell scripts compatible with openrc default shell

#### Verification ####

Try the install.sh script on a openrc distro (i.e. (Devuan)[https://devuan.org] and at the end there will be an error reported when launching /etc/init.d/k3s. This simple fix solves the issue.

#### Testing ####

I'm happy to have a look to any install.sh integration tests if needed.

#### Linked Issues ####

I haven't found any open issues addressing this bug yet.

#### User-Facing Change ####
```release-note
Fix to startup script on OpenRC init
```

#### Further Comments ####

none.
