### PR TITLE
Add E2E to Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -515,8 +515,8 @@ steps:
   commands:
     - DOCKER_BUILDKIT=1 docker build --target test-e2e -t test-e2e -f Dockerfile.test .
   volumes:
-    - name: docker
-      path: /var/run/docker.sock
+  - name: docker
+    path: /var/run/docker.sock
 
 - name: test-e2e
   image: test-e2e
@@ -525,13 +525,18 @@ steps:
     cpu: 6000
     memory: 10Gi
   commands:
+  - docker stop registry && docker rm registry
+  - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
   - cd tests/e2e/validatecluster
   - vagrant destroy -f
-  - go test -v -timeout=30m ./validatecluster_test.go -ci
-
+  - E2E_REGISTRY=true go test -v -timeout=30m ./validatecluster_test.go -ci
+  - docker stop registry && docker rm registry
   volumes:
   - name: libvirt
     path: /var/run/libvirt/
+  - name: docker
+    path: /var/run/docker.sock
+
 
 volumes:
 - name: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -579,14 +579,12 @@ steps:
   - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
   - cd tests/e2e/validatecluster
   - vagrant destroy -f
-  # We only have to add the box once, prevents errors when bringing up nodes in parallel
   - go test -v -timeout=30m ./validatecluster_test.go -ci -local
   - cd ../secretsencryption
   - vagrant destroy -f
   - go test -v -timeout=30m ./secretsencryption_test.go -ci -local
-  - cd ../snapshotrestore
-  - vagrant destroy -f
-  - go test -v -timeout=30m ./snapshotrestore_test.go -ci -local
+  - cd ../upgradecluster
+  - E2E_RELEASE_CHANNEL="latest" go test -v -timeout=45m ./upgradecluster_test.go  -ci -local
   - docker stop registry && docker rm registry
   volumes:
   - name: libvirt

--- a/.drone.yml
+++ b/.drone.yml
@@ -502,7 +502,7 @@ depends_on:
 
 ---
 kind: pipeline
-name: vagrant
+name: e2e
 type: docker
 
 platform:
@@ -510,30 +510,33 @@ platform:
   arch: amd64
 
 steps:
-- name: install-vagrant
-  image: vagrantlibvirt/vagrant-libvirt:0.10.6
-  privileged: true
+- name: build-e2e-image
+  image: rancher/dapper:v0.5.0
   commands:
-  - whoami
-  - ls -la /root/.vagrant.d/boxes
-  - vagrant plugin install vagrant-k3s vagrant-reload
+    - DOCKER_BUILDKIT=1 docker build --target test-e2e -t test-e2e -f Dockerfile.test .
+  volumes:
+    - name: docker
+      path: /var/run/docker.sock
+
+- name: test-e2e
+  image: test-e2e
+  pull: never
+  resources:
+    cpu: 6000
+    memory: 10Gi
+  commands:
   - cd tests/e2e/validatecluster
   - vagrant destroy -f
-  - vagrant up serve
-  - sleep 30
-  - vagrant ssh server-0 -c "sudo k3s kubectl get nodes"
-  - vagrant destroy -f
+  - go test -v -timeout=30m ./validatecluster_test.go -ci
 
   volumes:
   - name: libvirt
     path: /var/run/libvirt/
-  - name: vagrant-boxes
-    path: /root/.vagrant.d/boxes
 
 volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
 - name: libvirt
   host:
     path: /var/run/libvirt/
-- name: vagrant-boxes
-  host:
-    path: /root/.vagrant.d/boxes/

--- a/.drone.yml
+++ b/.drone.yml
@@ -557,7 +557,7 @@ steps:
   commands:
     - DOCKER_BUILDKIT=1 docker build --target test-e2e -t test-e2e -f Dockerfile.test .
     - SKIP_VALIDATE=true SKIP_AIRGAP=true dapper ci
