### PR TITLE
Remove `--containerd` flag from windows kubelet args

### DIFF
--- a/pkg/daemons/agent/agent_windows.go
+++ b/pkg/daemons/agent/agent_windows.go
@@ -17,9 +17,11 @@ import (
 	"k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
 )
 
+// NetworkName may be overridden at runtime in downstream projects
+var NetworkName = "vxlan0"
+
 const (
 	socketPrefix = "npipe://"
-	networkName  = "vxlan0"
 )
 
 func kubeProxyArgs(cfg *config.Agent) map[string]string {
@@ -38,7 +40,7 @@ func kubeProxyArgs(cfg *config.Agent) map[string]string {
 		argsMap["hostname-override"] = cfg.NodeName
 	}
 
-	if sourceVip := waitForManagementIP(networkName); sourceVip != "" {
+	if sourceVip := waitForManagementIP(NetworkName); sourceVip != "" {
 		argsMap["source-vip"] = sourceVip
 	}
 

--- a/pkg/daemons/agent/agent_windows.go
+++ b/pkg/daemons/agent/agent_windows.go
@@ -81,9 +81,6 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 	}
 	if cfg.RuntimeSocket != "" {
 		argsMap["serialize-image-pulls"] = "false"
-		if strings.Contains(cfg.RuntimeSocket, "containerd") {
-			argsMap["containerd"] = cfg.RuntimeSocket
-		}
 		// cadvisor wants the containerd CRI socket without the prefix, but kubelet wants it with the prefix
 		if strings.HasPrefix(cfg.RuntimeSocket, socketPrefix) {
 			argsMap["container-runtime-endpoint"] = cfg.RuntimeSocket


### PR DESCRIPTION
#### Proposed Changes ####

Remove `--containerd` flag from windows kubelet args; the Windows kubelet does not accept cadvisor flags.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

no e2e tests for K3s windows agents

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/3258

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
