### PR TITLE
Fix ServiceLB dual-stack ingress IP listing

### DIFF
--- a/pkg/cloudprovider/servicelb_test.go
+++ b/pkg/cloudprovider/servicelb_test.go
@@ -1,0 +1,91 @@
+package cloudprovider
+
+import (
+	"reflect"
+	"testing"
+
+	core "k8s.io/api/core/v1"
+)
+
+const (
+	addrv4 = "1.2.3.4"
+	addrv6 = "2001:db8::1"
+)
+
+func Test_UnitFilterByIPFamily(t *testing.T) {
+	type args struct {
+		ips []string
+		svc *core.Service
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "No IPFamily",
+			args: args{
+				ips: []string{addrv4, addrv6},
+				svc: &core.Service{
+					Spec: core.ServiceSpec{
+						IPFamilies: []core.IPFamily{},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "IPv4 Only",
+			args: args{
+				ips: []string{addrv4, addrv6},
+				svc: &core.Service{
+					Spec: core.ServiceSpec{
+						IPFamilies: []core.IPFamily{core.IPv4Protocol},
+					},
+				},
+			},
+			want:    []string{addrv4},
+			wantErr: false,
+		},
+		{
+			name: "IPv6 Only",
+			args: args{
+				ips: []string{addrv4, addrv6},
+				svc: &core.Service{
+					Spec: core.ServiceSpec{
+						IPFamilies: []core.IPFamily{core.IPv6Protocol},
+					},
+				},
+			},
+			want:    []string{addrv6},
+			wantErr: false,
+		},
+		{
+			name: "Dual-Stack",
+			args: args{
+				ips: []string{addrv4, addrv6},
+				svc: &core.Service{
+					Spec: core.ServiceSpec{
+						IPFamilies: []core.IPFamily{core.IPv4Protocol, core.IPv6Protocol},
+					},
+				},
+			},
+			want:    []string{addrv4, addrv6},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := filterByIPFamily(tt.args.ips, tt.args.svc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("filterByIPFamily() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterByIPFamily() = %+v\nWant = %+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Proposed Changes ####

Fix ServiceLB dual-stack ingress IP listing

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

added a unit test for this function

#### Linked Issues ####

* #6978 
#### User-Facing Change ####
```release-note
Resolved an issue with ServiceLB that would cause it to advertise node IPv6 addresses, even if the cluster or service was not enabled for dual-stack operation.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
