### PR TITLE
Use debugger-friendly compile settings if DEBUG is set

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -42,7 +42,7 @@ ARG SELINUX=true
 ENV SELINUX $SELINUX
 
 ENV DAPPER_RUN_ARGS --privileged -v k3s-cache:/go/src/github.com/k3s-io/k3s/.cache -v trivy-cache:/root/.cache/trivy
-ENV DAPPER_ENV REPO TAG DRONE_TAG IMAGE_NAME SKIP_VALIDATE SKIP_AIRGAP GCLOUD_AUTH GITHUB_TOKEN GOLANG
+ENV DAPPER_ENV REPO TAG DRONE_TAG IMAGE_NAME SKIP_VALIDATE SKIP_AIRGAP GCLOUD_AUTH GITHUB_TOKEN GOLANG DEBUG
 ENV DAPPER_SOURCE /go/src/github.com/k3s-io/k3s/
 ENV DAPPER_OUTPUT ./bin ./dist ./build/out ./build/static ./pkg/static ./pkg/deploy
 

--- a/scripts/binary_size_check.sh
+++ b/scripts/binary_size_check.sh
@@ -24,6 +24,11 @@ fi
 CMD_NAME="dist/artifacts/k3s${BIN_SUFFIX}"
 SIZE=$(stat -c '%s' ${CMD_NAME})
 
+if [ -n "${DEBUG}" ]; then
+    echo "DEBUG is set, ignoring binary size"
+    exit 0
+fi
+
 if [ ${SIZE} -gt ${MAX_BINARY_SIZE} ]; then
   echo "k3s binary ${CMD_NAME} size ${SIZE} exceeds max acceptable size of ${MAX_BINARY_SIZE} bytes (${MAX_BINARY_MB} MiB)"
   exit 1

--- a/scripts/build
+++ b/scripts/build
@@ -42,8 +42,12 @@ VERSIONFLAGS="
     -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Commit=${COMMIT}
     -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.buildDate=${buildDate}
 "
-LDFLAGS="
-    -w -s"
+
+if [ -n "${DEBUG}" ]; then
+  GCFLAGS="-N -l"
+else
+  LDFLAGS="-w -s"
+fi
 
 STATIC="
     -extldflags '-static -lm -ldl -lz -lpthread'
@@ -106,12 +110,12 @@ if [ ! -x ${INSTALLBIN}/cni ]; then
     WORKDIR=$TMPDIR/src/github.com/containernetworking/plugins
     git clone -b $VERSION_CNIPLUGINS https://github.com/rancher/plugins.git $WORKDIR
     cd $WORKDIR
-    GO111MODULE=off GOPATH=$TMPDIR CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o $INSTALLBIN/cni
+    GO111MODULE=off GOPATH=$TMPDIR CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o $INSTALLBIN/cni
 )
 fi
 
 echo Building k3s
-CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s ./cmd/server/main.go
+CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s ./cmd/server/main.go
 ln -s k3s ./bin/k3s-agent
 ln -s k3s ./bin/k3s-server
 ln -s k3s ./bin/k3s-etcd-snapshot
@@ -127,14 +131,14 @@ export GOPATH=$(pwd)/build
 echo Building containerd
 pushd ./build/src/github.com/containerd/containerd
 TAGS="${TAGS/netcgo/netgo}"
-CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/containerd              ./cmd/containerd
-CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/containerd-shim-runc-v2 ./cmd/containerd-shim-runc-v2
+CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/containerd              ./cmd/containerd
+CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/containerd-shim-runc-v2 ./cmd/containerd-shim-runc-v2
 popd
 cp -vf ./build/src/github.com/containerd/containerd/bin/* ./bin/
 
 echo Building runc
 pushd ./build/src/github.com/opencontainers/runc
 rm -f runc
-make EXTRA_LDFLAGS="-w -s" BUILDTAGS="$RUNC_TAGS" $RUNC_STATIC
+make EXTRA_FLAGS="-gcflags=\"all=${GCFLAGS}\"" EXTRA_LDFLAGS="$LDFLAGS" BUILDTAGS="$RUNC_TAGS" $RUNC_STATIC
 popd
 cp -vf ./build/src/github.com/opencontainers/runc/runc ./bin/


### PR DESCRIPTION
#### Proposed Changes ####

In order to use a debugger such as [Delve](https://github.com/go-delve/delve), binaries have to be compiled with debugging symbols and disabling some optimizations.

This PR makes it possible to build binaries in such a way.

I have a [companion project to run Delve as an ephemeral container](https://github.com/moio/delve-debugger) to make attaching a debugger as easy in containerized environments such as k3d ([instructions](https://github.com/moio/delve-debugger/blob/master/docs/guides/README-k3d.md)).

#### Types of Changes ####

Build script changes, activated with the `DEBUG` environment variable set. Nothing should change without adding it.

#### Verification ####

- `make` should continue to work as before
- `DEBUG=true make` should build as well
- `bin/k3s` should **not** be stripped after building with `DEBUG=true`. Eg. (on Linux, amd64):
```
silvio@lenovo:~/repos/k3s> file bin/k3s
bin/k3s: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
```
- to verify that it is actually possible to attach ad debugger, see [instructions](https://github.com/moio/delve-debugger/blob/master/docs/guides/README-k3d.md)
- 
#### Testing ####

This is only interesting for developers and build scripts are not covered with tests anyway, so I do not believe it needs automated testing.

#### Linked Issues ####

Addresses https://github.com/k3s-io/k3s/issues/6146

#### User-Facing Change ####

```release-note
NONE
```

