### PR TITLE
Enable E2E test on PRs

### DIFF
--- a/.github/workflows/build-k3s.yaml
+++ b/.github/workflows/build-k3s.yaml
@@ -1,0 +1,39 @@
+name: Build K3s
+
+on: 
+  workflow_call:
+   inputs:
+    upload-repo:
+      type: boolean
+      required: false
+      default: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    steps:
+    - name: Checkout K3s
+      uses: actions/checkout@v3
+    - name: Build K3s binary
+      run: |
+        DOCKER_BUILDKIT=1 SKIP_AIRGAP=1 SKIP_VALIDATE=1 make
+      
+    - name: bundle repo
+      if: inputs.upload-repo == true
+      run: |
+        tar -czvf ../k3s-repo.tar.gz .
+        mv ../k3s-repo.tar.gz .
+    - name: "Upload K3s directory"
+      if: inputs.upload-repo == true
+      uses: actions/upload-artifact@v3
+      with:
+        name: k3s-repo.tar.gz
+        path: k3s-repo.tar.gz
+    - name: "Upload K3s binary"
+      if: inputs.upload-repo == false
+      uses: actions/upload-artifact@v3
+      with:
+        name: k3s
+        path: dist/artifacts/k3s

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,7 +47,7 @@ jobs:
         source: "./*"
         target: "k3s-${{ github.sha }}"
     
-    - name: Run E2E tests
+    - name: Prepare E2E tests
       uses: appleboy/ssh-action@v0.1.4
       with:
         host: ${{ secrets.PR_RUNNER_IP }}
@@ -56,12 +56,22 @@ jobs:
         script_stop: true
         script: |
           export PATH=$PATH:/usr/local/go/bin
-          echo $PATH
           cd k3s-${{ github.sha }}
           go mod tidy && go mod download
-          cd tests/e2e
+
+    - name: Run E2E tests
+      uses: appleboy/ssh-action@v0.1.4
+      with:
+        host: ${{ secrets.PR_RUNNER_IP }}
+        username: ${{ secrets.PR_RUNNER_USER }}
+        key: ${{ secrets.PR_RUNNER_PERM }}
+        script_stop: true
+        command_timeout: 60m
+        script: |
+          export PATH=$PATH:/usr/local/go/bin
+          cd k3s-${{ github.sha }}/tests/e2e
           echo 'RUNNING CLUSTER VALIDATION TEST'
-          go test -v -timeout=30m validatecluster/validatecluster_test.go -local
+          go test -v -timeout=45m validatecluster/validatecluster_test.go -local -ci
           cd ~
           rm -rf k3s-${{ github.sha }}
     

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,7 @@ jobs:
   test:
     name: E2E Tests
     runs-on: ubuntu-20.04
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
     - name: "Checkout K3s"
       uses: actions/checkout@v3
@@ -46,24 +46,28 @@ jobs:
         key: ${{ secrets.PR_RUNNER_PERM }}
         source: "./*"
         target: "k3s-${{ github.sha }}"
-
+    
     - name: Run E2E tests
-      uses: appleboy/ssh-action@v0.1.5
+      uses: appleboy/ssh-action@v0.1.4
       with:
         host: ${{ secrets.PR_RUNNER_IP }}
         username: ${{ secrets.PR_RUNNER_USER }}
         key: ${{ secrets.PR_RUNNER_PERM }}
         script_stop: true
-        #./scripts/run-tests.sh
         script: |
-          cd k3s-${{ github.sha }}/tests/e2e
-          ls -la
-          ls -la ../../../dist/artifacts
-          
-
+          export PATH=$PATH:/usr/local/go/bin
+          echo $PATH
+          cd k3s-${{ github.sha }}
+          go mod tidy && go mod download
+          cd tests/e2e
+          echo 'RUNNING CLUSTER VALIDATION TEST'
+          go test -v -timeout=30m validatecluster/validatecluster_test.go -local
+          cd ~
+          rm -rf k3s-${{ github.sha }}
+    
     - name: Save logs on failure
       if: failure()
