### PR TITLE
Change Updatecli GH action reference branch

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Follow-up from PR https://github.com/k3s-io/k3s/pull/6583. K3s uses the `master` branch instead of `main`, otherwise the GH action workflow will not run.