### PR TITLE
Fix flakey etcd test

### DIFF
--- a/scripts/test-run-etcd
+++ b/scripts/test-run-etcd
@@ -10,7 +10,7 @@ all_services=(
 export NUM_SERVERS=2
 export NUM_AGENTS=0
 export WAIT_SERVICES="${all_services[@]}"
-export SERVER_1_ARGS="--cluster-init"
+export SERVER_1_ARGS="--cluster-init --node-taint=node-role.kubernetes.io/control-plane=effect:NoSchedule"
 
 REPO=${REPO:-rancher}
 IMAGE_NAME=${IMAGE_NAME:-k3s}


### PR DESCRIPTION
#### Proposed Changes ####

Fix flakey etcd test

Taint the first node so that the helm job doesn't run on it. In a real cluster the helm job would eventually succeed once all the servers were upgraded and had the new chart tarball.

#### Types of Changes ####

Test

#### Verification ####

Note that CI no longer flakes on this test

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6222

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
