### PR TITLE
Bump klipper-helm and klipper-lb versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/gruntwork-io/terratest v0.40.6
 	github.com/json-iterator/go v1.1.12
-	github.com/k3s-io/helm-controller v0.13.0
+	github.com/k3s-io/helm-controller v0.13.1
 	github.com/k3s-io/kine v0.9.6
 	github.com/klauspost/compress v1.15.12
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -610,8 +610,8 @@ github.com/k3s-io/etcd/etcdutl/v3 v3.5.3-k3s1 h1:uPCEhACmVoFJnI9Izb2Y+UKRS5JM/F/
 github.com/k3s-io/etcd/etcdutl/v3 v3.5.3-k3s1/go.mod h1:F9bW3+f+cKZIcjWHkdfJ3lnCajF4FnPh7DjcgiBRb7g=
 github.com/k3s-io/etcd/server/v3 v3.5.3-k3s1 h1:MVTrb5cp75kSMA9K240VMa5I+GKuYYP9xN/Nj+US27w=
 github.com/k3s-io/etcd/server/v3 v3.5.3-k3s1/go.mod h1:xwZlQLuAWsWw5rpb/Gwzi3nFie9STKcrKQbM6evLi5g=
-github.com/k3s-io/helm-controller v0.13.0 h1:JfGEU6zrA6wBuVIBt73TbQYC3H+WDJaAc6Q5NbbaDwk=
-github.com/k3s-io/helm-controller v0.13.0/go.mod h1:f8aOuHQDpkshmUK/GiE+jJCJkUL8vp+EzCjV0uCFcsY=
+github.com/k3s-io/helm-controller v0.13.1 h1:eG2yZ0QzbtcfMe8GpTVtRtP6HgMDO/Pr9Q1EGbMKKCA=
+github.com/k3s-io/helm-controller v0.13.1/go.mod h1:f8aOuHQDpkshmUK/GiE+jJCJkUL8vp+EzCjV0uCFcsY=
 github.com/k3s-io/kine v0.9.6 h1:qomCtPrxIpFi09Q6JUDEbjWPjCliDgJ1Ns2N7l7aWxI=
 github.com/k3s-io/kine v0.9.6/go.mod h1:3N3AE7WgqbX4wYKJ9NdUItJ0i8koC+qaKbYc2sEaVns=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=

--- a/pkg/cloudprovider/servicelb.go
+++ b/pkg/cloudprovider/servicelb.go
@@ -42,7 +42,7 @@ var (
 const (
 	Ready          = condition.Cond("Ready")
 	DefaultLBNS    = meta.NamespaceSystem
-	DefaultLBImage = "rancher/klipper-lb:v0.3.5"
+	DefaultLBImage = "rancher/klipper-lb:v0.4.0"
 )
 
 func (k *k3s) Register(ctx context.Context,

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,5 +1,5 @@
-docker.io/rancher/klipper-helm:v0.7.3-build20220613
-docker.io/rancher/klipper-lb:v0.3.5
+docker.io/rancher/klipper-helm:v0.7.4-build20221121
+docker.io/rancher/klipper-lb:v0.4.0
 docker.io/rancher/local-path-provisioner:v0.0.23
 docker.io/rancher/mirrored-coredns-coredns:1.9.4
 docker.io/rancher/mirrored-library-busybox:1.34.1


### PR DESCRIPTION
#### Proposed Changes ####

Bump klipper-helm and klipper-lb versions

* waiting on https://github.com/k3s-io/helm-controller/pull/164

#### Types of Changes ####

version bump

#### Verification ####

Check image tags

#### Testing ####


#### Linked Issues ####

* tbd

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The embedded Load-Balancer controller image has been bumped to klipper-lb:v0.4.0, which includes support for the [LoadBalancerSourceRanges](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#:~:text=loadBalancerSourceRanges) field.
The embedded Helm controller image has been bumped to klipper-helm:v0.7.4-build20221121
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
