### PR TITLE
Slow dependency CI to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,37 @@
 version: 2
 updates:
 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "/conformance"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "/tests/e2e/scripts"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "/package"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "/tests/integration"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "/tests/terraform"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -3,7 +3,7 @@ name: "Updatecli: Dependency Management"
 on:
   schedule:
     # Runs at 06 PM UTC
-    - cron: '0 18 * * *'
+    - cron: '0 18 * * 0'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/updatecli/updatecli.d/golang-alpine.yaml
+++ b/updatecli/updatecli.d/golang-alpine.yaml
@@ -21,6 +21,8 @@ actions:
     scmid: "k3s"
     spec:
       automerge: false
+      mergemethod: "squash"
+      labels: "dependencies"
 
 sources:
   # Find Alpine latest semver version in DockerHub

--- a/updatecli/updatecli.d/golang-alpine.yaml
+++ b/updatecli/updatecli.d/golang-alpine.yaml
@@ -22,7 +22,8 @@ actions:
     spec:
       automerge: false
       mergemethod: "squash"
-      labels: "dependencies"
+      labels: 
+        - "dependencies"
 
 sources:
   # Find Alpine latest semver version in DockerHub

--- a/updatecli/updatecli.d/helm-controller.yaml
+++ b/updatecli/updatecli.d/helm-controller.yaml
@@ -23,6 +23,7 @@ actions:
       automerge: false
       mergemethod: "squash"
       usetitleforautomerge: true
+      labels: "dependencies"
 
 sources:
   helm-controller:

--- a/updatecli/updatecli.d/helm-controller.yaml
+++ b/updatecli/updatecli.d/helm-controller.yaml
@@ -23,7 +23,8 @@ actions:
       automerge: false
       mergemethod: "squash"
       usetitleforautomerge: true
-      labels: "dependencies"
+      labels: 
+        - "dependencies"
 
 sources:
   helm-controller:

--- a/updatecli/updatecli.d/klipper.yaml
+++ b/updatecli/updatecli.d/klipper.yaml
@@ -43,7 +43,8 @@ actions:
       automerge: false
       mergemethod: "squash"
       usetitleforautomerge: true
-      labels: "dependencies"
+      labels: 
+        - "dependencies"
 
 sources:
   klipper-helm:

--- a/updatecli/updatecli.d/klipper.yaml
+++ b/updatecli/updatecli.d/klipper.yaml
@@ -43,6 +43,7 @@ actions:
       automerge: false
       mergemethod: "squash"
       usetitleforautomerge: true
+      labels: "dependencies"
 
 sources:
   klipper-helm:

--- a/updatecli/updatecli.d/local-path-provisioner.yaml
+++ b/updatecli/updatecli.d/local-path-provisioner.yaml
@@ -33,7 +33,8 @@ actions:
       automerge: false
       mergemethod: "squash"
       usetitleforautomerge: true
-      labels: "dependencies"
+      labels: 
+        - "dependencies"
 
 sources:
   local-path-provisioner:

--- a/updatecli/updatecli.d/local-path-provisioner.yaml
+++ b/updatecli/updatecli.d/local-path-provisioner.yaml
@@ -33,6 +33,7 @@ actions:
       automerge: false
       mergemethod: "squash"
       usetitleforautomerge: true
+      labels: "dependencies"
 
 sources:
   local-path-provisioner:

--- a/updatecli/updatecli.d/sonobuoy.yaml
+++ b/updatecli/updatecli.d/sonobuoy.yaml
@@ -19,6 +19,8 @@ actions:
     scmid: "k3s"
     spec:
       automerge: false
+      labels: "dependencies"
+
 
 sources:
   sonobuoy:

--- a/updatecli/updatecli.d/sonobuoy.yaml
+++ b/updatecli/updatecli.d/sonobuoy.yaml
@@ -19,7 +19,8 @@ actions:
     scmid: "k3s"
     spec:
       automerge: false
-      labels: "dependencies"
+      labels: 
+        - "dependencies"
 
 
 sources:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Sets dependabot and updatecli to only run weekly. We are being overwhelmed with the amount of PRs being open daily by these tools. 
- Label updatecli PRs with the `dependencies` label to match dependabot. Since these PR bumps to not have issues attached, this helps with PR filtering. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CI
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

