### PR TITLE
Use structured logging instead of logrus for event recorders

### DIFF
--- a/pkg/util/api.go
+++ b/pkg/util/api.go
@@ -104,7 +104,7 @@ func WaitForAPIServerReady(ctx context.Context, kubeconfigPath string, timeout t
 func BuildControllerEventRecorder(k8s clientset.Interface, controllerName, namespace string) record.EventRecorder {
 	logrus.Infof("Creating %s event broadcaster", controllerName)
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(logrus.Infof)
+	eventBroadcaster.StartStructuredLogging(0)
 	eventBroadcaster.StartRecordingToSink(&coregetter.EventSinkImpl{Interface: k8s.CoreV1().Events(namespace)})
 	nodeName := os.Getenv("NODE_NAME")
 	return eventBroadcaster.NewRecorder(schemes.All, v1.EventSource{Component: controllerName, Host: nodeName})


### PR DESCRIPTION
#### Proposed Changes ####

Use structured logging instead of logrus for event recorders

Gives the same readable log format as generated by upstream events, instead of outputting the raw Event structure.

#### Types of Changes ####

enhancement

#### Verification ####

Note that events are now formatted nicely in the log. 

Before: `INFO[0006] Event(v1.ObjectReference{Kind:"Addon", Namespace:"kube-system", Name:"ccm", UID:"1c8427cf-6a47-49e3-a56b-756dc6e90189", APIVersion:"k3s.cattle.io/v1", ResourceVersion:"244", FieldPath:""}): type: 'Normal' reason: 'ApplyingManifest' Applying manifest at "/var/lib/rancher/k3s/server/manifests/ccm.yaml"`

After: `I0930 21:53:49.093091      54 event.go:294] "Event occurred" object="kube-system/ccm" fieldPath="" kind="Addon" apiVersion="k3s.cattle.io/v1" type="Normal" reason="ApplyingManifest" message="Applying manifest at \"/var/lib/rancher/k3s/server/manifests/ccm.yaml\""`

#### Testing ####

n/a

#### Linked Issues ####

* 

#### User-Facing Change ####
```release-note
Events recorded to the cluster are now properly formatted in the service logs.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
