### PR TITLE
Added NodeIP autodect in case of dualstack connection

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -73,7 +73,7 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 	if (serviceIPv6 != clusterIPv6) || (dualCluster != dualService) || (serviceIPv4 != clusterIPv4) {
 		return fmt.Errorf("cluster-cidr: %v and service-cidr: %v, must share the same IP version (IPv4, IPv6 or dual-stack)", nodeConfig.AgentConfig.ClusterCIDRs, nodeConfig.AgentConfig.ServiceCIDRs)
 	}
-	if (clusterIPv6 != nodeIPv6) || (dualCluster != dualNode) || (clusterIPv4 != nodeIPv4) {
+	if (clusterIPv6 && !nodeIPv6) || (dualCluster && !dualNode) || (clusterIPv4 && !nodeIPv4) {
 		return fmt.Errorf("cluster-cidr: %v and node-ip: %v, must share the same IP version (IPv4, IPv6 or dual-stack)", nodeConfig.AgentConfig.ClusterCIDRs, nodeConfig.AgentConfig.NodeIPs)
 	}
 	enableIPv6 := dualCluster || clusterIPv6

--- a/pkg/netutil/iface.go
+++ b/pkg/netutil/iface.go
@@ -38,7 +38,7 @@ func getIPFromInterface(ifaceName string) (string, error) {
 		if err != nil {
 			return "", errors.Wrapf(err, "unable to parse CIDR for interface %s", iface.Name)
 		}
-		// skipping if not ipv4
+		// if not IPv4 adding it on IPv6 list
 		if ip.To4() == nil {
 			if ip.IsGlobalUnicast() {
 				globalUnicastsIPv6 = append(globalUnicastsIPv6, ip.String())

--- a/pkg/netutil/iface.go
+++ b/pkg/netutil/iface.go
@@ -32,6 +32,7 @@ func getIPFromInterface(ifaceName string) (string, error) {
 	}
 
 	globalUnicasts := []string{}
+	globalUnicastsIPv6 := []string{}
 	for _, addr := range addrs {
 		ip, _, err := net.ParseCIDR(addr.String())
 		if err != nil {
@@ -39,6 +40,9 @@ func getIPFromInterface(ifaceName string) (string, error) {
 		}
 		// skipping if not ipv4
 		if ip.To4() == nil {
+			if ip.IsGlobalUnicast() {
+				globalUnicastsIPv6 = append(globalUnicastsIPv6, ip.String())
+			}
 			continue
 		}
 		if ip.IsGlobalUnicast() {
@@ -49,8 +53,12 @@ func getIPFromInterface(ifaceName string) (string, error) {
 	if len(globalUnicasts) > 1 {
 		return "", fmt.Errorf("multiple global unicast addresses defined for %s, please set ip from one of %v", ifaceName, globalUnicasts)
 	}
-	if len(globalUnicasts) == 1 {
+	if len(globalUnicasts) == 1 && len(globalUnicastsIPv6) == 0 {
 		return globalUnicasts[0], nil
+	} else if len(globalUnicastsIPv6) > 0 && len(globalUnicasts) == 1 {
+		return globalUnicasts[0] + "," + globalUnicastsIPv6[0], nil
+	} else if len(globalUnicastsIPv6) > 0 {
+		return globalUnicastsIPv6[0], nil
 	}
 
 	return "", fmt.Errorf("can't find ip for interface %s", ifaceName)

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -142,6 +142,10 @@ func GetHostnameAndIPs(name string, nodeIPs cli.StringSlice) (string, []net.IP, 
 			return "", nil, err
 		}
 		ips = append(ips, hostIP)
+		hostIPv6, err := apinet.ResolveBindAddress(net.IPv6loopback)
+		if err == nil && !hostIPv6.Equal(hostIP) {
+			ips = append(ips, hostIPv6)
+		}
 	} else {
 		var err error
 		ips, err = ParseStringSliceToIPs(nodeIPs)

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -142,9 +142,12 @@ func GetHostnameAndIPs(name string, nodeIPs cli.StringSlice) (string, []net.IP, 
 			return "", nil, err
 		}
 		ips = append(ips, hostIP)
-		hostIPv6, err := apinet.ResolveBindAddress(net.IPv6loopback)
-		if err == nil && !hostIPv6.Equal(hostIP) {
-			ips = append(ips, hostIPv6)
+		// If IPv6 it's an IPv6 only node
+		if hostIP.To4() != nil {
+			hostIPv6, err := apinet.ResolveBindAddress(net.IPv6loopback)
+			if err == nil && !hostIPv6.Equal(hostIP) {
+				ips = append(ips, hostIPv6)
+			}
 		}
 	} else {
 		var err error


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
In case of a node with both IPv4 and IPv6 when NodeIP is not configured it autodetects both versions as NodeIP.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
New Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
#5918

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added dualstack IP auto detection
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
It needs to check Netpol in case of singlestack setup on a dualstack node.