### PR TITLE
[release-1.25] Bump kine to v0.9.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/gruntwork-io/terratest v0.40.6
 	github.com/json-iterator/go v1.1.12
 	github.com/k3s-io/helm-controller v0.13.1
-	github.com/k3s-io/kine v0.9.6
+	github.com/k3s-io/kine v0.9.9
 	github.com/klauspost/compress v1.15.12
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -624,8 +624,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.3-k3s1 h1:MVTrb5cp75kSMA9K240VMa5I+GKuYYP9
 github.com/k3s-io/etcd/server/v3 v3.5.3-k3s1/go.mod h1:xwZlQLuAWsWw5rpb/Gwzi3nFie9STKcrKQbM6evLi5g=
 github.com/k3s-io/helm-controller v0.13.1 h1:eG2yZ0QzbtcfMe8GpTVtRtP6HgMDO/Pr9Q1EGbMKKCA=
 github.com/k3s-io/helm-controller v0.13.1/go.mod h1:f8aOuHQDpkshmUK/GiE+jJCJkUL8vp+EzCjV0uCFcsY=
-github.com/k3s-io/kine v0.9.6 h1:qomCtPrxIpFi09Q6JUDEbjWPjCliDgJ1Ns2N7l7aWxI=
-github.com/k3s-io/kine v0.9.6/go.mod h1:3N3AE7WgqbX4wYKJ9NdUItJ0i8koC+qaKbYc2sEaVns=
+github.com/k3s-io/kine v0.9.9 h1:DuKVDn4lFw9BDcni8bu+B+cBaWKcWm8ajXnpbGPSfeI=
+github.com/k3s-io/kine v0.9.9/go.mod h1:iQvdpQ7EAyI+24mEITK5nlOBglOOLUa7+4YIaTB8vX8=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 github.com/k3s-io/klog/v2 v2.60.1-k3s1 h1:C1hsMF1Eo6heGVQzts6cZ+rDZAReSiOBUxsYMuUkkZI=


### PR DESCRIPTION
#### Proposed Changes ####

Bump kine to v0.9.9

#### Types of Changes ####

version bump

#### Verification ####

Check version in go.mod

#### Testing ####


#### Linked Issues ####

* #6959

#### User-Facing Change ####
```release-note
The embedded kine version has been bumped to v0.9.9. Compaction log messages are now omitted at `info` level for increased visibility.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
