### PR TITLE
Bump deps: trivy, sonobuoy, dapper, golangci-lint, gopls

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.4'
+          go-version: '1.19.5'
 
       - name: Install Updatecli
         uses: updatecli/updatecli-action@v2

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -20,24 +20,24 @@ RUN apk -U --no-cache add bash git gcc musl-dev docker vim less file curl wget c
 RUN python3 -m pip install awscli
 
 RUN if [ "$(go env GOARCH)" = "arm64" ]; then                                                               \
-    wget https://github.com/aquasecurity/trivy/releases/download/v0.25.3/trivy_0.25.3_Linux-ARM64.tar.gz && \
-    tar -zxvf trivy_0.25.3_Linux-ARM64.tar.gz                                                            && \
+    wget https://github.com/aquasecurity/trivy/releases/download/v0.36.1/trivy_0.36.1_Linux-ARM64.tar.gz && \
+    tar -zxvf trivy_0.36.1_Linux-ARM64.tar.gz                                                            && \
     mv trivy /usr/local/bin;                                                                                \
     elif [ "$(go env GOARCH)" = "arm" ]; then                                                               \
-    wget https://github.com/aquasecurity/trivy/releases/download/v0.25.3/trivy_0.25.3_Linux-ARM.tar.gz   && \
-    tar -zxvf trivy_0.25.3_Linux-ARM.tar.gz                                                              && \
+    wget https://github.com/aquasecurity/trivy/releases/download/v0.36.1/trivy_0.36.1_Linux-ARM.tar.gz   && \
+    tar -zxvf trivy_0.36.1_Linux-ARM.tar.gz                                                              && \
     mv trivy /usr/local/bin;                                                                                \
     elif [ "$(go env GOARCH)" = "amd64" ]; then                                                             \
-    wget https://github.com/aquasecurity/trivy/releases/download/v0.25.3/trivy_0.25.3_Linux-64bit.tar.gz && \
-    tar -zxvf trivy_0.25.3_Linux-64bit.tar.gz                                                            && \
+    wget https://github.com/aquasecurity/trivy/releases/download/v0.36.1/trivy_0.36.1_Linux-64bit.tar.gz && \
+    tar -zxvf trivy_0.36.1_Linux-64bit.tar.gz                                                            && \
     mv trivy /usr/local/bin;                                                                                \
     fi
 # this works for both go 1.17 and 1.18
-RUN GOPROXY=direct go install golang.org/x/tools/cmd/goimports@gopls/v0.8.2
+RUN GOPROXY=direct go install golang.org/x/tools/cmd/goimports@gopls/v0.11.0
 RUN rm -rf /go/src /go/pkg
 
 RUN if [ "$(go env GOARCH)" = "amd64" ]; then \
-    curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/v1.45.2/install.sh | sh -s;  \
+    curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/v1.50.1/install.sh | sh -s;  \
     fi
 
 ARG SELINUX=true

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -18,7 +18,7 @@ RUN apk -U --no-cache add git gcc musl-dev docker curl coreutils python3 openssl
 
 RUN python3 -m pip install awscli
 
-ENV SONOBUOY_VERSION 0.56.10
+ENV SONOBUOY_VERSION 0.56.14
 
 RUN OS=linux; \
     ARCH=$(go env GOARCH); \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TARGETS := $(shell ls scripts | grep -v \\.sh)
 
 .dapper:
 	@echo Downloading dapper
-	@curl -sL https://releases.rancher.com/dapper/v0.5.7/dapper-$$(uname -s)-$$(uname -m) > .dapper.tmp
+	@curl -sL https://releases.rancher.com/dapper/v0.6.0/dapper-$$(uname -s)-$$(uname -m) > .dapper.tmp
 	@@chmod +x .dapper.tmp
 	@./.dapper.tmp -v
 	@mv .dapper.tmp .dapper

--- a/conformance/Dockerfile
+++ b/conformance/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.17
-ENV SONOBUOY_VERSION 0.56.10
+ENV SONOBUOY_VERSION 0.56.14
 RUN apk add curl tar gzip
 RUN curl -sfL https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz | tar xvzf - -C /usr/bin
 COPY run-test.sh /usr/bin

--- a/conformance/run-test.sh
+++ b/conformance/run-test.sh
@@ -11,6 +11,6 @@ sed 's/localhost/server/g' /etc/rancher/k3s/k3s.yaml > /root/.kube/config
 export KUBECONFIG=/root/.kube/config
 cat /etc/rancher/k3s/k3s.yaml
 cat $KUBECONFIG
-sonobuoy run --sonobuoy-image=rancher/sonobuoy-sonobuoy:v0.56.4
+sonobuoy run --sonobuoy-image=rancher/mirrored-sonobuoy-sonobuoy:v0.56.14
 sleep 15
 sonobuoy logs -f


### PR DESCRIPTION
#### Proposed Changes ####

Bump a few dependencies:

- trivy v0.36.1
- sonobuoy v0.56.14
- golangci-lint v1.50.1
- gopls v0.11.0
- dapper v0.6.0
- golang v1.19.5

#### Types of Changes ####

Version bump.

#### Verification ####

The CI checks should suffice for regression verification.

#### Testing ####

N/A

#### Linked Issues ####

N/A

#### User-Facing Change ####

N/A
