### PR TITLE
Fix access to hostNetwork port on NodeIP when egress-selector-mode=agent

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -344,13 +344,13 @@ func configureNode(ctx context.Context, nodeConfig *daemonconfig.Node, nodes typ
 		}
 
 		// inject node config
-		if changed, err := nodeconfig.SetNodeConfigAnnotations(node); err != nil {
+		if changed, err := nodeconfig.SetNodeConfigAnnotations(nodeConfig, node); err != nil {
 			return false, err
 		} else if changed {
 			updateNode = true
 		}
 
-		if changed, err := nodeconfig.SetNodeConfigLabels(node); err != nil {
+		if changed, err := nodeconfig.SetNodeConfigLabels(nodeConfig, node); err != nil {
 			return false, err
 		} else if changed {
 			updateNode = true

--- a/pkg/nodeconfig/nodeconfig_test.go
+++ b/pkg/nodeconfig/nodeconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +21,7 @@ var FakeNodeWithNoAnnotation = &corev1.Node{
 }
 
 var TestEnvName = version.ProgramUpper + "_NODE_NAME"
+var FakeNodeConfig = &config.Node{}
 var FakeNodeWithAnnotation = &corev1.Node{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "Node",
@@ -39,7 +41,7 @@ func Test_UnitSetExistingNodeConfigAnnotations(t *testing.T) {
 	// adding same config
 	os.Args = []string{version.Program, "server", "--flannel-backend=none"}
 	os.Setenv(version.ProgramUpper+"_NODE_NAME", "fakeNode-with-annotation")
-	nodeUpdated, err := SetNodeConfigAnnotations(FakeNodeWithAnnotation)
+	nodeUpdated, err := SetNodeConfigAnnotations(FakeNodeConfig, FakeNodeWithAnnotation)
 	if err != nil {
 		t.Fatalf("Failed to set node config annotation: %v", err)
 	}
@@ -50,6 +52,7 @@ func Test_UnitSetExistingNodeConfigAnnotations(t *testing.T) {
 
 func Test_UnitSetNodeConfigAnnotations(t *testing.T) {
 	type args struct {
+		config *config.Node
 		node   *corev1.Node
 		osArgs []string
 	}
@@ -72,6 +75,7 @@ func Test_UnitSetNodeConfigAnnotations(t *testing.T) {
 		{
 			name: "Set empty NodeConfigAnnotations",
 			args: args{
+				config: FakeNodeConfig,
 				node:   FakeNodeWithAnnotation,
 				osArgs: []string{version.Program, "server", "--flannel-backend=none"},
 			},
@@ -83,6 +87,7 @@ func Test_UnitSetNodeConfigAnnotations(t *testing.T) {
 		{
 			name: "Set args with equal",
 			args: args{
+				config: FakeNodeConfig,
 				node:   FakeNodeWithNoAnnotation,
 				osArgs: []string{version.Program, "server", "--flannel-backend=none", "--write-kubeconfig-mode=777"},
 			},
@@ -98,7 +103,7 @@ func Test_UnitSetNodeConfigAnnotations(t *testing.T) {
 				t.Errorf("Setup for SetNodeConfigAnnotations() failed = %v", err)
 				return
 			}
-			got, err := SetNodeConfigAnnotations(tt.args.node)
+			got, err := SetNodeConfigAnnotations(tt.args.config, tt.args.node)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SetNodeConfigAnnotations() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
With `egress-selector-mode: agent` (the default), and `egress.X.io/cluster: true` node labels (also a default), if any Pods are running with `hostNetwork: true` (and therefore use the Node IP), then the API Server will attempt to use agent tunnels to communicate with those Pods, but tunnel authorization will fail, resulting in connection failures.

This commit fixes the issue by adjusting the API Server such that the `egress.X.io/cluster: true` node labels are ignored with `egress-selector-mode: agent`.  This ensures that agent tunnels are only used when connecting to kubelet ports on Node IPs, and will not be used when connecting to `hostNetwork` Pod ports on Node IPs.

### Linked Issue
* https://github.com/k3s-io/k3s/issues/6830

### More details

This is loosely related to the following issues: https://github.com/k3s-io/k3s/issues/5637 https://github.com/rancher/rke2/issues/3016

When deciding whether to tunnel connections, the server (prior to this commit):
* Always skips tunneling for connections to the local node: https://github.com/k3s-io/k3s/blob/b411864be5c4f88ae2570fe8ac5238ffb7373372/pkg/daemons/control/tunnel.go#L256-L257
* Always tunnels to other nodes accessed using the node name: https://github.com/k3s-io/k3s/blob/b411864be5c4f88ae2570fe8ac5238ffb7373372/pkg/daemons/control/tunnel.go#L243-L247
* Checks the destination against a list of CIDRs: https://github.com/k3s-io/k3s/blob/b411864be5c4f88ae2570fe8ac5238ffb7373372/pkg/daemons/control/tunnel.go#L227-L230
  * This list is not populated if `egress-selector-mode` is `disabled`: https://github.com/k3s-io/k3s/blob/b411864be5c4f88ae2570fe8ac5238ffb7373372/pkg/daemons/control/tunnel.go#L111-L112
  * If `egress-selector-mode` is `agent` then this list is populated with Node IPs: https://github.com/k3s-io/k3s/blob/b411864be5c4f88ae2570fe8ac5238ffb7373372/pkg/daemons/control/tunnel.go#L130
  * If `egress-selector-mode` is `pod` or `cluster` then this list is populated with both Node and Pod IPs: https://github.com/k3s-io/k3s/blob/b411864be5c4f88ae2570fe8ac5238ffb7373372/pkg/daemons/control/tunnel.go#L155
* Tunnels if the destination matches the CIDR list and either:
  * The connection is to the kubelet port: https://github.com/k3s-io/k3s/blob/b411864be5c4f88ae2570fe8ac5238ffb7373372/pkg/daemons/control/tunnel.go#L233-L235
  * The destination node is labeled with `egress.X.io/cluster: true` : https://github.com/k3s-io/k3s/blob/b411864be5c4f88ae2570fe8ac5238ffb7373372/pkg/daemons/control/tunnel.go#L237
* Otherwise does not tunnel

When deciding whether to accept a tunnel connection, the server:
* Always accepts connections to the kubelet port: https://github.com/k3s-io/k3s/blob/76729d813b434c3573a67ad5b18429347c13803b/pkg/agent/tunnel/tunnel.go#L343-L344
* Checks the destination against a list of CIDRs, and accepts the connection if a match is found: https://github.com/k3s-io/k3s/blob/76729d813b434c3573a67ad5b18429347c13803b/pkg/agent/tunnel/tunnel.go#L346-L347
  * This list is not populated if `egress-selector-mode` is `disabled` or `agent`: https://github.com/k3s-io/k3s/blob/76729d813b434c3573a67ad5b18429347c13803b/pkg/agent/tunnel/tunnel.go#L107
  * If `egress-selector-mode` is `cluster` then this list is populated with Node IPs and Cluster CIDRs: https://github.com/k3s-io/k3s/blob/76729d813b434c3573a67ad5b18429347c13803b/pkg/agent/tunnel/tunnel.go#L174
  * If `egress-selector-mode` is `pod` then this list is populated with Node and Pod IPs.  If the destination matches a Node IP, then an additional check is made on the destination port, and the connection is accepted only if the destination port belongs to a Pod that has `hostNetwork: true`: https://github.com/k3s-io/k3s/blob/76729d813b434c3573a67ad5b18429347c13803b/pkg/agent/tunnel/tunnel.go#L190 https://github.com/k3s-io/k3s/blob/76729d813b434c3573a67ad5b18429347c13803b/pkg/agent/tunnel/tunnel.go#L349-L350
* Otherwise blocks the tunneled connection


#### In my particular case ####

I'm running RKE2 with the ingress configured with `hostNetwork: true`.  (This was configured to permit IPv6 access to the ingress from outside the cluster before we had IPv6 working within the cluster, although it may no longer be necessary now that we have IPv6 working within the cluster.)

At some point a few months ago, ingress creation/configuration became unreliable.  It would eventually succeed if we retried it enough times, but it would usually fail with the following error:
```
Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": failed to call webhook: Post "https://rke2-ingress-nginx-controller-admission.kube-system.svc:443/networking/v1/ingresses?timeout=30s": EOF
```
(We now know that it would succeed if the API Server happened to connect to the ingress on the local node, but would fail if the API Server connected to the ingress on any other node.)

The `rke2 server` log on the source node included:
```
error in remotedialer server [400]: websocket: close 1006 (abnormal closure): unexpected EOF
Proxy error: read failed: tunnel disconnect
```

The `rke2 server` log on the destination node included:
```
msg="Remotedialer proxy error" error="connection not allowed"
```

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an issue that would cause the apiserver egress proxy to attempt to use the agent tunnel to connect to service endpoints even in agent or disabled mode.
```