### PR TITLE
Make rootless settings configurable

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -258,7 +258,11 @@ func Run(ctx context.Context, cfg cmds.Agent) error {
 	}
 
 	if cfg.Rootless && !cfg.RootlessAlreadyUnshared {
-		if err := rootless.Rootless(cfg.DataDir); err != nil {
+		dualNode, err := utilsnet.IsDualStackIPStrings(cfg.NodeIP)
+		if err != nil {
+			return err
+		}
+		if err := rootless.Rootless(cfg.DataDir, dualNode); err != nil {
 			return err
 		}
 	}

--- a/pkg/cli/agent/agent.go
+++ b/pkg/cli/agent/agent.go
@@ -33,8 +33,8 @@ func Run(ctx *cli.Context) error {
 		return err
 	}
 
-	if os.Getuid() != 0 && runtime.GOOS != "windows" {
-		return fmt.Errorf("agent must be ran as root")
+	if runtime.GOOS != "windows" && os.Getuid() != 0 && !cmds.AgentConfig.Rootless {
+		return fmt.Errorf("agent must be run as root, or with --rootless")
 	}
 
 	if cmds.AgentConfig.TokenFile != "" {

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -81,7 +81,11 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		}
 		cfg.DataDir = dataDir
 		if !cfg.DisableAgent {
-			if err := rootless.Rootless(dataDir); err != nil {
+			dualNode, err := utilsnet.IsDualStackIPStrings(cmds.AgentConfig.NodeIP)
+			if err != nil {
+				return err
+			}
+			if err := rootless.Rootless(dataDir, dualNode); err != nil {
 				return err
 			}
 		}

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -71,7 +71,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	}
 
 	if !cfg.DisableAgent && os.Getuid() != 0 && !cfg.Rootless {
-		return fmt.Errorf("must run as root unless --disable-agent is specified")
+		return fmt.Errorf("server must run as root, or with --rootless and/or --disable-agent")
 	}
 
 	if cfg.Rootless {

--- a/pkg/rootless/mounts.go
+++ b/pkg/rootless/mounts.go
@@ -1,4 +1,5 @@
 //go:build !windows
+// +build !windows
 
 package rootless
 

--- a/pkg/rootless/portdriver.go
+++ b/pkg/rootless/portdriver.go
@@ -6,12 +6,22 @@ package rootless
 import (
 	"io"
 	"path"
+	"strings"
 
 	"github.com/rootless-containers/rootlesskit/pkg/port"
 	portbuiltin "github.com/rootless-containers/rootlesskit/pkg/port/builtin"
 	portslirp4netns "github.com/rootless-containers/rootlesskit/pkg/port/slirp4netns"
 	"github.com/sirupsen/logrus"
 )
+
+type logrusDebugWriter struct {
+}
+
+func (w *logrusDebugWriter) Write(p []byte) (int, error) {
+	s := strings.TrimSuffix(string(p), "\n")
+	logrus.Debug(s)
+	return len(p), nil
+}
 
 type portDriver interface {
 	NewParentDriver() (port.ParentDriver, error)
@@ -74,7 +84,9 @@ func (s *slirp4netnsDriver) APISocketPath() string {
 	return ""
 }
 
-func getDriver(driverName string, logWriter io.Writer) portDriver {
+func getDriver(driverName string) portDriver {
+	logWriter := &logrusDebugWriter{}
+
 	if driverName == "slirp4netns" {
 		return &slirp4netnsDriver{logWriter: logWriter}
 	}

--- a/pkg/rootless/portdriver.go
+++ b/pkg/rootless/portdriver.go
@@ -1,0 +1,87 @@
+//go:build !windows
+// +build !windows
+
+package rootless
+
+import (
+	"io"
+	"path"
+
+	"github.com/rootless-containers/rootlesskit/pkg/port"
+	portbuiltin "github.com/rootless-containers/rootlesskit/pkg/port/builtin"
+	portslirp4netns "github.com/rootless-containers/rootlesskit/pkg/port/slirp4netns"
+	"github.com/sirupsen/logrus"
+)
+
+type portDriver interface {
+	NewParentDriver() (port.ParentDriver, error)
+	NewChildDriver() port.ChildDriver
+	LogWriter() io.Writer
+	SetStateDir(string)
+	APISocketPath() string
+}
+
+type builtinDriver struct {
+	logWriter io.Writer
+	stateDir  string
+}
+
+func (b *builtinDriver) NewParentDriver() (port.ParentDriver, error) {
+	return portbuiltin.NewParentDriver(b.logWriter, b.stateDir)
+}
+
+func (b *builtinDriver) NewChildDriver() port.ChildDriver {
+	return portbuiltin.NewChildDriver(b.logWriter)
+}
+
+func (b *builtinDriver) LogWriter() io.Writer {
+	return b.logWriter
+}
+
+func (b *builtinDriver) SetStateDir(stateDir string) {
+	b.stateDir = stateDir
+}
+
+func (b *builtinDriver) APISocketPath() string {
+	return ""
+}
+
+type slirp4netnsDriver struct {
+	logWriter io.Writer
+	stateDir  string
+}
+
+func (s *slirp4netnsDriver) NewParentDriver() (port.ParentDriver, error) {
+	return portslirp4netns.NewParentDriver(s.logWriter, s.APISocketPath())
+}
+
+func (s *slirp4netnsDriver) NewChildDriver() port.ChildDriver {
+	return portslirp4netns.NewChildDriver()
+}
+
+func (s *slirp4netnsDriver) LogWriter() io.Writer {
+	return s.logWriter
+}
+
+func (s *slirp4netnsDriver) SetStateDir(stateDir string) {
+	s.stateDir = stateDir
+}
+
+func (s *slirp4netnsDriver) APISocketPath() string {
+	if s.stateDir != "" {
+		return path.Join(s.stateDir, ".s4nn.sock")
+	}
+	return ""
+}
+
+func getDriver(driverName string, logWriter io.Writer) portDriver {
+	if driverName == "slirp4netns" {
+		return &slirp4netnsDriver{logWriter: logWriter}
+	}
+
+	if driverName != "" && driverName != "builtin" {
+		logrus.Warnf("Unsupported port driver %s, using default builtin", driverName)
+	}
+
+	return &builtinDriver{logWriter: logWriter}
+}

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -42,9 +42,8 @@ func Rootless(stateDir string, enableIPv6 bool) error {
 
 	hasFD := os.Getenv(pipeFD) != ""
 	hasChildEnv := os.Getenv(childEnv) != ""
-	driverName := strings.ToLower(os.Getenv(portDriverEnv))
 	rootlessDir := filepath.Join(stateDir, "rootless")
-	driver := getDriver(driverName, &logrusDebugWriter{})
+	driver := getDriver(strings.ToLower(os.Getenv(portDriverEnv)))
 
 	if hasFD {
 		logrus.Debug("Running rootless child")
@@ -166,7 +165,7 @@ func createParentOpt(driver portDriver, stateDir string, enableIPv6 bool) (*pare
 	mtu := 0
 	if val := os.Getenv(mtuEnv); val != "" {
 		if v, err := strconv.ParseInt(val, 10, 0); err != nil {
-			logrus.Warn("Failed to parse rootless mtu; using default")
+			logrus.Warn("Failed to parse rootless mtu value; using default")
 		} else {
 			mtu = int(v)
 		}
@@ -215,15 +214,6 @@ func createParentOpt(driver portDriver, stateDir string, enableIPv6 bool) (*pare
 	opt.PipeFDEnvKey = pipeFD
 
 	return opt, nil
-}
-
-type logrusDebugWriter struct {
-}
-
-func (w *logrusDebugWriter) Write(p []byte) (int, error) {
-	s := strings.TrimSuffix(string(p), "\n")
-	logrus.Debug(s)
-	return len(p), nil
 }
 
 func createChildOpt(driver portDriver) (*child.Opt, error) {

--- a/pkg/rootless/rootless_windows.go
+++ b/pkg/rootless/rootless_windows.go
@@ -1,5 +1,5 @@
 package rootless
 
-func Rootless(stateDir string) error {
-	panic("Rootless not supported on windows")
+func Rootless(stateDir string, enableIPv6 bool) error {
+	panic("Rootless is not supported on windows")
 }


### PR DESCRIPTION
#### Proposed Changes ####

Add environment variables for port-driver, cidr, mtu, enable-ipv6, and disable-host-loopback settings. Since rootless is still experimental, I don't think they deserve full CLI flag status.

#### Types of Changes ####

new feature

#### Verification ####

Follow the rootless K3s setup instructions (delegating cgroup controllers), then create a k3s-rootless.service as follows:

```systemd
[Unit]
Description=k3s (Rootless)

[Service]
Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin K3S_ROOTLESS_MTU=1500 K3S_ROOTLESS_PORT_DRIVER=slirp4netns
ExecStart=k3s server --rootless --snapshotter=fuse-overlayfs
ExecReload=/bin/kill -s HUP $MAINPID
TimeoutSec=0
RestartSec=2
Restart=always
StartLimitBurst=3
StartLimitInterval=60s
LimitNOFILE=infinity
LimitNPROC=infinity
LimitCORE=infinity
TasksMax=infinity
Delegate=yes
Type=simple
KillMode=mixed
```

#### Testing ####

tbd

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6487
* https://github.com/k3s-io/k3s/issues/6488


#### User-Facing Change ####
```release-note
The rootless `port-driver`, `cidr`, `mtu`, `enable-ipv6`, and `disable-host-loopback` settings can now be configured via environment variables.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
