### PR TITLE
Use setup-go action to cache dependencies

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -44,14 +44,19 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2 
-      with: 
-        go-version: '1.19.1'
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with: 
+        go-version: '1.19.1'
+        check-latest: true
+        cache: true
+        cache-dependency-path: |
+          **/go.sum
+          **/go.mod
     - name: "Download k3s binary"
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/unitcoverage.yaml
+++ b/.github/workflows/unitcoverage.yaml
@@ -30,14 +30,19 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04]
     timeout-minutes: 20
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2 
-      with: 
-        go-version: '1.19.1'
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with: 
+        go-version: '1.19.1'
+        check-latest: true
+        cache: true
+        cache-dependency-path: |
+          **/go.sum
+          **/go.mod
     - name: Run Unit Tests
       run: | 
         go test -coverpkg=./... -coverprofile=coverage.out ./pkg/... -run Unit


### PR DESCRIPTION
Signed-off-by: jongwooo <han980817@gmail.com>

## Description

I changed the workflow to cache dependencies using [actions/setup-go](https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs). `actions/setup-go@v3` or newer has caching **built-in**.

### AS-IS

```yml
- name: Install Go
  uses: actions/setup-go@v2
  with:
    go-version: '1.19.1'
- name: Checkout
  uses: actions/checkout@v2
  with:
    fetch-depth: 1
```

### TO-BE

```yml
- name: Checkout
  uses: actions/checkout@v3
  with:
    fetch-depth: 1
- name: Install Go
  uses: actions/setup-go@v3
  with:
    go-version: '1.19.1'
    check-latest: true
    cache: true
    cache-dependency-path: |
          **/go.sum
          **/go.mod
```

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)