### PR TITLE
Fix test-mods to allow for pinning version from k8s.io

### DIFF
--- a/scripts/test-mods
+++ b/scripts/test-mods
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -x
 
-res=$(go mod edit --json | jq '.Replace[] | select(.Old.Path | contains("k8s.io/")) | .New.Path' | grep -v k3s-io | wc -l)
+res=$(go mod edit --json | jq -r '.Replace[] | select(.Old.Path | contains("k8s.io/")) | .New.Path' | grep -vE '^(k8s.io/|github.com/k3s-io/)' | wc -l)
 if [ $res -gt 0 ];then
   echo "Incorrect kubernetes replacement fork in go.mod"
   exit 1


### PR DESCRIPTION
#### Proposed Changes ####

While backporting changes to older branches, it has been necessary to pin the `k8s-io/kube-openapi` module to a specific commit, as upstream does:

https://github.com/kubernetes/kubernetes/blob/release-1.24/go.mod#L465

This module isn't staged through the main kubernetes/kubernetes repo so we don't have it in our fork, and the current module replacement checks don't allow pinning versions from upstream and will fail if the replacement isn't in the k3s-io org.

#### Types of Changes ####

CI fix

#### Verification ####

note that CI doesn't fail

#### Testing ####

yes

#### Linked Issues ####

n/a

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
