### PR TITLE
E2E: Local cluster testing

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,6 +20,32 @@ A E2E test consists of two parts:
 
 See the [validate cluster test](../tests/e2e/validatecluster/validatecluster_test.go) as an example.
 
+
+## Setup
+
+To run the E2E tests, you must first install the following:
+- Vagrant
+- Libvirt
+- Vagrant plugins
+
+### Vagrant 
+
+Download the latest version (currently 2.2.19) of Vagrant [*from the website*](https://www.vagrantup.com/downloads). Do not use built-in packages, they often old or do not include the required ruby library extensions necessary to get certain plugins working.
+
+### Libvirt
+Follow the OS specific guides to install libvirt/qemu on your host:  
+    - [openSUSE](https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-vt-installation.html)
+    - [ubuntu](https://ubuntu.com/server/docs/virtualization-libvirt)
+    - [debian](https://wiki.debian.org/KVM#Installation)
+    - [fedora](https://developer.fedoraproject.org/tools/virtualization/installing-libvirt-and-virt-install-on-fedora-linux.html)
+
+### Vagrant plugins
+Install the necessary vagrant plugins with the following command:
+
+```bash
+vagrant plugin install vagrant-libvirt vagrant-scp vagrant-k3s vagrant-reload
+```
+
 ## Running
 
 Generally, E2E tests are run as a nightly Jenkins job for QA. They can still be run locally but additional setup may be required. By default, all E2E tests are designed with `libvirt` as the underlying VM provider. Instructions for installing libvirt and its associated vagrant plugin, `vagrant-libvirt` can be found [here.](https://github.com/vagrant-libvirt/vagrant-libvirt#installation) `VirtualBox` is also supported as a backup VM provider.

--- a/tests/e2e/docker/Vagrantfile
+++ b/tests/e2e/docker/Vagrantfile
@@ -36,6 +36,7 @@ def provision(vm, role, role_num, node_num)
     vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
       k3s.args = %W[agent --server https://#{NETWORK_PREFIX}.100:6443 --flannel-iface=eth1 --docker]
       k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
     end
   end
 

--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -26,12 +26,13 @@ def provision(vm, roles, role_num, node_num)
     :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
     :libvirt__ipv6_prefix => "64"
     
-  vagrant_defaults = '../vagrantdefaults.rb'
-  load vagrant_defaults if File.exists?(vagrant_defaults)
+  scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
+  vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  load vagrant_defaults
   
   defaultOSConfigure(vm)
 
-  vm.provision "IPv6 Setup", type: "shell", path: "../scripts/ipv6.sh", args: [node_ip4, node_ip6, vm.box]
+  vm.provision "IPv6 Setup", type: "shell", path: scripts_location +"/ipv6.sh", args: [node_ip4, node_ip6, vm.box.to_s]
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
 
   vm.provision "Ping Check", type: "shell", inline: "ping -c 2 k3s.io"

--- a/tests/e2e/scripts/ipv6.sh
+++ b/tests/e2e/scripts/ipv6.sh
@@ -5,11 +5,17 @@ os=$3
 
 sysctl -w net.ipv6.conf.all.disable_ipv6=0
 sysctl -w net.ipv6.conf.eth1.accept_dad=0
+sysctl -w net.ipv6.conf.eth1.accept_ra=0
+sysctl -w net.ipv6.conf.eth1.forwarding=0
 
 if [ -z "${os##*ubuntu*}" ]; then
   netplan set ethernets.eth1.accept-ra=false
   netplan set ethernets.eth1.addresses=["$ip4_addr"/24,"$ip6_addr"/64]
   netplan apply
+elif [ -z "${os##*alpine*}" ]; then
+  iplink set eth1 down
+  iplink set eth1 up
+  ip -6 addr add "$ip6_addr"/64 dev eth1
 else
   ip -6 addr add "$ip6_addr"/64 dev eth1
 fi

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Verify Upgrade", func() {
 
 			// Check data after re-creation
 			Eventually(func() (string, error) {
-				cmd = "kubectl exec volume-test cat /data/test --kubeconfig=" + kubeConfigFile
+				cmd := "kubectl exec volume-test --kubeconfig=" + kubeConfigFile + " -- cat /data/test"
 				return e2e.RunCommand(cmd)
 			}, "180s", "2s").Should(ContainSubstring("local-path-test"))
 		})
@@ -364,7 +364,7 @@ var _ = Describe("Verify Upgrade", func() {
 
 		It("After upgrade verify Local Path Provisioner storage ", func() {
 			Eventually(func() (string, error) {
-				cmd := "kubectl exec volume-test cat /data/test --kubeconfig=" + kubeConfigFile
+				cmd := "kubectl exec volume-test --kubeconfig=" + kubeConfigFile + " -- cat /data/test"
 				return e2e.RunCommand(cmd)
 			}, "180s", "2s").Should(ContainSubstring("local-path-test"))
 		})

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -224,13 +224,11 @@ var _ = Describe("Verify Create", func() {
 				g.Expect(res).Should(ContainSubstring("Running"))
 			}, "420s", "2s").Should(Succeed())
 
-			When("Data is stored in pvc: local-path-test", func() {
-				cmd := "kubectl --kubeconfig=" + kubeConfigFile + " exec volume-test -- sh -c 'echo local-path-test > /data/test'"
-				_, err = e2e.RunCommand(cmd)
-				Expect(err).NotTo(HaveOccurred())
-			})
+			cmd := "kubectl --kubeconfig=" + kubeConfigFile + " exec volume-test -- sh -c 'echo local-path-test > /data/test'"
+			_, err = e2e.RunCommand(cmd)
+			Expect(err).NotTo(HaveOccurred())
 
-			cmd := "kubectl delete pod volume-test --kubeconfig=" + kubeConfigFile
+			cmd = "kubectl delete pod volume-test --kubeconfig=" + kubeConfigFile
 			res, err := e2e.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd+" result: "+res)
 
@@ -253,7 +251,7 @@ var _ = Describe("Verify Create", func() {
 			}, "420s", "2s").Should(Succeed())
 
 			Eventually(func(g Gomega) {
-				cmd = "kubectl exec volume-test cat /data/test --kubeconfig=" + kubeConfigFile
+				cmd := "kubectl exec volume-test --kubeconfig=" + kubeConfigFile + " -- cat /data/test"
 				res, err = e2e.RunCommand(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd+" result: "+res)
 				fmt.Println("Data after re-creation", res)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Add `CreateLocalCluster`: enables devs to test local builds of k3s when running E2E tests. Designed for debugging and writing new E2E tests. 
- Cleanup `validatecluster` printout and checks. Removed lots of `println` but added more information when errors occur. End result is the same amount of info when things fail, less logs when things pass. 
- Add test-pad support for dualstack (coming in a future PR, dualstack still has bugs that need to be worked out)
- Fix to docker e2e test. 

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Internal Testing Fixes
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
`go test -v -timeout=15m ./tests/e2e/docker/docker_test.go`
`go test -v -timeout=15m ./tests/e2e/validatecluster/validatecluster_test.go`
Changed several test to `CreateLocalCluster`, they all pass just fine. 
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
Its all testing changes
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
