### PR TITLE
Bugfix: honor the -v commandline flag

### DIFF
--- a/pkg/cli/cmds/log.go
+++ b/pkg/cli/cmds/log.go
@@ -80,4 +80,5 @@ func setupLogging() {
 	if Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
+	logrus.SetLevel(logrus.Level(LogConfig.VLevel))
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Set log level in logrus according to the commandline parameter.

#### Types of Changes ####

Bugfix.

#### Verification ####

 - Install k3s (tested with v1.24.6+k3s1)
 - Run k3s with  the `-v=6` option

#### Testing ####

Only tested manually, only really relevant for developers. Please advise if any kind of automated test is required to get the PR merged.

#### Linked Issues ####

Fixes https://github.com/k3s-io/k3s/issues/6656

#### User-Facing Change ####

```release-note
NONE
```
