### PR TITLE
Upgrade GH Actions macos-10.15 to macos-12

### DIFF
--- a/.github/workflows/cgroup.yaml
+++ b/.github/workflows/cgroup.yaml
@@ -37,7 +37,7 @@ jobs:
     name: "Conformance Test"
     needs: prep
     # nested virtualization is only available on macOS hosts
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   test:
     name: "Smoke Test"
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/snapshotter.yaml
+++ b/.github/workflows/snapshotter.yaml
@@ -37,7 +37,7 @@ jobs:
     name: "Smoke Test"
     needs: prep
     # nested virtualization is only available on macOS hosts
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 40
     strategy:
       fail-fast: false


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- macos-10.15 is deprecated in GH actions - https://github.com/actions/virtual-environments/issues/5583
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Internal testing change
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
GH Actions now pass
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
