### PR TITLE
Add `kubeadm` style bootstrap token secret support 

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -37,6 +37,7 @@ func main() {
 		return
 	}
 
+	tokenCommand := internalCLIAction(version.Program+"-"+cmds.TokenCommand, dataDir, os.Args)
 	etcdsnapshotCommand := internalCLIAction(version.Program+"-"+cmds.EtcdSnapshotCommand, dataDir, os.Args)
 	secretsencryptCommand := internalCLIAction(version.Program+"-"+cmds.SecretsEncryptCommand, dataDir, os.Args)
 	certCommand := internalCLIAction(version.Program+"-"+cmds.CertCommand, dataDir, os.Args)
@@ -51,6 +52,12 @@ func main() {
 		cmds.NewCRICTL(externalCLIAction("crictl", dataDir)),
 		cmds.NewCtrCommand(externalCLIAction("ctr", dataDir)),
 		cmds.NewCheckConfigCommand(externalCLIAction("check-config", dataDir)),
+		cmds.NewTokenCommands(
+			tokenCommand,
+			tokenCommand,
+			tokenCommand,
+			tokenCommand,
+		),
 		cmds.NewEtcdSnapshotCommands(
 			etcdsnapshotCommand,
 			etcdsnapshotCommand,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/cli/kubectl"
 	"github.com/k3s-io/k3s/pkg/cli/secretsencrypt"
 	"github.com/k3s-io/k3s/pkg/cli/server"
+	"github.com/k3s-io/k3s/pkg/cli/token"
 	"github.com/k3s-io/k3s/pkg/configfilearg"
 	"github.com/k3s-io/k3s/pkg/containerd"
 	ctr2 "github.com/k3s-io/k3s/pkg/ctr"
@@ -48,6 +49,12 @@ func main() {
 		cmds.NewKubectlCommand(kubectl.Run),
 		cmds.NewCRICTL(crictl.Run),
 		cmds.NewCtrCommand(ctr.Run),
+		cmds.NewTokenCommands(
+			token.Create,
+			token.Delete,
+			token.Generate,
+			token.List,
+		),
 		cmds.NewEtcdSnapshotCommands(
 			etcdsnapshot.Run,
 			etcdsnapshot.Delete,

--- a/cmd/token/main.go
+++ b/cmd/token/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/cli/token"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+func main() {
+	app := cmds.NewApp()
+	app.Commands = []cli.Command{
+		cmds.NewTokenCommands(
+			token.Create,
+			token.Delete,
+			token.Generate,
+			token.List,
+		),
+	}
+
+	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil && !errors.Is(err, context.Canceled) {
+		logrus.Fatal(err)
+	}
+}

--- a/docs/adrs/agent-join-token.md
+++ b/docs/adrs/agent-join-token.md
@@ -1,0 +1,64 @@
+# Support `kubeadm`-style Bootstrap Token Secrets
+
+Date: 2022-12-20
+
+## Status
+
+Accepted
+
+## Context
+
+### K3s Token Types and Use
+
+K3s currently supports two tokens that can be used to join nodes to the cluster:
+* `--token`: This is the default token, and a random value is generated during initial cluster startup if not
+  specified by the user. This token is also used as the passphrase input to the PBKDF2 function used to generate
+  the encryption key for cluster bootstrap data. For this reason, all server nodes must use the same token value
+  once the cluster has been started, and the token value cannot be changed.
+* `--agent-token`: By default, this is set to the same as the `--token` value. If set, this token can be used
+  to join new agents to the cluster, but not servers. This token value can be changed after the cluster has
+  beens started, but doing so requires coordinatating reconfiguration and restart of all of the servers in the
+  cluster.
+
+Internally, these tokens are used as the password for HTTP Basic authentication to the K3s supervisor when the
+agent bootstraps its configuration and certificates. Servers use a username of `server`, while agents
+(including servers local agents) use `node`. Once nodes join the cluster they also populate a node password
+secret that prevents other nodes from using the same node name, but this is unrelated to the token.
+
+### Security Considerations
+
+Users have requested the ability to generate single-use or limited-duration tokens that can be used to join
+nodes to the cluster, but can be deleted or automatically expire in order to reduce the impact should the
+token be compromised. Currently, compromise of the server token would require a complete rebuild of the
+cluster in order to use a new token. Compromise of the agent token would require a coordinated restart of all
+nodes in the cluster.
+
+### Existing Work
+
+`kubeadm` includes a `kubeadm token create` command that creates secrets of type
+`bootstrap.kubernetes.io/token`, which is a core upstream type that is not restricted for use by kubeadm.
+
+There are helpers for interacting with bootstrap token secrets in the `k8s.io/cluster-bootstrap` package, and
+upstream Kubernetes includes two controllers (`tokencleaner` and `bootstrapsigner`) to support use of cluster
+bootstrap secrets. The latter controller is not relevant for our use case, as it serves the same function as
+existing K3s supervisor routes - making initial cluster CA certificates and a client kubeconfig available for
+bootstrapping nodes. The [boostrap-tokens](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/)
+documentation can be referenced for more information.
+
+## Decision
+
+* K3s will allow joining agents to the cluster using bootstrap token secrets.
+* K3s will NOT allow joining servers to the cluster using bootstrap token secrets.
+* K3s will include a `k3s token` subcommand that allows for token create/list/delete operations, similar to
+  the the functionality offered by `kubeadm`.
+* K3s will enable the `tokencleaner` controller, in order to ensure that bootstrap token secrets are cleaned
+  up when their TTL expires.
+* K3s agent bootstrap functionality will allow a agent to connect the cluster using existing [Node
+  Authorization](https://kubernetes.io/docs/reference/access-authn-authz/node/) to authenticate to the
+  cluster during startup, even after its join token has been invalidated.
+* K3s agent bootstrap functionality will NOT allow an agent to connect to the cluster if it does not have a valid
+  token, and its Node object has been deleted from the cluster.
+
+## Consequences
+
+This will require additional documentation, CLI subcommands, and QA work to validate use of bootstrap token secret auth.

--- a/go.mod
+++ b/go.mod
@@ -152,6 +152,7 @@ require (
 	k8s.io/apiserver v0.26.1
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/cloud-provider v0.26.1
+	k8s.io/cluster-bootstrap v0.0.0
 	k8s.io/component-base v0.26.1
 	k8s.io/component-helpers v0.26.1
 	k8s.io/cri-api v0.26.1
@@ -396,7 +397,6 @@ require (
 	honnef.co/go/tools v0.2.2 // indirect
 	k8s.io/apiextensions-apiserver v0.25.4 // indirect
 	k8s.io/cli-runtime v0.22.2 // indirect
-	k8s.io/cluster-bootstrap v0.0.0 // indirect
 	k8s.io/code-generator v0.25.4 // indirect
 	k8s.io/controller-manager v0.25.4 // indirect
 	k8s.io/csi-translation-lib v0.0.0 // indirect

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -101,7 +101,7 @@ RETRY:
 	}
 }
 
-type HTTPRequester func(u string, client *http.Client, username, password string) ([]byte, error)
+type HTTPRequester func(u string, client *http.Client, username, password, token string) ([]byte, error)
 
 func Request(path string, info *clientaccess.Info, requester HTTPRequester) ([]byte, error) {
 	u, err := url.Parse(info.BaseURL)
@@ -109,17 +109,19 @@ func Request(path string, info *clientaccess.Info, requester HTTPRequester) ([]b
 		return nil, err
 	}
 	u.Path = path
-	return requester(u.String(), clientaccess.GetHTTPClient(info.CACerts), info.Username, info.Password)
+	return requester(u.String(), clientaccess.GetHTTPClient(info.CACerts, info.CertFile, info.KeyFile), info.Username, info.Password, info.Token())
 }
 
 func getNodeNamedCrt(nodeName string, nodeIPs []net.IP, nodePasswordFile string) HTTPRequester {
-	return func(u string, client *http.Client, username, password string) ([]byte, error) {
+	return func(u string, client *http.Client, username, password, token string) ([]byte, error) {
 		req, err := http.NewRequest(http.MethodGet, u, nil)
 		if err != nil {
 			return nil, err
 		}
 
-		if username != "" {
+		if token != "" {
+			req.Header.Add("Authorization", "Bearer "+token)
+		} else if username != "" {
 			req.SetBasicAuth(username, password)
 		}
 
@@ -320,8 +322,10 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	if envInfo.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-
-	info, err := clientaccess.ParseAndValidateToken(proxy.SupervisorURL(), envInfo.Token)
+	clientKubeletCert := filepath.Join(envInfo.DataDir, "agent", "client-kubelet.crt")
+	clientKubeletKey := filepath.Join(envInfo.DataDir, "agent", "client-kubelet.key")
+	withCert := clientaccess.WithClientCertificate(clientKubeletCert, clientKubeletKey)
+	info, err := clientaccess.ParseAndValidateToken(proxy.SupervisorURL(), envInfo.Token, withCert)
 	if err != nil {
 		return nil, err
 	}
@@ -399,8 +403,6 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		return nil, err
 	}
 
-	clientKubeletCert := filepath.Join(envInfo.DataDir, "agent", "client-kubelet.crt")
-	clientKubeletKey := filepath.Join(envInfo.DataDir, "agent", "client-kubelet.key")
 	if err := getNodeNamedHostFile(clientKubeletCert, clientKubeletKey, nodeName, nodeIPs, newNodePasswordFile, info); err != nil {
 		return nil, err
 	}
@@ -447,6 +449,8 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	nodeConfig.Images = filepath.Join(envInfo.DataDir, "agent", "images")
 	nodeConfig.AgentConfig.NodeName = nodeName
 	nodeConfig.AgentConfig.NodeConfigPath = nodeConfigPath
+	nodeConfig.AgentConfig.ClientKubeletCert = clientKubeletCert
+	nodeConfig.AgentConfig.ClientKubeletKey = clientKubeletKey
 	nodeConfig.AgentConfig.ServingKubeletCert = servingKubeletCert
 	nodeConfig.AgentConfig.ServingKubeletKey = servingKubeletKey
 	nodeConfig.AgentConfig.ClusterDNS = controlConfig.ClusterDNS
@@ -603,7 +607,8 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 
 // getAPIServers attempts to return a list of apiservers from the server.
 func getAPIServers(ctx context.Context, node *config.Node, proxy proxy.Proxy) ([]string, error) {
-	info, err := clientaccess.ParseAndValidateToken(proxy.SupervisorURL(), node.Token)
+	withCert := clientaccess.WithClientCertificate(node.AgentConfig.ClientKubeletCert, node.AgentConfig.ClientKubeletKey)
+	info, err := clientaccess.ParseAndValidateToken(proxy.SupervisorURL(), node.Token, withCert)
 	if err != nil {
 		return nil, err
 	}
@@ -620,7 +625,8 @@ func getAPIServers(ctx context.Context, node *config.Node, proxy proxy.Proxy) ([
 // getKubeProxyDisabled attempts to return the DisableKubeProxy setting from the server configuration data.
 // It first checks the server readyz endpoint, to ensure that the configuration has stabilized before use.
 func getKubeProxyDisabled(ctx context.Context, node *config.Node, proxy proxy.Proxy) (bool, error) {
-	info, err := clientaccess.ParseAndValidateToken(proxy.SupervisorURL(), node.Token)
+	withCert := clientaccess.WithClientCertificate(node.AgentConfig.ClientKubeletCert, node.AgentConfig.ClientKubeletKey)
+	info, err := clientaccess.ParseAndValidateToken(proxy.SupervisorURL(), node.Token, withCert)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -266,6 +266,9 @@ func Run(ctx context.Context, cfg cmds.Agent) error {
 
 func createProxyAndValidateToken(ctx context.Context, cfg *cmds.Agent) (proxy.Proxy, error) {
 	agentDir := filepath.Join(cfg.DataDir, "agent")
+	clientKubeletCert := filepath.Join(agentDir, "client-kubelet.crt")
+	clientKubeletKey := filepath.Join(agentDir, "client-kubelet.key")
+
 	if err := os.MkdirAll(agentDir, 0700); err != nil {
 		return nil, err
 	}
@@ -276,8 +279,13 @@ func createProxyAndValidateToken(ctx context.Context, cfg *cmds.Agent) (proxy.Pr
 		return nil, err
 	}
 
+	options := []clientaccess.ValidationOption{
+		clientaccess.WithUser("node"),
+		clientaccess.WithClientCertificate(clientKubeletCert, clientKubeletKey),
+	}
+
 	for {
-		newToken, err := clientaccess.ParseAndValidateTokenForUser(proxy.SupervisorURL(), cfg.Token, "node")
+		newToken, err := clientaccess.ParseAndValidateToken(proxy.SupervisorURL(), cfg.Token, options...)
 		if err != nil {
 			logrus.Error(err)
 			select {

--- a/pkg/cli/agent/agent.go
+++ b/pkg/cli/agent/agent.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/erikdubbelboer/gspt"
@@ -45,7 +47,11 @@ func Run(ctx *cli.Context) error {
 		cmds.AgentConfig.Token = token
 	}
 
-	if cmds.AgentConfig.Token == "" {
+	clientKubeletCert := filepath.Join(cmds.AgentConfig.DataDir, "agent", "client-kubelet.crt")
+	clientKubeletKey := filepath.Join(cmds.AgentConfig.DataDir, "agent", "client-kubelet.key")
+	_, err := tls.LoadX509KeyPair(clientKubeletCert, clientKubeletKey)
+
+	if err != nil && cmds.AgentConfig.Token == "" {
 		return fmt.Errorf("--token is required")
 	}
 

--- a/pkg/cli/cert/cert.go
+++ b/pkg/cli/cert/cert.go
@@ -285,7 +285,7 @@ func rotateCA(app *cli.Context, cfg *cmds.Server, sync *cmds.CertRotateCA) error
 		return err
 	}
 
-	info, err := clientaccess.ParseAndValidateTokenForUser(cmds.ServerConfig.ServerURL, serverConfig.ControlConfig.Token, "server")
+	info, err := clientaccess.ParseAndValidateToken(cmds.ServerConfig.ServerURL, serverConfig.ControlConfig.Token, clientaccess.WithUser("server"))
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmds/token.go
+++ b/pkg/cli/cmds/token.go
@@ -1,0 +1,97 @@
+package cmds
+
+import (
+	"time"
+
+	"github.com/urfave/cli"
+)
+
+const TokenCommand = "token"
+
+// Config holds CLI values for the token subcommands
+type Token struct {
+	Description string
+	Kubeconfig  string
+	Token       string
+	Output      string
+	Groups      cli.StringSlice
+	Usages      cli.StringSlice
+	TTL         time.Duration
+}
+
+var (
+	TokenConfig = Token{}
+	TokenFlags  = []cli.Flag{
+		DataDirFlag,
+		cli.StringFlag{
+			Name:        "kubeconfig",
+			Usage:       "(cluster) Server to connect to",
+			EnvVar:      "KUBECONFIG",
+			Destination: &TokenConfig.Kubeconfig,
+		},
+	}
+)
+
+func NewTokenCommands(create, delete, generate, list func(ctx *cli.Context) error) cli.Command {
+	return cli.Command{
+		Name:            TokenCommand,
+		Usage:           "Manage bootstrap tokens",
+		SkipFlagParsing: false,
+		SkipArgReorder:  true,
+		Subcommands: []cli.Command{
+			{
+				Name:  "create",
+				Usage: "Create bootstrap tokens on the server",
+				Flags: append(TokenFlags, &cli.StringFlag{
+					Name:        "description",
+					Usage:       "A human friendly description of how this token is used",
+					Destination: &TokenConfig.Description,
+				}, &cli.StringSliceFlag{
+					Name:  "groups",
+					Usage: "Extra groups that this token will authenticate as when used for authentication",
+					Value: &TokenConfig.Groups,
+				}, &cli.DurationFlag{
+					Name:        "ttl",
+					Usage:       "The duration before the token is automatically deleted (e.g. 1s, 2m, 3h). If set to '0', the token will never expire",
+					Value:       time.Hour * 24,
+					Destination: &TokenConfig.TTL,
+				}, &cli.StringSliceFlag{
+					Name:  "usages",
+					Usage: "Describes the ways in which this token can be used.",
+					Value: &TokenConfig.Usages,
+				}),
+				SkipFlagParsing: false,
+				SkipArgReorder:  true,
+				Action:          create,
+			},
+			{
+				Name:            "delete",
+				Usage:           "Delete bootstrap tokens on the server",
+				Flags:           TokenFlags,
+				SkipFlagParsing: false,
+				SkipArgReorder:  true,
+				Action:          delete,
+			},
+			{
+				Name:            "generate",
+				Usage:           "Generate and print a bootstrap token, but do not create it on the server",
+				Flags:           TokenFlags,
+				SkipFlagParsing: false,
+				SkipArgReorder:  true,
+				Action:          generate,
+			},
+			{
+				Name:  "list",
+				Usage: "List bootstrap tokens on the server",
+				Flags: append(TokenFlags, &cli.StringFlag{
+					Name:        "output,o",
+					Value:       "text",
+					Destination: &TokenConfig.Output,
+				}),
+				SkipFlagParsing: false,
+				SkipArgReorder:  true,
+				Action:          list,
+			},
+		},
+	}
+}

--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -38,7 +38,7 @@ func commandPrep(app *cli.Context, cfg *cmds.Server) (*clientaccess.Info, error)
 		}
 		cfg.Token = string(bytes.TrimRight(tokenByte, "\n"))
 	}
-	return clientaccess.ParseAndValidateTokenForUser(cmds.ServerConfig.ServerURL, cfg.Token, "server")
+	return clientaccess.ParseAndValidateToken(cmds.ServerConfig.ServerURL, cfg.Token, clientaccess.WithUser("server"))
 }
 
 func wrapServerError(err error) error {

--- a/pkg/cli/token/token.go
+++ b/pkg/cli/token/token.go
@@ -1,0 +1,224 @@
+package token
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/clientaccess"
+	"github.com/k3s-io/k3s/pkg/kubeadm"
+	"github.com/k3s-io/k3s/pkg/util"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/client-go/tools/clientcmd"
+	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
+	bootstraputil "k8s.io/cluster-bootstrap/token/util"
+)
+
+func Create(app *cli.Context) error {
+	if err := cmds.InitLogging(); err != nil {
+		return err
+	}
+	return create(app, &cmds.TokenConfig)
+}
+
+func create(app *cli.Context, cfg *cmds.Token) error {
+	if err := kubeadm.SetDefaults(app, cfg); err != nil {
+		return err
+	}
+
+	cfg.Kubeconfig = util.GetKubeConfigPath(cfg.Kubeconfig)
+	client, err := util.GetClientSet(cfg.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", cfg.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	if len(restConfig.TLSClientConfig.CAData) == 0 && restConfig.TLSClientConfig.CAFile != "" {
+		restConfig.TLSClientConfig.CAData, err = os.ReadFile(restConfig.TLSClientConfig.CAFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	bts, err := kubeadm.NewBootstrapTokenString(cfg.Token)
+	if err != nil {
+		return err
+	}
+
+	bt := kubeadm.BootstrapToken{
+		Token:       bts,
+		Description: cfg.Description,
+		TTL:         &metav1.Duration{Duration: cfg.TTL},
+		Usages:      cfg.Usages,
+		Groups:      cfg.Groups,
+	}
+
+	secretName := bootstraputil.BootstrapTokenSecretName(bt.Token.ID)
+	if secret, err := client.CoreV1().Secrets(metav1.NamespaceSystem).Get(context.TODO(), secretName, metav1.GetOptions{}); secret != nil && err == nil {
+		return fmt.Errorf("a token with id %q already exists", bt.Token.ID)
+	}
+
+	secret := kubeadm.BootstrapTokenToSecret(&bt)
+	if _, err := client.CoreV1().Secrets(metav1.NamespaceSystem).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+
+	token, err := clientaccess.FormatTokenBytes(bt.Token.String(), restConfig.TLSClientConfig.CAData)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(token)
+	return nil
+}
+
+func Delete(app *cli.Context) error {
+	if err := cmds.InitLogging(); err != nil {
+		return err
+	}
+	return delete(app, &cmds.TokenConfig)
+}
+
+func delete(app *cli.Context, cfg *cmds.Token) error {
+	args := app.Args()
+	if len(args) < 1 {
+		return errors.New("missing argument; 'token delete' is missing token")
+	}
+
+	cfg.Kubeconfig = util.GetKubeConfigPath(cfg.Kubeconfig)
+	client, err := util.GetClientSet(cfg.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	for _, token := range args {
+		if !bootstraputil.IsValidBootstrapTokenID(token) {
+			bts, err := kubeadm.NewBootstrapTokenString(cfg.Token)
+			if err != nil {
+				return fmt.Errorf("given token didn't match pattern %q or %q", bootstrapapi.BootstrapTokenIDPattern, bootstrapapi.BootstrapTokenIDPattern)
+			}
+			token = bts.ID
+		}
+		secretName := bootstraputil.BootstrapTokenSecretName(token)
+		if err := client.CoreV1().Secrets(metav1.NamespaceSystem).Delete(context.TODO(), secretName, metav1.DeleteOptions{}); err != nil {
+			return errors.Wrapf(err, "failed to delete bootstrap token %q", err)
+		}
+
+		fmt.Printf("bootstrap token %q deleted\n", token)
+	}
+	return nil
+}
+
+func Generate(app *cli.Context) error {
+	if err := cmds.InitLogging(); err != nil {
+		return err
+	}
+	return generate(app, &cmds.TokenConfig)
+}
+
+func generate(app *cli.Context, cfg *cmds.Token) error {
+	token, err := bootstraputil.GenerateBootstrapToken()
+	if err != nil {
+		return err
+	}
+	fmt.Println(token)
+	return nil
+}
+
+func List(app *cli.Context) error {
+	if err := cmds.InitLogging(); err != nil {
+		return err
+	}
+	return list(app, &cmds.TokenConfig)
+}
+
+func list(app *cli.Context, cfg *cmds.Token) error {
+	if err := kubeadm.SetDefaults(app, cfg); err != nil {
+		return err
+	}
+
+	cfg.Kubeconfig = util.GetKubeConfigPath(cfg.Kubeconfig)
+	client, err := util.GetClientSet(cfg.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	tokenSelector := fields.SelectorFromSet(
+		map[string]string{
+			"type": string(bootstrapapi.SecretTypeBootstrapToken),
+		},
+	)
+	listOptions := metav1.ListOptions{
+		FieldSelector: tokenSelector.String(),
+	}
+
+	secrets, err := client.CoreV1().Secrets(metav1.NamespaceSystem).List(context.TODO(), listOptions)
+	if err != nil {
+		return errors.Wrapf(err, "failed to list bootstrap tokens")
+	}
+
+	tokens := make([]*kubeadm.BootstrapToken, len(secrets.Items))
+	for i, secret := range secrets.Items {
+		token, err := kubeadm.BootstrapTokenFromSecret(&secret)
+		if err != nil {
+			fmt.Printf("%v", err)
+			continue
+		}
+		tokens[i] = token
+	}
+
+	switch cfg.Output {
+	case "json":
+		if err := json.NewEncoder(os.Stdout).Encode(tokens); err != nil {
+			return err
+		}
+		return nil
+	case "yaml":
+		if err := yaml.NewEncoder(os.Stdout).Encode(tokens); err != nil {
+			return err
+		}
+		return nil
+	default:
+		format := "%s\t%s\t%s\t%s\t%s\t%s\n"
+		w := tabwriter.NewWriter(os.Stdout, 10, 4, 3, ' ', 0)
+		defer w.Flush()
+
+		fmt.Fprintf(w, format, "TOKEN", "TTL", "EXPIRES", "USAGES", "DESCRIPTION", "EXTRA GROUPS")
+		for _, token := range tokens {
+			ttl := "<forever>"
+			expires := "<never>"
+			if token.Expires != nil {
+				ttl = duration.ShortHumanDuration(token.Expires.Sub(time.Now()))
+				expires = token.Expires.Format(time.RFC3339)
+			}
+
+			fmt.Fprintf(w, format, token.Token.ID, ttl, expires, joinOrNone(token.Usages...), joinOrNone(token.Description), joinOrNone(token.Groups...))
+		}
+	}
+
+	return nil
+}
+
+// joinOrNone joins strings with a comma. If the resulting output is an empty string,
+// it instead returns the replacement string "<none>"
+func joinOrNone(s ...string) string {
+	j := strings.Join(s, ",")
+	if j == "" {
+		return "<none>"
+	}
+	return j
+}

--- a/pkg/clientaccess/token.go
+++ b/pkg/clientaccess/token.go
@@ -369,7 +369,7 @@ func put(u string, body []byte, client *http.Client, username, password string) 
 	return nil
 }
 
-// FormatToken takes a username:password string, and a path to a certificate bundle, and
+// FormatToken takes a username:password string or join token, and a path to a certificate bundle, and
 // returns a string containing the full K10 format token string. If the credentials are
 // empty, an empty token is returned. If the certificate bundle does not exist or does not
 // contain a valid bundle, an error is returned.
@@ -381,6 +381,15 @@ func FormatToken(creds, certFile string) (string, error) {
 	b, err := os.ReadFile(certFile)
 	if err != nil {
 		return "", err
+	}
+	return FormatTokenBytes(creds, b)
+}
+
+// FormatTokenBytes has the same interface as FormatToken, but accepts a byte slice instead
+// of file path.
+func FormatTokenBytes(creds string, b []byte) (string, error) {
+	if len(creds) == 0 {
+		return "", nil
 	}
 
 	digest, err := hashCA(b)

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -94,7 +94,7 @@ func (c *Cluster) shouldBootstrapLoad(ctx context.Context) (bool, bool, error) {
 			// etcd is promoted from learner. Odds are we won't need this info, and we don't want to fail startup
 			// due to failure to retrieve it as this will break cold cluster restart, so we ignore any errors.
 			if c.config.JoinURL != "" && c.config.Token != "" {
-				c.clientAccessInfo, _ = clientaccess.ParseAndValidateTokenForUser(c.config.JoinURL, c.config.Token, "server")
+				c.clientAccessInfo, _ = clientaccess.ParseAndValidateToken(c.config.JoinURL, c.config.Token, clientaccess.WithUser("server"))
 			}
 			return false, true, nil
 		} else if c.config.JoinURL == "" {
@@ -109,7 +109,7 @@ func (c *Cluster) shouldBootstrapLoad(ctx context.Context) (bool, bool, error) {
 
 			// Fail if the token isn't syntactically valid, or if the CA hash on the remote server doesn't match
 			// the hash in the token. The password isn't actually checked until later when actually bootstrapping.
-			info, err := clientaccess.ParseAndValidateTokenForUser(c.config.JoinURL, c.config.Token, "server")
+			info, err := clientaccess.ParseAndValidateToken(c.config.JoinURL, c.config.Token, clientaccess.WithUser("server"))
 			if err != nil {
 				return false, false, err
 			}
@@ -453,7 +453,7 @@ func (c *Cluster) compareConfig() error {
 	if token == "" {
 		token = c.config.Token
 	}
-	agentClientAccessInfo, err := clientaccess.ParseAndValidateTokenForUser(c.config.JoinURL, token, "node")
+	agentClientAccessInfo, err := clientaccess.ParseAndValidateToken(c.config.JoinURL, token, clientaccess.WithUser("node"))
 	if err != nil {
 		return err
 	}

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -76,6 +76,8 @@ type Agent struct {
 	PodManifests            string
 	NodeName                string
 	NodeConfigPath          string
+	ClientKubeletCert       string
+	ClientKubeletKey        string
 	ServingKubeletCert      string
 	ServingKubeletKey       string
 	ServiceCIDR             *net.IPNet

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -90,6 +90,7 @@ func Server(ctx context.Context, cfg *config.Control) error {
 func controllerManager(ctx context.Context, cfg *config.Control) error {
 	runtime := cfg.Runtime
 	argsMap := map[string]string{
+		"controllers":                      "*,tokencleaner",
 		"feature-gates":                    "JobTrackingWithFinalizers=true",
 		"kubeconfig":                       runtime.KubeConfigController,
 		"authorization-kubeconfig":         runtime.KubeConfigController,
@@ -117,7 +118,7 @@ func controllerManager(ctx context.Context, cfg *config.Control) error {
 	}
 	if !cfg.DisableCCM {
 		argsMap["configure-cloud-routes"] = "false"
-		argsMap["controllers"] = "*,-service,-route,-cloud-node-lifecycle"
+		argsMap["controllers"] = argsMap["controllers"] + ",-service,-route,-cloud-node-lifecycle"
 	}
 
 	args := config.GetArgs(argsMap, cfg.ExtraControllerArgs)
@@ -158,6 +159,7 @@ func apiServer(ctx context.Context, cfg *config.Control) error {
 
 	argsMap["cert-dir"] = certDir
 	argsMap["allow-privileged"] = "true"
+	argsMap["enable-bootstrap-token-auth"] = "true"
 	argsMap["authorization-mode"] = strings.Join([]string{modes.ModeNode, modes.ModeRBAC}, ",")
 	argsMap["service-account-signing-key-file"] = runtime.ServiceCurrentKey
 	argsMap["service-cluster-ip-range"] = util.JoinIPNets(cfg.ServiceIPRanges)

--- a/pkg/kubeadm/token.go
+++ b/pkg/kubeadm/token.go
@@ -1,0 +1,52 @@
+package kubeadm
+
+import (
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
+	bootstraputil "k8s.io/cluster-bootstrap/token/util"
+)
+
+var (
+	NodeBootstrapTokenAuthGroup = "system:bootstrappers:" + version.Program + ":default-node-token"
+)
+
+// SetDefaults ensures that the default values are set on the token configuration.
+// These are set here, rather than in the default Token struct, to avoid
+// importing the cluster-bootstrap packages into the CLI.
+func SetDefaults(clx *cli.Context, cfg *cmds.Token) error {
+	if !clx.IsSet("groups") {
+		cfg.Groups = []string{NodeBootstrapTokenAuthGroup}
+	}
+
+	if !clx.IsSet("usages") {
+		cfg.Usages = bootstrapapi.KnownTokenUsages
+	}
+
+	if cfg.Output == "" {
+		cfg.Output = "text"
+	} else {
+		switch cfg.Output {
+		case "text", "json", "yaml":
+		default:
+			return errors.New("invalid output format: " + cfg.Output)
+		}
+	}
+
+	args := clx.Args()
+	if len(args) > 0 {
+		cfg.Token = args[0]
+	}
+
+	if cfg.Token == "" {
+		var err error
+		cfg.Token, err = bootstraputil.GenerateBootstrapToken()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/kubeadm/types.go
+++ b/pkg/kubeadm/types.go
@@ -1,0 +1,45 @@
+package kubeadm
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// kubeadm bootstrap token types cribbed from:
+// https://github.com/kubernetes/kubernetes/blob/v1.25.4/cmd/kubeadm/app/apis/bootstraptoken/v1/types.go
+// Copying these instead of importing from kubeadm saves about 4mb of binary size.
+
+// BootstrapToken describes one bootstrap token, stored as a Secret in the cluster
+type BootstrapToken struct {
+	// Token is used for establishing bidirectional trust between nodes and control-planes.
+	// Used for joining nodes in the cluster.
+	Token *BootstrapTokenString `json:"token" datapolicy:"token"`
+	// Description sets a human-friendly message why this token exists and what it's used
+	// for, so other administrators can know its purpose.
+	// +optional
+	Description string `json:"description,omitempty"`
+	// TTL defines the time to live for this token. Defaults to 24h.
+	// Expires and TTL are mutually exclusive.
+	// +optional
+	TTL *metav1.Duration `json:"ttl,omitempty"`
+	// Expires specifies the timestamp when this token expires. Defaults to being set
+	// dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+	// +optional
+	Expires *metav1.Time `json:"expires,omitempty"`
+	// Usages describes the ways in which this token can be used. Can by default be used
+	// for establishing bidirectional trust, but that can be changed here.
+	// +optional
+	Usages []string `json:"usages,omitempty"`
+	// Groups specifies the extra groups that this token will authenticate as when/if
+	// used for authentication
+	// +optional
+	Groups []string `json:"groups,omitempty"`
+}
+
+// BootstrapTokenString is a token of the format abcdef.abcdef0123456789 that is used
+// for both validation of the identity of the API server from a joining node's point
+// of view and as an authentication method for the node. This token is and should be
+// short-lived.
+type BootstrapTokenString struct {
+	ID     string `json:"-"`
+	Secret string `json:"-" datapolicy:"token"`
+}

--- a/pkg/kubeadm/utils.go
+++ b/pkg/kubeadm/utils.go
@@ -1,0 +1,173 @@
+package kubeadm
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
+	bootstraputil "k8s.io/cluster-bootstrap/token/util"
+	bootstrapsecretutil "k8s.io/cluster-bootstrap/util/secrets"
+)
+
+// kubeadm bootstrap token utilities cribbed from:
+// https://github.com/kubernetes/kubernetes/blob/v1.25.4/cmd/kubeadm/app/apis/bootstraptoken/v1/utils.go
+// Copying these instead of importing from kubeadm saves about 4mb of binary size.
+
+// String returns the string representation of the BootstrapTokenString
+func (bts BootstrapTokenString) String() string {
+	if len(bts.ID) > 0 && len(bts.Secret) > 0 {
+		return bootstraputil.TokenFromIDAndSecret(bts.ID, bts.Secret)
+	}
+	return ""
+}
+
+// NewBootstrapTokenString converts the given Bootstrap Token as a string
+// to the BootstrapTokenString object used for serialization/deserialization
+// and internal usage. It also automatically validates that the given token
+// is of the right format
+func NewBootstrapTokenString(token string) (*BootstrapTokenString, error) {
+	substrs := bootstraputil.BootstrapTokenRegexp.FindStringSubmatch(token)
+	if len(substrs) != 3 {
+		return nil, errors.Errorf("the bootstrap token %q was not of the form %q", token, bootstrapapi.BootstrapTokenPattern)
+	}
+
+	return &BootstrapTokenString{ID: substrs[1], Secret: substrs[2]}, nil
+}
+
+// NewBootstrapTokenStringFromIDAndSecret is a wrapper around NewBootstrapTokenString
+// that allows the caller to specify the ID and Secret separately
+func NewBootstrapTokenStringFromIDAndSecret(id, secret string) (*BootstrapTokenString, error) {
+	return NewBootstrapTokenString(bootstraputil.TokenFromIDAndSecret(id, secret))
+}
+
+// BootstrapTokenToSecret converts the given BootstrapToken object to its Secret representation that
+// may be submitted to the API Server in order to be stored.
+func BootstrapTokenToSecret(bt *BootstrapToken) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bootstraputil.BootstrapTokenSecretName(bt.Token.ID),
+			Namespace: metav1.NamespaceSystem,
+		},
+		Type: v1.SecretType(bootstrapapi.SecretTypeBootstrapToken),
+		Data: encodeTokenSecretData(bt, time.Now()),
+	}
+}
+
+// encodeTokenSecretData takes the token discovery object and an optional duration and returns the .Data for the Secret
+// now is passed in order to be able to used in unit testing
+func encodeTokenSecretData(token *BootstrapToken, now time.Time) map[string][]byte {
+	data := map[string][]byte{
+		bootstrapapi.BootstrapTokenIDKey:     []byte(token.Token.ID),
+		bootstrapapi.BootstrapTokenSecretKey: []byte(token.Token.Secret),
+	}
+
+	if len(token.Description) > 0 {
+		data[bootstrapapi.BootstrapTokenDescriptionKey] = []byte(token.Description)
+	}
+
+	// If for some strange reason both token.TTL and token.Expires would be set
+	// (they are mutually exclusive in validation so this shouldn't be the case),
+	// token.Expires has higher priority, as can be seen in the logic here.
+	if token.Expires != nil {
+		// Format the expiration date accordingly
+		// TODO: This maybe should be a helper function in bootstraputil?
+		expirationString := token.Expires.Time.UTC().Format(time.RFC3339)
+		data[bootstrapapi.BootstrapTokenExpirationKey] = []byte(expirationString)
+
+	} else if token.TTL != nil && token.TTL.Duration > 0 {
+		// Only if .Expires is unset, TTL might have an effect
+		// Get the current time, add the specified duration, and format it accordingly
+		expirationString := now.Add(token.TTL.Duration).UTC().Format(time.RFC3339)
+		data[bootstrapapi.BootstrapTokenExpirationKey] = []byte(expirationString)
+	}
+
+	for _, usage := range token.Usages {
+		data[bootstrapapi.BootstrapTokenUsagePrefix+usage] = []byte("true")
+	}
+
+	if len(token.Groups) > 0 {
+		data[bootstrapapi.BootstrapTokenExtraGroupsKey] = []byte(strings.Join(token.Groups, ","))
+	}
+	return data
+}
+
+// BootstrapTokenFromSecret returns a BootstrapToken object from the given Secret
+func BootstrapTokenFromSecret(secret *v1.Secret) (*BootstrapToken, error) {
+	// Get the Token ID field from the Secret data
+	tokenID := bootstrapsecretutil.GetData(secret, bootstrapapi.BootstrapTokenIDKey)
+	if len(tokenID) == 0 {
+		return nil, errors.Errorf("bootstrap Token Secret has no token-id data: %s", secret.Name)
+	}
+
+	// Enforce the right naming convention
+	if secret.Name != bootstraputil.BootstrapTokenSecretName(tokenID) {
+		return nil, errors.Errorf("bootstrap token name is not of the form '%s(token-id)'. Actual: %q. Expected: %q",
+			bootstrapapi.BootstrapTokenSecretPrefix, secret.Name, bootstraputil.BootstrapTokenSecretName(tokenID))
+	}
+
+	tokenSecret := bootstrapsecretutil.GetData(secret, bootstrapapi.BootstrapTokenSecretKey)
+	if len(tokenSecret) == 0 {
+		return nil, errors.Errorf("bootstrap Token Secret has no token-secret data: %s", secret.Name)
+	}
+
+	// Create the BootstrapTokenString object based on the ID and Secret
+	bts, err := NewBootstrapTokenStringFromIDAndSecret(tokenID, tokenSecret)
+	if err != nil {
+		return nil, errors.Wrap(err, "bootstrap Token Secret is invalid and couldn't be parsed")
+	}
+
+	// Get the description (if any) from the Secret
+	description := bootstrapsecretutil.GetData(secret, bootstrapapi.BootstrapTokenDescriptionKey)
+
+	// Expiration time is optional, if not specified this implies the token
+	// never expires.
+	secretExpiration := bootstrapsecretutil.GetData(secret, bootstrapapi.BootstrapTokenExpirationKey)
+	var expires *metav1.Time
+	if len(secretExpiration) > 0 {
+		expTime, err := time.Parse(time.RFC3339, secretExpiration)
+		if err != nil {
+			return nil, errors.Wrapf(err, "can't parse expiration time of bootstrap token %q", secret.Name)
+		}
+		expires = &metav1.Time{Time: expTime}
+	}
+
+	// Build an usages string slice from the Secret data
+	var usages []string
+	for k, v := range secret.Data {
+		// Skip all fields that don't include this prefix
+		if !strings.HasPrefix(k, bootstrapapi.BootstrapTokenUsagePrefix) {
+			continue
+		}
+		// Skip those that don't have this usage set to true
+		if string(v) != "true" {
+			continue
+		}
+		usages = append(usages, strings.TrimPrefix(k, bootstrapapi.BootstrapTokenUsagePrefix))
+	}
+	// Only sort the slice if defined
+	if usages != nil {
+		sort.Strings(usages)
+	}
+
+	// Get the extra groups information from the Secret
+	// It's done this way to make .Groups be nil in case there is no items, rather than an
+	// empty slice or an empty slice with a "" string only
+	var groups []string
+	groupsString := bootstrapsecretutil.GetData(secret, bootstrapapi.BootstrapTokenExtraGroupsKey)
+	g := strings.Split(groupsString, ",")
+	if len(g) > 0 && len(g[0]) > 0 {
+		groups = g
+	}
+
+	return &BootstrapToken{
+		Token:       bts,
+		Description: description,
+		Expires:     expires,
+		Usages:      usages,
+		Groups:      groups,
+	}, nil
+}

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 )
 
 const (
@@ -44,7 +45,7 @@ func router(ctx context.Context, config *Config, cfg *cmds.Server) http.Handler 
 
 	prefix := "/v1-" + version.Program
 	authed := mux.NewRouter().SkipClean(true)
-	authed.Use(authMiddleware(serverConfig, version.Program+":agent"))
+	authed.Use(authMiddleware(serverConfig, version.Program+":agent", user.NodesGroup, bootstrapapi.BootstrapDefaultGroup))
 	authed.Path(prefix + "/serving-kubelet.crt").Handler(servingKubeletCert(serverConfig, serverConfig.Runtime.ServingKubeletKey, nodeAuth))
 	authed.Path(prefix + "/client-kubelet.crt").Handler(clientKubeletCert(serverConfig, serverConfig.Runtime.ClientKubeletKey, nodeAuth))
 	authed.Path(prefix + "/client-kube-proxy.crt").Handler(fileHandler(serverConfig.Runtime.ClientKubeProxyCert, serverConfig.Runtime.ClientKubeProxyKey))

--- a/scripts/build
+++ b/scripts/build
@@ -92,6 +92,7 @@ fi
 rm -f \
     bin/k3s-agent \
     bin/k3s-server \
+    bin/k3s-token \
     bin/k3s-etcd-snapshot \
     bin/k3s-secrets-encrypt \
     bin/k3s-certificate \
@@ -127,6 +128,7 @@ echo Building k3s
 CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s ./cmd/server/main.go
 ln -s k3s ./bin/k3s-agent
 ln -s k3s ./bin/k3s-server
+ln -s k3s ./bin/k3s-token
 ln -s k3s ./bin/k3s-etcd-snapshot
 ln -s k3s ./bin/k3s-secrets-encrypt
 ln -s k3s ./bin/k3s-certificate

--- a/scripts/package-cli
+++ b/scripts/package-cli
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 
 GO=${GO-go}
 
-for i in crictl kubectl k3s-agent k3s-server k3s-etcd-snapshot k3s-secrets-encrypt k3s-certificate k3s-completion; do
+for i in crictl kubectl k3s-agent k3s-server k3s-token k3s-etcd-snapshot k3s-secrets-encrypt k3s-certificate k3s-completion; do
     rm -f bin/$i
     ln -s k3s bin/$i
 done

--- a/scripts/test
+++ b/scripts/test
@@ -26,6 +26,9 @@ echo "Did test-run-hardened $?"
 . ./scripts/test-run-cacerts
 echo "Did test-run-cacerts $?"
 
+. ./scripts/test-run-bootstraptoken
+echo "Did test-run-bootstraptoken $?"
+
 . ./scripts/test-run-upgrade
 echo "Did test-run-upgrade $?"
 

--- a/scripts/test-run-bootstraptoken
+++ b/scripts/test-run-bootstraptoken
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+all_services=(
+    coredns
+    local-path-provisioner
+    metrics-server
+    traefik
+)
+
+export NUM_SERVERS=1
+export NUM_AGENTS=1
+export WAIT_SERVICES="${all_services[@]}"
+
+agent-pre-hook() {
+    local server=$(cat $TEST_DIR/servers/1/metadata/name)
+    docker exec $server k3s token create --ttl=5m --description=Test > $TEST_DIR/metadata/secret
+}
+export -f agent-pre-hook
+
+start-test() {
+  echo "Cluster is up with ephemeral join token"
+}
+export -f start-test
+
+# --- create a basic cluster with an agent joined using the ephemeral token and check for functionality
+LABEL=BOOTSTRAP-TOKEN run-test
+
+cleanup-test-env


### PR DESCRIPTION
#### Proposed Changes ####

* Add `k3s token create` - same functionality as `kubeadm token create`
  Can be used to create time-limited join tokens that are automatically cleaned up by the controller-manager when the TTL expires. Tokens are for joining agents only. Servers must know the legacy join/encryption token.
* Allow agents to join using bootstrap tokens or existing kubelet certs (via NodeAuth admission plugin)

#### Types of Changes ####

enhancement

#### Verification ####

* use `k3s token create` to create a join token
  * join an agent to the cluster with the token
* use `k3s token list` to list the token
* use `k3s token delete` to delete the token
* use `k3s token create --ttl 5m` to create a time-limited token
  * note that it is removed when the TTL is up
  * note that nodes joined to the cluster using this token can restart successfully
  * note that nodes cannot rejoin the cluster with the expired token if their node object is deleted from the cluster

#### Testing ####

Covered by CI

#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/2645
* https://github.com/k3s-io/k3s/issues/6175
* https://github.com/rancher/rke2/issues/3245

#### User-Facing Change ####
```release-note
* K3s now supports `kubeadm` style join tokens. `k3s token create` now creates join token secrets, optionally with a limited TTL.
* K3s agents joined with an expired or deleted token stay in the cluster using existing client certificates via the NodeAuthorization admission plugin, unless their Node object is deleted from the cluster.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
