### PR TITLE
Removing checkbox indicating backports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,9 +34,3 @@ Cluster Configuration:
 
 **Additional context / logs:**
 <!-- Add any other context and/or logs about the problem here. -->
-
-**Backporting**
-<!--
-Does this fix need to be backported to older releases?  If so, please check this box and list the branches it should be backported to.
--->
-- [ ] Needs backporting to older releases

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -21,8 +21,3 @@ assignees: ''
 **Additional context**
 <!-- Add any other context or screenshots about the feature request here. -->
 
-**Backporting**
-<!--
-Does this fix need to be backported to older releases?  If so, please check this box and list the branches it should be backported to.
--->
-- [ ] Needs backporting to older releases


### PR DESCRIPTION
Removing the "Backports needed" checklist in the issue templates since we're backporting everything at this point.

Signed-off-by: Chris Wayne <cwayne18@gmail.com>
