### PR TITLE
[release-1.23] Fix access to hostNetwork port on NodeIP when egress-selector-mode=agent

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -339,13 +339,13 @@ func configureNode(ctx context.Context, nodeConfig *daemonconfig.Node, nodes typ
 		}
 
 		// inject node config
-		if changed, err := nodeconfig.SetNodeConfigAnnotations(node); err != nil {
+		if changed, err := nodeconfig.SetNodeConfigAnnotations(nodeConfig, node); err != nil {
 			return false, err
 		} else if changed {
 			updateNode = true
 		}
 
-		if changed, err := nodeconfig.SetNodeConfigLabels(node); err != nil {
+		if changed, err := nodeconfig.SetNodeConfigLabels(nodeConfig, node); err != nil {
 			return false, err
 		} else if changed {
 			updateNode = true

--- a/pkg/nodeconfig/nodeconfig_test.go
+++ b/pkg/nodeconfig/nodeconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +21,7 @@ var FakeNodeWithNoAnnotation = &corev1.Node{
 }
 
 var TestEnvName = version.ProgramUpper + "_NODE_NAME"
+var FakeNodeConfig = &config.Node{}
 var FakeNodeWithAnnotation = &corev1.Node{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "Node",
@@ -39,7 +41,7 @@ func Test_UnitSetExistingNodeConfigAnnotations(t *testing.T) {
 	// adding same config
 	os.Args = []string{version.Program, "server", "--no-flannel"}
 	os.Setenv(version.ProgramUpper+"_NODE_NAME", "fakeNode-with-annotation")
-	nodeUpdated, err := SetNodeConfigAnnotations(FakeNodeWithAnnotation)
+	nodeUpdated, err := SetNodeConfigAnnotations(FakeNodeConfig, FakeNodeWithAnnotation)
 	if err != nil {
 		t.Fatalf("Failed to set node config annotation: %v", err)
 	}
@@ -50,6 +52,7 @@ func Test_UnitSetExistingNodeConfigAnnotations(t *testing.T) {
 
 func Test_UnitSetNodeConfigAnnotations(t *testing.T) {
 	type args struct {
+		config *config.Node
 		node   *corev1.Node
 		osArgs []string
 	}
@@ -72,6 +75,7 @@ func Test_UnitSetNodeConfigAnnotations(t *testing.T) {
 		{
 			name: "Set empty NodeConfigAnnotations",
 			args: args{
+				config: FakeNodeConfig,
 				node:   FakeNodeWithAnnotation,
 				osArgs: []string{version.Program, "server", "--no-flannel"},
 			},
@@ -83,6 +87,7 @@ func Test_UnitSetNodeConfigAnnotations(t *testing.T) {
 		{
 			name: "Set args with equal",
 			args: args{
+				config: FakeNodeConfig,
 				node:   FakeNodeWithNoAnnotation,
 				osArgs: []string{version.Program, "server", "--no-flannel", "--write-kubeconfig-mode=777"},
 			},
@@ -98,7 +103,7 @@ func Test_UnitSetNodeConfigAnnotations(t *testing.T) {
 				t.Errorf("Setup for SetNodeConfigAnnotations() failed = %v", err)
 				return
 			}
-			got, err := SetNodeConfigAnnotations(tt.args.node)
+			got, err := SetNodeConfigAnnotations(tt.args.config, tt.args.node)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SetNodeConfigAnnotations() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION

#### Proposed Changes ####

Fix access to hostNetwork port on NodeIP when egress-selector-mode=agent

#### Types of Changes ####

bugfix

#### Verification ####


#### Testing ####

* Test that by default, the egress.k3s.io/cluster label is absent (egress-selector-mode is agent or disabled)
*Test that the egress.k3s.io/cluster label is present when k3s is in pod or cluster mode.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6935

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an issue that would cause the apiserver egress proxy to attempt to use the agent tunnel to connect to service endpoints even in agent or disabled mode.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
