### PR TITLE
[release-1.23] Preload iptable_filter/ip6table_filter

### DIFF
--- a/pkg/agent/syssetup/setup.go
+++ b/pkg/agent/syssetup/setup.go
@@ -33,8 +33,10 @@ func Configure(enableIPv6 bool, config *kubeproxyconfig.KubeProxyConntrackConfig
 	loadKernelModule("nf_conntrack")
 	loadKernelModule("br_netfilter")
 	loadKernelModule("iptable_nat")
+	loadKernelModule("iptable_filter")
 	if enableIPv6 {
 		loadKernelModule("ip6table_nat")
+		loadKernelModule("ip6table_filter")
 	}
 
 	// Kernel is inconsistent about how devconf is configured for

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -51,7 +51,7 @@ if [ -z "$VERSION_KUBE_ROUTER" ]; then
     VERSION_KUBE_ROUTER="v0.0.0"
 fi
 
-VERSION_ROOT="v0.12.0"
+VERSION_ROOT="v0.12.1"
 
 if [[ -n "$GIT_TAG" ]]; then
     if [[ ! "$GIT_TAG" =~ ^"$VERSION_K8S"[+-] ]]; then


### PR DESCRIPTION

#### Proposed Changes ####

Preload iptable_filter/ip6table_filter
ServiceLB now requires this module, but it will not get autoloaded by the kubelet if the host is using nftables.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6644

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
