### PR TITLE
[release-1.24] Bump containerd to v1.6.8-k3s1

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -24,7 +24,7 @@ fi
 
 # We're building k3s against containerd 1.5 in go.mod because 1.6 has dependency
 # conflicts with Kubernetes, but we still need to bundle containerd 1.6.
-VERSION_CONTAINERD="v1.6.6-k3s1"
+VERSION_CONTAINERD="v1.6.8-k3s1"
 
 VERSION_CRICTL=$(grep github.com/kubernetes-sigs/cri-tools go.mod | head -n1 | awk '{print $4}')
 if [ -z "$VERSION_CRICTL" ]; then


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to v1.6.8-k3s1

#### Types of Changes ####

version bump

#### Verification ####

Check containerd version in `kubectl get node -o wide`

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6080

#### User-Facing Change ####
```release-note
The embedded containerd version has been bumped to v1.6.8-k3s1
```

#### Further Comments ####
