### PR TITLE
Bump containerd to v1.6.15-k3s1

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -24,7 +24,7 @@ fi
 
 # We're building k3s against containerd 1.5 in go.mod because 1.6 has dependency
 # conflicts with Kubernetes, but we still need to bundle containerd 1.6.
-VERSION_CONTAINERD="v1.6.14-k3s1"
+VERSION_CONTAINERD="v1.6.15-k3s1"
 
 VERSION_CRICTL=$(grep github.com/kubernetes-sigs/cri-tools go.mod | head -n1 | awk '{print $4}')
 if [ -z "$VERSION_CRICTL" ]; then


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to v1.6.15-k3s1

#### Types of Changes ####

version bump

#### Verification ####

check containerd version

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6721

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The embedded containerd version has been bumped to v1.6.15-k3s1
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
