### PR TITLE
Replace deprecated k8s registry references.

### DIFF
--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -456,7 +456,7 @@ provision-registry-proxy() {
     set -e -o pipefail
     local image="docker.io/library/registry:2.8.1"
     local prefix="docker-registry-"
-    local registries="docker.io:registry-1.docker.io k8s.gcr.io gcr.io quay.io ghcr.io"
+    local registries="docker.io:registry-1.docker.io registry.k8s.io gcr.io quay.io ghcr.io"
     local registries_yaml="$TEST_DIR/registries.yaml"
 
     echo "mirrors:" > $registries_yaml

--- a/tests/perf/tests/density/deployment.yaml
+++ b/tests/perf/tests/density/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         group: {{.Group}}
     spec:
       containers:
-      - image: k8s.gcr.io/pause:3.1
+      - image: registry.k8s.io/pause:3.1
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/tests/perf/tests/load/config.yaml
+++ b/tests/perf/tests/load/config.yaml
@@ -199,7 +199,7 @@ steps:
     - basename: daemonset
       objectTemplatePath: daemonset.yaml
       templateFillMap:
-        Image: k8s.gcr.io/pause:3.0
+        Image: registry.k8s.io/pause:3.0
   {{end}}
   - namespaceRange:
       min: 1
@@ -434,7 +434,7 @@ steps:
       - basename: daemonset
         objectTemplatePath: daemonset.yaml
         templateFillMap:
-          Image: k8s.gcr.io/pause:3.1
+          Image: registry.k8s.io/pause:3.1
   {{end}}
   {{if $ENABLE_JOBS}}
   - namespaceRange:

--- a/tests/perf/tests/load/daemonset.yaml
+++ b/tests/perf/tests/load/daemonset.yaml
@@ -1,4 +1,4 @@
-{{$Image := DefaultParam .Image "k8s.gcr.io/pause:3.1"}}
+{{$Image := DefaultParam .Image "registry.k8s.io/pause:3.1"}}
 
 apiVersion: apps/v1
 kind: DaemonSet

--- a/tests/perf/tests/load/deployment.yaml
+++ b/tests/perf/tests/load/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         svc: {{.SvcName}}-{{.Index}}
     spec:
       containers:
-      - image: k8s.gcr.io/pause:3.1
+      - image: registry.k8s.io/pause:3.1
         name: {{.Name}}
         resources:
           requests:

--- a/tests/perf/tests/load/job.yaml
+++ b/tests/perf/tests/load/job.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: {{.Name}}
         # TODO(#799): We should test the "run-to-completion" workflow and hence don't use pause pods.
-        image: k8s.gcr.io/pause:3.1
+        image: registry.k8s.io/pause:3.1
         resources:
           requests:
             cpu: 10m

--- a/tests/perf/tests/load/statefulset.yaml
+++ b/tests/perf/tests/load/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: k8s.gcr.io/pause:3.1
+        image: registry.k8s.io/pause:3.1
         ports:
           - containerPort: 80
             name: web


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Problem:
Previously all of Kubernetes' image hosting has been out of gcr.io. There were significant egress costs associated with this when images were pulled from entities outside gcp.  Refer to https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Solution:
As highlighted at KubeCon NA 2022 k8s infra SIG update, the replacement for k8s.gcr.io which is registry.k8s.io is now ready for mainstream use and the old k8s.gcr.io has been formally deprecated. This commit migrates all references for k3s to registry.k8s.io.

#### Types of Changes ####

Bugfix for deprecated container registry.

#### Verification ####

The only image references still in this codebase appear to be `registry.k8s.io/pause:3.1` and `registry.k8s.io/pause:3.0`.  I've verified that both of those images are pulling successfully from the new `registry.k8s.io`.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
