### PR TITLE
Add journalctl logs to E2E tests

### DIFF
--- a/.github/workflows/build-k3s.yaml
+++ b/.github/workflows/build-k3s.yaml
@@ -1,0 +1,39 @@
+name: Build K3s
+
+on: 
+  workflow_call:
+   inputs:
+    upload-repo:
+      type: boolean
+      required: false
+      default: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    steps:
+    - name: Checkout K3s
+      uses: actions/checkout@v3
+    - name: Build K3s binary
+      run: |
+        DOCKER_BUILDKIT=1 SKIP_AIRGAP=1 SKIP_VALIDATE=1 make
+      
+    - name: bundle repo
+      if: inputs.upload-repo == true
+      run: |
+        tar -czvf ../k3s-repo.tar.gz .
+        mv ../k3s-repo.tar.gz .
+    - name: "Upload K3s directory"
+      if: inputs.upload-repo == true
+      uses: actions/upload-artifact@v3
+      with:
+        name: k3s-repo.tar.gz
+        path: k3s-repo.tar.gz
+    - name: "Upload K3s binary"
+      if: inputs.upload-repo == false
+      uses: actions/upload-artifact@v3
+      with:
+        name: k3s
+        path: dist/artifacts/k3s

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -5,9 +5,8 @@ on:
       - "**.md"
       - "channel.yaml"
       - "install.sh"
-      - "tests/snapshotter/**"
-      - "tests/install/**"
-      - "tests/cgroup/**"
+      - "tests/**"
+      - "!tests/integration**"
       - ".github/**"
       - "!.github/workflows/integration.yaml"
   pull_request:
@@ -15,29 +14,14 @@ on:
       - "**.md"
       - "channel.yaml"
       - "install.sh"
-      - "tests/snapshotter/**"
-      - "tests/install/**"
-      - "tests/cgroup/**"
+      - "tests/**"
+      - "!tests/integration**"
       - ".github/**"
       - "!.github/workflows/integration.yaml"
   workflow_dispatch: {}
 jobs:
   build:
-    name: Build
-    runs-on: ubuntu-20.04
-    timeout-minutes: 20
-    steps:
-    - name: "Checkout"
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    - name: "Make"
-      run: DOCKER_BUILDKIT=1 SKIP_VALIDATE=1 make
-    - name: "Upload k3s binary"
-      uses: actions/upload-artifact@v2
-      with:
-        name: k3s
-        path: dist/artifacts/k3s
+    uses: ./.github/workflows/build-k3s.yaml
   test:
     needs: build
     name: Integration Tests

--- a/tests/e2e/clusterreset/clusterreset_test.go
+++ b/tests/e2e/clusterreset/clusterreset_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			} else {
 				serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 			}
-			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Server Nodes:", serverNodeNames)

--- a/tests/e2e/docker/docker_test.go
+++ b/tests/e2e/docker/docker_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Verify CRI-Dockerd", Ordered, func() {
 		It("Starts up with no issues", func() {
 			var err error
 			serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
-			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Server Nodes:", serverNodeNames)

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 	It("Starts up with no issues", func() {
 		var err error
 		serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
-		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 		fmt.Println("CLUSTER CONFIG")
 		fmt.Println("OS:", *nodeOS)
 		fmt.Println("Server Nodes:", serverNodeNames)

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 		It("Starts up with no issues", func() {
 			var err error
 			etcdNodeNames, cpNodeNames, agentNodeNames, err = createSplitCluster(*nodeOS, *etcdCount, *controlPlaneCount, *agentCount)
-			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Etcd Server Nodes:", etcdNodeNames)

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 		It("Starts up with no issues", func() {
 			var err error
 			serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
-			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Server Nodes:", serverNodeNames)

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			} else {
 				serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 			}
-			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog())
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
 			fmt.Println("Server Nodes:", serverNodeNames)


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

This PR is taking good parts from https://github.com/k3s-io/k3s/pull/6214.
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Improved E2E failure logging. Now when a VM fails to start the K3s service, the tests will attempt to record the journalctl logs from that failure before cleanup.
- Added a reusable workflow for building K3s in GH actions, DRY!
- Reduce triggering of Integration tests, only run when K3s code is changed and integration tests are changed, ignore when other test types change.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Test improvements
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI Passes
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
N/A internal CI changes only
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
