### PR TITLE
Fix dualStack test

### DIFF
--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -16,6 +16,7 @@ def provision(vm, roles, role_num, node_num)
   vm.hostname = "#{roles[0]}-#{role_num}"
   node_ip4 = "#{NETWORK4_PREFIX}.#{100+node_num}"
   node_ip6 = "#{NETWORK6_PREFIX}::#{10+node_num}"
+  node_ip6_gw = "#{NETWORK6_PREFIX}::1"
   # Only works with libvirt, which allows IPv4 + IPv6 on a single network/interface
   vm.network "private_network", 
     :ip => node_ip4,
@@ -32,7 +33,7 @@ def provision(vm, roles, role_num, node_num)
   
   defaultOSConfigure(vm)
 
-  vm.provision "IPv6 Setup", type: "shell", path: scripts_location +"/ipv6.sh", args: [node_ip4, node_ip6, vm.box.to_s]
+  vm.provision "IPv6 Setup", type: "shell", path: scripts_location +"/ipv6.sh", args: [node_ip4, node_ip6, node_ip6_gw, vm.box.to_s]
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
 
   vm.provision "Ping Check", type: "shell", inline: "ping -c 2 k3s.io"

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		for _, node := range nodeIPs {
 			Expect(node.ipv4).Should(ContainSubstring("10.10.10"))
-			Expect(node.ipv6).Should(ContainSubstring("a11:decf:c0ff"))
+			Expect(node.ipv6).Should(ContainSubstring("fd11:decf:c0ff"))
 		}
 	})
 	It("Verifies that each pod has IPv4 and IPv6", func() {
@@ -125,7 +125,7 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		for _, pod := range podIPs {
 			Expect(pod.ipv4).Should(Or(ContainSubstring("10.10.10"), ContainSubstring("10.42.")), pod.name)
-			Expect(pod.ipv6).Should(Or(ContainSubstring("a11:decf:c0ff"), ContainSubstring("2001:cafe:42")), pod.name)
+			Expect(pod.ipv6).Should(Or(ContainSubstring("fd11:decf:c0ff"), ContainSubstring("2001:cafe:42")), pod.name)
 		}
 	})
 

--- a/tests/e2e/scripts/ipv6.sh
+++ b/tests/e2e/scripts/ipv6.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 ip4_addr=$1
 ip6_addr=$2
-os=$3
+ip6_addr_gw=$3
+os=$4
 
 sysctl -w net.ipv6.conf.all.disable_ipv6=0
 sysctl -w net.ipv6.conf.eth1.accept_dad=0
@@ -20,3 +21,4 @@ else
   ip -6 addr add "$ip6_addr"/64 dev eth1
 fi
 ip addr show dev eth1
+ip -6 r add default via "$ip6_addr_gw"


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
1 - Updates the node IP check which was wrong
2 - Adds an ipv6 gateway to the nodes. Without it, the curl to an ipv6 service is never done as the kernel can't forward packets and thus we get:
```
curl: (7) Couldn't connect to server
```
```
Summarizing 1 Failure:
  [FAIL] Verify DualStack Configuration [It] Verifies ClusterIP Service
  /home/manuel/go/src/github.com/rancher/k3s/tests/e2e/dualstack/dualstack_test.go:156
```


#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bug fix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
go test -v -timeout=10m tests/e2e/dualstack/dualstack_test.go

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/6244

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
