### PR TITLE
[release-1.23] Allow for multiple sets of leader-elected controllers

### DIFF
--- a/pkg/cli/cert/cert.go
+++ b/pkg/cli/cert/cert.go
@@ -70,7 +70,7 @@ func commandSetup(app *cli.Context, cfg *cmds.Server, sc *server.Config) (string
 	}
 	sc.ControlConfig.Token = cfg.Token
 
-	sc.ControlConfig.Runtime = &config.ControlRuntime{}
+	sc.ControlConfig.Runtime = config.NewRuntime(nil)
 
 	return dataDir, nil
 }
@@ -292,7 +292,7 @@ func rotateCA(app *cli.Context, cfg *cmds.Server, sync *cmds.CertRotateCA) error
 
 	// Set up dummy server config for reading new bootstrap data from disk.
 	tmpServer := &config.Control{
-		Runtime: &config.ControlRuntime{},
+		Runtime: config.NewRuntime(nil),
 		DataDir: filepath.Dir(sync.CACertPath),
 	}
 	deps.CreateRuntimeCertFiles(tmpServer)

--- a/pkg/cli/etcdsnapshot/etcd_snapshot.go
+++ b/pkg/cli/etcdsnapshot/etcd_snapshot.go
@@ -60,7 +60,7 @@ func commandSetup(app *cli.Context, cfg *cmds.Server, sc *server.Config) error {
 	sc.ControlConfig.EtcdS3Folder = cfg.EtcdS3Folder
 	sc.ControlConfig.EtcdS3Insecure = cfg.EtcdS3Insecure
 	sc.ControlConfig.EtcdS3Timeout = cfg.EtcdS3Timeout
-	sc.ControlConfig.Runtime = &config.ControlRuntime{}
+	sc.ControlConfig.Runtime = config.NewRuntime(nil)
 	sc.ControlConfig.Runtime.ETCDServerCA = filepath.Join(dataDir, "tls", "etcd", "server-ca.crt")
 	sc.ControlConfig.Runtime.ClientETCDCert = filepath.Join(dataDir, "tls", "etcd", "client.crt")
 	sc.ControlConfig.Runtime.ClientETCDKey = filepath.Join(dataDir, "tls", "etcd", "client.key")

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -99,7 +99,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 
 	serverConfig := server.Config{}
 	serverConfig.DisableAgent = cfg.DisableAgent
-	serverConfig.ControlConfig.Runtime = &config.ControlRuntime{AgentReady: agentReady}
+	serverConfig.ControlConfig.Runtime = config.NewRuntime(agentReady)
 	serverConfig.ControlConfig.Token = cfg.Token
 	serverConfig.ControlConfig.AgentToken = cfg.AgentToken
 	serverConfig.ControlConfig.JoinURL = cfg.ServerURL

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -14,6 +13,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/util"
 	"github.com/k3s-io/kine/pkg/endpoint"
 	"github.com/rancher/wrangler/pkg/generated/controllers/core"
+	"github.com/rancher/wrangler/pkg/leader"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	utilsnet "k8s.io/utils/net"
@@ -270,13 +270,13 @@ type ControlRuntimeBootstrap struct {
 type ControlRuntime struct {
 	ControlRuntimeBootstrap
 
-	HTTPBootstrap                       bool
-	APIServerReady                      <-chan struct{}
-	AgentReady                          <-chan struct{}
-	ETCDReady                           <-chan struct{}
-	StartupHooksWg                      *sync.WaitGroup
-	ClusterControllerStart              func(ctx context.Context) error
-	LeaderElectedClusterControllerStart func(ctx context.Context) error
+	HTTPBootstrap                        bool
+	APIServerReady                       <-chan struct{}
+	AgentReady                           <-chan struct{}
+	ETCDReady                            <-chan struct{}
+	StartupHooksWg                       *sync.WaitGroup
+	ClusterControllerStarts              map[string]leader.Callback
+	LeaderElectedClusterControllerStarts map[string]leader.Callback
 
 	ClientKubeAPICert string
 	ClientKubeAPIKey  string
@@ -331,6 +331,14 @@ type ControlRuntime struct {
 
 	Core       *core.Factory
 	EtcdConfig endpoint.ETCDConfig
+}
+
+func NewRuntime(agentReady <-chan struct{}) *ControlRuntime {
+	return &ControlRuntime{
+		AgentReady:                           agentReady,
+		ClusterControllerStarts:              map[string]leader.Callback{},
+		LeaderElectedClusterControllerStarts: map[string]leader.Callback{},
+	}
 }
 
 type ArgString []string

--- a/pkg/etcd/apiaddresses_controller.go
+++ b/pkg/etcd/apiaddresses_controller.go
@@ -17,10 +17,6 @@ import (
 )
 
 func registerEndpointsHandlers(ctx context.Context, etcd *ETCD) {
-	if etcd.config.DisableAPIServer {
-		return
-	}
-
 	endpoints := etcd.config.Runtime.Core.Core().V1().Endpoints()
 	fieldSelector := fields.Set{metav1.ObjectNameField: "kubernetes"}.String()
 	lw := &cache.ListWatch{

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -37,7 +37,7 @@ func generateTestConfig() *config.Control {
 		ServiceIPRange: testutil.ServiceIPNet(),
 	}
 	return &config.Control{
-		Runtime:               &config.ControlRuntime{AgentReady: agentReady},
+		Runtime:               config.NewRuntime(agentReady),
 		HTTPSPort:             6443,
 		SupervisorPort:        6443,
 		AdvertisePort:         6443,

--- a/pkg/etcd/member_controller.go
+++ b/pkg/etcd/member_controller.go
@@ -12,10 +12,6 @@ import (
 )
 
 func registerMemberHandlers(ctx context.Context, etcd *ETCD) {
-	if etcd.config.DisableETCD {
-		return
-	}
-
 	nodes := etcd.config.Runtime.Core.Core().V1().Node()
 	e := &etcdMemberHandler{
 		etcd:           etcd,

--- a/pkg/server/cert.go
+++ b/pkg/server/cert.go
@@ -54,11 +54,12 @@ func caCertReplace(server *config.Control, buf io.ReadCloser, force bool) error 
 	}
 	defer os.RemoveAll(tmpdir)
 
+	runtime := config.NewRuntime(nil)
+	runtime.EtcdConfig = server.Runtime.EtcdConfig
+	runtime.ServerToken = server.Runtime.ServerToken
+
 	tmpServer := &config.Control{
-		Runtime: &config.ControlRuntime{
-			EtcdConfig:  server.Runtime.EtcdConfig,
-			ServerToken: server.Runtime.ServerToken,
-		},
+		Runtime: runtime,
 		Token:   server.Token,
 		DataDir: tmpdir,
 	}

--- a/tests/unit.go
+++ b/tests/unit.go
@@ -43,7 +43,7 @@ func CleanupDataDir(cnf *config.Control) {
 // GenerateRuntime creates a temporary data dir and configures
 // config.ControlRuntime with all the appropriate certificate keys.
 func GenerateRuntime(cnf *config.Control) error {
-	cnf.Runtime = &config.ControlRuntime{}
+	cnf.Runtime = config.NewRuntime(nil)
 	if err := GenerateDataDir(cnf); err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Proposed Changes ####

Allow for multiple sets of leader-elected controllers; addresses an issue where etcd controllers did not run on etcd-only nodes

#### Types of Changes ####

bugfix

#### Verification ####

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/6819
* https://github.com/rancher/rancher/issues/40301

#### User-Facing Change ####
```release-note
Fixed an issue where leader-elected controllers for managed etcd did not run on etcd-only nodes
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
