### PR TITLE
[release-1.23] Bump containerd to v1.5.16-k3s2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.22
 	github.com/cloudnativelabs/kube-router => github.com/k3s-io/kube-router v1.5.2-0.20221026101626-e01045262706
 	github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
-	github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.16-k3s1-1-22
+	github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.16-k3s2-1-22
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker => github.com/docker/docker v20.10.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -657,8 +657,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/k3s-io/cadvisor v0.43.0-k3s1 h1:bc51UHUKERI+X4DjgHmKq9Ong0KT3TnFVmvUIkFTCoU=
 github.com/k3s-io/cadvisor v0.43.0-k3s1/go.mod h1:+RdMSbc3FVr5NYCD2dOEJy/LI0jYJ/0xJXkzWXEyiFQ=
-github.com/k3s-io/containerd v1.5.16-k3s1-1-22 h1:0S9r3ciFft3wSrdbFHvi6ukscnAjDj6uApZ/vapSigk=
-github.com/k3s-io/containerd v1.5.16-k3s1-1-22/go.mod h1:vhtc7YWaaOgx4lfsEc+uVIoijIRIGTcwZJiIPbBjDuY=
+github.com/k3s-io/containerd v1.5.16-k3s2-1-22 h1:D1qqI5hCbNToUcswDxsp8XwLwNv5TdH3H+WpENw1srg=
+github.com/k3s-io/containerd v1.5.16-k3s2-1-22/go.mod h1:vhtc7YWaaOgx4lfsEc+uVIoijIRIGTcwZJiIPbBjDuY=
 github.com/k3s-io/cri-tools v1.22.0-k3s1 h1:a+7srHjpHVtCgYT4dtZQUTThLfo8xWR2SR53+JtKa0I=
 github.com/k3s-io/cri-tools v1.22.0-k3s1/go.mod h1:06cMrzcMIFKwDJziI2YyLdA0NVzN054GMRRWsL+NRPk=
 github.com/k3s-io/etcd/api/v3 v3.5.4-k3s1 h1:Ac7cbUC5A0E4mlvbNne82N1x5ROSwXIrzXhBGR0cg94=


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to fix issue with CNI info being forgotten on restart

#### Types of Changes ####

version bump

#### Verification ####

* restart k3s
* note that pods are not restarted

#### Testing ####

TBD

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6809

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The embedded containerd version has been bumped to v1.5.16-k3s2. This includes a backported fix for [containerd/7843](https://github.com/containerd/containerd/issues/7843) which caused pods to lose their CNI info when containerd was restarted, which in turn caused the kubelet to recreate the pod. 
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
