### PR TITLE
[release-1.25] Bump containerd to v1.6.12-k3s1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/Mirantis/cri-dockerd => github.com/k3s-io/cri-dockerd v0.2.4-0.20220826195316-d6cb76f15a6a
 	github.com/cloudnativelabs/kube-router => github.com/k3s-io/kube-router v1.5.2-0.20221026101626-e01045262706
 	github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
-	github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.14-k3s1
+	github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.16-k3s1
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/docker/distribution => github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker => github.com/docker/docker v20.10.12+incompatible

--- a/go.sum
+++ b/go.sum
@@ -594,8 +594,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k3s-io/containerd v1.5.14-k3s1 h1:j4Z2GXNdOaLySmV5gaoLjvSTiFG52ajcq5wK7dWzzCE=
-github.com/k3s-io/containerd v1.5.14-k3s1/go.mod h1:z80+PXdmZrqwd/D3kpoEpjOU42soeJ/9J1qDPufB3T0=
+github.com/k3s-io/containerd v1.5.16-k3s1 h1:r8WBp1DJS5OfGWV4XMohQ3SkQnreZRK1E4lT02xUXiA=
+github.com/k3s-io/containerd v1.5.16-k3s1/go.mod h1:vCILl/gWFsZXZVuIrDefia9pbKe7cpWbpavHNET9axM=
 github.com/k3s-io/cri-dockerd v0.2.4-0.20220826195316-d6cb76f15a6a h1:hpjpKn8LqUm9vFcuV7YLh+5Ml/6sTuRRjZYsEkHlw98=
 github.com/k3s-io/cri-dockerd v0.2.4-0.20220826195316-d6cb76f15a6a/go.mod h1:EIOBOIv+NC6cVRQsgLZN97UIDu24/jFWGP9l1qNn1kM=
 github.com/k3s-io/cri-tools v1.25.0-k3s1 h1:LbNyVzjDyXqLfpGd+vVJ76kWYMx7u0eVyHLLsuUpitA=

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -24,7 +24,7 @@ fi
 
 # We're building k3s against containerd 1.5 in go.mod because 1.6 has dependency
 # conflicts with Kubernetes, but we still need to bundle containerd 1.6.
-VERSION_CONTAINERD="v1.6.10-k3s1"
+VERSION_CONTAINERD="v1.6.12-k3s1"
 
 VERSION_CRICTL=$(grep github.com/kubernetes-sigs/cri-tools go.mod | head -n1 | awk '{print $4}')
 if [ -z "$VERSION_CRICTL" ]; then


### PR DESCRIPTION

#### Proposed Changes ####

Bump containerd to v1.6.12-k3s1
Also bump containerd client module to v1.5.16-k3s1

#### Types of Changes ####

version bump

#### Verification ####

Check containerd version

#### Testing ####

#### Linked Issues ####

* 
#### User-Facing Change ####
```release-note
The embedded containerd version has been bumped to v1.6.12
```

#### Further Comments ####