### PR TITLE
[Release 1.24] Upgrade kube-router to v1.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.22
 	github.com/Mirantis/cri-dockerd => github.com/k3s-io/cri-dockerd v0.2.4-0.20220729204449-bcbb75d5abff // k3s-master
-	github.com/cloudnativelabs/kube-router => github.com/k3s-io/kube-router v1.5.1-0.20220630214451-a43bcd8511d2
+	github.com/cloudnativelabs/kube-router => github.com/k3s-io/kube-router v1.5.2-0.20221026101626-e01045262706
 	github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
 	github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.13-k3s1 // k3s-release/1.5
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e

--- a/go.sum
+++ b/go.sum
@@ -730,8 +730,8 @@ github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGB
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 github.com/k3s-io/klog/v2 v2.60.1-k3s1 h1:C1hsMF1Eo6heGVQzts6cZ+rDZAReSiOBUxsYMuUkkZI=
 github.com/k3s-io/klog/v2 v2.60.1-k3s1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
-github.com/k3s-io/kube-router v1.5.1-0.20220630214451-a43bcd8511d2 h1:AMTXNbNnFDCO6OeLUbG9OONyBLHMYUcolU5T66xHkbk=
-github.com/k3s-io/kube-router v1.5.1-0.20220630214451-a43bcd8511d2/go.mod h1:qwtM4SC13qwpq56JjKZ/Hm6m7MCu3OiU/9sVYvmrycg=
+github.com/k3s-io/kube-router v1.5.2-0.20221026101626-e01045262706 h1:69mODM8rQwFqKxw7nNUCq62MVBpoCOgMZ6tFThnZvgc=
+github.com/k3s-io/kube-router v1.5.2-0.20221026101626-e01045262706/go.mod h1:qwtM4SC13qwpq56JjKZ/Hm6m7MCu3OiU/9sVYvmrycg=
 github.com/k3s-io/kubernetes v1.24.7-k3s1 h1:KhALmmHxGtw2PbgiElVowUvNEVwnOaSdNkeEhXpR8MM=
 github.com/k3s-io/kubernetes v1.24.7-k3s1/go.mod h1:FVc+LqOr+8hV8DcUacqcjFXCjHzxwFXHO95W4eLwAkI=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/api v1.24.7-k3s1 h1:W8ITcsrhaKCqK/CZhx2a5TNUSpHqG8p9bZfVG/CruzI=


### PR DESCRIPTION
Backport: https://github.com/k3s-io/k3s/pull/6345
Issue: https://github.com/k3s-io/k3s/issues/6350

Signed-off-by: Manuel Buil <mbuil@suse.com>