-    - cp dist/artifacts/* /tmp/artifacts/*
+    - cp dist/artifacts/* /tmp/artifacts/
   volumes:
   - name: cache
     path: /tmp/artifacts
@@ -574,7 +574,7 @@ steps:
     E2E_REGISTRY: 'true'
   commands:
   - mkdir -p dist/artifacts
-  - cp /tmp/artifacts/* dist/artifacts/*
+  - cp /tmp/artifacts/* dist/artifacts/
   - docker stop registry && docker rm registry
   - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
   - cd tests/e2e/validatecluster

--- a/.drone.yml
+++ b/.drone.yml
@@ -514,7 +514,11 @@ steps:
   image: rancher/dapper:v0.5.0
   commands:
     - DOCKER_BUILDKIT=1 docker build --target test-e2e -t test-e2e -f Dockerfile.test .
+    - SKIP_VALIDATE=true SKIP_AIRGAP=true dapper ci
+    - cp dist/artifacts/* /tmp/artifacts/*
   volumes:
+  - name: cache
+    path: /tmp/artifacts
   - name: docker
     path: /var/run/docker.sock
 
@@ -527,24 +531,27 @@ steps:
   environment:
     E2E_REGISTRY: 'true'
   commands:
+  - mkdir -p dist/artifacts
+  - cp /tmp/artifacts/* dist/artifacts/*
   - docker stop registry && docker rm registry
   - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
   - cd tests/e2e/validatecluster
   - vagrant destroy -f
-  - go test -v -timeout=30m ./validatecluster_test.go -ci
+  - go test -v -timeout=30m ./validatecluster_test.go -ci -local
   - cd ../secretsencryption
   - vagrant destroy -f
-  - go test -v -timeout=30m ./secretsencryption_test.go -ci
+  - go test -v -timeout=30m ./secretsencryption_test.go -ci -local
   - cd ../snapshotrestore
   - vagrant destroy -f
-  - go test -v -timeout=30m ./snapshotrestore_test.go -ci
+  - go test -v -timeout=30m ./snapshotrestore_test.go -ci -local
   - docker stop registry && docker rm registry
   volumes:
   - name: libvirt
     path: /var/run/libvirt/
   - name: docker
     path: /var/run/docker.sock
-
+  - name: cache
+    path: /tmp/artifacts
 
 volumes:
 - name: docker
@@ -553,3 +560,5 @@ volumes:
 - name: libvirt
   host:
     path: /var/run/libvirt/
+- name: cache
+  temp: {}

--- a/.drone.yml
+++ b/.drone.yml
@@ -499,3 +499,41 @@ trigger:
 
 depends_on:
 - manifest
+
+---
+kind: pipeline
+name: vagrant
+type: docker
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: install-vagrant
+  image: vagrantlibvirt/vagrant-libvirt:0.10.6
+  privileged: true
+  commands:
+  - whoami
+  - ls -la /root/.vagrant.d/boxes
+  - vagrant plugin install vagrant-k3s vagrant-reload
+  - cd tests/e2e/validatecluster
+  - vagrant destroy -f
+  - vagrant up serve
+  - sleep 30
+  - vagrant ssh server-0 -c "sudo k3s kubectl get nodes"
+  - vagrant destroy -f
+
+  volumes:
+  - name: libvirt
+    path: /var/run/libvirt/
+  - name: vagrant-boxes
+    path: /root/.vagrant.d/boxes
+
+volumes:
+- name: libvirt
+  host:
+    path: /var/run/libvirt/
+- name: vagrant-boxes
+  host:
+    path: /root/.vagrant.d/boxes/

--- a/.drone.yml
+++ b/.drone.yml
@@ -524,12 +524,20 @@ steps:
   resources:
     cpu: 6000
     memory: 10Gi
+  environment:
+    E2E_REGISTRY: 'true'
   commands:
   - docker stop registry && docker rm registry
   - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
   - cd tests/e2e/validatecluster
   - vagrant destroy -f
-  - E2E_REGISTRY=true go test -v -timeout=30m ./validatecluster_test.go -ci
+  - go test -v -timeout=30m ./validatecluster_test.go -ci
+  - cd ../secretsencryption
+  - vagrant destroy -f
+  - go test -v -timeout=30m ./secretsencryption_test.go -ci
+  - cd ../snapshotrestore
+  - vagrant destroy -f
+  - go test -v -timeout=30m ./snapshotrestore_test.go -ci
   - docker stop registry && docker rm registry
   volumes:
   - name: libvirt

--- a/.drone.yml
+++ b/.drone.yml
@@ -130,6 +130,48 @@ volumes:
 
 ---
 kind: pipeline
+name: conformance
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  event:
+  - cron
+  cron:
+  - nightly
+
+steps:
+- name: build
+  image: rancher/dapper:v0.5.0
+  commands:
+  - dapper ci
+  - echo "${DRONE_TAG}-amd64" | sed -e 's/+/-/g' >.tags
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+
+- name: test
+  image: rancher/dapper:v0.5.0
+  environment:
+    ENABLE_REGISTRY: 'true'
+  commands:
+  - docker build --target test-k3s -t k3s:test-${DRONE_STAGE_ARCH}-${DRONE_COMMIT} -f Dockerfile.test .
+  - >
+    docker run -i -e REPO -e TAG -e DRONE_TAG -e DRONE_BUILD_EVENT -e IMAGE_NAME -e SONOBUOY_VERSION -e ENABLE_REGISTRY
+    -v /var/run/docker.sock:/var/run/docker.sock --privileged --network host -v /tmp:/tmp k3s:test-${DRONE_STAGE_ARCH}-${DRONE_COMMIT}
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+
+---
+kind: pipeline
 name: arm64
 
 platform:
@@ -537,6 +579,7 @@ steps:
   - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
   - cd tests/e2e/validatecluster
   - vagrant destroy -f
+  # We only have to add the box once, prevents errors when bringing up nodes in parallel
   - go test -v -timeout=30m ./validatecluster_test.go -ci -local
   - cd ../secretsencryption
   - vagrant destroy -f

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -36,7 +36,7 @@ ENTRYPOINT ["./scripts/entry.sh"]
 CMD ["test"]
 
 
-FROM vagrantlibvirt/vagrant-libvirt:0.10.6 AS test-e2e
+FROM vagrantlibvirt/vagrant-libvirt:0.11.2 AS test-e2e
 
 RUN apt-get update && apt-get install -y docker.io
 RUN vagrant plugin install vagrant-k3s vagrant-reload

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -36,7 +36,7 @@ ENTRYPOINT ["./scripts/entry.sh"]
 CMD ["test"]
 
 
-FROM vagrantlibvirt/vagrant-libvirt:0.11.2 AS test-e2e
+FROM vagrantlibvirt/vagrant-libvirt:0.10.7 AS test-e2e
 
 RUN apt-get update && apt-get install -y docker.io
 RUN vagrant plugin install vagrant-k3s vagrant-reload

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -38,6 +38,7 @@ CMD ["test"]
 
 FROM vagrantlibvirt/vagrant-libvirt:0.10.6 AS test-e2e
 
+RUN apt-get update && apt-get install -y docker.io
 RUN vagrant plugin install vagrant-k3s vagrant-reload
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"; \
     chmod +x ./kubectl; \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -34,3 +34,19 @@ ENV TEST_CLEANUP true
 
 ENTRYPOINT ["./scripts/entry.sh"]
 CMD ["test"]
+
+
+FROM vagrantlibvirt/vagrant-libvirt:0.10.6 AS test-e2e
+
+RUN vagrant plugin install vagrant-k3s vagrant-reload
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"; \
+    chmod +x ./kubectl; \
+    mv ./kubectl /usr/local/bin/kubectl
+ENV GO_VERSION 1.19.2
+RUN curl -O -L "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz"; \
+    rm -rf /usr/local/go; \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz;
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+
+

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -39,7 +39,8 @@ CMD ["test"]
 FROM vagrantlibvirt/vagrant-libvirt:0.10.7 AS test-e2e
 
 RUN apt-get update && apt-get install -y docker.io
-RUN vagrant plugin install vagrant-k3s vagrant-reload
+RUN vagrant plugin install vagrant-k3s vagrant-reload vagrant-scp
+RUN vagrant box add generic/ubuntu2004 --provider libvirt --force
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"; \
     chmod +x ./kubectl; \
     mv ./kubectl /usr/local/bin/kubectl

--- a/scripts/test
+++ b/scripts/test
@@ -72,14 +72,6 @@ done
 )
 E2E_OUTPUT=$artifacts test-run-sonobuoy parallel
 echo "Did test-run-sonobuoy parallel $?"
-test-run-sonobuoy etcd parallel
-echo "Did test-run-sonobuoy-etcd parallel $?"
-test-run-sonobuoy mysql parallel
-echo "Did test-run-sonobuoy-mysql parallel $?"
-test-run-sonobuoy postgres parallel
-echo "Did test-run-sonobuoy-postgres parallel $?"
-
-
 
 
 exit 0

--- a/scripts/test
+++ b/scripts/test
@@ -54,6 +54,35 @@ if [ "$DRONE_BUILD_EVENT" = 'tag' ]; then
 fi
 # ---
 
+if [ "$DRONE_BUILD_EVENT" = 'cron' ]; then
+  E2E_OUTPUT=$artifacts test-run-sonobuoy serial
+  echo "Did test-run-sonobuoy serial $?"
+  test-run-sonobuoy etcd serial
+  echo "Did test-run-sonobuoy-etcd serial $?"
+  test-run-sonobuoy mysql serial
+  echo "Did test-run-sonobuoy-mysqk serial $?"
+  test-run-sonobuoy postgres serial
+  echo "Did test-run-sonobuoy-postgres serial $?"
+
+  # Wait until all serial tests have finished
+  delay=15
+  (
+  set +x
+  while [ $(count-running-tests) -ge 1 ]; do
+      sleep $delay
+  done
+  )
+
+  E2E_OUTPUT=$artifacts test-run-sonobuoy parallel
+  echo "Did test-run-sonobuoy parallel $?"
+  test-run-sonobuoy etcd parallel
+  echo "Did test-run-sonobuoy-etcd parallel $?"
+  test-run-sonobuoy mysql parallel
+  echo "Did test-run-sonobuoy-mysql parallel $?"
+  test-run-sonobuoy postgres parallel
+  echo "Did test-run-sonobuoy-postgres parallel $?"
+fi
+
 # Wait until all tests have finished
 delay=15
 (

--- a/scripts/test
+++ b/scripts/test
@@ -43,26 +43,18 @@ echo "Did test-run-lazypull $?"
 [ "$ARCH" != 'amd64' ] && \
   early-exit "Skipping remaining tests, images not available for $ARCH."
 
-E2E_OUTPUT=$artifacts test-run-sonobuoy serial
-echo "Did test-run-sonobuoy serial $?"
-
 # ---
 
 if [ "$DRONE_BUILD_EVENT" = 'tag' ]; then
+  E2E_OUTPUT=$artifacts test-run-sonobuoy serial
+  echo "Did test-run-sonobuoy serial $?"
   E2E_OUTPUT=$artifacts test-run-sonobuoy parallel
   echo "Did test-run-sonobuoy parallel $?"
   early-exit 'Skipping remaining tests on tag.'
 fi
 # ---
 
-test-run-sonobuoy etcd serial
-echo "Did test-run-sonobuoy-etcd serial $?"
-test-run-sonobuoy mysql serial
-echo "Did test-run-sonobuoy-mysqk serial $?"
-test-run-sonobuoy postgres serial
-echo "Did test-run-sonobuoy-postgres serial $?"
-
-# Wait until all serial tests have finished
+# Wait until all tests have finished
 delay=15
 (
 set +x
@@ -70,8 +62,5 @@ while [ $(count-running-tests) -ge 1 ]; do
     sleep $delay
 done
 )
-E2E_OUTPUT=$artifacts test-run-sonobuoy parallel
-echo "Did test-run-sonobuoy parallel $?"
-
 
 exit 0

--- a/tests/e2e/scripts/run_tests.sh
+++ b/tests/e2e/scripts/run_tests.sh
@@ -29,9 +29,6 @@ E2E_REGISTRY=true E2E_HARDENED="$hardened" /usr/local/go/bin/go test -v validate
 echo 'RUNNING SECRETS ENCRYPTION TEST'
 /usr/local/go/bin/go test -v secretsencryption/secretsencryption_test.go -nodeOS="$nodeOS" -serverCount=$((servercount)) -timeout=1h -json -ci | tee -a k3s_"$OS".log
 
-echo 'RUN CLUSTER RESET TEST'
-/usr/local/go/bin/go test -v clusterreset/clusterreset_test.go -nodeOS="$nodeOS" -serverCount=3 -agentCount=1 -timeout=30m -json -ci | tee -a createreport/k3s_"$OS".log
-
 echo 'RUNNING SPLIT SERVER VALIDATION TEST'
 E2E_HARDENED="$hardened" /usr/local/go/bin/go test -v splitserver/splitserver_test.go -nodeOS="$nodeOS" -timeout=30m -json -ci | tee -a k3s_"$OS".log
 

--- a/tests/e2e/secretsencryption/secretsencryption_test.go
+++ b/tests/e2e/secretsencryption/secretsencryption_test.go
@@ -17,6 +17,7 @@ var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
 var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var hardened = flag.Bool("hardened", false, "true or false")
 var ci = flag.Bool("ci", false, "running on CI")
+var local = flag.Bool("local", false, "deploy a locally built K3s binary")
 
 // Environment Variables Info:
 // E2E_RELEASE_VERSION=v1.23.1+k3s2 or nil for latest commit from master
@@ -39,7 +40,11 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 	Context("Secrets Keys are rotated:", func() {
 		It("Starts up with no issues", func() {
 			var err error
-			serverNodeNames, _, err = e2e.CreateCluster(*nodeOS, *serverCount, 0)
+			if *local {
+				serverNodeNames, _, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, 0)
+			} else {
+				serverNodeNames, _, err = e2e.CreateCluster(*nodeOS, *serverCount, 0)
+			}
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)

--- a/tests/e2e/secretsencryption/secretsencryption_test.go
+++ b/tests/e2e/secretsencryption/secretsencryption_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		})
 
 		It("Restarts K3s servers", func() {
-			Expect(e2e.RestartCluster(serverNodeNames)).To(Succeed())
+			Expect(e2e.RestartCluster(serverNodeNames)).To(Succeed(), e2e.GetVagrantLog(nil))
 		})
 
 		It("Checks node and pod status", func() {
@@ -167,7 +167,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		})
 
 		It("Restarts K3s servers", func() {
-			Expect(e2e.RestartCluster(serverNodeNames)).To(Succeed())
+			Expect(e2e.RestartCluster(serverNodeNames)).To(Succeed(), e2e.GetVagrantLog(nil))
 		})
 
 		It("Verifies encryption rotate stage", func() {
@@ -202,7 +202,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		})
 
 		It("Restarts K3s Servers", func() {
-			Expect(e2e.RestartCluster(serverNodeNames)).To(Succeed())
+			Expect(e2e.RestartCluster(serverNodeNames)).To(Succeed(), e2e.GetVagrantLog(nil))
 		})
 
 		It("Verifies Encryption Reencrypt Stage", func() {

--- a/tests/e2e/snapshotrestore/snapshotrestore_test.go
+++ b/tests/e2e/snapshotrestore/snapshotrestore_test.go
@@ -44,7 +44,7 @@ var (
 var _ = ReportAfterEach(e2e.GenReport)
 
 var _ = Describe("Verify snapshots and cluster restores work", Ordered, func() {
-	Context("Cluster :", func() {
+	Context("Cluster creates snapshots and workloads:", func() {
 		It("Starts up with no issues", func() {
 			var err error
 			if *local {
@@ -123,6 +123,8 @@ var _ = Describe("Verify snapshots and cluster restores work", Ordered, func() {
 			}, "240s", "5s").Should(Succeed())
 		})
 
+	})
+	Context("Cluster is reset normally", func() {
 		It("Resets the cluster", func() {
 			for _, nodeName := range serverNodeNames {
 				cmd := "sudo systemctl stop k3s"
@@ -177,9 +179,9 @@ var _ = Describe("Verify snapshots and cluster restores work", Ordered, func() {
 				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
 				for _, node := range nodes {
-					g.Expect(node.Status).Should(Equal("Ready"))
+					g.Expect(node.Status).Should(Equal("Ready"), node)
 				}
-			}, "420s", "5s").Should(Succeed())
+			}, "480s", "5s").Should(Succeed())
 
 			_, _ = e2e.ParseNodes(kubeConfigFile, true)
 
@@ -204,6 +206,8 @@ var _ = Describe("Verify snapshots and cluster restores work", Ordered, func() {
 			Expect(res).Should(ContainSubstring("test-nodeport"))
 		})
 
+	})
+	Context("Cluster restores from snapshot", func() {
 		It("Restores the snapshot", func() {
 			//Stop k3s on all nodes
 			for _, nodeName := range serverNodeNames {

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -25,6 +25,10 @@ type Node struct {
 	ExternalIP string
 }
 
+func (n Node) String() string {
+	return fmt.Sprintf("Node (name: %s, status: %s, roles: %s)", n.Name, n.Status, n.Roles)
+}
+
 type Pod struct {
 	NameSpace string
 	Name      string
@@ -302,13 +306,18 @@ func GenReport(specReport ginkgo.SpecReport) {
 	fmt.Printf("%s", status)
 }
 
+func GetJournalLogs(node string) (string, error) {
+	cmd := "journalctl -u k3s* --no-pager"
+	return RunCmdOnNode(cmd, node)
+}
+
 // GetVagrantLog returns the logs of on vagrant commands that initialize the nodes and provision K3s on each node.
 // It also attempts to fetch the systemctl logs of K3s on nodes where the k3s.service failed.
 func GetVagrantLog(cErr error) string {
 	var nodeErr *NodeError
 	nodeJournal := ""
 	if errors.As(cErr, &nodeErr) {
-		nodeJournal, _ = RunCmdOnNode("sudo journalctl -u k3s* --no-pager", nodeErr.Node)
+		nodeJournal, _ = GetJournalLogs(nodeErr.Node)
 		nodeJournal = "\nNode Journal Logs:\n" + nodeJournal
 	}
 

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -331,7 +331,7 @@ func ParseNodes(kubeConfig string, print bool) ([]Node, error) {
 	res, err := RunCommand(cmd)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get nodes: %s: %v", res, err)
 	}
 	nodeList = strings.TrimSpace(res)
 	split := strings.Split(nodeList, "\n")

--- a/tests/e2e/upgradecluster/Vagrantfile
+++ b/tests/e2e/upgradecluster/Vagrantfile
@@ -25,8 +25,10 @@ def provision(vm, role, role_num, node_num)
   load vagrant_defaults
 
   defaultOSConfigure(vm)
-    
-  if !RELEASE_VERSION.empty?
+  
+  if RELEASE_VERSION == "skip"
+    install_type = "INSTALL_K3S_SKIP_DOWNLOAD=true"
+  elsif !RELEASE_VERSION.empty?
     install_type = "INSTALL_K3S_VERSION=#{RELEASE_VERSION}"
   elsif RELEASE_CHANNEL == "commit"
     vm.provision "shell", path: "../scripts/latest_commit.sh", args: ["master", "/tmp/k3s_commits"]

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -20,10 +20,11 @@ var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var agentCount = flag.Int("agentCount", 2, "number of agent nodes")
 var hardened = flag.Bool("hardened", false, "true or false")
 var ci = flag.Bool("ci", false, "running on CI")
+var local = flag.Bool("local", false, "Controls which version k3s upgrades too, local binary or latest commit on master")
 
 // Environment Variables Info:
 // E2E_REGISTRY: true/false (default: false)
-// Controls which K3s version is installed first, upgrade is always to latest commit
+// Controls which K3s version is installed first
 // E2E_RELEASE_VERSION=v1.23.3+k3s1
 // OR
 // E2E_RELEASE_CHANNEL=(commit|latest|stable), commit pulls latest commit from master
@@ -249,9 +250,8 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 
 		It("Upgrades with no issues", func() {
 			var err error
-			err = e2e.UpgradeCluster(serverNodeNames, agentNodeNames)
-			fmt.Println(err)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(e2e.UpgradeCluster(append(serverNodeNames, agentNodeNames...), *local)).To(Succeed())
+			Expect(e2e.RestartCluster(append(serverNodeNames, agentNodeNames...))).To(Succeed())
 			fmt.Println("CLUSTER UPGRADED")
 			kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodeNames[0])
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Add new drone pipeline, E2E. This pipeline creates a k3s binary from the PR, then runs the following E2E tests:
    - Validate Cluster
    - Secrets Encryption
    - Upgrade Cluster
- Removes Sonobuoy tests in PRs. We will no longer run any serial or parallel sonobuoy conformance tests. We will still run serial and parallel tests on the publish pipeline. Docker K3s tests in drone are untouched. 
- Minor fixes to E2E timeouts and error messages to match drone HW performance

#### Types of Changes ####
CI and E2E tests
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI Passes
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
