### PR TITLE
!fix "Skipping installation of SELinux RPM " on offline installations

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -483,7 +483,7 @@ setup_selinux() {
     ${package_installer} install -y https://${rpm_site}/k3s/${rpm_channel}/common/${rpm_site_infix}/noarch/k3s-selinux-0.4-1.${rpm_target}.noarch.rpm
 "
 
-    if [ "$INSTALL_K3S_SKIP_SELINUX_RPM" = true ] || [ ! -d /usr/share/selinux ]; then
+    if [ "$INSTALL_K3S_SKIP_SELINUX_RPM" = true ] || can_skip_download || [ ! -d /usr/share/selinux ]; then
         info "Skipping installation of SELinux RPM"
     elif  [ "${ID_LIKE:-}" != coreos ] && [ "${VARIANT_ID:-}" != coreos ]; then
         install_selinux_rpm ${rpm_site} ${rpm_channel} ${rpm_target} ${rpm_site_infix}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
I think on this PR here, there got a bug introduced: https://github.com/k3s-io/k3s/pull/6003/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL486-R486
 (I think it maybe got removed for testing and accidentally committed)

Executing with ansible `INSTALL_K3S_SKIP_DOWNLOAD=true INSTALL_K3S_BIN_DIR=/usr/bin files/install.sh` on an offline environment, I get the following error with the latest version:

````
    "stderr": "Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=stock error was\n14: curl#6 - \"Could not resolve host: mirrorlist.centos.org; Name or service not known\"\n\n\n One of the configured repositories failed (Unknown),\n and yum doesn't have enough cached data to continue. At this point the only\n safe thing yum can do is fail. There are a few ways to work \"fix\" this:\n\n     1. Contact the upstream for the repository and get them to fix the problem.\n\n     2. Reconfigure the baseurl/etc. for the repository, to point to a working\n        upstream. This is most often useful if you are using a newer\n        distribution release than is supported by the repository (and the\n        packages for the previous distribution release still work).\n\n     3. Run the command with the repository temporarily disabled\n            yum --disablerepo=<repoid> ...\n\n     4. Disable the repository permanently, so yum won't use it by default. Yum\n        will then just ignore the repository until you permanently enable it\n        again or use --enablerepo for temporary usage:\n\n            yum-config-manager --disable <repoid>\n        or\n            subscription-manager repos --disable=<repoid>\n\n     5. Configure the failing repository to be skipped, if it is unavailable.\n        Note that yum will try to contact the repo. when it runs most commands,\n        so will have to try and fail each time (and thus. yum will be be much\n        slower). If it is a very temporary problem though, this is often a nice\n        compromise:\n\n            yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true\n\nCannot find a valid baseurl for repo: base/7/x86_64",
    "stderr_lines": [
        "Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=stock error was",
        "14: curl#6 - \"Could not resolve host: mirrorlist.centos.org; Name or service not known\"",
        "",
        "",
        " One of the configured repositories failed (Unknown),",
        " and yum doesn't have enough cached data to continue. At this point the only",
        " safe thing yum can do is fail. There are a few ways to work \"fix\" this:",
        "",
        "     1. Contact the upstream for the repository and get them to fix the problem.",
        "",
        "     2. Reconfigure the baseurl/etc. for the repository, to point to a working",
        "        upstream. This is most often useful if you are using a newer",
        "        distribution release than is supported by the repository (and the",
        "        packages for the previous distribution release still work).",
        "",
        "     3. Run the command with the repository temporarily disabled",
        "            yum --disablerepo=<repoid> ...",
        "",
        "     4. Disable the repository permanently, so yum won't use it by default. Yum",
        "        will then just ignore the repository until you permanently enable it",
        "        again or use --enablerepo for temporary usage:",
        "",
        "            yum-config-manager --disable <repoid>",
        "        or",
        "            subscription-manager repos --disable=<repoid>",
        "",
        "     5. Configure the failing repository to be skipped, if it is unavailable.",
        "        Note that yum will try to contact the repo. when it runs most commands,",
        "        so will have to try and fail each time (and thus. yum will be be much",
        "        slower). If it is a very temporary problem though, this is often a nice",
        "        compromise:",
        "",
        "            yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true",
        "",
        "Cannot find a valid baseurl for repo: base/7/x86_64"
````

This is resolved, once I added back this change

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
just move the offline resources to an offline plain centos machine and executing the installation with install.sh script offline `INSTALL_K3S_SKIP_DOWNLOAD=true INSTALL_K3S_BIN_DIR=/usr/bin files/install.sh`
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/pull/6003/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL486-R486
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Signed-off-by: sauerborn-git <fabian.sauerborn@grenzebach.digital>
