### PR TITLE
[Release 1.24] log kube-router version when starting netpol controller

### DIFF
--- a/pkg/agent/netpol/netpol.go
+++ b/pkg/agent/netpol/netpol.go
@@ -8,8 +8,11 @@ package netpol
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"sync"
+
+	"github.com/cloudnativelabs/kube-router/pkg/version"
 
 	"github.com/cloudnativelabs/kube-router/pkg/controllers/netpol"
 	"github.com/cloudnativelabs/kube-router/pkg/healthcheck"
@@ -131,7 +134,7 @@ func Run(ctx context.Context, nodeConfig *config.Node) error {
 	npInformer.AddEventHandler(npc.NetworkPolicyEventHandler)
 
 	wg.Add(1)
-	logrus.Info("Starting the netpol controller")
+	logrus.Infof("Starting the netpol controller version %s, built on %s, %s", version.Version, version.BuildDate, runtime.Version())
 	go npc.Run(healthCh, stopCh, &wg)
 
 	return nil

--- a/scripts/build
+++ b/scripts/build
@@ -14,6 +14,7 @@ PKG_CRICTL="github.com/kubernetes-sigs/cri-tools/pkg"
 PKG_K8S_BASE="k8s.io/component-base"
 PKG_K8S_CLIENT="k8s.io/client-go/pkg"
 PKG_CNI_PLUGINS="github.com/containernetworking/plugins"
+PKG_KUBE_ROUTER="github.com/cloudnativelabs/kube-router"
 
 buildDate=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
@@ -41,6 +42,9 @@ VERSIONFLAGS="
     -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Version=${VERSION_FLANNEL}
     -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Commit=${COMMIT}
     -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.buildDate=${buildDate}
+
+    -X ${PKG_KUBE_ROUTER}/pkg/version.Version=${VERSION_KUBE_ROUTER}
+    -X ${PKG_KUBE_ROUTER}/pkg/version.BuildDate=${buildDate}
 "
 
 if [ -n "${DEBUG}" ]; then

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -48,6 +48,11 @@ fi
 
 VERSION_CNIPLUGINS="v1.1.1-k3s1"
 
+VERSION_KUBE_ROUTER=$(grep github.com/k3s-io/kube-router go.mod | head -n1 | awk '{print $4}')
+if [ -z "$VERSION_KUBE_ROUTER" ]; then
+    VERSION_KUBE_ROUTER="v0.0.0"
+fi
+
 VERSION_ROOT="v0.11.0"
 
 if [[ -n "$GIT_TAG" ]]; then


### PR DESCRIPTION
Backport of: https://github.com/k3s-io/k3s/pull/6405
Issue: https://github.com/k3s-io/k3s/issues/6436
