### PR TITLE
[release-1.24] Return ProviderID in URI format

### DIFF
--- a/pkg/cloudprovider/instances.go
+++ b/pkg/cloudprovider/instances.go
@@ -2,6 +2,7 @@ package cloudprovider
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/k3s-io/k3s/pkg/version"
@@ -70,7 +71,7 @@ func (k *k3s) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovid
 	}
 
 	return &cloudprovider.InstanceMetadata{
-		ProviderID:    version.Program,
+		ProviderID:    fmt.Sprintf("%s://%s", version.Program, node.Name),
 		InstanceType:  version.Program,
 		NodeAddresses: addresses,
 		Zone:          "",


### PR DESCRIPTION
#### Proposed Changes ####

Return ProviderID in URI format

The InstancesV1 interface handled this for us by combining the ProviderName and InstanceID values; the new interface requires us to do it manually

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6285

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
