### PR TITLE
[release-1.24] Bump containerd to v1.6.14-k3s1

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -24,7 +24,7 @@ fi
 
 # We're building k3s against containerd 1.5 in go.mod because 1.6 has dependency
 # conflicts with Kubernetes, but we still need to bundle containerd 1.6.
-VERSION_CONTAINERD="v1.6.12-k3s1"
+VERSION_CONTAINERD="v1.6.14-k3s1"
 
 VERSION_CRICTL=$(grep github.com/kubernetes-sigs/cri-tools go.mod | head -n1 | awk '{print $4}')
 if [ -z "$VERSION_CRICTL" ]; then


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to fix issue with CNI info being forgotten on restart

#### Types of Changes ####

version bump

#### Verification ####

* restart k3s
* note that pods are not restarted

#### Testing ####

TBD

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6692

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The embedded containerd version has been bumped to v1.6.14-k3s1. This includes a backported fix for [containerd/7843](https://github.com/containerd/containerd/issues/7843) which caused pods to lose their CNI info when containerd was restarted, which in turn caused the kubelet to recreate the pod. 
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
