### PR TITLE
Restore original INSTALL_K3S_SKIP_DOWNLOAD behavior

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -43,7 +43,7 @@ jobs:
       run:
         working-directory: tests/install/${{ matrix.vm }}
     env:
-      INSTALL_K3S_SKIP_DOWNLOAD: true
+      INSTALL_K3S_SKIP_DOWNLOAD: binary
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2

--- a/install.sh
+++ b/install.sh
@@ -275,6 +275,12 @@ can_skip_download() {
     fi
 }
 
+can_skip_selinux_download() {                                                        
+    if [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != true ] && [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != "selinux" ]; then 
+        return 1                                                                     
+    fi                                                                               
+}  
+
 # --- verify an executable k3s binary is installed ---
 verify_k3s_is_executable() {
     if [ ! -x ${BIN_DIR}/k3s ]; then
@@ -483,7 +489,7 @@ setup_selinux() {
     ${package_installer} install -y https://${rpm_site}/k3s/${rpm_channel}/common/${rpm_site_infix}/noarch/k3s-selinux-0.4-1.${rpm_target}.noarch.rpm
 "
 
-    if [ "$INSTALL_K3S_SKIP_SELINUX_RPM" = true ] || [ ! -d /usr/share/selinux ]; then
+    if [ "$INSTALL_K3S_SKIP_SELINUX_RPM" = true ] || can_skip_selinux_download || [ ! -d /usr/share/selinux ]; then
         info "Skipping installation of SELinux RPM"
     elif  [ "${ID_LIKE:-}" != coreos ] && [ "${VARIANT_ID:-}" != coreos ]; then
         install_selinux_rpm ${rpm_site} ${rpm_channel} ${rpm_target} ${rpm_site_infix}

--- a/install.sh
+++ b/install.sh
@@ -269,13 +269,13 @@ setup_env() {
 }
 
 # --- check if skip download environment variable set ---
-can_skip_download() {
-    if [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != true ]; then
+can_skip_download_binary() {
+    if [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != true ] && [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != "binary" ]; then
         return 1
     fi
 }
 
-can_skip_selinux_download() {                                                        
+can_skip_download_selinux() {                                                        
     if [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != true ] && [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != "selinux" ]; then 
         return 1                                                                     
     fi                                                                               
@@ -489,7 +489,7 @@ setup_selinux() {
     ${package_installer} install -y https://${rpm_site}/k3s/${rpm_channel}/common/${rpm_site_infix}/noarch/k3s-selinux-0.4-1.${rpm_target}.noarch.rpm
 "
 
-    if [ "$INSTALL_K3S_SKIP_SELINUX_RPM" = true ] || can_skip_selinux_download || [ ! -d /usr/share/selinux ]; then
+    if [ "$INSTALL_K3S_SKIP_SELINUX_RPM" = true ] || can_skip_download_selinux || [ ! -d /usr/share/selinux ]; then
         info "Skipping installation of SELinux RPM"
     elif  [ "${ID_LIKE:-}" != coreos ] && [ "${VARIANT_ID:-}" != coreos ]; then
         install_selinux_rpm ${rpm_site} ${rpm_channel} ${rpm_target} ${rpm_site_infix}
@@ -558,7 +558,7 @@ EOF
 
 # --- download and verify k3s ---
 download_and_verify() {
-    if can_skip_download; then
+    if can_skip_download_binary; then
        info 'Skipping k3s download and verify'
        verify_k3s_is_executable
        return

--- a/install.sh
+++ b/install.sh
@@ -270,13 +270,13 @@ setup_env() {
 
 # --- check if skip download environment variable set ---
 can_skip_download_binary() {
-    if [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != true ] && [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != "binary" ]; then
+    if [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != true ] && [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != binary ]; then
         return 1
     fi
 }
 
 can_skip_download_selinux() {                                                        
-    if [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != true ] && [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != "selinux" ]; then 
+    if [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != true ] && [ "${INSTALL_K3S_SKIP_DOWNLOAD}" != selinux ]; then 
         return 1                                                                     
     fi                                                                               
 }  


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
 INSTALL_K3S_SKIP_DOWNLOAD has been modified to no longer be `true/false` but can now be:
 - `true`: original behavior, skip all downloads
 - `false/nil/other`: default behavior, download everything
 -  `binary`: skip the k3s binary download
 - `selinux`: skip the selinux rpm download
  
 This enables use to support the *original* behavior users expect from the install script while also allowing us fine grain control for testing purposes, such as the openSUSE leap install tests, where we want a local built of K3s with remote download of the selinux RPM. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix, Install Enhancement
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
All install tests pass in GH CI

`INSTALL_K3S_SKIP_DOWNLOAD=true` no longer attempts to download SELINUX RPMS.

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/6128
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
