### PR TITLE
Add validation check to confirm correct golang version for Kubernetes

### DIFF
--- a/scripts/validate
+++ b/scripts/validate
@@ -2,6 +2,7 @@
 set -e
 
 cd $(dirname $0)/..
+. ./scripts/version.sh
 
 echo Running: go mod tidy
 go mod tidy
@@ -13,13 +14,16 @@ if [ -n "$SKIP_VALIDATE" ]; then
     echo Skipping validation
     exit
 fi
+echo Running validation
 
-if ! command -v golangci-lint; then
-    echo Skipping validation: no golangci-lint available
-    exit
+echo Running: go version
+DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${VERSION_K8S}/build/dependencies.yaml"
+GOLANG_VERSION=$(curl -sL "${DEPENDENCIES_URL}" | yq e '.dependencies[] | select(.name == "golang: upstream version").version' -)
+if ! go version | grep -s "go version go${GOLANG_VERSION} "; then
+  echo "Unexpected $(go version) - Kubernetes ${VERSION_K8S} should be built with go version go${GOLANG_VERSION}"
+  exit 1
 fi
 
-echo Running validation
 echo Running: go mod verify
 go mod verify
 
@@ -27,14 +31,17 @@ if [ ! -e build/data ];then
     mkdir -p build/data
 fi
 
-echo Running: golangci-lint
-golangci-lint run -v
-
-. ./scripts/version.sh
-
 if [ -n "$DIRTY" ]; then
     echo Source dir is dirty
     git status --porcelain --untracked-files=no
     git diff
     exit 1
 fi
+
+if ! command -v golangci-lint; then
+    echo Skipping validation: no golangci-lint available
+    exit
+fi
+
+echo Running: golangci-lint
+golangci-lint run -v


### PR DESCRIPTION
#### Proposed Changes ####

Ensure that we're building K3s with the same Golang patch as upstream.

#### Types of Changes ####

CI validation

#### Verification ####

Run build; confirm that it errors if not using the correct golang release.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* tbd

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