-      uses: appleboy/ssh-action@v0.1.5
+      uses: appleboy/ssh-action@v0.1.4
       with:
         host: ${{ secrets.PR_RUNNER_IP }}
         username: ${{ secrets.PR_RUNNER_USER }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,27 +9,38 @@ on:
       - "!tests/e2e**"
       - ".github/**"
       - "!.github/workflows/e2e.yaml"
-  # pull_request:
-  #   paths-ignore:
-  #     - "**.md"
-  #     - "channel.yaml"
-  #     - "install.sh"
-  #     - "tests/**"
-  #     - "!tests/e2e**"
-  #     - ".github/**"
-  #     - "!.github/workflows/e2e.yaml"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "channel.yaml"
+      - "install.sh"
+      - "tests/**"
+      - "!tests/e2e**"
+      - ".github/**"
+      - "!.github/workflows/e2e.yaml"
   workflow_dispatch: {}
 jobs:
+  # we split the build into a separate job to make testing reruns faster
+  # if build passes, later runs will skip this job and reuse the artifacts
+  build:
+    uses: ./.github/workflows/build-k3s.yaml
+    with:
+      upload-repo: true
   test:
     name: E2E Tests
+    needs: build
     runs-on: ubuntu-20.04
-    timeout-minutes: 120
+    timeout-minutes: 60
+    concurrency: e2e_runner_limit
     steps:
-    - name: "Checkout K3s"
-      uses: actions/checkout@v3
-
-    - name: Build K3s binary
-      run: DOCKER_BUILDKIT=1 SKIP_AIRGAP=1 SKIP_VALIDATE=1 make
+    - name: Download K3s repo
+      uses: actions/download-artifact@v3
+      with:
+        name: k3s-repo.tar.gz
+        path: ./
+    - run: |
+        tar -xzvf k3s-repo.tar.gz .
+        rm k3s-repo.tar.gz
 
     - name: Connect to Fremont VPN
       uses: aduriseti/ovpn3-connect-action@v1
@@ -71,7 +82,7 @@ jobs:
           export PATH=$PATH:/usr/local/go/bin
           cd k3s-${{ github.sha }}/tests/e2e
           echo 'RUNNING CLUSTER VALIDATION TEST'
-          go test -v -timeout=45m validatecluster/validatecluster_test.go -local -ci
+          E2E_REGISTRY=true go test -v -timeout=45m validatecluster/validatecluster_test.go -local -ci
           cd ~
           rm -rf k3s-${{ github.sha }}
     

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,80 @@
+name: E2E Test Coverage
+on: 
+  push:
+    paths-ignore:
+      - "**.md"
+      - "channel.yaml"
+      - "install.sh"
+      - "tests/**"
+      - "!tests/e2e**"
+      - ".github/**"
+      - "!.github/workflows/e2e.yaml"
+  # pull_request:
+  #   paths-ignore:
+  #     - "**.md"
+  #     - "channel.yaml"
+  #     - "install.sh"
+  #     - "tests/**"
+  #     - "!tests/e2e**"
+  #     - ".github/**"
+  #     - "!.github/workflows/e2e.yaml"
+  workflow_dispatch: {}
+jobs:
+  test:
+    name: E2E Tests
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    steps:
+    - name: "Checkout K3s"
+      uses: actions/checkout@v3
+
+    - name: Build K3s binary
+      run: DOCKER_BUILDKIT=1 SKIP_AIRGAP=1 SKIP_VALIDATE=1 make
+
+    - name: Connect to Fremont VPN
+      uses: aduriseti/ovpn3-connect-action@v1
+      with:
+        ovpn-config:  ${{ secrets.OVPN_CONFIG }}
+        vpn-user:     ${{ secrets.OVPN_USER }}
+        vpn-pass:     ${{ secrets.OVPN_PASS }}
+
+    - name: Transfer K3s to E2E runner
+      uses: appleboy/scp-action@master
+      with:
+        host: ${{ secrets.PR_RUNNER_IP }}
+        username: ${{ secrets.PR_RUNNER_USER }}
+        key: ${{ secrets.PR_RUNNER_PERM }}
+        source: "./*"
+        target: "k3s-${{ github.sha }}"
+
+    - name: Run E2E tests
+      uses: appleboy/ssh-action@v0.1.5
+      with:
+        host: ${{ secrets.PR_RUNNER_IP }}
+        username: ${{ secrets.PR_RUNNER_USER }}
+        key: ${{ secrets.PR_RUNNER_PERM }}
+        script_stop: true
+        #./scripts/run-tests.sh
+        script: |
+          cd k3s-${{ github.sha }}/tests/e2e
+          ls -la
+          ls -la ../../../dist/artifacts
+          
+
+    - name: Save logs on failure
+      if: failure()
+      uses: appleboy/ssh-action@v0.1.5
+      with:
+        host: ${{ secrets.PR_RUNNER_IP }}
+        username: ${{ secrets.PR_RUNNER_USER }}
+        key: ${{ secrets.PR_RUNNER_PERM }}
+        script: |
+          mkdir -p failed_logs/${{ github.sha }}
+          find ./k3s-${{ github.sha }}/tests/e2e -name \*.log -exec cp {} failed_logs/${{ github.sha }} \;
+          rm -rf ./k3s-${{ github.sha }}
+
+    - name: Kill VPN Connection
+      if: always()
+      run: |
+        sudo pkill openvpn  
+ 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -5,9 +5,8 @@ on:
       - "**.md"
       - "channel.yaml"
       - "install.sh"
-      - "tests/snapshotter/**"
-      - "tests/install/**"
-      - "tests/cgroup/**"
+      - "tests/**"
+      - "!tests/integration**"
       - ".github/**"
       - "!.github/workflows/integration.yaml"
   pull_request:
@@ -15,9 +14,8 @@ on:
       - "**.md"
       - "channel.yaml"
       - "install.sh"
-      - "tests/snapshotter/**"
-      - "tests/install/**"
-      - "tests/cgroup/**"
+      - "tests/**"
+      - "!tests/integration**"
       - ".github/**"
       - "!.github/workflows/integration.yaml"
   workflow_dispatch: {}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -23,21 +23,7 @@ on:
   workflow_dispatch: {}
 jobs:
   build:
-    name: Build
-    runs-on: ubuntu-20.04
-    timeout-minutes: 20
-    steps:
-    - name: "Checkout"
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    - name: "Make"
-      run: DOCKER_BUILDKIT=1 SKIP_VALIDATE=1 make
-    - name: "Upload k3s binary"
-      uses: actions/upload-artifact@v2
-      with:
-        name: k3s
-        path: dist/artifacts/k3s
+    uses: ./.github/workflows/build-k3s.yaml
   test:
     needs: build
     name: Integration Tests

--- a/tests/e2e/clusterreset/Vagrantfile
+++ b/tests/e2e/clusterreset/Vagrantfile
@@ -5,7 +5,6 @@ NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
   ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
 GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
-EXTERNAL_DB = (ENV['E2E_EXTERNAL_DB'] || "etcd")
 HARDENED = (ENV['E2E_HARDENED'] || "")
 NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
 NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 1024).to_i
