### PR TITLE
Fix check for (open)SUSE version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -466,7 +466,7 @@ setup_selinux() {
     fi
 
     [ -r /etc/os-release ] && . /etc/os-release
-    if [ "${ID_LIKE%%[ ]*}" = "suse" ]; then
+    if [ `expr "${ID_LIKE}" : ".*suse.*"` != 0 ]; then
         rpm_target=sle
         rpm_site_infix=microos
         package_installer=zypper


### PR DESCRIPTION
Fix the check, if we're running SUSE or openSUSE in the installer script.

#### Proposed Changes ####

Proposed fix for https://github.com/k3s-io/k3s/issues/6790

#### Types of Changes ####

Bugfix

#### Verification ####

Manual installation performed in a Tumbleweed and MicroOS VM (passed)

In addition I also manipulated the `$ID_LIKE` on the Tumbleweed machine to check, if non-SUSE systems are affected by the change:

```
...
+ '[' -r /etc/os-release ']'
+ . /etc/os-release
++ NAME='openSUSE Tumbleweed'
++ ID=opensuse-tumbleweed
++ ID_LIKE=centos8                                  # Manual change
++ VERSION_ID=20230116
++ PRETTY_NAME='openSUSE Tumbleweed'
++ ANSI_COLOR='0;32'
++ CPE_NAME=cpe:/o:opensuse:tumbleweed:20230116
++ BUG_REPORT_URL=https://bugs.opensuse.org
++ HOME_URL=https://www.opensuse.org/
++ DOCUMENTATION_URL=https://en.opensuse.org/Portal:Tumbleweed
++ LOGO=distributor-logo-Tumbleweed
++ expr centos8 : '.*suse.*'                        # Does not validate
+ '[' 0 '!=' 0 ']'
+ '[' 20230116 = 7 ']'
+ rpm_target=el8
+ rpm_site_infix=centos/8
+ package_installer=yum
+ '[' yum = yum ']'
+ '[' -x /usr/bin/dnf ']'
+ policy_hint='please install:
    yum install -y container-selinux
    yum install -y https://rpm.rancher.io/k3s/stable/common/centos/8/noarch/k3s-selinux-1.2-2.el8.noarch.rpm
'
```

This shows that non-SUSE variants should not be affected by the change.

#### Testing ####

* Should be covered by nightly tests

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6790

#### User-Facing Change ####

NONE

#### Further Comments ####
