### PR TITLE
[release-1.24] Use default address family when adding kubernetes service address to SAN list

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -209,18 +209,17 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	}
 
 	if serverConfig.ControlConfig.PrivateIP == "" && len(cmds.AgentConfig.NodeIP) != 0 {
-		// ignoring the error here is fine since etcd will fall back to the interface's IPv4 address
-		serverConfig.ControlConfig.PrivateIP, _, _ = util.GetFirstString(cmds.AgentConfig.NodeIP)
+		serverConfig.ControlConfig.PrivateIP = util.GetFirstValidIPString(cmds.AgentConfig.NodeIP)
 	}
 
 	// if not set, try setting advertise-ip from agent node-external-ip
 	if serverConfig.ControlConfig.AdvertiseIP == "" && len(cmds.AgentConfig.NodeExternalIP) != 0 {
-		serverConfig.ControlConfig.AdvertiseIP, _, _ = util.GetFirstString(cmds.AgentConfig.NodeExternalIP)
+		serverConfig.ControlConfig.AdvertiseIP = util.GetFirstValidIPString(cmds.AgentConfig.NodeExternalIP)
 	}
 
 	// if not set, try setting advertise-ip from agent node-ip
 	if serverConfig.ControlConfig.AdvertiseIP == "" && len(cmds.AgentConfig.NodeIP) != 0 {
-		serverConfig.ControlConfig.AdvertiseIP, _, _ = util.GetFirstString(cmds.AgentConfig.NodeIP)
+		serverConfig.ControlConfig.AdvertiseIP = util.GetFirstValidIPString(cmds.AgentConfig.NodeIP)
 	}
 
 	// if we ended up with any advertise-ips, ensure they're added to the SAN list;
@@ -302,7 +301,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	}
 
 	// the apiserver service does not yet support dual-stack operation
-	_, apiServerServiceIP, err := controlplane.ServiceIPRange(*serverConfig.ControlConfig.ServiceIPRange)
+	_, apiServerServiceIP, err := controlplane.ServiceIPRange(*serverConfig.ControlConfig.ServiceIPRanges[0])
 	if err != nil {
 		return err
 	}

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -189,6 +189,19 @@ func ParseStringSliceToIPs(s cli.StringSlice) ([]net.IP, error) {
 	return ips, nil
 }
 
+// GetFirstValidIPString returns the first valid address from a list of IP address strings,
+// without preference for IP family. If no address are found, an empty string is returned.
+func GetFirstValidIPString(s cli.StringSlice) string {
+	for _, unparsedIP := range s {
+		for _, v := range strings.Split(unparsedIP, ",") {
+			if ip := net.ParseIP(v); ip != nil {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
 // GetFirstIP returns the first IPv4 address from the list of IP addresses.
 // If no IPv4 addresses are found, returns the first IPv6 address
 // if neither of IPv4 or IPv6 are found an error is raised.


### PR DESCRIPTION
#### Proposed Changes ####

Use default address family when adding kubernetes service address to SAN list

We were using the legacy ServiceCIDR, which is always IPv4 if one is configured. We should instead use the first CIDR, which determines the cluster's default address family.

For the same reason, don't prefer advertising the IPv4 node addresses if both IPv4 and IPv6 addresses are given, just use whatever's given first.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

* See linked issue
* On a dual-stack cluster with IPv6 preferred (given first in the CIDR list), check for the cluster service address in the apiserver cert: `openssl x509 -noout -text /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt`

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6892

#### User-Facing Change ####
```release-note
The apiserver advertised address and IP SAN entry are now set correctly on clusters that use IPv6 as the default IP family.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
