### PR TITLE
Exclude December r1 releases from channel server

### DIFF
--- a/channel.yaml
+++ b/channel.yaml
@@ -1,10 +1,10 @@
 # Example channels config
 channels:
 - name: stable
-  latest: v1.25.5+k3s1
+  latest: v1.25.4+k3s1
 - name: latest
   latestRegexp: .*
-  excludeRegexp: ^[^+]+-
+  excludeRegexp: (^[^+]+-|v1\.25\.5\+k3s1|v1\.26\.0\+k3s1)
 - name: testing
   latestRegexp: -(alpha|beta|rc)
 - name: v1.16
@@ -40,10 +40,13 @@ channels:
   excludeRegexp: ^[^+]+-
 - name: v1.24
   latestRegexp: v1\.24\..*
-  excludeRegexp: ^[^+]+-
+  excludeRegexp: (^[^+]+-|v1\.24\.9\+k3s1)
 - name: v1.25
   latestRegexp: v1\.25\..*
-  excludeRegexp: ^[^+]+-
+  excludeRegexp: (^[^+]+-|v1\.25\.5\+k3s1)
+- name: v1.26
+  latestRegexp: v1\.26\..*
+  excludeRegexp: (^[^+]+-|v1\.26\.0\+k3s1)
 github:
   owner: k3s-io
   repo: k3s


### PR DESCRIPTION
#### Proposed Changes ####

Stop offering installs of these releases due to the critical containerd regression.

#### Types of Changes ####

channel server

#### Verification ####

attempt to install from channel server; note that it will not serve the affected releases as latest for these channels.


#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####


* https://github.com/k3s-io/k3s/issues/6692

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
