### PR TITLE
Disable CCM metrics port when legacy CCM functionality is disabled

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -319,6 +319,7 @@ func cloudControllerManager(ctx context.Context, cfg *config.Control) error {
 	}
 	if cfg.DisableCCM {
 		argsMap["controllers"] = argsMap["controllers"] + ",-cloud-node,-cloud-node-lifecycle"
+		argsMap["secure-port"] = "0"
 	}
 	if cfg.DisableServiceLB {
 		argsMap["controllers"] = argsMap["controllers"] + ",-service"


### PR DESCRIPTION
#### Proposed Changes ####

Disable CCM metrics port when traditional CCM functionality is disabled

Prevents port conflicts on upgrade for users that have deployed other cloud controllers.

#### Types of Changes ####

bugfix

#### Verification ####

Start k3s with --disable-cloud-controller; note that port 10258 is not in use.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6554

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The embedded cloud-controller-manager's metrics listener on port 10258 is now disabled when the `--disable-cloud-controller` flag is set.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
