### PR TITLE
Fix sonobouy tests on v1.25

### DIFF
--- a/scripts/test-setup-sonobuoy
+++ b/scripts/test-setup-sonobuoy
@@ -2,7 +2,7 @@
 
 export NUM_SERVERS=1
 export NUM_AGENTS=1
-export SERVER_ARGS='--no-deploy=traefik'
+export SERVER_ARGS='--disable=traefik'
 export WAIT_SERVICES='coredns local-path-provisioner metrics-server'
 
 export sonobuoyParallelArgs=(--e2e-focus='\[Conformance\]' --e2e-skip='\[Serial\]' --e2e-parallel=y)
@@ -14,10 +14,10 @@ start-test() {
 export -f start-test
 
 test-post-hook() {
-  if [[ $1 -eq 0 ]]; then
-    return
+  if [[ $1 -eq 0 ]] || [[ ! -f "$TEST_DIR/sonobuoy/plugins/e2e/results/global/e2e.log" ]]; then
+    return $1
   fi
-  local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
+  local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR/sonobuoy/plugins/e2e/results/global/e2e.log")
   # Ignore sonobuoy failures if only these flaky tests have failed
   flakyFails=$( grep -scF -f ./scripts/flaky-tests <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )

--- a/scripts/test-setup-sonobuoy-etcd
+++ b/scripts/test-setup-sonobuoy-etcd
@@ -15,10 +15,10 @@ server-post-hook() {
 export -f server-post-hook
 
 test-post-hook() {
-  if [[ $1 -eq 0 ]]; then
-    return
+  if [[ $1 -eq 0 ]] || [[ ! -f "$TEST_DIR/sonobuoy/plugins/e2e/results/global/e2e.log" ]]; then
+    return $1
   fi
-  local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
+  local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR/sonobuoy/plugins/e2e/results/global/e2e.log")
   # Ignore sonobuoy failures if only these flaky tests have failed
   flakyFails=$( grep -scF -f ./scripts/flaky-tests <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )

--- a/scripts/test-setup-sonobuoy-mysql
+++ b/scripts/test-setup-sonobuoy-mysql
@@ -42,10 +42,10 @@ cluster-pre-hook() {
 export -f cluster-pre-hook
 
 test-post-hook() {
-  if [[ $1 -eq 0 ]]; then
-    return
+  if [[ $1 -eq 0 ]] || [[ ! -f "$TEST_DIR/sonobuoy/plugins/e2e/results/global/e2e.log" ]]; then
+    return $1
   fi
-  local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
+  local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR/sonobuoy/plugins/e2e/results/global/e2e.log")
   # Ignore sonobuoy failures if only these flaky tests have failed
   flakyFails=$( grep -scF -f ./scripts/flaky-tests <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )

--- a/scripts/test-setup-sonobuoy-postgres
+++ b/scripts/test-setup-sonobuoy-postgres
@@ -42,10 +42,10 @@ cluster-pre-hook() {
 export -f cluster-pre-hook
 
 test-post-hook() {
-  if [[ $1 -eq 0 ]]; then
-    return
+  if [[ $1 -eq 0 ]] || [[ ! -f "$TEST_DIR/sonobuoy/plugins/e2e/results/global/e2e.log" ]]; then
+    return $1
   fi
-  local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR"/sonobuoy/plugins/e2e/results/global/e2e.log)
+  local failures=$(awk '/^Summarizing .* Failures?:$/,0' "$TEST_DIR/sonobuoy/plugins/e2e/results/global/e2e.log")
   # Ignore sonobuoy failures if only these flaky tests have failed
   flakyFails=$( grep -scF -f ./scripts/flaky-tests <<< "$failures" )
   totalFails=$( grep -scF -e "[Fail]" <<< "$failures" )


### PR DESCRIPTION
#### Proposed Changes ####

Looks like the sonobuoy tests have been failing since we made use of `--no-deploy` an error. Compounding this was another issue in the test scripts that caused the error to be swallowed if sonobuoy never ran at all.

* Use --disable instead of --no-deploy
* Don't silently succeed if sonobuoy never runs

#### Types of Changes ####

CI bugfix

#### Verification ####

Check CI logs

#### Testing ####

yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6110

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
