### PR TITLE
[release-1.24] Bugfix: do not break cert-manager when pprof is enabled

### DIFF
--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -97,7 +97,7 @@ func (c *Cluster) initClusterAndHTTPS(ctx context.Context) error {
 	}
 
 	if c.config.EnablePProf {
-		mux := mux.NewRouter()
+		mux := mux.NewRouter().SkipClean(true)
 		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Change router set up when `--enable-pprof` is enabled so that cert-manager will install correctly.

#### Types of Changes ####

Bugfix.

#### Verification ####

 - Install k3s (tested with v1.24.6+k3s1)
 - Run k3s with  the `--enable-pprof` option
 - install the cert-manager Helm chart (tested with https://charts.jetstack.io/charts/cert-manager-v1.10.1.tgz)

#### Testing ####

Only tested manually, only really relevant for developers. Please advise if any kind of automated test is required to get the PR merged.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6835

#### User-Facing Change ####

```release-note
NONE
```
