### PR TITLE
[Release-1.25] Bump vagrant boxes to fedora37

### DIFF
--- a/.github/workflows/cgroup.yaml
+++ b/.github/workflows/cgroup.yaml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vm: [fedora-35]
+        vm: [fedora]
         mode: [unified]
       max-parallel: 1
     defaults:
@@ -65,7 +65,7 @@ jobs:
         id: vagrant-cache
         continue-on-error: true
       - name: "Vagrant Plugin(s)"
-        run: vagrant plugin install vagrant-k3s
+        run: vagrant plugin install vagrant-k3s vagrant-reload
       - name: "Vagrant Up"
         run: vagrant up
       - name: "K3s Prepare"
@@ -90,6 +90,6 @@ jobs:
       - name: "[Rootless] K3s Ready"
         env: {TEST_KUBECONFIG: /home/vagrant/.kube/k3s.yaml}
         run: vagrant provision --provision-with=k3s-ready
-      - name: "[Rootless] Sonobuoy (--mode=quick)"
-        env: {TEST_KUBECONFIG: /home/vagrant/.kube/k3s.yaml, TEST_RESULTS_PATH: rootless}
-        run: vagrant provision --provision-with=k3s-sonobuoy
+      # - name: "[Rootless] Sonobuoy (--mode=quick)"
+      #   env: {TEST_KUBECONFIG: /home/vagrant/.kube/k3s.yaml, TEST_RESULTS_PATH: rootless}
+      #   run: vagrant provision --provision-with=k3s-sonobuoy

--- a/.github/workflows/epic.yaml
+++ b/.github/workflows/epic.yaml
@@ -6,6 +6,8 @@ jobs:
   epics:
     runs-on: ubuntu-latest
     name: Update epic issues
+    permissions:
+      issues: write
     steps:
       - name: Run epics action
         uses: cloudaper/epics-action@v1

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -66,13 +66,13 @@ The sub-directories therein contain fixtures for running simple clusters to asse
 - [Install Script](../tests/install) :arrow_right: scheduled nightly
   - [CentOS 7](../tests/install/centos-7) (stand-in for RHEL 7)
   - [Rocky Linux 8](../tests/install/rocky-8) (stand-in for RHEL 8)
-  - [Fedora](../tests/install/fedora)
+  - [Fedora 37](../tests/install/fedora)
   - [Leap 15.4](../tests/install/opensuse-leap) (stand-in for SLES)
   - [MicroOS](../tests/install/opensuse-microos) (stand-in for SLE-Micro)
   - [Ubuntu 20.04](../tests/install/ubuntu-focal) (Focal Fossa)
 - [Control Groups](../tests/cgroup) :arrow_right: on any code change
   - [mode=unified](../tests/cgroup/unified) (cgroups v2)
-    - [Fedora 35](../tests/cgroup/unified/fedora-35) (rootfull + rootless)
+    - [Fedora 37](../tests/cgroup/unified/fedora) (rootfull + rootless)
 - [Snapshotter](../tests/snapshotter/btrfs/opensuse-leap) :arrow_right: on any code change
   - [BTRFS](../tests/snapshotter/btrfs) ([containerd built-in](https://github.com/containerd/containerd/tree/main/snapshots/btrfs))
     - [Leap 15.4](../tests/snapshotter/btrfs/opensuse-leap)

--- a/tests/cgroup/unified/fedora/Vagrantfile
+++ b/tests/cgroup/unified/fedora/Vagrantfile
@@ -10,13 +10,14 @@ Vagrant.configure("2") do |config|
   config.vagrant.plugins = {
     'vagrant-k3s' => {:version => '~> 0.1.3'},
   }
-  config.vm.box = "fedora/35-cloud-base"
+  config.vm.box = "generic/fedora37"
   config.vm.boot_timeout = ENV['TEST_VM_BOOT_TIMEOUT'] || 600 # seconds
   config.vm.synced_folder '../../../../dist/artifacts', '/vagrant', type: 'rsync', disabled: false,
     rsync__exclude: ENV['RSYNC_EXCLUDE'] || '*.tar.*'
 
   config.vm.define 'cgroup-unified', primary: true do |test|
     test.vm.hostname = 'smoke'
+    test.vm.provision "disable-firewall", type: "shell", inline: "systemctl stop firewalld && systemctl disable firewalld"
     test.vm.provision :file, run: 'always', source: ENV['TEST_UNITFILE_ROOTFULL'], destination: 'k3s-rootfull.service'
     test.vm.provision :file, run: 'always', source: ENV['TEST_UNITFILE_ROOTLESS'], destination: 'k3s-rootless.service'
     test.vm.provision 'k3s-prepare', type: "shell", run: ENV['CI'] == 'true' ? 'never' : 'once', privileged: true do |sh|
@@ -36,9 +37,11 @@ Vagrant.configure("2") do |config|
         systemctl daemon-reload
 
         # Install sonobuoy binary
-        curl -fsSL https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.20.0/sonobuoy_0.20.0_linux_amd64.tar.gz | tar xzvC /usr/local/bin sonobuoy
+        SONOBUOY_VER=0.56.15
+        curl -fsSL https://github.com/vmware-tanzu/sonobuoy/releases/download/v"$SONOBUOY_VER"/sonobuoy_"$SONOBUOY_VER"_linux_amd64.tar.gz | tar xzvC /usr/local/bin sonobuoy
 
         # [Rootless] Configure sysctl
+        dnf install -y fuse-overlayfs fuse
         echo "net.ipv4.ip_forward=1" > /etc/sysctl.d/rootless.conf
         sysctl --system
         # [Rootless] Enable cgroup v2 delegation
@@ -47,6 +50,7 @@ Vagrant.configure("2") do |config|
 [Service]
 Delegate=yes
 EOF
+
         systemctl daemon-reload
 
         # [Rootless] Enable systemd lingering
@@ -58,6 +62,7 @@ EOF
         chown -R vagrant:vagrant /home/vagrant/.config
       SHELL
     end
+
     test.vm.provision 'k3s-install', type: 'k3s', run: ENV['CI'] == 'true' ? 'never' : 'once' do |k3s|
       k3s.args = %w[server]
       k3s.env = %w[INSTALL_K3S_NAME=server INSTALL_K3S_SKIP_DOWNLOAD=true K3S_TOKEN=vagrant INSTALL_K3S_SKIP_ENABLE=true]

--- a/tests/install/fedora/Vagrantfile
+++ b/tests/install/fedora/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
   config.vagrant.plugins = {
     'vagrant-k3s' => {:version => '~> 0.1.3'},
   }
-  config.vm.box = 'generic/fedora36'
+  config.vm.box = 'generic/fedora37'
   config.vm.boot_timeout = ENV['TEST_VM_BOOT_TIMEOUT'] || 600 # seconds
   config.vm.synced_folder '.', '/vagrant', disabled: true
 


### PR DESCRIPTION
Backport https://github.com/k3s-io/k3s/pull/6832 to release-1.25
* Bump to generic/fedora37
* fix epic permissions
* Disable sonobuoy on rootless

Signed-off-by: Derek Nola <derek.nola@suse.com>
