### PR TITLE
Add Kairos to ADOPTERS

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -9,3 +9,4 @@ A non-exhaustive list of k3s adopters is provided below.  To add your company to
  - SUSE's RKE2 (or RKE Government) [RKE2](github.com/rancher/rke2/)
  - [k3ai](https://k3ai.github.io/)
  - SUSE's [Rancher Desktop](https://rancherdesktop.io/)
+ - [Kairos](https://kairos.io)


### PR DESCRIPTION
#### Proposed Changes ####

Adds Kairos to ADOPTERS.

Kairos uses k3s to provision Kubernetes clusters on baremetal, see github.com/kairos-io/kairos

#### Types of Changes ####

Documentation

#### Further Comments ####

Noticed with https://twitter.com/Rancher_Labs/status/1588133536531419136 :)
