### PR TITLE
[Release-1.23] Update etcd error to match correct url

### DIFF
--- a/.github/workflows/cgroup.yaml
+++ b/.github/workflows/cgroup.yaml
@@ -37,7 +37,7 @@ jobs:
     name: "Conformance Test"
     needs: prep
     # nested virtualization is only available on macOS hosts
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   test:
     name: "Smoke Test"
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/snapshotter.yaml
+++ b/.github/workflows/snapshotter.yaml
@@ -37,7 +37,7 @@ jobs:
     name: "Smoke Test"
     needs: prep
     # nested virtualization is only available on macOS hosts
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-ARG GOLANG=golang:1.17.5-alpine3.15
+ARG GOLANG=golang:1.17.13-alpine3.16
 FROM ${GOLANG}
 
 ARG http_proxy=$http_proxy

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-ARG GOLANG=golang:1.17.13-alpine3.16
+ARG GOLANG=golang:1.17.5-alpine3.15
 FROM ${GOLANG}
 
 ARG http_proxy=$http_proxy

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -224,7 +224,7 @@ func (e *ETCD) Test(ctx context.Context) error {
 			memberNameUrls = append(memberNameUrls, member.Name+"="+member.PeerURLs[0])
 		}
 	}
-	return &MembershipError{Members: memberNameUrls, Self: e.name + "=" + e.address}
+	return &MembershipError{Members: memberNameUrls, Self: e.name + "=" + e.peerURL()}
 }
 
 // DBDir returns the path to dataDir/db/etcd


### PR DESCRIPTION
- Backport of https://github.com/k3s-io/k3s/pull/5909
- Bumps to macos to 12 for GH actions, macos-10.15 is being removed https://github.com/actions/virtual-environments/issues/5583
Signed-off-by: Derek Nola <derek.nola@suse.com>


#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/5931
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The etcd error on incorrect peer urls now correctly includes the expected https and 2380 port.
```
