### PR TITLE
Add build tag to disable cri-dockerd

### DIFF
--- a/pkg/agent/cridockerd/config_linux.go
+++ b/pkg/agent/cridockerd/config_linux.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux && !no_cri_dockerd
+// +build linux,!no_cri_dockerd
 
 package cridockerd
 

--- a/pkg/agent/cridockerd/config_windows.go
+++ b/pkg/agent/cridockerd/config_windows.go
@@ -1,5 +1,5 @@
-//go:build windows
-// +build windows
+//go:build windows && !no_cri_dockerd
+// +build windows,!no_cri_dockerd
 
 package cridockerd
 

--- a/pkg/agent/cridockerd/cridockerd.go
+++ b/pkg/agent/cridockerd/cridockerd.go
@@ -1,3 +1,6 @@
+//go:build !no_cri_dockerd
+// +build !no_cri_dockerd
+
 package cridockerd
 
 import (

--- a/pkg/agent/cridockerd/nocridockerd.go
+++ b/pkg/agent/cridockerd/nocridockerd.go
@@ -1,0 +1,15 @@
+//go:build no_cri_dockerd
+// +build no_cri_dockerd
+
+package cridockerd
+
+import (
+	"context"
+	"errors"
+
+	"github.com/k3s-io/k3s/pkg/daemons/config"
+)
+
+func Run(ctx context.Context, cfg *config.Node) error {
+	return errors.New("cri-dockerd disabled at build time")
+}


### PR DESCRIPTION


#### Proposed Changes ####

Add build tag to disable cri-dockerd. We should be able to prevent it from being pulled in if downstream projects don't want it.

#### Types of Changes ####

packaging

#### Verification ####

No changes to k3s; the tag will remain unset in this project.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
* TBD
* https://github.com/rancher/rke2/pull/3788#discussion_r1070302580

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
