### PR TITLE
Add the gateway parameter in netplan

### DIFF
--- a/tests/e2e/scripts/ipv6.sh
+++ b/tests/e2e/scripts/ipv6.sh
@@ -12,13 +12,16 @@ sysctl -w net.ipv6.conf.eth1.forwarding=0
 if [ -z "${os##*ubuntu*}" ]; then
   netplan set ethernets.eth1.accept-ra=false
   netplan set ethernets.eth1.addresses=["$ip4_addr"/24,"$ip6_addr"/64]
+  netplan set ethernets.eth1.gateway6="$ip6_addr_gw"
   netplan apply
 elif [ -z "${os##*alpine*}" ]; then
   iplink set eth1 down
   iplink set eth1 up
   ip -6 addr add "$ip6_addr"/64 dev eth1
+  ip -6 r add default via "$ip6_addr_gw"
 else
   ip -6 addr add "$ip6_addr"/64 dev eth1
+  ip -6 r add default via "$ip6_addr_gw"
 fi
 ip addr show dev eth1
-ip -6 r add default via "$ip6_addr_gw"
+ip -6 r


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Incorporate the ipv6 gateway to the netplan config, otherwise it gets removed when rebooting

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
go test -v -timeout=25m ./tests/e2e/dualstack/dualstack_test.go

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/6291

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
