### PR TITLE
Add NoPivotRoot to options, to allow k3s working on initrd/RAMdisk (for example buildroot)

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -461,6 +461,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	nodeConfig.AgentConfig.Snapshotter = envInfo.Snapshotter
 	nodeConfig.AgentConfig.IPSECPSK = controlConfig.IPSECPSK
 	nodeConfig.AgentConfig.StrongSwanDir = filepath.Join(envInfo.DataDir, "agent", "strongswan")
+	nodeConfig.AgentConfig.NoPivotRoot = envInfo.NoPivotRoot
 	nodeConfig.Containerd.Config = filepath.Join(envInfo.DataDir, "agent", "etc", "containerd", "config.toml")
 	nodeConfig.Containerd.Root = filepath.Join(envInfo.DataDir, "agent", "containerd")
 	nodeConfig.CRIDockerd.Root = filepath.Join(envInfo.DataDir, "agent", "cri-dockerd")

--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -66,6 +66,7 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 		NodeConfig:            cfg,
 		DisableCgroup:         disableCgroup,
 		SystemdCgroup:         cfg.AgentConfig.Systemd,
+		NoPivotRoot:           cfg.AgentConfig.NoPivotRoot,
 		IsRunningInUserNS:     isRunningInUserNS,
 		EnableUnprivileged:    kernel.CheckKernelVersion(4, 11, 0),
 		PrivateRegistryConfig: privRegistries.Registry,

--- a/pkg/agent/containerd/config_windows.go
+++ b/pkg/agent/containerd/config_windows.go
@@ -46,6 +46,7 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 		NodeConfig:            cfg,
 		DisableCgroup:         true,
 		SystemdCgroup:         false,
+		NoPivotRoot:           false,
 		IsRunningInUserNS:     false,
 		PrivateRegistryConfig: privRegistries.Registry,
 	}

--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -15,6 +15,7 @@ type ContainerdConfig struct {
 	NodeConfig            *config.Node
 	DisableCgroup         bool
 	SystemdCgroup         bool
+	NoPivotRoot           bool
 	IsRunningInUserNS     bool
 	EnableUnprivileged    bool
 	PrivateRegistryConfig *registries.Registry

--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -85,6 +85,7 @@ enable_keychain = true
 
 [plugins.cri.containerd.runtimes.runc.options]
 	SystemdCgroup = {{ .SystemdCgroup }}
+	NoPivotRoot = {{ .NoPivotRoot }}
 
 {{ if .PrivateRegistryConfig }}
 {{ if .PrivateRegistryConfig.Mirrors }}

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -37,6 +37,7 @@ type Agent struct {
 	RootlessAlreadyUnshared  bool
 	WithNodeID               bool
 	EnableSELinux            bool
+	NoPivotRoot              bool
 	ProtectKernelDefaults    bool
 	ClusterReset             bool
 	PrivateRegistry          string
@@ -96,6 +97,12 @@ var (
 		Usage:       "(agent/node) Enable SELinux in containerd",
 		Destination: &AgentConfig.EnableSELinux,
 		EnvVar:      version.ProgramUpper + "_SELINUX",
+	}
+	NoPivotRootFlag = cli.BoolFlag{
+		Name:        "no-pivot-root",
+		Usage:       "(agent/node) NoPivotRoot disables pivot root when creating a container",
+		Destination: &AgentConfig.NoPivotRoot,
+		EnvVar:      version.ProgramUpper + "_NO_PIVOT_ROOT",
 	}
 	LBServerPortFlag = cli.IntFlag{
 		Name:        "lb-server-port",
@@ -253,6 +260,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			NodeTaints,
 			ImageCredProvBinDirFlag,
 			ImageCredProvConfigFlag,
+			NoPivotRootFlag,
 			&SELinuxFlag,
 			LBServerPortFlag,
 			ProtectKernelDefaultsFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -507,6 +507,7 @@ var ServerFlags = []cli.Flag{
 		Usage:       "(experimental) Enable Secret encryption at rest",
 		Destination: &ServerConfig.EncryptSecrets,
 	},
+	NoPivotRootFlag,
 	&SELinuxFlag,
 	LBServerPortFlag,
 

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -130,6 +130,7 @@ type Agent struct {
 	DisableServiceLB        bool
 	EnableIPv4              bool
 	EnableIPv6              bool
+	NoPivotRoot             bool
 }
 
 // CriticalControlArgs contains parameters that all control plane nodes in HA must share


### PR DESCRIPTION
#### Proposed Changes ####

Add NoPivotRoot to configure containerd to work on initrd / RAMdisk, will add the --no-pivot-root option on server / agent.

#### Types of Changes ####

Added flag for --no-pivot-root (agent and server which boots agent), this will append configuration to the plugins.cri.containerd.runtimes.runc.options, where it will add NoPivotRoot = true (when true). The default for windows = false.

#### Verification ####

Normally you would get (in initrd / RAMdisk):
jailing process inside rootfs caused \\\\\\\"pivot_root invalid argument\\\\\\\"\\\"\":

now containers will spawn correctly (with --no-pivot-root flag enabled)

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/510

#### User-Facing Change ####
```release-note
Add --no-pivot-root option for agent / server
```

#### Further Comments ####
I've added it to AgentConfig, since DIsableCgroup is also inside the AgentConfig. It however seems more like a Containerd config, but I left this alone.
