### PR TITLE
Bump testing to opensuse Leap 15.4

### DIFF
--- a/contrib/util/check-config.sh
+++ b/contrib/util/check-config.sh
@@ -364,6 +364,8 @@ if [ "$(cat /sys/module/apparmor/parameters/enabled 2>/dev/null)" = 'Y' ]; then
       wrap_color '(use "apt-get install apparmor" to fix this)'
     elif command -v yum &> /dev/null; then
       wrap_color '(your best bet is "yum install apparmor-parser")'
+    elif command -v zypper &> /dev/null; then
+      wrap_color '(your best bet is "zypper install apparmor-parser")'
     else
       wrap_color '(look for an "apparmor" package for your distribution)'
     fi

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -74,7 +74,7 @@ The sub-directories therein contain fixtures for running simple clusters to asse
     - [Fedora 35](../tests/cgroup/unified/fedora-35) (rootfull + rootless)
 - [Snapshotter](../tests/snapshotter/btrfs/opensuse-leap) :arrow_right: on any code change
   - [BTRFS](../tests/snapshotter/btrfs) ([containerd built-in](https://github.com/containerd/containerd/tree/main/snapshots/btrfs))
-    - [Leap 15.3](../tests/snapshotter/btrfs/opensuse-leap)
+    - [Leap 15.4](../tests/snapshotter/btrfs/opensuse-leap)
 
 When adding new installer test(s) please copy the prevalent style for the `Vagrantfile`.
 Ideally, the boxes used for additional assertions will support the default `virtualbox` provider which

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -66,7 +66,7 @@ The sub-directories therein contain fixtures for running simple clusters to asse
 - [Install Script](../tests/install) :arrow_right: on proposed changes to [install.sh](../install.sh) 
   - [CentOS 7](../tests/install/centos-7) (stand-in for RHEL 7)
   - [Rocky Linux 8](../tests/install/rocky-8) (stand-in for RHEL 8)
-  - [Leap 15.3](../tests/install/opensuse-microos) (stand-in for SLES)
+  - [Leap 15.4](../tests/install/opensuse-leap) (stand-in for SLES)
   - [MicroOS](../tests/install/opensuse-microos) (stand-in for SLE-Micro)
   - [Ubuntu 20.04](../tests/install/ubuntu-focal) (Focal Fossa)
 - [Control Groups](../tests/cgroup) :arrow_right: on any code change

--- a/tests/install/opensuse-leap/Vagrantfile
+++ b/tests/install/opensuse-leap/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
   config.vagrant.plugins = {
     'vagrant-k3s' => {:version => '~> 0.1.3'},
   }
-  config.vm.box = 'opensuse/Leap-15.3.x86_64'
+  config.vm.box = 'opensuse/Leap-15.4.x86_64'
   config.vm.boot_timeout = ENV['TEST_VM_BOOT_TIMEOUT'] || 600 # seconds
   config.vm.synced_folder '.', '/vagrant', disabled: true
 

--- a/tests/snapshotter/btrfs/opensuse-leap/Vagrantfile
+++ b/tests/snapshotter/btrfs/opensuse-leap/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
   config.vagrant.plugins = {
     'vagrant-k3s' => {:version => '~> 0.1.3'},
   }
-  config.vm.box = "opensuse/Leap-15.3.x86_64"
+  config.vm.box = "opensuse/Leap-15.4.x86_64"
   config.vm.boot_timeout = ENV['TEST_VM_BOOT_TIMEOUT'] || 600 # seconds
   config.vm.synced_folder '../../../../dist/artifacts', '/vagrant', type: 'rsync', disabled: false,
     rsync__exclude: ENV['RSYNC_EXCLUDE'] || '*.tar.*'


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Move from 15.3 to 15.4 builds of Leap. This should help resolve issues of CI failure on snapshotter tests. 15.4 boxes are actively being published by opensuse, while 15.3 have gotten stale. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Test Improvements
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI passes
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
