### PR TITLE
Fix the typo in the test

### DIFF
--- a/tests/integration/certrotation/certrotation_int_test.go
+++ b/tests/integration/certrotation/certrotation_int_test.go
@@ -71,7 +71,7 @@ var _ = Describe("certificate rotation", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 			certHashAfter, err := testutil.RunCommand("md5sum " + tmpdDataDir + "/server/tls/serving-kube-apiserver.crt | cut -f 1 -d' '")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(caCertHash).To(Not(Equal(certHashAfter)))
+			Expect(certHash).To(Not(Equal(certHashAfter)))
 			Expect(caCertHash).To(Equal(caCertHashAfter))
 		})
 	})


### PR DESCRIPTION

#### Proposed Changes ####

CA cert will never be equal to the serving-kube-apiserver cert so it seems like a copy-paste error.

#### Types of Changes ####

Bugfix

#### Verification ####

Visual 😄

#### Testing ####

This is the test.

#### Linked Issues ####

N/A

#### User-Facing Change ####

```release-note
NONE
```
