### PR TITLE
Restore `--docker` flag backed by embedded cri-dockerd

### DIFF
--- a/docs/adrs/cri-dockerd.md
+++ b/docs/adrs/cri-dockerd.md
@@ -1,0 +1,53 @@
+# Package cri-dockerd to replace dockershim
+
+Date: 2022-07-29
+
+## Status
+
+Accepted
+
+## Context
+
+Upstream Kubernetes dropped dockershim from the kubelet in the 1.24 branch: https://kubernetes.io/blog/2022/02/17/dockershim-faq/
+
+This means that the docker container runtime is no longer directly supported by the Kubelet; continuing to use it
+requires installing cri-dockerd to translate the CRI API to the Docker API. After some internal discussion, it was
+decided that we did not wish to include dockershim, in favor of requiring users to deploy cri-dockerd themselves.
+
+```
+<BD> what’s our roadmap for dockershim/cri-dockerd migration? Kubernetes 1.24 finally drops dockershim.
+<BD> RKE will clearly need to migrate over to cri-dockerd, but for products like K3s where docker is supported but not the default, do we want to keep it around? Seems to work OK in K3s with some slight modifications.
+<CJ> If we don't do this work, can a user configure k3s manually to use the shim?
+<CJ> I'd rather reduce the surface area if possible
+<BD> the work is already done, the question is do we want to include it lol
+<CJ> Understood, the second half of the question is the part I care about
+<BD> kk
+<CJ> Can they manually get there without it
+<CJ> If they can, then I don't want to include it. Less surface area for bug fixes and CVEs. And i don't see a need to make it easy for users to user docker with k3s.
+<BD> users should be able to install and start cri-dockerd and then run k3s agent --container-runtime-endpoint=unix:///var/run/cri-dockerd.sock and it’ll work. 
+<BD> But we would need to drop the --docker flag since that explicitly uses the kubelet’s dockershim
+<BD> Well, we historically did make it easy. If we want to stop, that’s fine.
+<CK> Isn’t K3s supposed to be “lightweight” anyway? Who’s to say we didn’t put it on a diet for 1.24 and made it get smaller (especially cause the containerd split made it bigger)
+<CJ> Ok, I THINK bill will be ok with this. CW, can you pitch to bill next week (um he might be out too) that we are dropping the docker flag with 1.24. I guess we have a little time, so no rush right?
+<CJ> with the way the ecosystem has evolved, I think we can easily justify the diet
+<CJ> does k3d use/need --docker for anything?
+<CJ> Ask thorsten to be sure but I didn't  think so.
+<CJ> But we do need product to agree, fyi
+```
+
+The initial releases of 1.24 shipped without docker support; use of the `--docker` flag returns an error indicating that
+the user should install and use cri-dockerd instead. This has been somewhat disruptive to the community; K3s is often
+used in CI or dev environments where it is useful to use docker as the container runtime, but users are not equipped to
+install and manage cri-dockerd due to its relative inaccessibility compared to docker itself. Ref:
+https://github.com/k3s-io/k3s/issues/5741
+
+## Decision
+
+* We will embed cri-dockerd, and start it when the `--docker` flag is used.  This is a drop-in replacement for K3s's
+  previous behavior when the Kubelet included dockershim. This meets user expectations around K3s support for the Docker
+  container runtime, and eases user adoption of Kubernetes 1.24.
+
+## Consequences
+
+* The size of our self-extracting binary and Docker images increase by several megabytes.
+* We take on the support burden of keeping cri-dockerd up to date, and supporting docker as a container runtime.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.22
+	github.com/Mirantis/cri-dockerd => github.com/k3s-io/cri-dockerd v0.2.4-0.20220729204449-bcbb75d5abff // k3s-master
 	github.com/cloudnativelabs/kube-router => github.com/k3s-io/kube-router v1.5.1-0.20220630214451-a43bcd8511d2
 	github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
 	github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.13-k3s1 // k3s-release/1.5
