### PR TITLE
E2E: Add support for CentOS 7 and Rocky 8

### DIFF
--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -15,7 +15,7 @@ import (
 // Valid nodeOS:
 // generic/ubuntu2004, generic/centos7, generic/rocky8
 // opensuse/Leap-15.3.x86_64, dweomer/microos.amd64
-var nodeOS = flag.String("nodeOS", "generic/centos7", "VM operating system")
+var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
 var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var agentCount = flag.Int("agentCount", 2, "number of agent nodes")
 var hardened = flag.Bool("hardened", false, "true or false")

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -12,8 +12,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// Valid nodeOS: generic/ubuntu2004, opensuse/Leap-15.3.x86_64, dweomer/microos.amd64
-var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
+// Valid nodeOS:
+// generic/ubuntu2004, generic/centos7, generic/rocky8
+// opensuse/Leap-15.3.x86_64, dweomer/microos.amd64
+var nodeOS = flag.String("nodeOS", "generic/centos7", "VM operating system")
 var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var agentCount = flag.Int("agentCount", 2, "number of agent nodes")
 var hardened = flag.Bool("hardened", false, "true or false")

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -158,9 +158,9 @@ var _ = Describe("Verify Upgrade", func() {
 			Expect(err).NotTo(HaveOccurred(), "Daemonset manifest not deployed")
 
 			nodes, _ := e2e.ParseNodes(kubeConfigFile, false) //nodes :=
-			pods, _ := e2e.ParsePods(kubeConfigFile, false)
 
 			Eventually(func(g Gomega) {
+				pods, _ := e2e.ParsePods(kubeConfigFile, false)
 				count := e2e.CountOfStringInSlice("test-daemonset", pods)
 				fmt.Println("POD COUNT")
 				fmt.Println(count)
@@ -346,9 +346,9 @@ var _ = Describe("Verify Upgrade", func() {
 
 		It("After upgrade verifies Daemonset", func() {
 			nodes, _ := e2e.ParseNodes(kubeConfigFile, false) //nodes :=
-			pods, _ := e2e.ParsePods(kubeConfigFile, false)
 
 			Eventually(func(g Gomega) {
+				pods, _ := e2e.ParsePods(kubeConfigFile, false)
 				count := e2e.CountOfStringInSlice("test-daemonset", pods)
 				fmt.Println("POD COUNT")
 				fmt.Println(count)

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -5,6 +5,12 @@ def defaultOSConfigure(vm)
     vm.provision "Install jq", type: "shell", inline: "apt install -y jq"
   elsif box.include?("Leap") || box.include?("Tumbleweed")
     vm.provision "Install jq", type: "shell", inline: "zypper install -y jq"
+  elsif box.include?("rocky8") || box.include?("rocky9")
+    vm.provision "Install jq", type: "shell", inline: "dnf install -y jq"
+    vm.provision "Disable firewall", type: "shell", inline: "systemctl stop firewalld"
+  elsif box.include?("centos7")
+    vm.provision "Install jq", type: "shell", inline: "yum install -y jq"
+    vm.provision "Disable firewall", type: "shell", inline: "systemctl stop firewalld"
   elsif box.include?("alpine")
     vm.provision "Install tools", type: "shell", inline: "apk add jq coreutils"
   elsif box.include?("microos")

--- a/tests/e2e/validatecluster/Vagrantfile
+++ b/tests/e2e/validatecluster/Vagrantfile
@@ -123,7 +123,7 @@ def getDBType(role, role_num, vm)
       return "cluster-init: true"
     end
   elsif ( EXTERNAL_DB == "none" )
-    # Use internal sqlite
+    # Use internal sqlite, only valid for single node clusters
   else
     puts "Unknown EXTERNAL_DB: " + EXTERNAL_DB
     abort

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -15,7 +15,7 @@ import (
 // Valid nodeOS:
 // generic/ubuntu2004, generic/centos7, generic/rocky8,
 // opensuse/Leap-15.3.x86_64, dweomer/microos.amd64
-var nodeOS = flag.String("nodeOS", "generic/centos7", "VM operating system")
+var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
 var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var agentCount = flag.Int("agentCount", 2, "number of agent nodes")
 var hardened = flag.Bool("hardened", false, "true or false")

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -12,15 +12,17 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// Valid nodeOS: generic/ubuntu2004, opensuse/Leap-15.3.x86_64, dweomer/microos.amd64
-var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
+// Valid nodeOS:
+// generic/ubuntu2004, generic/centos7, generic/rocky8,
+// opensuse/Leap-15.3.x86_64, dweomer/microos.amd64
+var nodeOS = flag.String("nodeOS", "generic/centos7", "VM operating system")
 var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var agentCount = flag.Int("agentCount", 2, "number of agent nodes")
 var hardened = flag.Bool("hardened", false, "true or false")
 
 // Environment Variables Info:
-// E2E_EXTERNAL_DB: mysql or postgres, nil for embedded etcd
-// E2E_RELEASE_VERSION=v1.23.1+k3s2 or nil for latest commit from master
+// E2E_EXTERNAL_DB: mysql, postgres, etcd (default: etcd)
+// E2E_RELEASE_VERSION=v1.23.1+k3s2 (default: latest commit from master)
 
 func Test_E2EClusterValidation(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -173,9 +175,9 @@ var _ = Describe("Verify Create", func() {
 			Expect(err).NotTo(HaveOccurred(), "Daemonset manifest not deployed")
 
 			nodes, _ := e2e.ParseNodes(kubeConfigFile, false)
-			pods, _ := e2e.ParsePods(kubeConfigFile, false)
 
 			Eventually(func(g Gomega) {
+				pods, _ := e2e.ParsePods(kubeConfigFile, false)
 				count := e2e.CountOfStringInSlice("test-daemonset", pods)
 				fmt.Println("POD COUNT")
 				fmt.Println(count)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Added support for CentOS7 and Rocky 8 to the E2E Validate and Upgrade Cluster tests
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Both E2E validate and upgrade cluster tests pass with the new OSes
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
New Testing Matrix
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
N/A internal testing change
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
