### PR TITLE
Ensure flag type consistency

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -95,7 +95,7 @@ var (
 		Destination: &AgentConfig.EnableSELinux,
 		EnvVar:      version.ProgramUpper + "_SELINUX",
 	}
-	LBServerPortFlag = cli.IntFlag{
+	LBServerPortFlag = &cli.IntFlag{
 		Name:        "lb-server-port",
 		Usage:       "(agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.",
 		Destination: &AgentConfig.LBServerPort,

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -57,39 +57,39 @@ type AgentShared struct {
 var (
 	appName        = filepath.Base(os.Args[0])
 	AgentConfig    Agent
-	AgentTokenFlag = cli.StringFlag{
+	AgentTokenFlag = &cli.StringFlag{
 		Name:        "token,t",
 		Usage:       "(cluster) Token to use for authentication",
 		EnvVar:      version.ProgramUpper + "_TOKEN",
 		Destination: &AgentConfig.Token,
 	}
-	NodeIPFlag = cli.StringSliceFlag{
+	NodeIPFlag = &cli.StringSliceFlag{
 		Name:  "node-ip,i",
 		Usage: "(agent/networking) IPv4/IPv6 addresses to advertise for node",
 		Value: &AgentConfig.NodeIP,
 	}
-	NodeExternalIPFlag = cli.StringSliceFlag{
+	NodeExternalIPFlag = &cli.StringSliceFlag{
 		Name:  "node-external-ip",
 		Usage: "(agent/networking) IPv4/IPv6 external IP addresses to advertise for node",
 		Value: &AgentConfig.NodeExternalIP,
 	}
-	NodeNameFlag = cli.StringFlag{
+	NodeNameFlag = &cli.StringFlag{
 		Name:        "node-name",
 		Usage:       "(agent/node) Node name",
 		EnvVar:      version.ProgramUpper + "_NODE_NAME",
 		Destination: &AgentConfig.NodeName,
 	}
-	WithNodeIDFlag = cli.BoolFlag{
+	WithNodeIDFlag = &cli.BoolFlag{
 		Name:        "with-node-id",
 		Usage:       "(agent/node) Append id to node name",
 		Destination: &AgentConfig.WithNodeID,
 	}
-	ProtectKernelDefaultsFlag = cli.BoolFlag{
+	ProtectKernelDefaultsFlag = &cli.BoolFlag{
 		Name:        "protect-kernel-defaults",
 		Usage:       "(agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.",
 		Destination: &AgentConfig.ProtectKernelDefaults,
 	}
-	SELinuxFlag = cli.BoolFlag{
+	SELinuxFlag = &cli.BoolFlag{
 		Name:        "selinux",
 		Usage:       "(agent/node) Enable SELinux in containerd",
 		Destination: &AgentConfig.EnableSELinux,
@@ -102,88 +102,88 @@ var (
 		EnvVar:      version.ProgramUpper + "_LB_SERVER_PORT",
 		Value:       6444,
 	}
-	DockerFlag = cli.BoolFlag{
+	DockerFlag = &cli.BoolFlag{
 		Name:        "docker",
 		Usage:       "(agent/runtime) (experimental) Use cri-dockerd instead of containerd",
 		Destination: &AgentConfig.Docker,
 	}
-	CRIEndpointFlag = cli.StringFlag{
+	CRIEndpointFlag = &cli.StringFlag{
 		Name:        "container-runtime-endpoint",
 		Usage:       "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path; when used with --docker this sets the docker socket path",
 		Destination: &AgentConfig.ContainerRuntimeEndpoint,
 	}
-	PrivateRegistryFlag = cli.StringFlag{
+	PrivateRegistryFlag = &cli.StringFlag{
 		Name:        "private-registry",
 		Usage:       "(agent/runtime) Private registry configuration file",
 		Destination: &AgentConfig.PrivateRegistry,
 		Value:       "/etc/rancher/" + version.Program + "/registries.yaml",
 	}
-	AirgapExtraRegistryFlag = cli.StringSliceFlag{
+	AirgapExtraRegistryFlag = &cli.StringSliceFlag{
 		Name:   "airgap-extra-registry",
 		Usage:  "(agent/runtime) Additional registry to tag airgap images as being sourced from",
 		Value:  &AgentConfig.AirgapExtraRegistry,
 		Hidden: true,
 	}
-	PauseImageFlag = cli.StringFlag{
+	PauseImageFlag = &cli.StringFlag{
 		Name:        "pause-image",
 		Usage:       "(agent/runtime) Customized pause image for containerd or docker sandbox",
 		Destination: &AgentConfig.PauseImage,
 		Value:       DefaultPauseImage,
 	}
-	SnapshotterFlag = cli.StringFlag{
+	SnapshotterFlag = &cli.StringFlag{
 		Name:        "snapshotter",
 		Usage:       "(agent/runtime) Override default containerd snapshotter",
 		Destination: &AgentConfig.Snapshotter,
 		Value:       DefaultSnapshotter,
 	}
-	FlannelIfaceFlag = cli.StringFlag{
+	FlannelIfaceFlag = &cli.StringFlag{
 		Name:        "flannel-iface",
 		Usage:       "(agent/networking) Override default flannel interface",
 		Destination: &AgentConfig.FlannelIface,
 	}
-	FlannelConfFlag = cli.StringFlag{
+	FlannelConfFlag = &cli.StringFlag{
 		Name:        "flannel-conf",
 		Usage:       "(agent/networking) Override default flannel config file",
 		Destination: &AgentConfig.FlannelConf,
 	}
-	FlannelCniConfFileFlag = cli.StringFlag{
+	FlannelCniConfFileFlag = &cli.StringFlag{
 		Name:        "flannel-cni-conf",
 		Usage:       "(agent/networking) Override default flannel cni config file",
 		Destination: &AgentConfig.FlannelCniConfFile,
 	}
-	ResolvConfFlag = cli.StringFlag{
+	ResolvConfFlag = &cli.StringFlag{
 		Name:        "resolv-conf",
 		Usage:       "(agent/networking) Kubelet resolv.conf file",
 		EnvVar:      version.ProgramUpper + "_RESOLV_CONF",
 		Destination: &AgentConfig.ResolvConf,
 	}
-	ExtraKubeletArgs = cli.StringSliceFlag{
+	ExtraKubeletArgs = &cli.StringSliceFlag{
 		Name:  "kubelet-arg",
 		Usage: "(agent/flags) Customized flag for kubelet process",
 		Value: &AgentConfig.ExtraKubeletArgs,
 	}
-	ExtraKubeProxyArgs = cli.StringSliceFlag{
+	ExtraKubeProxyArgs = &cli.StringSliceFlag{
 		Name:  "kube-proxy-arg",
 		Usage: "(agent/flags) Customized flag for kube-proxy process",
 		Value: &AgentConfig.ExtraKubeProxyArgs,
 	}
-	NodeTaints = cli.StringSliceFlag{
+	NodeTaints = &cli.StringSliceFlag{
 		Name:  "node-taint",
 		Usage: "(agent/node) Registering kubelet with set of taints",
 		Value: &AgentConfig.Taints,
 	}
-	NodeLabels = cli.StringSliceFlag{
+	NodeLabels = &cli.StringSliceFlag{
 		Name:  "node-label",
 		Usage: "(agent/node) Registering and starting kubelet with set of labels",
 		Value: &AgentConfig.Labels,
 	}
-	ImageCredProvBinDirFlag = cli.StringFlag{
+	ImageCredProvBinDirFlag = &cli.StringFlag{
 		Name:        "image-credential-provider-bin-dir",
 		Usage:       "(agent/node) The path to the directory where credential provider plugin binaries are located",
 		Destination: &AgentConfig.ImageCredProvBinDir,
 		Value:       "/var/lib/rancher/credentialprovider/bin",
 	}
-	ImageCredProvConfigFlag = cli.StringFlag{
+	ImageCredProvConfigFlag = &cli.StringFlag{
 		Name:        "image-credential-provider-config",
 		Usage:       "(agent/node) The path to the credential provider plugin config file",
 		Destination: &AgentConfig.ImageCredProvConfig,
@@ -205,19 +205,19 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			LogFile,
 			AlsoLogToStderr,
 			AgentTokenFlag,
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name:        "token-file",
 				Usage:       "(cluster) Token file to use for authentication",
 				EnvVar:      version.ProgramUpper + "_TOKEN_FILE",
 				Destination: &AgentConfig.TokenFile,
 			},
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name:        "server,s",
 				Usage:       "(cluster) Server to connect to",
 				EnvVar:      version.ProgramUpper + "_URL",
 				Destination: &AgentConfig.ServerURL,
 			},
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name:        "data-dir,d",
 				Usage:       "(agent/data) Folder to hold state",
 				Destination: &AgentConfig.DataDir,
@@ -229,7 +229,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			NodeTaints,
 			ImageCredProvBinDirFlag,
 			ImageCredProvConfigFlag,
-			&SELinuxFlag,
+			SELinuxFlag,
 			LBServerPortFlag,
 			ProtectKernelDefaultsFlag,
 			CRIEndpointFlag,
@@ -246,7 +246,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			ExtraKubeletArgs,
 			ExtraKubeProxyArgs,
 			// Experimental flags
-			cli.BoolFlag{
+			&cli.BoolFlag{
 				Name:        "rootless",
 				Usage:       "(experimental) Run rootless",
 				Destination: &AgentConfig.Rootless,

--- a/pkg/cli/cmds/certs.go
+++ b/pkg/cli/cmds/certs.go
@@ -15,7 +15,7 @@ var (
 		LogFile,
 		AlsoLogToStderr,
 		DataDirFlag,
-		cli.StringSliceFlag{
+		&cli.StringSliceFlag{
 			Name:  "service,s",
 			Usage: "List of services to rotate certificates for. Options include (admin, api-server, controller-manager, scheduler, " + version.Program + "-controller, " + version.Program + "-server, cloud-controller, etcd, auth-proxy, kubelet, kube-proxy)",
 			Value: &ServicesList,

--- a/pkg/cli/cmds/completion.go
+++ b/pkg/cli/cmds/completion.go
@@ -11,7 +11,7 @@ func NewCompletionCommand(action func(*cli.Context) error) cli.Command {
 		UsageText: appName + " completion [SHELL] (valid shells: bash, zsh)",
 		Action:    action,
 		Flags: []cli.Flag{
-			cli.BoolFlag{
+			&cli.BoolFlag{
 				Name:  "i",
 				Usage: "Install source line to rc file",
 			},

--- a/pkg/cli/cmds/config.go
+++ b/pkg/cli/cmds/config.go
@@ -8,7 +8,7 @@ import (
 var (
 	// ConfigFlag is here to show to the user, but the actually processing is done by configfileargs before
 	// call urfave
-	ConfigFlag = cli.StringFlag{
+	ConfigFlag = &cli.StringFlag{
 		Name:   "config,c",
 		Usage:  "(config) Load configuration from `FILE`",
 		EnvVar: version.ProgramUpper + "_CONFIG_FILE",

--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -14,7 +14,7 @@ var EtcdSnapshotFlags = []cli.Flag{
 	ConfigFlag,
 	LogFile,
 	AlsoLogToStderr,
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "node-name",
 		Usage:       "(agent/node) Node name",
 		EnvVar:      version.ProgramUpper + "_NODE_NAME",

--- a/pkg/cli/cmds/log.go
+++ b/pkg/cli/cmds/log.go
@@ -26,17 +26,17 @@ var (
 		Usage:       "(logging) Number for the log level verbosity",
 		Destination: &LogConfig.VLevel,
 	}
-	VModule = cli.StringFlag{
+	VModule = &cli.StringFlag{
 		Name:        "vmodule",
 		Usage:       "(logging) Comma-separated list of FILE_PATTERN=LOG_LEVEL settings for file-filtered logging",
 		Destination: &LogConfig.VModule,
 	}
-	LogFile = cli.StringFlag{
+	LogFile = &cli.StringFlag{
 		Name:        "log,l",
 		Usage:       "(logging) Log to file",
 		Destination: &LogConfig.LogFile,
 	}
-	AlsoLogToStderr = cli.BoolFlag{
+	AlsoLogToStderr = &cli.BoolFlag{
 		Name:        "alsologtostderr",
 		Usage:       "(logging) Log to standard error as well as file (if set)",
 		Destination: &LogConfig.AlsoLogToStderr,

--- a/pkg/cli/cmds/log.go
+++ b/pkg/cli/cmds/log.go
@@ -21,7 +21,7 @@ type Log struct {
 var (
 	LogConfig Log
 
-	VLevel = cli.IntFlag{
+	VLevel = &cli.IntFlag{
 		Name:        "v",
 		Usage:       "(logging) Number for the log level verbosity",
 		Destination: &LogConfig.VLevel,

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -11,13 +11,13 @@ import (
 
 var (
 	Debug     bool
-	DebugFlag = cli.BoolFlag{
+	DebugFlag = &cli.BoolFlag{
 		Name:        "debug",
 		Usage:       "(logging) Turn on debug logs",
 		Destination: &Debug,
 		EnvVar:      version.ProgramUpper + "_DEBUG",
 	}
-	PreferBundledBin = cli.BoolFlag{
+	PreferBundledBin = &cli.BoolFlag{
 		Name:  "prefer-bundled-bin",
 		Usage: "(experimental) Prefer bundled userspace binaries over host binaries",
 	}
@@ -41,7 +41,7 @@ func NewApp() *cli.App {
 	}
 	app.Flags = []cli.Flag{
 		DebugFlag,
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "data-dir,d",
 			Usage: "(data) Folder to hold state (default: /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root)",
 		},

--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -8,7 +8,7 @@ import (
 const SecretsEncryptCommand = "secrets-encrypt"
 
 var (
-	forceFlag = cli.BoolFlag{
+	forceFlag = &cli.BoolFlag{
 		Name:        "f,force",
 		Usage:       "Force this stage.",
 		Destination: &ServerConfig.EncryptForce,
@@ -16,7 +16,7 @@ var (
 	EncryptFlags = []cli.Flag{
 		DataDirFlag,
 		ServerToken,
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:        "server, s",
 			Usage:       "(cluster) Server to connect to",
 			EnvVar:      version.ProgramUpper + "_URL",
@@ -62,14 +62,14 @@ func NewSecretsEncryptCommands(status, enable, disable, prepare, rotate, reencry
 				Usage:          "Prepare for encryption keys rotation",
 				SkipArgReorder: true,
 				Action:         prepare,
-				Flags:          append(EncryptFlags, &forceFlag),
+				Flags:          append(EncryptFlags, forceFlag),
 			},
 			{
 				Name:           "rotate",
 				Usage:          "Rotate secrets encryption keys",
 				SkipArgReorder: true,
 				Action:         rotate,
-				Flags:          append(EncryptFlags, &forceFlag),
+				Flags:          append(EncryptFlags, forceFlag),
 			},
 			{
 				Name:           "reencrypt",
@@ -77,7 +77,7 @@ func NewSecretsEncryptCommands(status, enable, disable, prepare, rotate, reencry
 				SkipArgReorder: true,
 				Action:         reencrypt,
 				Flags: append(EncryptFlags,
-					&forceFlag,
+					forceFlag,
 					&cli.BoolFlag{
 						Name:        "skip",
 						Usage:       "Skip removing old key",

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -107,60 +107,60 @@ type Server struct {
 
 var (
 	ServerConfig Server
-	DataDirFlag  = cli.StringFlag{
+	DataDirFlag  = &cli.StringFlag{
 		Name:        "data-dir,d",
 		Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
 		Destination: &ServerConfig.DataDir,
 	}
-	ServerToken = cli.StringFlag{
+	ServerToken = &cli.StringFlag{
 		Name:        "token,t",
 		Usage:       "(cluster) Shared secret used to join a server or agent to a cluster",
 		Destination: &ServerConfig.Token,
 		EnvVar:      version.ProgramUpper + "_TOKEN",
 	}
-	ClusterCIDR = cli.StringSliceFlag{
+	ClusterCIDR = &cli.StringSliceFlag{
 		Name:  "cluster-cidr",
 		Usage: "(networking) IPv4/IPv6 network CIDRs to use for pod IPs (default: 10.42.0.0/16)",
 		Value: &ServerConfig.ClusterCIDR,
 	}
-	ServiceCIDR = cli.StringSliceFlag{
+	ServiceCIDR = &cli.StringSliceFlag{
 		Name:  "service-cidr",
 		Usage: "(networking) IPv4/IPv6 network CIDRs to use for service IPs (default: 10.43.0.0/16)",
 		Value: &ServerConfig.ServiceCIDR,
 	}
-	ServiceNodePortRange = cli.StringFlag{
+	ServiceNodePortRange = &cli.StringFlag{
 		Name:        "service-node-port-range",
 		Usage:       "(networking) Port range to reserve for services with NodePort visibility",
 		Destination: &ServerConfig.ServiceNodePortRange,
 		Value:       "30000-32767",
 	}
-	ClusterDNS = cli.StringSliceFlag{
+	ClusterDNS = &cli.StringSliceFlag{
 		Name:  "cluster-dns",
 		Usage: "(networking) IPv4 Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
 		Value: &ServerConfig.ClusterDNS,
 	}
-	ClusterDomain = cli.StringFlag{
+	ClusterDomain = &cli.StringFlag{
 		Name:        "cluster-domain",
 		Usage:       "(networking) Cluster Domain",
 		Destination: &ServerConfig.ClusterDomain,
 		Value:       "cluster.local",
 	}
-	ExtraAPIArgs = cli.StringSliceFlag{
+	ExtraAPIArgs = &cli.StringSliceFlag{
 		Name:  "kube-apiserver-arg",
 		Usage: "(flags) Customized flag for kube-apiserver process",
 		Value: &ServerConfig.ExtraAPIArgs,
 	}
-	ExtraEtcdArgs = cli.StringSliceFlag{
+	ExtraEtcdArgs = &cli.StringSliceFlag{
 		Name:  "etcd-arg",
 		Usage: "(flags) Customized flag for etcd process",
 		Value: &ServerConfig.ExtraEtcdArgs,
 	}
-	ExtraSchedulerArgs = cli.StringSliceFlag{
+	ExtraSchedulerArgs = &cli.StringSliceFlag{
 		Name:  "kube-scheduler-arg",
 		Usage: "(flags) Customized flag for kube-scheduler process",
 		Value: &ServerConfig.ExtraSchedulerArgs,
 	}
-	ExtraControllerArgs = cli.StringSliceFlag{
+	ExtraControllerArgs = &cli.StringSliceFlag{
 		Name:  "kube-controller-manager-arg",
 		Usage: "(flags) Customized flag for kube-controller-manager process",
 		Value: &ServerConfig.ExtraControllerArgs,
@@ -174,7 +174,7 @@ var ServerFlags = []cli.Flag{
 	VModule,
 	LogFile,
 	AlsoLogToStderr,
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "bind-address",
 		Usage:       "(listener) " + version.Program + " bind address (default: 0.0.0.0)",
 		Destination: &ServerConfig.BindAddress,
@@ -185,7 +185,7 @@ var ServerFlags = []cli.Flag{
 		Value:       6443,
 		Destination: &ServerConfig.HTTPSPort,
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "advertise-address",
 		Usage:       "(listener) IPv4 address that apiserver uses to advertise to members of the cluster (default: node-external-ip/node-ip)",
 		Destination: &ServerConfig.AdvertiseIP,
@@ -195,7 +195,7 @@ var ServerFlags = []cli.Flag{
 		Usage:       "(listener) Port that apiserver uses to advertise to members of the cluster (default: listen-port)",
 		Destination: &ServerConfig.AdvertisePort,
 	},
-	cli.StringSliceFlag{
+	&cli.StringSliceFlag{
 		Name:  "tls-san",
 		Usage: "(listener) Add additional hostnames or IPv4/IPv6 addresses as Subject Alternative Names on the server TLS cert",
 		Value: &ServerConfig.TLSSan,
@@ -206,78 +206,78 @@ var ServerFlags = []cli.Flag{
 	ServiceNodePortRange,
 	ClusterDNS,
 	ClusterDomain,
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "flannel-backend",
 		Usage:       "(networking) backend<=option1=val1,option2=val2> where backend is one of 'none', 'vxlan', 'ipsec' (deprecated), 'host-gw', 'wireguard-native', 'wireguard' (deprecated)",
 		Destination: &ServerConfig.FlannelBackend,
 		Value:       "vxlan",
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "flannel-ipv6-masq",
 		Usage:       "(networking) Enable IPv6 masquerading for pod",
 		Destination: &ServerConfig.FlannelIPv6Masq,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "flannel-external-ip",
 		Usage:       "(networking) Use node external IP addresses for Flannel traffic",
 		Destination: &ServerConfig.FlannelExternalIP,
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "egress-selector-mode",
 		Usage:       "(networking) One of 'agent', 'cluster', 'pod', 'disabled'",
 		Destination: &ServerConfig.EgressSelectorMode,
 		Value:       "agent",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "servicelb-namespace",
 		Usage:       "(networking) Namespace of the pods for the servicelb component",
 		Destination: &ServerConfig.ServiceLBNamespace,
 		Value:       "kube-system",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "write-kubeconfig,o",
 		Usage:       "(client) Write kubeconfig for admin client to this file",
 		Destination: &ServerConfig.KubeConfigOutput,
 		EnvVar:      version.ProgramUpper + "_KUBECONFIG_OUTPUT",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "write-kubeconfig-mode",
 		Usage:       "(client) Write kubeconfig with this mode",
 		Destination: &ServerConfig.KubeConfigMode,
 		EnvVar:      version.ProgramUpper + "_KUBECONFIG_MODE",
 	},
 	ServerToken,
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "token-file",
 		Usage:       "(cluster) File containing the token",
 		Destination: &ServerConfig.TokenFile,
 		EnvVar:      version.ProgramUpper + "_TOKEN_FILE",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "agent-token",
 		Usage:       "(cluster) Shared secret used to join agents to the cluster, but not servers",
 		Destination: &ServerConfig.AgentToken,
 		EnvVar:      version.ProgramUpper + "_AGENT_TOKEN",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "agent-token-file",
 		Usage:       "(cluster) File containing the agent secret",
 		Destination: &ServerConfig.AgentTokenFile,
 		EnvVar:      version.ProgramUpper + "_AGENT_TOKEN_FILE",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "server,s",
 		Usage:       "(cluster) Server to connect to, used to join a cluster",
 		EnvVar:      version.ProgramUpper + "_URL",
 		Destination: &ServerConfig.ServerURL,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "cluster-init",
 		Usage:       "(cluster) Initialize a new cluster using embedded Etcd",
 		EnvVar:      version.ProgramUpper + "_CLUSTER_INIT",
 		Destination: &ServerConfig.ClusterInit,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "cluster-reset",
 		Usage:       "(cluster) Forget all peers and become sole member of a new cluster",
 		EnvVar:      version.ProgramUpper + "_CLUSTER_RESET",
@@ -292,30 +292,30 @@ var ServerFlags = []cli.Flag{
 	ExtraEtcdArgs,
 	ExtraControllerArgs,
 	ExtraSchedulerArgs,
-	cli.StringSliceFlag{
+	&cli.StringSliceFlag{
 		Name:  "kube-cloud-controller-manager-arg",
 		Usage: "(flags) Customized flag for kube-cloud-controller-manager process",
 		Value: &ServerConfig.ExtraCloudControllerArgs,
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "datastore-endpoint",
 		Usage:       "(db) Specify etcd, Mysql, Postgres, or Sqlite (default) data source name",
 		Destination: &ServerConfig.DatastoreEndpoint,
 		EnvVar:      version.ProgramUpper + "_DATASTORE_ENDPOINT",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "datastore-cafile",
 		Usage:       "(db) TLS Certificate Authority file used to secure datastore backend communication",
 		Destination: &ServerConfig.DatastoreCAFile,
 		EnvVar:      version.ProgramUpper + "_DATASTORE_CAFILE",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "datastore-certfile",
 		Usage:       "(db) TLS certification file used to secure datastore backend communication",
 		Destination: &ServerConfig.DatastoreCertFile,
 		EnvVar:      version.ProgramUpper + "_DATASTORE_CERTFILE",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "datastore-keyfile",
 		Usage:       "(db) TLS key file used to secure datastore backend communication",
 		Destination: &ServerConfig.DatastoreKeyFile,
@@ -419,53 +419,53 @@ var ServerFlags = []cli.Flag{
 		Destination: &ServerConfig.EtcdS3Timeout,
 		Value:       5 * time.Minute,
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "default-local-storage-path",
 		Usage:       "(storage) Default local storage path for local provisioner storage class",
 		Destination: &ServerConfig.DefaultLocalStoragePath,
 	},
-	cli.StringSliceFlag{
+	&cli.StringSliceFlag{
 		Name:  "disable",
 		Usage: "(components) Do not deploy packaged components and delete any deployed components (valid items: " + DisableItems + ")",
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "disable-scheduler",
 		Usage:       "(components) Disable Kubernetes default scheduler",
 		Destination: &ServerConfig.DisableScheduler,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "disable-cloud-controller",
 		Usage:       "(components) Disable " + version.Program + " default cloud controller manager",
 		Destination: &ServerConfig.DisableCCM,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "disable-kube-proxy",
 		Usage:       "(components) Disable running kube-proxy",
 		Destination: &ServerConfig.DisableKubeProxy,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "disable-network-policy",
 		Usage:       "(components) Disable " + version.Program + " default network policy controller",
 		Destination: &ServerConfig.DisableNPC,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "disable-helm-controller",
 		Usage:       "(components) Disable Helm controller",
 		Destination: &ServerConfig.DisableHelmController,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "disable-apiserver",
 		Hidden:      true,
 		Usage:       "(experimental/components) Disable running api server",
 		Destination: &ServerConfig.DisableAPIServer,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "disable-controller-manager",
 		Hidden:      true,
 		Usage:       "(experimental/components) Disable running kube-controller-manager",
 		Destination: &ServerConfig.DisableControllerManager,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "disable-etcd",
 		Hidden:      true,
 		Usage:       "(experimental/components) Disable running etcd",
@@ -482,7 +482,7 @@ var ServerFlags = []cli.Flag{
 	PauseImageFlag,
 	SnapshotterFlag,
 	PrivateRegistryFlag,
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:        "system-default-registry",
 		Usage:       "(agent/runtime) Private registry to be used for all system images",
 		EnvVar:      version.ProgramUpper + "_SYSTEM_DEFAULT_REGISTRY",
@@ -498,41 +498,41 @@ var ServerFlags = []cli.Flag{
 	ExtraKubeletArgs,
 	ExtraKubeProxyArgs,
 	ProtectKernelDefaultsFlag,
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "secrets-encryption",
 		Usage:       "Enable secret encryption at rest",
 		Destination: &ServerConfig.EncryptSecrets,
 	},
 	// Experimental flags
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "enable-pprof",
 		Usage:       "(experimental) Enable pprof endpoint on supervisor port",
 		Destination: &ServerConfig.EnablePProf,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "rootless",
 		Usage:       "(experimental) Run rootless",
 		Destination: &ServerConfig.Rootless,
 	},
 	PreferBundledBin,
-	&SELinuxFlag,
+	SELinuxFlag,
 	LBServerPortFlag,
 
 	// Hidden/Deprecated flags below
 
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:        "disable-agent",
 		Usage:       "Do not run a local agent and register a local kubelet",
 		Hidden:      true,
 		Destination: &ServerConfig.DisableAgent,
 	},
-	cli.StringSliceFlag{
+	&cli.StringSliceFlag{
 		Hidden: true,
 		Name:   "kube-controller-arg",
 		Usage:  "(flags) Customized flag for kube-controller-manager process",
 		Value:  &ServerConfig.ExtraControllerArgs,
 	},
-	cli.StringSliceFlag{
+	&cli.StringSliceFlag{
 		Hidden: true,
 		Name:   "kube-cloud-controller-arg",
 		Usage:  "(flags) Customized flag for kube-cloud-controller-manager process",

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -179,7 +179,7 @@ var ServerFlags = []cli.Flag{
 		Usage:       "(listener) " + version.Program + " bind address (default: 0.0.0.0)",
 		Destination: &ServerConfig.BindAddress,
 	},
-	cli.IntFlag{
+	&cli.IntFlag{
 		Name:        "https-listen-port",
 		Usage:       "(listener) HTTPS listen port",
 		Value:       6443,
@@ -190,7 +190,7 @@ var ServerFlags = []cli.Flag{
 		Usage:       "(listener) IPv4 address that apiserver uses to advertise to members of the cluster (default: node-external-ip/node-ip)",
 		Destination: &ServerConfig.AdvertiseIP,
 	},
-	cli.IntFlag{
+	&cli.IntFlag{
 		Name:        "advertise-port",
 		Usage:       "(listener) Port that apiserver uses to advertise to members of the cluster (default: listen-port)",
 		Destination: &ServerConfig.AdvertisePort,


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Converts all flags to their respective "pointer" types. So bools are always defined as `&cli.BoolFlag` and string flags as `&cli.StringFlag`, now all flags maintain the same declaration structure. 

#### Types of Changes ####
Code Consistency
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
N/A K3s builds
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
K3s builds
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/2308
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####
I chose to go with "all pointers" because if we ever upgrade to urfave cli v2, flags are required to be pointers.
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
