### PR TITLE
Bump k3s root to v0.12.0 and remove strongswan binaries

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -461,7 +461,6 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	}
 	nodeConfig.AgentConfig.Snapshotter = envInfo.Snapshotter
 	nodeConfig.AgentConfig.IPSECPSK = controlConfig.IPSECPSK
-	nodeConfig.AgentConfig.StrongSwanDir = filepath.Join(envInfo.DataDir, "agent", "strongswan")
 	nodeConfig.Containerd.Config = filepath.Join(envInfo.DataDir, "agent", "etc", "containerd", "config.toml")
 	nodeConfig.Containerd.Root = filepath.Join(envInfo.DataDir, "agent", "containerd")
 	nodeConfig.CRIDockerd.Root = filepath.Join(envInfo.DataDir, "agent", "cri-dockerd")

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -208,7 +208,7 @@ var ServerFlags = []cli.Flag{
 	ClusterDomain,
 	cli.StringFlag{
 		Name:        "flannel-backend",
-		Usage:       "(networking) backend<=option1=val1,option2=val2> where backend is one of 'none', 'vxlan', 'ipsec', 'host-gw', 'wireguard-native', or 'wireguard' (deprecated)",
+		Usage:       "(networking) backend<=option1=val1,option2=val2> where backend is one of 'none', 'vxlan', 'ipsec' (deprecated), 'host-gw', 'wireguard-native', 'wireguard' (deprecated)",
 		Destination: &ServerConfig.FlannelBackend,
 		Value:       "vxlan",
 	},

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -112,7 +112,6 @@ type Agent struct {
 	ImageCredProvConfig     string
 	IPSECPSK                string
 	FlannelCniConfFile      string
-	StrongSwanDir           string
 	PrivateRegistry         string
 	SystemDefaultRegistry   string
 	AirgapExtraRegistry     []string

--- a/scripts/download
+++ b/scripts/download
@@ -20,7 +20,7 @@ rm -rf ${CONTAINERD_DIR}
 mkdir -p ${CHARTS_DIR}
 mkdir -p ${DATA_DIR}
 
-curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${VERSION_ROOT}/k3s-root-${ARCH}.tar | tar xf - --exclude=bin/socat
+curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${VERSION_ROOT}/k3s-root-${ARCH}.tar | tar xf -
 
 git clone --single-branch --branch=${VERSION_RUNC} --depth=1 https://github.com/opencontainers/runc ${RUNC_DIR}
 
@@ -31,4 +31,4 @@ for CHART_FILE in $(grep -rlF HelmChart manifests/ | xargs yq eval --no-doc .spe
   curl -sfL ${CHARTS_URL}/${CHART_NAME}/${CHART_FILE} -o ${CHARTS_DIR}/${CHART_FILE}
 done
 
-cp scripts/wg-add.sh bin/aux/
+cp scripts/wg-add.sh bin/aux

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -53,7 +53,7 @@ if [ -z "$VERSION_KUBE_ROUTER" ]; then
     VERSION_KUBE_ROUTER="v0.0.0"
 fi
 
-VERSION_ROOT="v0.11.0"
+VERSION_ROOT="v0.12.0"
 
 if [[ -n "$GIT_TAG" ]]; then
     if [[ ! "$GIT_TAG" =~ ^"$VERSION_K8S"[+-] ]]; then


### PR DESCRIPTION
#### Proposed Changes ####

Bump k3s-root and remove embedded strongswan support. This saves 2124 kB of space from the K3s binary.

before/after K3s binary size comparison:
```
k3s binary dist/artifacts/k3s size 67129344 is less than max acceptable size of 73400320 bytes (70 MiB)
k3s binary dist/artifacts/k3s size 64954368 is less than max acceptable size of 73400320 bytes (70 MiB)
```

#### Types of Changes ####

version bump

#### Verification ####

* Configure a cluster (1 or more nodes) using --flannel-backend=ipsec
* Upgrade the cluster without installing strongswan on the host: note that k3s fails to start
* Upgrade the cluster after installing strongwan packages on the host: note that k3s continues to work as usual

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6027

#### User-Facing Change ####

```release-note
The embedded k3s-root version has been bumped to v0.12.0, based on buildroot 2022.08.1.
The embedded swanctl and charon binaries have been removed. If you are using the ipsec flannel backend, please ensure that the strongswan `swanctl` and `charon` packages are installed on your node before upgrading k3s.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
