### PR TITLE
Update kube-router and add extra logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.22
 	github.com/Mirantis/cri-dockerd => github.com/k3s-io/cri-dockerd v0.2.4-0.20220826195316-d6cb76f15a6a
-	github.com/cloudnativelabs/kube-router => github.com/k3s-io/kube-router v1.5.1-0.20220630214451-a43bcd8511d2
+	github.com/cloudnativelabs/kube-router => github.com/k3s-io/kube-router v1.5.2-0.20221026101626-e01045262706
 	github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
 	github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.13-k3s2
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e

--- a/go.sum
+++ b/go.sum
@@ -673,8 +673,8 @@ github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGB
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 github.com/k3s-io/klog/v2 v2.60.1-k3s1 h1:C1hsMF1Eo6heGVQzts6cZ+rDZAReSiOBUxsYMuUkkZI=
 github.com/k3s-io/klog/v2 v2.60.1-k3s1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
-github.com/k3s-io/kube-router v1.5.1-0.20220630214451-a43bcd8511d2 h1:AMTXNbNnFDCO6OeLUbG9OONyBLHMYUcolU5T66xHkbk=
-github.com/k3s-io/kube-router v1.5.1-0.20220630214451-a43bcd8511d2/go.mod h1:qwtM4SC13qwpq56JjKZ/Hm6m7MCu3OiU/9sVYvmrycg=
+github.com/k3s-io/kube-router v1.5.2-0.20221026101626-e01045262706 h1:69mODM8rQwFqKxw7nNUCq62MVBpoCOgMZ6tFThnZvgc=
+github.com/k3s-io/kube-router v1.5.2-0.20221026101626-e01045262706/go.mod h1:qwtM4SC13qwpq56JjKZ/Hm6m7MCu3OiU/9sVYvmrycg=
 github.com/k3s-io/kubernetes v1.25.3-k3s1 h1:8f7YI1oy1SfUgLChqLrdzg1SrqS8Oh9K3Bm9JgOpB9A=
 github.com/k3s-io/kubernetes v1.25.3-k3s1/go.mod h1:lvEY+3iJhh+sGIK1LorGkI56rW0eLGsfalnp68wQwYU=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/api v1.25.3-k3s1 h1:UQi6J9KXQgx0c3WqvJ3wqU8XIgpORzaK269oWbV782g=


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- Move kube-router to the next release. Among others, this release adds extra logs. These logs will allow us to know what network policy dropped the packets and what packets were dropped

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Feature & version bump

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

1 - Install ulogd2 (e.g. sudo apt install ulogd2)
2 - Edit `/etc/ulogd.conf` and under `[ulog1]` set `nlgroup=100`
3 - Deploy k3s on that node
4 - Deploy some pods and a network policy that would block traffic
5 - Send traffic and verify that it gets blocked
6 - Check that inside the file `/var/log/ulog/syslogemu.log` packets get logged, showing the policy that blocked them

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/6344

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update kube-router to v1.5.1 with extra logging
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

* I must document how to check the extra logs
* I dedicate this PR to @rancher-max :partying_face: 
