### PR TITLE
[Release-1.25] Wait for cri-dockerd socket

### DIFF
--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -6,7 +6,6 @@ package containerd
 import (
 	"context"
 	"os"
-	"time"
 
 	"github.com/containerd/containerd"
 	"github.com/docker/docker/pkg/parsers/kernel"
@@ -20,8 +19,6 @@ import (
 	"github.com/rancher/wharfie/pkg/registries"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
-	"google.golang.org/grpc"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 )
 
@@ -97,30 +94,6 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 	}
 
 	return util2.WriteFile(cfg.Containerd.Config, parsedTemplate)
-}
-
-// criConnection connects to a CRI socket at the given path.
-func CriConnection(ctx context.Context, address string) (*grpc.ClientConn, error) {
-	addr, dialer, err := util.GetAddressAndDialer(socketPrefix + address)
-	if err != nil {
-		return nil, err
-	}
-
-	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(3*time.Second), grpc.WithContextDialer(dialer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
-	if err != nil {
-		return nil, err
-	}
-
-	c := runtimeapi.NewRuntimeServiceClient(conn)
-	_, err = c.Version(ctx, &runtimeapi.VersionRequest{
-		Version: "0.1.0",
-	})
-	if err != nil {
-		conn.Close()
-		return nil, err
-	}
-
-	return conn, nil
 }
 
 func Client(address string) (*containerd.Client, error) {

--- a/pkg/agent/containerd/config_windows.go
+++ b/pkg/agent/containerd/config_windows.go
@@ -6,7 +6,6 @@ package containerd
 import (
 	"context"
 	"os"
-	"time"
 
 	"github.com/containerd/containerd"
 	"github.com/k3s-io/k3s/pkg/agent/templates"
@@ -14,8 +13,6 @@ import (
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/rancher/wharfie/pkg/registries"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 )
 
@@ -64,30 +61,6 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 	}
 
 	return util2.WriteFile(cfg.Containerd.Config, parsedTemplate)
-}
-
-// criConnection connects to a CRI socket at the given path.
-func CriConnection(ctx context.Context, address string) (*grpc.ClientConn, error) {
-	addr, dialer, err := util.GetAddressAndDialer(address)
-	if err != nil {
-		return nil, err
-	}
-
-	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(3*time.Second), grpc.WithContextDialer(dialer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
-	if err != nil {
-		return nil, err
-	}
-
-	c := runtimeapi.NewRuntimeServiceClient(conn)
-	_, err = c.Version(ctx, &runtimeapi.VersionRequest{
-		Version: "0.1.0",
-	})
-	if err != nil {
-		conn.Close()
-		return nil, err
-	}
-
-	return conn, nil
 }
 
 func Client(address string) (*containerd.Client, error) {

--- a/pkg/agent/cri/cri.go
+++ b/pkg/agent/cri/cri.go
@@ -1,0 +1,36 @@
+package cri
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const maxMsgSize = 1024 * 1024 * 16
+
+// WaitForService blocks in a retry loop until the CRI service
+// is functional at the provided socket address. It will return only on success,
+// or when the context is cancelled.
+func WaitForService(ctx context.Context, address string, service string) error {
+	first := true
+	for {
+		conn, err := Connection(ctx, address)
+		if err == nil {
+			conn.Close()
+			break
+		}
+		if first {
+			first = false
+		} else {
+			logrus.Infof("Waiting for %s startup: %v", service, err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+	logrus.Infof("%s is now running", service)
+	return nil
+}

--- a/pkg/agent/cri/cri_linux.go
+++ b/pkg/agent/cri/cri_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+// +build linux
+
+package cri
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	k8sutil "k8s.io/kubernetes/pkg/kubelet/util"
+)
+
+const socketPrefix = "unix://"
+
+// Connection connects to a CRI socket at the given path.
+func Connection(ctx context.Context, address string) (*grpc.ClientConn, error) {
+	addr, dialer, err := k8sutil.GetAddressAndDialer(socketPrefix + address)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(3*time.Second), grpc.WithContextDialer(dialer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
+	if err != nil {
+		return nil, err
+	}
+
+	c := runtimeapi.NewRuntimeServiceClient(conn)
+	_, err = c.Version(ctx, &runtimeapi.VersionRequest{
+		Version: "0.1.0",
+	})
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}

--- a/pkg/agent/cri/cri_windows.go
+++ b/pkg/agent/cri/cri_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+// +build windows
+
+package cri
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/kubernetes/pkg/kubelet/util"
+)
+
+// Connection connects to a CRI socket at the given path.
+func Connection(ctx context.Context, address string) (*grpc.ClientConn, error) {
+	addr, dialer, err := util.GetAddressAndDialer(address)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(3*time.Second), grpc.WithContextDialer(dialer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
+	if err != nil {
+		return nil, err
+	}
+
+	c := runtimeapi.NewRuntimeServiceClient(conn)
+	_, err = c.Version(ctx, &runtimeapi.VersionRequest{
+		Version: "0.1.0",
+	})
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}

--- a/pkg/agent/cridockerd/cridockerd.go
+++ b/pkg/agent/cridockerd/cridockerd.go
@@ -8,9 +8,12 @@ import (
 
 	"github.com/Mirantis/cri-dockerd/cmd"
 	"github.com/Mirantis/cri-dockerd/cmd/version"
+
+	"github.com/k3s-io/k3s/pkg/agent/cri"
 	"github.com/k3s-io/k3s/pkg/cgroups"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/sirupsen/logrus"
+
 	utilsnet "k8s.io/utils/net"
 )
 
@@ -34,7 +37,7 @@ func Run(ctx context.Context, cfg *config.Node) error {
 		logrus.Fatalf("cri-dockerd exited: %v", command.ExecuteContext(ctx))
 	}()
 
-	return nil
+	return cri.WaitForService(ctx, cfg.CRIDockerd.Address, "cri-dockerd")
 }
 
 func getDockerCRIArgs(cfg *config.Node) []string {


### PR DESCRIPTION
Backport https://github.com/k3s-io/k3s/pull/6812 to release-1.25
* Wait for cri-dockerd socket
* Consolidate cri utility functions

Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/6855
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