@@ -91,16 +90,10 @@ def provision(vm, role, role_num, node_num)
   end
 end
 
+# Cluster reset only works on embedded etcd
 def getDBType(role, role_num, vm)
-  if ( EXTERNAL_DB == "" || EXTERNAL_DB == "etcd" )
-    if role.include?("server") && role_num == 0
-      return "cluster-init: true"
-    end
-  elsif ( EXTERNAL_DB == "none" )
-    # Use internal sqlite, only valid for single node clusters
-  else
-    puts "Unknown EXTERNAL_DB: " + EXTERNAL_DB
-    abort
+  if role.include?("server") && role_num == 0
+    return "cluster-init: true"
   end
   return ""
 end

--- a/tests/e2e/clusterreset/clusterreset_test.go
+++ b/tests/e2e/clusterreset/clusterreset_test.go
@@ -23,7 +23,6 @@ var ci = flag.Bool("ci", false, "running on CI")
 var local = flag.Bool("local", false, "deploy a locally built K3s binary")
 
 // Environment Variables Info:
-// E2E_EXTERNAL_DB: mysql, postgres, etcd (default: etcd)
 // E2E_RELEASE_VERSION=v1.23.1+k3s2 (default: latest commit from master)
 
 func Test_E2EClusterReset(t *testing.T) {
@@ -47,7 +46,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			} else {
 				serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 			}
-			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Server Nodes:", serverNodeNames)

--- a/tests/e2e/docker/docker_test.go
+++ b/tests/e2e/docker/docker_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Verify CRI-Dockerd", Ordered, func() {
 		It("Starts up with no issues", func() {
 			var err error
 			serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
-			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Server Nodes:", serverNodeNames)

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 	It("Starts up with no issues", func() {
 		var err error
 		serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
-		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 		fmt.Println("CLUSTER CONFIG")
 		fmt.Println("OS:", *nodeOS)
 		fmt.Println("Server Nodes:", serverNodeNames)

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 		It("Starts up with no issues", func() {
 			var err error
 			etcdNodeNames, cpNodeNames, agentNodeNames, err = createSplitCluster(*nodeOS, *etcdCount, *controlPlaneCount, *agentCount)
-			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Etcd Server Nodes:", etcdNodeNames)

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 		It("Starts up with no issues", func() {
 			var err error
 			serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
-			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Server Nodes:", serverNodeNames)

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			} else {
 				serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 			}
-			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Server Nodes:", serverNodeNames)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- E2E tests, starting with `validatecluster` will now run on every PR. These tests will be deploy on a private runner with enough resources to deploy the 5 VMs used in this and other E2E tests. Github action runners are not powerful enough to run these tests natively. 
- Improved E2E failure logging. Now when a VM fails to start the K3s service, the tests will attempt to record the journalctl logs from that failure before cleanup.
- Added a reusable workflow for building K3s in GH actions, DRY!
- Reduce triggering of Integration tests, only run when K3s code is changed and integration tests are changed, ignore when other test types change. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Testing and CI improvements
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
A new E2E workflow should pass.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
This is all testing changes
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
TBD
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
