### PR TITLE
Don't enable unprivileged ports and icmp on old kernels

### DIFF
--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd"
+	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/k3s-io/k3s/pkg/agent/templates"
 	util2 "github.com/k3s-io/k3s/pkg/agent/util"
 	"github.com/k3s-io/k3s/pkg/cgroups"
@@ -64,6 +65,7 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 		DisableCgroup:         disableCgroup,
 		SystemdCgroup:         cfg.AgentConfig.Systemd,
 		IsRunningInUserNS:     isRunningInUserNS,
+		EnableUnprivileged:    kernel.CheckKernelVersion(4, 11, 0),
 		PrivateRegistryConfig: privRegistries.Registry,
 		ExtraRuntimes:         findNvidiaContainerRuntimes(os.DirFS(string(os.PathSeparator))),
 	}

--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -16,6 +16,7 @@ type ContainerdConfig struct {
 	DisableCgroup         bool
 	SystemdCgroup         bool
 	IsRunningInUserNS     bool
+	EnableUnprivileged    bool
 	PrivateRegistryConfig *registries.Registry
 	ExtraRuntimes         map[string]ContainerdRuntimeConfig
 }

--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -15,8 +15,8 @@ const ContainerdConfigTemplate = `
   stream_server_address = "127.0.0.1"
   stream_server_port = "10010"
   enable_selinux = {{ .NodeConfig.SELinux }}
-  enable_unprivileged_ports = true
-  enable_unprivileged_icmp = true
+  enable_unprivileged_ports = {{ .EnableUnprivileged }}
+  enable_unprivileged_icmp = {{ .EnableUnprivileged }}
 
 {{- if .DisableCgroup}}
   disable_cgroup = true


### PR DESCRIPTION

#### Proposed Changes ####

Don't enable unprivileged ports and icmp on old kernels

#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5912

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
K3s no longer sets containerd's `enable_unprivileged_icmp` and `enable_unprivileged_ports` options on kernels that do not support them.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
