### PR TITLE
Fix `error dialing backend` errors in apiserver network proxy

### DIFF
--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -32,15 +32,7 @@ const (
 	EgressSelectorModePod         = "pod"
 	CertificateRenewDays          = 90
 	StreamServerPort              = "10010"
-	KubeletPort                   = "10250"
 )
-
-// These ports can always be accessed via the tunnel server, at the loopback address.
-// Other addresses and ports are only accessible via the tunnel on newer agents, when used by a pod.
-var KubeletReservedPorts = map[string]bool{
-	StreamServerPort: true,
-	KubeletPort:      true,
-}
 
 type Node struct {
 	Docker                   bool

--- a/pkg/daemons/control/proxy/proxy.go
+++ b/pkg/daemons/control/proxy/proxy.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"io"
-	"net"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -14,7 +13,7 @@ type proxy struct {
 	errc         chan error
 }
 
-func Proxy(lconn, rconn net.Conn) error {
+func Proxy(lconn, rconn io.ReadWriteCloser) error {
 	p := &proxy{
 		lconn: lconn,
 		rconn: rconn,


### PR DESCRIPTION
#### Proposed Changes ####

* Fix occasional "TLS handshake error" in apiserver network proxy.
  We should be reading from the hijacked bufio.ReaderWriter instead of
  directly from the net.Conn. There is a race condition where the
  underlying http handler may consume bytes from the hijacked request
  stream, if it comes in the same packet as the CONNECT header. These
  bytes are left in the buffered reader, which we were not using. This was
  causing us to occasionally drop a few bytes from the start of the
  tunneled connection's client data stream.

* Handle custom kubelet port in agent tunnel
  The kubelet port can be overridden by users; we shouldn't assume its always 10250

#### Types of Changes ####

bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

* Install k3s single-node cluster on a host with many cores (seemed to take 32 to reproduce reliably for me). 
  Run the following command: 
  ```bash
  POD=$(kubectl get pod -n kube-system -l app=local-path-provisioner -o jsonpath='{.items[].metadata.name}'); while true; do kubectl exec -n kube-system $POD -- ls -la > /dev/null || break; done
  ``` 
  The command should run essentially forever until stopped with no errors.
* Run k3s 1-server/1-agent with `--kubelet-arg=port=20250` and port 20250 not open on firewall or security group between nodes; note that `kubectl logs` and `kubectl exec` for pod on agent node work properly.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/5835

#### User-Facing Change ####

```release-note
Fixed an issue with the apiserver network proxy that caused `kubectl exec` to occasionally fail with `error dialing backend: EOF`
Fixed an issue with the apiserver network proxy that caused `kubectl exec` and `kubectl logs` to fail when a custom kubelet port was used, and the custom port was blocked by firewall or security group rules.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
