### PR TITLE
log kube-router version when starting netpol controller

### DIFF
--- a/pkg/agent/netpol/netpol.go
+++ b/pkg/agent/netpol/netpol.go
@@ -8,8 +8,11 @@ package netpol
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"sync"
+
+	"github.com/cloudnativelabs/kube-router/pkg/version"
 
 	"github.com/cloudnativelabs/kube-router/pkg/controllers/netpol"
 	"github.com/cloudnativelabs/kube-router/pkg/healthcheck"
@@ -131,7 +134,7 @@ func Run(ctx context.Context, nodeConfig *config.Node) error {
 	npInformer.AddEventHandler(npc.NetworkPolicyEventHandler)
 
 	wg.Add(1)
-	logrus.Info("Starting the netpol controller")
+	logrus.Infof("Starting the netpol controller version %s, built on %s, %s", version.Version, version.BuildDate, runtime.Version())
 	go npc.Run(healthCh, stopCh, &wg)
 
 	return nil

--- a/scripts/build
+++ b/scripts/build
@@ -14,6 +14,7 @@ PKG_CRICTL="github.com/kubernetes-sigs/cri-tools/pkg"
 PKG_K8S_BASE="k8s.io/component-base"
 PKG_K8S_CLIENT="k8s.io/client-go/pkg"
 PKG_CNI_PLUGINS="github.com/containernetworking/plugins"
+PKG_KUBE_ROUTER="github.com/cloudnativelabs/kube-router"
 
 buildDate=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
@@ -41,6 +42,9 @@ VERSIONFLAGS="
     -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Version=${VERSION_FLANNEL}
     -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Commit=${COMMIT}
     -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.buildDate=${buildDate}
+
+    -X ${PKG_KUBE_ROUTER}/pkg/version.Version=${VERSION_KUBE_ROUTER}
+    -X ${PKG_KUBE_ROUTER}/pkg/version.BuildDate=${buildDate}
 "
 
 if [ -n "${DEBUG}" ]; then

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -48,6 +48,11 @@ fi
 
 VERSION_CNIPLUGINS="v1.1.1-k3s1"
 
+VERSION_KUBE_ROUTER=$(grep github.com/k3s-io/kube-router go.mod | head -n1 | awk '{print $4}')
+if [ -z "$VERSION_KUBE_ROUTER" ]; then
+    VERSION_KUBE_ROUTER="v0.0.0"
+fi
+
 VERSION_ROOT="v0.11.0"
 
 if [[ -n "$GIT_TAG" ]]; then


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

log the kube-router version at start-up to help debugging

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

The k3s should display a line similar to:
```
INFO[0002] Starting the netpol controller version v1.5.2-0.20221026101626-e01045262706
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/6372

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
