### PR TITLE
Updates to CLI flag grouping + deprecated flag warnings.

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -515,6 +515,9 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 
 	if nodeConfig.FlannelBackend == config.FlannelBackendNone {
 		nodeConfig.NoFlannel = true
+	} else if envInfo.NoFlannel {
+		logrus.Warn("no-flannel is deprecated, it will be removed in v1.25. Use --flannel-backend=none instead.")
+		nodeConfig.NoFlannel = envInfo.NoFlannel
 	} else {
 		nodeConfig.NoFlannel = envInfo.NoFlannel
 	}

--- a/pkg/cli/agent/agent.go
+++ b/pkg/cli/agent/agent.go
@@ -46,6 +46,7 @@ func Run(ctx *cli.Context) error {
 	}
 
 	if cmds.AgentConfig.Token == "" && cmds.AgentConfig.ClusterSecret != "" {
+		logrus.Warn("cluster-secret is deprecated, it will be removed in v1.25. Use --token instead.")
 		cmds.AgentConfig.Token = cmds.AgentConfig.ClusterSecret
 	}
 

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -86,11 +86,23 @@ var (
 		Usage:       "(agent/node) Append id to node name",
 		Destination: &AgentConfig.WithNodeID,
 	}
-	DockerFlag = cli.BoolFlag{
-		Hidden:      true,
-		Name:        "docker",
-		Usage:       "(deprecated) (agent/runtime) Use docker instead of containerd",
-		Destination: &AgentConfig.Docker,
+	ProtectKernelDefaultsFlag = cli.BoolFlag{
+		Name:        "protect-kernel-defaults",
+		Usage:       "(agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.",
+		Destination: &AgentConfig.ProtectKernelDefaults,
+	}
+	SELinuxFlag = cli.BoolFlag{
+		Name:        "selinux",
+		Usage:       "(agent/node) Enable SELinux in containerd",
+		Destination: &AgentConfig.EnableSELinux,
+		EnvVar:      version.ProgramUpper + "_SELINUX",
+	}
+	LBServerPortFlag = cli.IntFlag{
+		Name:        "lb-server-port",
+		Usage:       "(agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.",
+		Destination: &AgentConfig.LBServerPort,
+		EnvVar:      version.ProgramUpper + "_LB_SERVER_PORT",
+		Value:       6444,
 	}
 	CRIEndpointFlag = cli.StringFlag{
 		Name:        "container-runtime-endpoint",
@@ -120,11 +132,6 @@ var (
 		Usage:       "(agent/runtime) Override default containerd snapshotter",
 		Destination: &AgentConfig.Snapshotter,
 		Value:       DefaultSnapshotter,
-	}
-	FlannelFlag = cli.BoolFlag{
-		Name:        "no-flannel",
-		Usage:       "(deprecated) use --flannel-backend=none",
-		Destination: &AgentConfig.NoFlannel,
 	}
 	FlannelIfaceFlag = cli.StringFlag{
 		Name:        "flannel-iface",
@@ -184,23 +191,16 @@ var (
 		Usage:  "(deprecated) Use --selinux to explicitly enable SELinux",
 		Hidden: true,
 	}
-	ProtectKernelDefaultsFlag = cli.BoolFlag{
-		Name:        "protect-kernel-defaults",
-		Usage:       "(agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.",
-		Destination: &AgentConfig.ProtectKernelDefaults,
+	DockerFlag = cli.BoolFlag{
+		Hidden:      true,
+		Name:        "docker",
+		Usage:       "(deprecated) (agent/runtime) Use docker instead of containerd",
+		Destination: &AgentConfig.Docker,
 	}
-	SELinuxFlag = cli.BoolFlag{
-		Name:        "selinux",
-		Usage:       "(agent/node) Enable SELinux in containerd",
-		Destination: &AgentConfig.EnableSELinux,
-		EnvVar:      version.ProgramUpper + "_SELINUX",
-	}
-	LBServerPortFlag = cli.IntFlag{
-		Name:        "lb-server-port",
-		Usage:       "(agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.",
-		Destination: &AgentConfig.LBServerPort,
-		EnvVar:      version.ProgramUpper + "_LB_SERVER_PORT",
-		Value:       6444,
+	FlannelFlag = cli.BoolFlag{
+		Name:        "no-flannel",
+		Usage:       "(deprecated) use --flannel-backend=none",
+		Destination: &AgentConfig.NoFlannel,
 	}
 )
 
@@ -253,7 +253,9 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			NodeTaints,
 			ImageCredProvBinDirFlag,
 			ImageCredProvConfigFlag,
-			DockerFlag,
+			&SELinuxFlag,
+			LBServerPortFlag,
+			ProtectKernelDefaultsFlag,
 			CRIEndpointFlag,
 			PauseImageFlag,
 			SnapshotterFlag,
@@ -267,18 +269,16 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			FlannelCniConfFileFlag,
 			ExtraKubeletArgs,
 			ExtraKubeProxyArgs,
-			ProtectKernelDefaultsFlag,
 			cli.BoolFlag{
 				Name:        "rootless",
 				Usage:       "(experimental) Run rootless",
 				Destination: &AgentConfig.Rootless,
 			},
-			&SELinuxFlag,
-			LBServerPortFlag,
 
 			// Deprecated/hidden below
 
 			&DisableSELinuxFlag,
+			DockerFlag,
 			FlannelFlag,
 			cli.StringFlag{
 				Name:        "cluster-secret",

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -198,6 +198,7 @@ var (
 		Destination: &AgentConfig.Docker,
 	}
 	FlannelFlag = cli.BoolFlag{
+		Hidden:      true,
 		Name:        "no-flannel",
 		Usage:       "(deprecated) use --flannel-backend=none",
 		Destination: &AgentConfig.NoFlannel,
@@ -285,6 +286,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 				Usage:       "(deprecated) use --token",
 				Destination: &AgentConfig.ClusterSecret,
 				EnvVar:      version.ProgramUpper + "_CLUSTER_SECRET",
+				Hidden:      true,
 			},
 		},
 	}

--- a/pkg/cli/cmds/certs.go
+++ b/pkg/cli/cmds/certs.go
@@ -14,11 +14,7 @@ var (
 		ConfigFlag,
 		LogFile,
 		AlsoLogToStderr,
-		cli.StringFlag{
-			Name:        "data-dir,d",
-			Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
-			Destination: &ServerConfig.DataDir,
-		},
+		DataDirFlag,
 		cli.StringSliceFlag{
 			Name:  "service,s",
 			Usage: "List of services to rotate certificates for. Options include (admin, api-server, controller-manager, scheduler, " + version.Program + "-controller, " + version.Program + "-server, cloud-controller, etcd, auth-proxy, kubelet, kube-proxy)",

--- a/pkg/cli/cmds/log.go
+++ b/pkg/cli/cmds/log.go
@@ -28,7 +28,7 @@ var (
 	}
 	VModule = cli.StringFlag{
 		Name:        "vmodule",
-		Usage:       "(logging) Comma-separated list of pattern=N settings for file-filtered logging",
+		Usage:       "(logging) Comma-separated list of FILE_PATTERN=LOG_LEVEL settings for file-filtered logging",
 		Destination: &LogConfig.VModule,
 	}
 	LogFile = cli.StringFlag{

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -39,7 +39,7 @@ func NewApp() *cli.App {
 		DebugFlag,
 		cli.StringFlag{
 			Name:  "data-dir,d",
-			Usage: "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
+			Usage: "(data) Folder to hold state (default: /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root)",
 		},
 	}
 

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -218,7 +218,7 @@ var ServerFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:        "egress-selector-mode",
-		Usage:       "(networking) One of 'agent', cluster', 'pod', 'disabled'",
+		Usage:       "(networking) One of 'agent', 'cluster', 'pod', 'disabled'",
 		Destination: &ServerConfig.EgressSelectorMode,
 		Value:       "agent",
 	},
@@ -227,13 +227,6 @@ var ServerFlags = []cli.Flag{
 		Usage:       "(networking) Namespace of the pods for the servicelb component",
 		Destination: &ServerConfig.ServiceLBNamespace,
 		Value:       "kube-system",
-	},
-	ServerToken,
-	cli.StringFlag{
-		Name:        "token-file",
-		Usage:       "(cluster) File containing the cluster-secret/token",
-		Destination: &ServerConfig.TokenFile,
-		EnvVar:      version.ProgramUpper + "_TOKEN_FILE",
 	},
 	cli.StringFlag{
 		Name:        "write-kubeconfig,o",
@@ -247,10 +240,47 @@ var ServerFlags = []cli.Flag{
 		Destination: &ServerConfig.KubeConfigMode,
 		EnvVar:      version.ProgramUpper + "_KUBECONFIG_MODE",
 	},
+	ServerToken,
+	cli.StringFlag{
+		Name:        "token-file",
+		Usage:       "(cluster) File containing the cluster-secret/token",
+		Destination: &ServerConfig.TokenFile,
+		EnvVar:      version.ProgramUpper + "_TOKEN_FILE",
+	},
+	cli.StringFlag{
+		Name:        "agent-token",
+		Usage:       "(cluster) Shared secret used to join agents to the cluster, but not servers",
+		Destination: &ServerConfig.AgentToken,
+		EnvVar:      version.ProgramUpper + "_AGENT_TOKEN",
+	},
+	cli.StringFlag{
+		Name:        "agent-token-file",
+		Usage:       "(cluster) File containing the agent secret",
+		Destination: &ServerConfig.AgentTokenFile,
+		EnvVar:      version.ProgramUpper + "_AGENT_TOKEN_FILE",
+	},
+	cli.StringFlag{
+		Name:        "server,s",
+		Usage:       "(cluster) Server to connect to, used to join a cluster",
+		EnvVar:      version.ProgramUpper + "_URL",
+		Destination: &ServerConfig.ServerURL,
+	},
 	cli.BoolFlag{
-		Name:        "enable-pprof",
-		Usage:       "(experimental) Enable pprof endpoint on supervisor port",
-		Destination: &ServerConfig.EnablePProf,
+		Name:        "cluster-init",
+		Usage:       "(cluster) Initialize a new cluster using embedded Etcd",
+		EnvVar:      version.ProgramUpper + "_CLUSTER_INIT",
+		Destination: &ServerConfig.ClusterInit,
+	},
+	cli.BoolFlag{
+		Name:        "cluster-reset",
+		Usage:       "(cluster) Forget all peers and become sole member of a new cluster",
+		EnvVar:      version.ProgramUpper + "_CLUSTER_RESET",
+		Destination: &ServerConfig.ClusterReset,
+	},
+	&cli.StringFlag{
+		Name:        "cluster-reset-restore-path",
+		Usage:       "(db) Path to snapshot file to be restored",
+		Destination: &ServerConfig.ClusterResetRestorePath,
 	},
 	ExtraAPIArgs,
 	ExtraEtcdArgs,
@@ -287,7 +317,7 @@ var ServerFlags = []cli.Flag{
 	},
 	&cli.BoolFlag{
 		Name:        "etcd-expose-metrics",
-		Usage:       "(db) Expose etcd metrics to client interface. (Default false)",
+		Usage:       "(db) Expose etcd metrics to client interface. (default: false)",
 		Destination: &ServerConfig.EtcdExposeMetrics,
 	},
 	&cli.BoolFlag{
@@ -297,7 +327,7 @@ var ServerFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:        "etcd-snapshot-name",
-		Usage:       "(db) Set the base name of etcd snapshots. Default: etcd-snapshot-<unix-timestamp>",
+		Usage:       "(db) Set the base name of etcd snapshots (default: etcd-snapshot-<unix-timestamp>)",
 		Destination: &ServerConfig.EtcdSnapshotName,
 		Value:       "etcd-snapshot",
 	},
@@ -315,7 +345,7 @@ var ServerFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:        "etcd-snapshot-dir",
-		Usage:       "(db) Directory to save db snapshots. (Default location: ${data-dir}/db/snapshots)",
+		Usage:       "(db) Directory to save db snapshots. (default: ${data-dir}/db/snapshots)",
 		Destination: &ServerConfig.EtcdSnapshotDir,
 	},
 	&cli.BoolFlag{
@@ -457,44 +487,14 @@ var ServerFlags = []cli.Flag{
 	ExtraKubeProxyArgs,
 	ProtectKernelDefaultsFlag,
 	cli.BoolFlag{
+		Name:        "enable-pprof",
+		Usage:       "(experimental) Enable pprof endpoint on supervisor port",
+		Destination: &ServerConfig.EnablePProf,
+	},
+	cli.BoolFlag{
 		Name:        "rootless",
 		Usage:       "(experimental) Run rootless",
 		Destination: &ServerConfig.Rootless,
-	},
-	cli.StringFlag{
-		Name:        "agent-token",
-		Usage:       "(cluster) Shared secret used to join agents to the cluster, but not servers",
-		Destination: &ServerConfig.AgentToken,
-		EnvVar:      version.ProgramUpper + "_AGENT_TOKEN",
-	},
-	cli.StringFlag{
-		Name:        "agent-token-file",
-		Usage:       "(cluster) File containing the agent secret",
-		Destination: &ServerConfig.AgentTokenFile,
-		EnvVar:      version.ProgramUpper + "_AGENT_TOKEN_FILE",
-	},
-	cli.StringFlag{
-		Name:        "server,s",
-		Usage:       "(cluster) Server to connect to, used to join a cluster",
-		EnvVar:      version.ProgramUpper + "_URL",
-		Destination: &ServerConfig.ServerURL,
-	},
-	cli.BoolFlag{
-		Name:        "cluster-init",
-		Usage:       "(cluster) Initialize a new cluster using embedded Etcd",
-		EnvVar:      version.ProgramUpper + "_CLUSTER_INIT",
-		Destination: &ServerConfig.ClusterInit,
-	},
-	cli.BoolFlag{
-		Name:        "cluster-reset",
-		Usage:       "(cluster) Forget all peers and become sole member of a new cluster",
-		EnvVar:      version.ProgramUpper + "_CLUSTER_RESET",
-		Destination: &ServerConfig.ClusterReset,
-	},
-	&cli.StringFlag{
-		Name:        "cluster-reset-restore-path",
-		Usage:       "(db) Path to snapshot file to be restored",
-		Destination: &ServerConfig.ClusterResetRestorePath,
 	},
 	cli.BoolFlag{
 		Name:        "secrets-encryption",

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -515,14 +515,16 @@ var ServerFlags = []cli.Flag{
 	&DisableSELinuxFlag,
 	FlannelFlag,
 	cli.StringSliceFlag{
-		Name:  "no-deploy",
-		Usage: "(deprecated) Do not deploy packaged components (valid items: " + DisableItems + ")",
+		Name:   "no-deploy",
+		Usage:  "(deprecated) Do not deploy packaged components (valid items: " + DisableItems + ")",
+		Hidden: true,
 	},
 	cli.StringFlag{
 		Name:        "cluster-secret",
 		Usage:       "(deprecated) use --token",
 		Destination: &ServerConfig.ClusterSecret,
 		EnvVar:      version.ProgramUpper + "_CLUSTER_SECRET",
+		Hidden:      true,
 	},
 	cli.BoolFlag{
 		Name:        "disable-agent",

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -88,6 +88,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	}
 
 	if cfg.Token == "" && cfg.ClusterSecret != "" {
+		logrus.Warn("cluster-secret is deprecated, it will be removed in v1.25. Use --token instead.")
 		cfg.Token = cfg.ClusterSecret
 	}
 
@@ -348,6 +349,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 
 	serverConfig.ControlConfig.Skips = map[string]bool{}
 	for _, noDeploy := range app.StringSlice("no-deploy") {
+		logrus.Warn("no-deploy flag is deprecated, it will be removed in v1.25. Use --skip-deploy instead.")
 		for _, v := range strings.Split(noDeploy, ",") {
 			v = strings.TrimSpace(v)
 			serverConfig.ControlConfig.Skips[v] = true


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- When updating the K3s docs, I noticed several inconsistencies in the spelling and grouping of K3s flags. These have been fixed
- Previously deprecated flags have been hidden and a warning has been added to each that informs the user of their removal in v1.25

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
`k3s server -h`
`-cluster-secret` `--no-flannel` and `no-deploy` now shows a warning log on startup the k3s server

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
N/A
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/5940
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Deprecated flags now warn of their v1.25 removal
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
