### PR TITLE
[Release-1.25] Bump action/download-artifact to v3

### DIFF
--- a/.github/workflows/cgroup.yaml
+++ b/.github/workflows/cgroup.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v3
         with: { fetch-depth: 1 }
       - name: "Download Binary"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with: { name: k3s, path: dist/artifacts/ }
       - name: "Vagrant Cache"
         uses: actions/cache@v3

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: "Vagrant Plugin(s)"
         run: vagrant plugin install vagrant-k3s vagrant-reload vagrant-scp
       - name: "Download k3s binary"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: k3s
           path: tests/install/${{ matrix.vm }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -42,7 +42,7 @@ jobs:
           **/go.sum
           **/go.mod
     - name: "Download k3s binary"
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: k3s
         path: ./dist/artifacts

--- a/.github/workflows/snapshotter.yaml
+++ b/.github/workflows/snapshotter.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v3
         with: { fetch-depth: 1 }
       - name: "Download Binary"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with: { name: k3s, path: dist/artifacts/ }
       - name: "Vagrant Cache"
         uses: actions/cache@v3


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Bump actions/download-artifact to v3
Nodejs 12 actions are being deprecated slowly in favor of nodejs 16 versions

#### Verification ####
CI passes
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->


#### Linked Issues ####
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