@@ -65,6 +66,7 @@ replace (
 
 require (
 	github.com/Microsoft/hcsshim v0.9.2
+	github.com/Mirantis/cri-dockerd v0.0.0-00010101000000-000000000000
 	github.com/cloudnativelabs/kube-router v1.3.2
 	github.com/containerd/cgroups v1.0.3
 	github.com/containerd/containerd v1.6.2
@@ -129,7 +131,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/cloud-provider v0.24.3
 	k8s.io/component-base v0.24.3
-	k8s.io/component-helpers v0.0.0
+	k8s.io/component-helpers v0.24.3
 	k8s.io/controller-manager v0.24.3 // indirect
 	k8s.io/cri-api v0.24.3
 	k8s.io/klog v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,7 @@ github.com/containerd/ttrpc v1.1.0/go.mod h1:XX4ZTnoOId4HklF4edwc4DcqskFZuvXB1Ev
 github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY7aY=
 github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcDZXTn6oPz9s=
 github.com/containerd/zfs v1.0.0/go.mod h1:m+m51S1DvAP6r3FcmYCp54bQ34pyOwTieQDNRIRHsFY=
+github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v1.0.1/go.mod h1:AKuhXbN5EzmD4yTNtfSsX3tPcmtrBI6QcRV0NiNt15Y=
 github.com/containernetworking/cni v1.1.0 h1:T00oIz4hef+/p9gpRZa57SnIN+QnbmAHBjbxaOSFo9U=
@@ -652,6 +653,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -706,6 +708,8 @@ github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E
 github.com/k-sone/critbitgo v1.4.0/go.mod h1:7E6pyoyADnFxlUBEKcnfS49b7SUAQGMK+OAp/UQvo0s=
 github.com/k3s-io/containerd v1.5.13-k3s1 h1:a5qvrZZ5u4dn65XVajzLGUeUGiBXSE5qos3xF4BdRc4=
 github.com/k3s-io/containerd v1.5.13-k3s1/go.mod h1:zUdlwwmj8Xwd65Wz+vPGjonBN3FFAkSGwRloPefnNN4=
+github.com/k3s-io/cri-dockerd v0.2.4-0.20220729204449-bcbb75d5abff h1:iyPObk0AH8KArYJ8AEpe5CfJQ2W8ffRbyKMETtT2NwI=
+github.com/k3s-io/cri-dockerd v0.2.4-0.20220729204449-bcbb75d5abff/go.mod h1:2SAxAoj3lTHgTDwxGcpxUrKEbIWWrCFwNRMbPBR3U7E=
 github.com/k3s-io/cri-tools v1.24.0-k3s1 h1:Em7IZ/ElBFbHlPLjV0w2ttORxFl5upBxnbP/9IlT/3c=
 github.com/k3s-io/cri-tools v1.24.0-k3s1/go.mod h1:w4C33mk2AZdmAVybCyVbHYJUKdbr1sRelBTG7lduYh0=
 github.com/k3s-io/etcd/api/v3 v3.5.3-k3s1 h1:XY2oUIIy2+DR7zXk/BVqQ4f2qFHbd2VTAGrnrT4IxhA=
@@ -942,6 +946,7 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
+github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -321,10 +321,6 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	if envInfo.Docker {
-		return nil, errors.New("--docker is no longer supported; to continue using docker, install cri-dockerd and set --container-runtime-endpoint")
-	}
-
 	info, err := clientaccess.ParseAndValidateToken(proxy.SupervisorURL(), envInfo.Token)
 	if err != nil {
 		return nil, err
@@ -437,6 +433,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	}
 
 	nodeConfig := &config.Node{
+		Docker:                   envInfo.Docker,
 		SELinux:                  envInfo.EnableSELinux,
 		ContainerRuntimeEndpoint: envInfo.ContainerRuntimeEndpoint,
 		FlannelBackend:           controlConfig.FlannelBackend,
@@ -466,7 +463,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	nodeConfig.AgentConfig.StrongSwanDir = filepath.Join(envInfo.DataDir, "agent", "strongswan")
 	nodeConfig.Containerd.Config = filepath.Join(envInfo.DataDir, "agent", "etc", "containerd", "config.toml")
 	nodeConfig.Containerd.Root = filepath.Join(envInfo.DataDir, "agent", "containerd")
-	if nodeConfig.ContainerRuntimeEndpoint == "" {
+	if !nodeConfig.Docker && nodeConfig.ContainerRuntimeEndpoint == "" {
 		switch nodeConfig.AgentConfig.Snapshotter {
 		case "overlayfs":
 			if err := containerd.OverlaySupported(nodeConfig.Containerd.Root); err != nil {
@@ -539,7 +536,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		nodeConfig.AgentConfig.FlannelCniConfFile = envInfo.FlannelCniConfFile
 	}
 
-	if nodeConfig.ContainerRuntimeEndpoint == "" {
+	if !nodeConfig.Docker && nodeConfig.ContainerRuntimeEndpoint == "" {
 		nodeConfig.AgentConfig.RuntimeSocket = nodeConfig.Containerd.Address
 	} else {
 		nodeConfig.AgentConfig.RuntimeSocket = nodeConfig.ContainerRuntimeEndpoint

--- a/pkg/agent/config/config_linux.go
+++ b/pkg/agent/config/config_linux.go
@@ -13,3 +13,7 @@ func applyContainerdStateAndAddress(nodeConfig *config.Node) {
 	nodeConfig.Containerd.State = "/run/k3s/containerd"
 	nodeConfig.Containerd.Address = filepath.Join(nodeConfig.Containerd.State, "containerd.sock")
 }
+
+func applyCRIDockerdAddress(nodeConfig *config.Node) {
+	nodeConfig.CRIDockerd.Address = "unix:///run/k3s/cri-dockerd/cri-dockerd.sock"
+}

--- a/pkg/agent/config/config_windows.go
+++ b/pkg/agent/config/config_windows.go
@@ -13,3 +13,7 @@ func applyContainerdStateAndAddress(nodeConfig *config.Node) {
 	nodeConfig.Containerd.State = filepath.Join(nodeConfig.Containerd.Root, "state")
 	nodeConfig.Containerd.Address = "npipe:////./pipe/containerd-containerd"
 }
+
+func applyCRIDockerdAddress(nodeConfig *config.Node) {
+	nodeConfig.CRIDockerd.Address = "npipe:////.pipe/cri-dockerd"
+}

--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util"
 )
 
+const socketPrefix = "unix://"
+
 func getContainerdArgs(cfg *config.Node) []string {
 	args := []string{
 		"containerd",
@@ -100,7 +102,7 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 
 // criConnection connects to a CRI socket at the given path.
 func CriConnection(ctx context.Context, address string) (*grpc.ClientConn, error) {
-	addr, dialer, err := util.GetAddressAndDialer("unix://" + address)
+	addr, dialer, err := util.GetAddressAndDialer(socketPrefix + address)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +125,7 @@ func CriConnection(ctx context.Context, address string) (*grpc.ClientConn, error
 }
 
 func Client(address string) (*containerd.Client, error) {
-	addr, _, err := util.GetAddressAndDialer("unix://" + address)
+	addr, _, err := util.GetAddressAndDialer(socketPrefix + address)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -38,12 +38,11 @@ const (
 // Run configures and starts containerd as a child process. Once it is up, images are preloaded
 // or pulled from files found in the agent images directory.
 func Run(ctx context.Context, cfg *config.Node) error {
-	args := getContainerdArgs(cfg)
-
 	if err := setupContainerdConfig(ctx, cfg); err != nil {
 		return err
 	}
 
+	args := getContainerdArgs(cfg)
 	stdOut := io.Writer(os.Stdout)
 	stdErr := io.Writer(os.Stderr)
 

--- a/pkg/agent/cridockerd/config_linux.go
+++ b/pkg/agent/cridockerd/config_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+// +build linux
+
+package cridockerd
+
+import (
+	"context"
+	"strings"
+
+	"github.com/docker/docker/client"
+	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/pkg/errors"
+)
+
+const socketPrefix = "unix://"
+
+func setupDockerCRIConfig(ctx context.Context, cfg *config.Node) error {
+	clientOpts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
+	if cfg.ContainerRuntimeEndpoint != "" {
+		host := cfg.ContainerRuntimeEndpoint
+		if !strings.HasPrefix(host, socketPrefix) {
+			host = socketPrefix + host
+		}
+		clientOpts = append(clientOpts, client.WithHost(host))
+	}
+	c, err := client.NewClientWithOpts(clientOpts...)
+	if err != nil {
+		return errors.Wrap(err, "failed to create docker client")
+	}
+	i, err := c.Info(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get docker runtime info")
+	}
+	// note: this mutatation of the passed agent.Config is later used to set the
+	// kubelet's cgroup-driver flag. This may merit moving to somewhere else in order
+	// to avoid mutating the configuration while setting up the docker CRI.
+	cfg.AgentConfig.Systemd = i.CgroupDriver == "systemd"
+	return nil
+}

--- a/pkg/agent/cridockerd/config_windows.go
+++ b/pkg/agent/cridockerd/config_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+// +build windows
+
+package cridockerd
+
+import (
+	"context"
+
+	"github.com/k3s-io/k3s/pkg/daemons/config"
+)
+
+const socketPrefix = "npipe://"
+
+func setupDockerCRIConfig(ctx context.Context, cfg *config.Node) error {
+	return nil
+}

--- a/pkg/agent/cridockerd/cridockerd.go
+++ b/pkg/agent/cridockerd/cridockerd.go
@@ -1,0 +1,79 @@
+package cridockerd
+
+import (
+	"context"
+	"os"
+	"runtime/debug"
+	"strings"
+
+	"github.com/Mirantis/cri-dockerd/cmd"
+	"github.com/k3s-io/k3s/pkg/cgroups"
+	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/sirupsen/logrus"
+	utilsnet "k8s.io/utils/net"
+)
+
+func Run(ctx context.Context, cfg *config.Node) error {
+	if err := setupDockerCRIConfig(ctx, cfg); err != nil {
+		return err
+	}
+
+	args := getDockerCRIArgs(cfg)
+	command := cmd.NewDockerCRICommand(ctx.Done())
+	command.SetArgs(args)
+	logrus.Infof("Running cri-dockerd %s", config.ArgString(args))
+
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				logrus.Fatalf("cri-dockerd panic: %s", debug.Stack())
+			}
+		}()
+		logrus.Fatalf("cri-dockerd exited: %v", command.ExecuteContext(ctx))
+	}()
+
+	return nil
+}
+
+func getDockerCRIArgs(cfg *config.Node) []string {
+	argsMap := map[string]string{
+		"container-runtime-endpoint": cfg.CRIDockerd.Address,
+		"cri-dockerd-root-directory": cfg.CRIDockerd.Root,
+	}
+
+	if dualNode, _ := utilsnet.IsDualStackIPs(cfg.AgentConfig.NodeIPs); dualNode {
+		argsMap["ipv6-dual-stack"] = "true"
+	}
+
+	if logLevel := os.Getenv("CRIDOCKERD_LOG_LEVEL"); logLevel != "" {
+		argsMap["log-level"] = logLevel
+	}
+
+	if cfg.ContainerRuntimeEndpoint != "" {
+		endpoint := cfg.ContainerRuntimeEndpoint
+		if !strings.HasPrefix(endpoint, socketPrefix) {
+			endpoint = socketPrefix + endpoint
+		}
+		argsMap["docker-endpoint"] = endpoint
+	}
+
+	if cfg.AgentConfig.CNIConfDir != "" {
+		argsMap["cni-conf-dir"] = cfg.AgentConfig.CNIConfDir
+	}
+	if cfg.AgentConfig.CNIBinDir != "" {
+		argsMap["cni-bin-dir"] = cfg.AgentConfig.CNIBinDir
+	}
+	if cfg.AgentConfig.CNIPlugin {
+		argsMap["network-plugin"] = "cni"
+	}
+	if cfg.AgentConfig.PauseImage != "" {
+		argsMap["pod-infra-container-image"] = cfg.AgentConfig.PauseImage
+	}
+
+	_, runtimeRoot, _ := cgroups.CheckCgroups()
+	if runtimeRoot != "" {
+		argsMap["runtime-cgroups"] = runtimeRoot
+	}
+
+	return config.GetArgs(argsMap, nil)
+}

--- a/pkg/agent/flannel/setup_test.go
+++ b/pkg/agent/flannel/setup_test.go
@@ -62,7 +62,7 @@ func Test_createFlannelConf(t *testing.T) {
 		var agent = config.Agent{}
 		agent.ClusterCIDR = stringToCIDR(tt.args)[0]
 		agent.ClusterCIDRs = stringToCIDR(tt.args)
-		var nodeConfig = &config.Node{ContainerRuntimeEndpoint: "", NoFlannel: false, SELinux: false, FlannelBackend: "vxlan", FlannelConfFile: "test_file", FlannelConfOverride: false, FlannelIface: nil, Containerd: containerd, Images: "", AgentConfig: agent, Token: "", Certificate: nil, ServerHTTPSPort: 0}
+		var nodeConfig = &config.Node{Docker: false, ContainerRuntimeEndpoint: "", NoFlannel: false, SELinux: false, FlannelBackend: "vxlan", FlannelConfFile: "test_file", FlannelConfOverride: false, FlannelIface: nil, Containerd: containerd, Images: "", AgentConfig: agent, Token: "", Certificate: nil, ServerHTTPSPort: 0}
 
 		t.Run(tt.name, func(t *testing.T) {
 			if err := createFlannelConf(nodeConfig); (err != nil) != tt.wantErr {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -101,7 +101,7 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 		}
 	}
 
-	if nodeConfig.ContainerRuntimeEndpoint == "" {
+	if !nodeConfig.Docker && nodeConfig.ContainerRuntimeEndpoint == "" {
 		if err := containerd.Run(ctx, nodeConfig); err != nil {
 			return err
 		}

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -13,6 +13,7 @@ import (
 	systemd "github.com/coreos/go-systemd/daemon"
 	"github.com/k3s-io/k3s/pkg/agent/config"
 	"github.com/k3s-io/k3s/pkg/agent/containerd"
+	"github.com/k3s-io/k3s/pkg/agent/cridockerd"
 	"github.com/k3s-io/k3s/pkg/agent/flannel"
 	"github.com/k3s-io/k3s/pkg/agent/netpol"
 	"github.com/k3s-io/k3s/pkg/agent/proxy"
@@ -101,7 +102,11 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 		}
 	}
 
-	if !nodeConfig.Docker && nodeConfig.ContainerRuntimeEndpoint == "" {
+	if nodeConfig.Docker {
+		if err := cridockerd.Run(ctx, nodeConfig); err != nil {
+			return err
+		}
+	} else if nodeConfig.ContainerRuntimeEndpoint == "" {
 		if err := containerd.Run(ctx, nodeConfig); err != nil {
 			return err
 		}

--- a/pkg/agent/run_linux.go
+++ b/pkg/agent/run_linux.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	dockershimSock = "unix:///var/run/dockershim.sock"
+	criDockerdSock = "unix:///run/k3s/cri-dockerd/cri-dockerd.sock"
 	containerdSock = "unix:///run/k3s/containerd/containerd.sock"
 )
 
@@ -24,7 +24,7 @@ func setupCriCtlConfig(cfg cmds.Agent, nodeConfig *config.Node) error {
 	if cre == "" {
 		switch {
 		case cfg.Docker:
-			cre = dockershimSock
+			cre = criDockerdSock
 		default:
 			cre = containerdSock
 		}

--- a/pkg/agent/run_linux.go
+++ b/pkg/agent/run_linux.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	dockershimSock = "unix:///var/run/dockershim.sock"
 	containerdSock = "unix:///run/k3s/containerd/containerd.sock"
 )
 
@@ -21,7 +22,12 @@ const (
 func setupCriCtlConfig(cfg cmds.Agent, nodeConfig *config.Node) error {
 	cre := nodeConfig.ContainerRuntimeEndpoint
 	if cre == "" {
-		cre = containerdSock
+		switch {
+		case cfg.Docker:
+			cre = dockershimSock
+		default:
+			cre = containerdSock
+		}
 	}
 
 	agentConfDir := filepath.Join(cfg.DataDir, "agent", "etc")

--- a/pkg/agent/run_windows.go
+++ b/pkg/agent/run_windows.go
@@ -7,12 +7,14 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 )
 
 const (
+	dockershimSock = "npipe:////./pipe/docker_engine"
 	containerdSock = "npipe:////./pipe/containerd-containerd"
 )
 
@@ -20,10 +22,16 @@ const (
 // with the given data from config.
 func setupCriCtlConfig(cfg cmds.Agent, nodeConfig *config.Node) error {
 	cre := nodeConfig.ContainerRuntimeEndpoint
-	if cre == "" {
+	if cre == "" || strings.HasPrefix(cre, "npipe:") {
+		switch {
+		case cfg.Docker:
+			cre = dockershimSock
+		default:
+			cre = containerdSock
+		}
+	} else {
 		cre = containerdSock
 	}
-
 	agentConfDir := filepath.Join(cfg.DataDir, "agent", "etc")
 	if _, err := os.Stat(agentConfDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(agentConfDir, 0700); err != nil {

--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -109,6 +109,9 @@ func CheckCgroups() (kubeletRoot, runtimeRoot string, controllers map[string]boo
 				// and thus need to set our kubelet root to something out of the context
 				// of `/user.slice` to ensure that `CPUAccounting` and `MemoryAccounting`
 				// are enabled, as they are generally disabled by default for `user.slice`
+				// Note that we are not setting the `runtimeRoot` as if we are running with
+				// `--docker`, we will inadvertently move the cgroup `dockerd` lives in
+				//  which is not ideal and causes dockerd to become unmanageable by systemd.
 				last := parts[len(parts)-1]
 				i := strings.LastIndex(last, ".scope")
 				if i > 0 {

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -104,9 +104,14 @@ var (
 		EnvVar:      version.ProgramUpper + "_LB_SERVER_PORT",
 		Value:       6444,
 	}
+	DockerFlag = cli.BoolFlag{
+		Name:        "docker",
+		Usage:       "(agent/runtime) (experimental) Use cri-dockerd instead of containerd",
+		Destination: &AgentConfig.Docker,
+	}
 	CRIEndpointFlag = cli.StringFlag{
 		Name:        "container-runtime-endpoint",
-		Usage:       "(agent/runtime) Disable embedded containerd and use alternative CRI implementation",
+		Usage:       "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path; when used with --docker this sets the docker socket path",
 		Destination: &AgentConfig.ContainerRuntimeEndpoint,
 	}
 	PrivateRegistryFlag = cli.StringFlag{
@@ -190,12 +195,6 @@ var (
 		Name:   "disable-selinux",
 		Usage:  "(deprecated) Use --selinux to explicitly enable SELinux",
 		Hidden: true,
-	}
-	DockerFlag = cli.BoolFlag{
-		Hidden:      true,
-		Name:        "docker",
-		Usage:       "(deprecated) (agent/runtime) Use docker instead of containerd",
-		Destination: &AgentConfig.Docker,
 	}
 	FlannelFlag = cli.BoolFlag{
 		Hidden:      true,

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -123,7 +123,7 @@ var (
 	}
 	PauseImageFlag = cli.StringFlag{
 		Name:        "pause-image",
-		Usage:       "(agent/runtime) Customized pause image for containerd sandbox",
+		Usage:       "(agent/runtime) Customized pause image for containerd or docker sandbox",
 		Destination: &AgentConfig.PauseImage,
 		Value:       DefaultPauseImage,
 	}

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -16,11 +16,6 @@ import (
 	_ "k8s.io/component-base/metrics/prometheus/version"    // for version metric registration
 )
 
-const (
-	unixPrefix    = "unix://"
-	windowsPrefix = "npipe://"
-)
-
 func Agent(ctx context.Context, nodeConfig *daemonconfig.Node, proxy proxy.Proxy) error {
 	rand.Seed(time.Now().UTC().UnixNano())
 

--- a/pkg/daemons/agent/agent_windows_test.go
+++ b/pkg/daemons/agent/agent_windows_test.go
@@ -37,7 +37,6 @@ func TestCheckRuntimeEndpoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			argsMap := map[string]string{}
-			checkRuntimeEndpoint(tt.args.cfg, argsMap)
 			if argsMap["container-runtime-endpoint"] != tt.want {
 				got := argsMap["container-runtime-endpoint"]
 				t.Errorf("error, input was " + tt.args.cfg.RuntimeSocket + " should be " + tt.want + ", but got " + got)

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -43,6 +43,7 @@ var KubeletReservedPorts = map[string]bool{
 }
 
 type Node struct {
+	Docker                   bool
 	ContainerRuntimeEndpoint string
 	NoFlannel                bool
 	SELinux                  bool

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -54,6 +54,7 @@ type Node struct {
 	FlannelIPv6Masq          bool
 	EgressSelectorMode       string
 	Containerd               Containerd
+	CRIDockerd               CRIDockerd
 	Images                   string
 	AgentConfig              Agent
 	Token                    string
@@ -70,6 +71,11 @@ type Containerd struct {
 	Opt      string
 	Template string
 	SELinux  bool
+}
+
+type CRIDockerd struct {
+	Address string
+	Root    string
 }
 
 type Agent struct {

--- a/pkg/daemons/executor/embed.go
+++ b/pkg/daemons/executor/embed.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 	"runtime"
+	"runtime/debug"
 
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
@@ -57,7 +58,7 @@ func (e *Embedded) Kubelet(ctx context.Context, args []string) error {
 	go func() {
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.Fatalf("kubelet panic: %v", err)
+				logrus.Fatalf("kubelet panic: %s", debug.Stack())
 			}
 		}()
 		// The embedded executor doesn't need the kubelet to come up to host any components, and
@@ -79,7 +80,7 @@ func (*Embedded) KubeProxy(ctx context.Context, args []string) error {
 	go func() {
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.Fatalf("kube-proxy panic: %v", err)
+				logrus.Fatalf("kube-proxy panic: %s", debug.Stack())
 			}
 		}()
 		logrus.Fatalf("kube-proxy exited: %v", command.ExecuteContext(ctx))
@@ -101,7 +102,7 @@ func (*Embedded) APIServer(ctx context.Context, etcdReady <-chan struct{}, args 
 		<-etcdReady
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.Fatalf("apiserver panic: %v", err)
+				logrus.Fatalf("apiserver panic: %s", debug.Stack())
 			}
 		}()
 		logrus.Fatalf("apiserver exited: %v", command.ExecuteContext(ctx))
@@ -130,7 +131,7 @@ func (e *Embedded) Scheduler(ctx context.Context, apiReady <-chan struct{}, args
 		}
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.Fatalf("scheduler panic: %v", err)
+				logrus.Fatalf("scheduler panic: %s", debug.Stack())
 			}
 		}()
 		logrus.Fatalf("scheduler exited: %v", command.ExecuteContext(ctx))
@@ -147,7 +148,7 @@ func (*Embedded) ControllerManager(ctx context.Context, apiReady <-chan struct{}
 		<-apiReady
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.Fatalf("controller-manager panic: %v", err)
+				logrus.Fatalf("controller-manager panic: %s", debug.Stack())
 			}
 		}()
 		logrus.Fatalf("controller-manager exited: %v", command.ExecuteContext(ctx))
@@ -190,7 +191,7 @@ func (*Embedded) CloudControllerManager(ctx context.Context, ccmRBACReady <-chan
 		<-ccmRBACReady
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.Fatalf("cloud-controller-manager panic: %v", err)
+				logrus.Fatalf("cloud-controller-manager panic: %s", debug.Stack())
 			}
 		}()
 		logrus.Errorf("cloud-controller-manager exited: %v", command.ExecuteContext(ctx))

--- a/tests/e2e/docker/Vagrantfile
+++ b/tests/e2e/docker/Vagrantfile
@@ -1,0 +1,75 @@
+ENV['VAGRANT_NO_PARALLEL'] = 'no'
+NODE_ROLES = (ENV['NODE_ROLES'] ||
+  ["server-0", "agent-0"])
+NODE_BOXES = (ENV['NODE_BOXES'] ||
+  ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
+GITHUB_BRANCH = (ENV['GITHUB_BRANCH'] || "master")
+RELEASE_VERSION = (ENV['RELEASE_VERSION'] || "")
+NODE_CPUS = (ENV['NODE_CPUS'] || 2).to_i
+NODE_MEMORY = (ENV['NODE_MEMORY'] || 1024).to_i
+# Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks 
+NETWORK_PREFIX = "10.10.10"
+install_type = ""
+
+def provision(vm, role, role_num, node_num)
+  vm.box = NODE_BOXES[node_num]
+  vm.hostname = role
+  # An expanded netmask is required to allow VM<-->VM communication, virtualbox defaults to /32
+  vm.network "private_network", ip: "#{NETWORK_PREFIX}.#{100+node_num}", netmask: "255.255.255.0"
+
+  vagrant_defaults = '../vagrantdefaults.rb'
+  load vagrant_defaults if File.exists?(vagrant_defaults)
+  
+  defaultOSConfigure(vm)
+  dockerInstall(vm)
+  install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
+  
+  vm.provision "shell", inline: "ping -c 2 k3s.io"
+  
+  if role.include?("server")
+    vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+      k3s.args = %W[server --node-external-ip=#{NETWORK_PREFIX}.100 --flannel-iface=eth1 --docker]
+      k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+  elsif role.include?("agent")
+    vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+      k3s.args = %W[agent --server https://#{NETWORK_PREFIX}.100:6443 --flannel-iface=eth1 --docker]
+      k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
+    end
+  end
+
+  if vm.box.to_s.include?("microos")
+    vm.provision 'k3s-reload', type: 'reload', run: 'once'
+  end
+end
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = ["vagrant-k3s", "vagrant-reload"]
+  # Default provider is libvirt, virtualbox is only provided as a backup
+  config.vm.provider "libvirt" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+  
+  if NODE_ROLES.kind_of?(String)
+    NODE_ROLES = NODE_ROLES.split(" ", -1)
+  end
+  if NODE_BOXES.kind_of?(String)
+    NODE_BOXES = NODE_BOXES.split(" ", -1)
+  end
+
+  # Must iterate on the index, vagrant does not understand iterating 
+  # over the node roles themselves
+  NODE_ROLES.length.times do |i|
+    name = NODE_ROLES[i]
+    role_num = name.split("-", -1).pop.to_i
+    config.vm.define name do |node|
+      provision(node.vm, name, role_num, i)
+    end
+  end
+end

--- a/tests/e2e/docker/docker_test.go
+++ b/tests/e2e/docker/docker_test.go
@@ -1,0 +1,89 @@
+package docker
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/k3s-io/k3s/tests/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Valid nodeOS: generic/ubuntu2004, opensuse/Leap-15.3.x86_64, dweomer/microos.amd64
+var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
+var serverCount = flag.Int("serverCount", 1, "number of server nodes")
+var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
+
+// Environment Variables Info:
+// E2E_RELEASE_VERSION=v1.23.1+k3s2 or nil for latest commit from master
+
+func Test_E2EClusterValidation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	flag.Parse()
+	RunSpecs(t, "Create Cluster Test Suite")
+}
+
+var (
+	kubeConfigFile  string
+	serverNodeNames []string
+	agentNodeNames  []string
+)
+
+var _ = Describe("Verify CRI-Dockerd", func() {
+	Context("Cluster :", func() {
+		It("Starts up with no issues", func() {
+			var err error
+			serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			fmt.Println("CLUSTER CONFIG")
+			fmt.Println("OS:", *nodeOS)
+			fmt.Println("Server Nodes:", serverNodeNames)
+			fmt.Println("Agent Nodes:", agentNodeNames)
+			kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Checks node and pod status", func() {
+			fmt.Printf("\nFetching node status\n")
+			Eventually(func(g Gomega) {
+				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, node := range nodes {
+					g.Expect(node.Status).Should(Equal("Ready"))
+				}
+			}, "420s", "5s").Should(Succeed())
+			_, _ = e2e.ParseNodes(kubeConfigFile, true)
+
+			fmt.Printf("\nFetching pods status\n")
+			Eventually(func(g Gomega) {
+				pods, err := e2e.ParsePods(kubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, pod := range pods {
+					if strings.Contains(pod.Name, "helm-install") {
+						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
+					} else {
+						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
+					}
+				}
+			}, "420s", "5s").Should(Succeed())
+			_, _ = e2e.ParsePods(kubeConfigFile, true)
+		})
+	})
+})
+
+var failed = false
+var _ = AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
+var _ = AfterSuite(func() {
+	if failed {
+		fmt.Println("FAILED!")
+	} else {
+		Expect(e2e.DestroyCluster()).To(Succeed())
+		Expect(os.Remove(kubeConfigFile)).To(Succeed())
+	}
+})

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -26,3 +26,23 @@ def getInstallType(vm, release_version, branch)
     return "INSTALL_K3S_COMMIT=$(head\ -n\ 1\ /tmp/k3s_commits)"
   end
 end
+
+def dockerInstall(vm)
+  vm.provider "libvirt" do |v|
+    v.memory = NODE_MEMORY + 1024
+  end
+  vm.provider "virtualbox" do |v|
+    v.memory = NODE_MEMORY + 1024
+  end
+  if vm.box.to_s.include?("ubuntu")
+    vm.provision "shell", inline: "apt install -y docker.io"
+  end
+  if vm.box.to_s.include?("Leap")
+    vm.provision "shell", inline: "zypper install -y docker apparmor-parser"
+  end
+  if vm.box.to_s.include?("microos")
+    vm.provision "shell", inline: "transactional-update pkg install -y docker apparmor-parser"
+    vm.provision 'docker-reload', type: 'reload', run: 'once'
+    vm.provision "shell", inline: "systemctl enable --now docker"
+  end
+end

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -131,27 +131,6 @@ def getDBType(role, role_num, vm)
   return ""
 end
 
-def dockerInstall(vm)
-  vm.provider "libvirt" do |v|
-    v.memory = NODE_MEMORY + 1024
-  end
-  vm.provider "virtualbox" do |v|
-    v.memory = NODE_MEMORY + 1024
-  end
-  if vm.box.to_s.include?("ubuntu")
-    vm.provision "shell", inline: "apt install -y docker.io"
-  end
-  if vm.box.to_s.include?("Leap")
-    vm.provision "shell", inline: "zypper install -y docker apparmor-parser"
-  end
-  if vm.box.to_s.include?("microos")
-    vm.provision "shell", inline: "transactional-update pkg install -y docker apparmor-parser"
-    vm.provision 'docker-reload', type: 'reload', run: 'once'
-    vm.provision "shell", inline: "systemctl enable --now docker"
-  end
-end
-
-
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = ["vagrant-k3s", "vagrant-reload"]
   # Default provider is libvirt, virtualbox is only provided as a backup


### PR DESCRIPTION
#### Proposed Changes ####

Restore `--docker` flag backed by embedded cri-dockerd

#### Types of Changes ####

enhancement

#### Verification ####

See linked issue

#### Testing ####

TBD

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5741
* https://github.com/k3s-io/k3s/issues/5910

#### User-Facing Change ####
```release-note
The `--docker` flag has been restored to k3s, as a shortcut to enabling embedded cri-dockerd
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
