### PR TITLE
[release-1.22] Bump runc to v1.1.4

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -37,7 +37,7 @@ if [ -z "$VERSION_K8S" ]; then
     VERSION_K8S="v0.0.0"
 fi
 
-VERSION_RUNC="v1.1.3"
+VERSION_RUNC="v1.1.4"
 
 VERSION_FLANNEL=$(grep github.com/flannel-io/flannel go.mod | head -n1 | awk '{print $2}')
 if [ -z "$VERSION_FLANNEL" ]; then


### PR DESCRIPTION
#### Proposed Changes ####

Bump runc to v1.1.4

#### Types of Changes ####

version bump / bugfix

#### Verification ####

See linked issue

#### Testing ####

n/a

#### Linked Issues ####

* tbd

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The bundled version of runc has been bumped to v1.1.4
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
