### PR TITLE
[Release-1.25] Ignore value conflicts when reencrypting secrets

### DIFF
--- a/pkg/secretsencrypt/controller.go
+++ b/pkg/secretsencrypt/controller.go
@@ -11,6 +11,7 @@ import (
 	coreclient "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -223,8 +224,8 @@ func (h *handler) updateSecrets(node *corev1.Node) error {
 	i := 0
 	err = meta.EachListItem(secretsList, func(obj runtime.Object) error {
 		if secret, ok := obj.(*corev1.Secret); ok {
-			if _, err := h.secrets.Update(secret); err != nil {
-				return fmt.Errorf("failed to reencrypted secret: %v", err)
+			if _, err := h.secrets.Update(secret); err != nil && !apierrors.IsConflict(err) {
+				return fmt.Errorf("failed to update secret: %v", err)
 			}
 			if i != 0 && i%10 == 0 {
 				h.recorder.Eventf(nodeRef, corev1.EventTypeNormal, secretsProgressEvent, "reencrypted %d secrets", i)


### PR DESCRIPTION
* Ignore conflict secrets

Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Backport of #6850 to release-1.25
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/6825
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
