### PR TITLE
Update node12->node16 based GH actions

### DIFF
--- a/.github/workflows/cgroup.yaml
+++ b/.github/workflows/cgroup.yaml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: { fetch-depth: 1 }
       - name: "Build"
         run: DOCKER_BUILDKIT=1 SKIP_VALIDATE=1 make
       - name: "Upload"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with: { name: k3s, path: dist/artifacts/k3s }
   test:
     name: "Conformance Test"
@@ -50,7 +50,7 @@ jobs:
         working-directory: tests/cgroup/${{ matrix.mode }}/${{ matrix.vm }}
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: { fetch-depth: 1 }
       - name: "Download Binary"
         uses: actions/download-artifact@v2

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -19,13 +19,13 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
     - name: "Make"
       run: DOCKER_BUILDKIT=1 SKIP_VALIDATE=1 make
     - name: "Upload k3s binary"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: k3s
         path: ./dist/artifacts/k3s
@@ -46,7 +46,7 @@ jobs:
       INSTALL_K3S_SKIP_DOWNLOAD: binary
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: {fetch-depth: 1}
       - name: "Vagrant Cache"
         uses: actions/cache@v3

--- a/.github/workflows/nightly-install.yaml
+++ b/.github/workflows/nightly-install.yaml
@@ -25,7 +25,7 @@ jobs:
       INSTALL_K3S_CHANNEL: ${{ matrix.channel }}
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: {fetch-depth: 1}
       - name: "Vagrant Cache"
         uses: actions/cache@v3

--- a/.github/workflows/snapshotter.yaml
+++ b/.github/workflows/snapshotter.yaml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: { fetch-depth: 1 }
       - name: "Build"
         run: DOCKER_BUILDKIT=1 SKIP_VALIDATE=1 make
       - name: "Upload Binary"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with: { name: k3s, path: dist/artifacts/k3s }
   test:
     name: "Smoke Test"
@@ -52,7 +52,7 @@ jobs:
       VAGRANT_EXPERIMENTAL: disks
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: { fetch-depth: 1 }
       - name: "Download Binary"
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Remove the last of the nodejs 12 based GH actions
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
GH CI 
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
GH actions all green
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
