### PR TITLE
[Release 1.23] Add a netpol test for podSelector & ingress type

### DIFF
--- a/tests/e2e/amd64_resource_files/netpol-fail.yaml
+++ b/tests/e2e/amd64_resource_files/netpol-fail.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-network-policy
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: nginx-app-clusterip
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: whatever
+    ports:
+    - protocol: TCP
+      port: 80

--- a/tests/e2e/amd64_resource_files/netpol-work.yaml
+++ b/tests/e2e/amd64_resource_files/netpol-work.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-network-policy
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: nginx-app-clusterip
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: client
+    ports:
+    - protocol: TCP
+      port: 80

--- a/tests/e2e/amd64_resource_files/pod_client.yaml
+++ b/tests/e2e/amd64_resource_files/pod_client.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: client
+  name: client-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: client
+  template:
+    metadata:
+      labels:
+        app: client
+    spec:
+      containers:
+      - image: ranchertest/mytestcontainer
+        imagePullPolicy: Always
+        name: client-curl
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - client
+            topologyKey: kubernetes.io/hostname
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: client-curl
+  labels:
+    app: client
+    service: client-curl
+spec:
+  type: ClusterIP
+  selector:
+    app: client
+  ports:
+  - port: 8080

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -1,4 +1,4 @@
-package validatecluster
+package validatedualstack
 
 import (
 	"flag"
@@ -14,8 +14,8 @@ import (
 
 // Valid nodeOS: generic/ubuntu2004, opensuse/Leap-15.3.x86_64
 var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
-var serverCount = flag.Int("serverCount", 3, "number of server nodes")
-var agentCount = flag.Int("agentCount", 0, "number of agent nodes")
+var serverCount = flag.Int("serverCount", 1, "number of server nodes")
+var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
 var hardened = flag.Bool("hardened", false, "true or false")
 
 // Environment Variables Info:
@@ -196,7 +196,28 @@ var _ = Describe("Verify DualStack Configuration", func() {
 			}, "10s", "1s").Should(ContainSubstring("ds-nodeport-pod"), "failed cmd: "+cmd)
 		}
 	})
-
+	It("Verifies podSelector Network Policy", func() {
+		_, err := e2e.DeployWorkload("pod_client.yaml", kubeConfigFile, *hardened)
+		Expect(err).NotTo(HaveOccurred())
+		cmd := "kubectl exec svc/client-curl --kubeconfig=" + kubeConfigFile + " -- curl -m7 ds-clusterip-svc/name.html"
+		Eventually(func() (string, error) {
+			return e2e.RunCommand(cmd)
+		}, "20s", "3s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
+		_, err = e2e.DeployWorkload("netpol-fail.yaml", kubeConfigFile, *hardened)
+		Expect(err).NotTo(HaveOccurred())
+		cmd = "kubectl exec svc/client-curl --kubeconfig=" + kubeConfigFile + " -- curl -m7 ds-clusterip-svc/name.html"
+		Eventually(func() error {
+			_, err = e2e.RunCommand(cmd)
+			Expect(err).To(HaveOccurred())
+			return err
+		}, "20s", "3s")
+		_, err = e2e.DeployWorkload("netpol-work.yaml", kubeConfigFile, *hardened)
+		Expect(err).NotTo(HaveOccurred())
+		cmd = "kubectl exec svc/client-curl --kubeconfig=" + kubeConfigFile + " -- curl -m7 ds-clusterip-svc/name.html"
+		Eventually(func() (string, error) {
+			return e2e.RunCommand(cmd)
+		}, "20s", "3s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
+	})
 })
 
 var failed bool


### PR DESCRIPTION
Backport: https://github.com/k3s-io/k3s/pull/6247
Issue: https://github.com/k3s-io/k3s/issues/6347

Signed-off-by: Manuel Buil <mbuil@suse.com>