### PR TITLE
Fix dualStack test and change ipv6 network prefix

### DIFF
--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -8,7 +8,7 @@ RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
 NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 2048).to_i
 NETWORK4_PREFIX = "10.10.10"
-NETWORK6_PREFIX = "a11:decf:c0ff:ee"
+NETWORK6_PREFIX = "fd11:decf:c0ff:ee"
 install_type = ""
 
 def provision(vm, roles, role_num, node_num)
@@ -50,6 +50,7 @@ def provision(vm, roles, role_num, node_num)
         service-cidr: 10.43.0.0/16,2001:cafe:42:1::/112
         bind-address: #{NETWORK4_PREFIX}.100
         flannel-iface: eth1
+        kubelet-arg: "--node-ip=0.0.0.0" # Workaround for https://github.com/kubernetes/kubernetes/issues/111695 
       YAML
       k3s.env = ["K3S_KUBECONFIG_MODE=0644", install_type]
     end
@@ -65,6 +66,7 @@ def provision(vm, roles, role_num, node_num)
         cluster-cidr: 10.42.0.0/16,2001:cafe:42:0::/56
         service-cidr: 10.43.0.0/16,2001:cafe:42:1::/112
         flannel-iface: eth1
+        kubelet-arg: "--node-ip=0.0.0.0" # Workaround for https://github.com/kubernetes/kubernetes/issues/111695
       YAML
       k3s.env = ["K3S_KUBECONFIG_MODE=0644", install_type]
     end
@@ -79,6 +81,7 @@ def provision(vm, roles, role_num, node_num)
         server: https://#{NETWORK4_PREFIX}.100:6443
         token: vagrant
         flannel-iface: eth1
+        kubelet-arg: "--node-ip=0.0.0.0" # Workaround for https://github.com/kubernetes/kubernetes/issues/111695
       YAML
       k3s.env = ["K3S_KUBECONFIG_MODE=0644", install_type]
     end


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
2 changes:

1. Add "kubelet-arg: "--node-ip=0.0.0.0" " which is a temporary workaround to avoid the current bug in upstream kubernetes: https://github.com/kubernetes/kubernetes/issues/111695
2. Change the ipv6 network prefix, which in my opinion, it is wrong. According to the RFCs, private ipv6 addresses must start with fc or fd. Public ipv6 addresses must start with 2001 ==> https://en.wikipedia.org/wiki/Reserved_IP_addresses#IPv6. Ipv6 addresses starting with `a11` is not complying with the standard. However, I wonder why linux does not complain about this :thinking: 

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Deploy the dualStack test without disabling network policies

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/5981

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
