### PR TITLE
skip all pipelines based on what is in the PR

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,18 @@ platform:
   arch: amd64
 
 steps:
+- name: skipfiles
+  image: plugins/git
+  commands:
+  - export NAME=$(test $DRONE_BUILD_EVENT = pull_request && echo remotes/origin/${DRONE_COMMIT_BRANCH:-master} || echo ${DRONE_COMMIT_SHA}~)
+  - export DIFF=$(git --no-pager diff --name-only $NAME | grep -v -f .droneignore);
+  - if [ -z "$DIFF" ]; then
+        echo "All files in PR are on ignore list";
+        exit 78;
+    else
+        echo "Some files in PR are not ignored, $DIFF";
+    fi;
+
 - name: build
   image: rancher/dapper:v0.5.0
   secrets: [ AWS_SECRET_ACCESS_KEY-k3s-ci-uploader, AWS_ACCESS_KEY_ID-k3s-ci-uploader, unprivileged_github_token ]
@@ -137,6 +149,18 @@ platform:
   arch: arm64
 
 steps:
+- name: skipfiles
+  image: plugins/git
+  commands:
+  - export NAME=$(test $DRONE_BUILD_EVENT = pull_request && echo remotes/origin/${DRONE_COMMIT_BRANCH:-master} || echo ${DRONE_COMMIT_SHA}~)
+  - export DIFF=$(git --no-pager diff --name-only $NAME | grep -v -f .droneignore);
+  - if [ -z "$DIFF" ]; then
+        echo "All files in PR are on ignore list";
+        exit 78;
+    else
+        echo "Some files in PR are not ignored, $DIFF";
+    fi;
+
 - name: build
   image: rancher/dapper:v0.5.0
   secrets: [ AWS_SECRET_ACCESS_KEY-k3s-ci-uploader, AWS_ACCESS_KEY_ID-k3s-ci-uploader ]
@@ -223,6 +247,18 @@ platform:
   arch: arm
 
 steps:
+- name: skipfiles
+  image: plugins/git
+  commands:
+  - export NAME=$(test $DRONE_BUILD_EVENT = pull_request && echo remotes/origin/${DRONE_COMMIT_BRANCH:-master} || echo ${DRONE_COMMIT_SHA}~)
+  - export DIFF=$(git --no-pager diff --name-only $NAME | grep -v -f .droneignore);
+  - if [ -z "$DIFF" ]; then
+        echo "All files in PR are on ignore list";
+        exit 78;
+    else
+        echo "Some files in PR are not ignored, $DIFF";
+    fi;
+
 - name: build
   image: rancher/dapper:v0.5.0
   secrets: [ AWS_SECRET_ACCESS_KEY-k3s-ci-uploader, AWS_ACCESS_KEY_ID-k3s-ci-uploader ]
@@ -323,6 +359,18 @@ steps:
   - git fetch origin $DRONE_COMMIT_REF
   - git checkout $DRONE_COMMIT -b origin/$DRONE_TARGET_BRANCH
 
+- name: skipfiles
+  image: alpine/git:v2.30.2-s390x
+  commands:
+  - export NAME=$(test $DRONE_BUILD_EVENT = pull_request && echo remotes/origin/${DRONE_COMMIT_BRANCH:-master} || echo ${DRONE_COMMIT_SHA}~)
+  - export DIFF=$(git --no-pager diff --name-only $NAME | grep -v -f .droneignore);
+  - if [ -z "$DIFF" ]; then
+        echo "All files in PR are on ignore list";
+        exit 78;
+    else
+        echo "Some files in PR are not ignored, $DIFF";
+    fi;
+
 - name: build
   image: rancher/dapper:v0.5.8
   secrets: [ AWS_SECRET_ACCESS_KEY-k3s-ci-uploader, AWS_ACCESS_KEY_ID-k3s-ci-uploader ]
@@ -413,19 +461,32 @@ platform:
   arch: amd64
 
 steps:
-  - name: validate_go_mods
-    image: rancher/dapper:v0.5.0
-    commands:
-      - docker build --target test-mods -t k3s:mod -f Dockerfile.test .
-      - docker run -i k3s:mod
+- name: skipfiles
+  image: plugins/git
+  commands:
+  - export NAME=$(test $DRONE_BUILD_EVENT = pull_request && echo remotes/origin/${DRONE_COMMIT_BRANCH:-master} || echo ${DRONE_COMMIT_SHA}~)
+  - export DIFF=$(git --no-pager diff --name-only $NAME | grep -v -f .droneignore);
+  - if [ -z "$DIFF" ]; then
+        echo "All files in PR are on ignore list";
+        exit 78;
+    else
+        echo "Some files in PR are not ignored, $DIFF";
+    fi;
 
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-volumes:
+- name: validate_go_mods
+  image: rancher/dapper:v0.5.0
+  commands:
+  - docker build --target test-mods -t k3s:mod -f Dockerfile.test .
+  - docker run -i k3s:mod
+
+  volumes:
   - name: docker
-    host:
-      path: /var/run/docker.sock
+    path: /var/run/docker.sock
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
 
 ---
 kind: pipeline
@@ -436,6 +497,18 @@ platform:
   arch: amd64
 
 steps:
+- name: skipfiles
+  image: plugins/git
+  commands:
+  - export NAME=$(test $DRONE_BUILD_EVENT = pull_request && echo remotes/origin/${DRONE_COMMIT_BRANCH:-master} || echo ${DRONE_COMMIT_SHA}~)
+  - export DIFF=$(git --no-pager diff --name-only $NAME | grep -v -f .droneignore);
+  - if [ -z "$DIFF" ]; then
+        echo "All files in PR are on ignore list";
+        exit 78;
+    else
+        echo "Some files in PR are not ignored, $DIFF";
+    fi;
+
 - name: manifest
   image: plugins/docker
   environment:
@@ -476,6 +549,18 @@ platform:
   arch: amd64
 
 steps:
+- name: skipfiles
+  image: plugins/git
+  commands:
+  - export NAME=$(test $DRONE_BUILD_EVENT = pull_request && echo remotes/origin/${DRONE_COMMIT_BRANCH:-master} || echo ${DRONE_COMMIT_SHA}~)
+  - export DIFF=$(git --no-pager diff --name-only $NAME | grep -v -f .droneignore);
+  - if [ -z "$DIFF" ]; then
+        echo "All files in PR are on ignore list";
+        exit 78;
+    else
+        echo "Some files in PR are not ignored, $DIFF";
+    fi;
+
 - name: dispatch
   image: curlimages/curl:7.74.0
   user: root

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,6 +18,10 @@ steps:
     else
         echo "Some files in PR are not ignored, $DIFF";
     fi;
+  when:
+    event:
+    - push
+    - pull_request
 
 - name: build
   image: rancher/dapper:v0.5.0
@@ -160,6 +164,10 @@ steps:
     else
         echo "Some files in PR are not ignored, $DIFF";
     fi;
+  when:
+    event:
+    - push
+    - pull_request
 
 - name: build
   image: rancher/dapper:v0.5.0
@@ -258,6 +266,10 @@ steps:
     else
         echo "Some files in PR are not ignored, $DIFF";
     fi;
+  when:
+    event:
+    - push
+    - pull_request
 
 - name: build
   image: rancher/dapper:v0.5.0
@@ -370,6 +382,10 @@ steps:
     else
         echo "Some files in PR are not ignored, $DIFF";
     fi;
+  when:
+    event:
+    - push
+    - pull_request
 
 - name: build
   image: rancher/dapper:v0.5.8
@@ -472,6 +488,10 @@ steps:
     else
         echo "Some files in PR are not ignored, $DIFF";
     fi;
+  when:
+    event:
+    - push
+    - pull_request
 
 - name: validate_go_mods
   image: rancher/dapper:v0.5.0
@@ -508,6 +528,10 @@ steps:
     else
         echo "Some files in PR are not ignored, $DIFF";
     fi;
+  when:
+    event:
+    - push
+    - pull_request
 
 - name: manifest
   image: plugins/docker
@@ -560,6 +584,10 @@ steps:
     else
         echo "Some files in PR are not ignored, $DIFF";
     fi;
+  when:
+    event:
+    - push
+    - pull_request
 
 - name: dispatch
   image: curlimages/curl:7.74.0

--- a/.droneignore
+++ b/.droneignore
@@ -1,0 +1,3 @@
+^.*\.md$
+^install\.sh$
+^\.droneignore$

--- a/.droneignore
+++ b/.droneignore
@@ -1,3 +1,9 @@
 ^.*\.md$
 ^install\.sh$
 ^\.droneignore$
+^\.github/*$
+^MAINTAINERS$
+^CODEOWNERS$
+^LICENSE$
+^DCO$
+^channel\.yaml$

--- a/README.md
+++ b/README.md
@@ -160,4 +160,5 @@ Please check out our [contributing guide](CONTRIBUTING.md) if you're interested 
 Security
 --------
 
-Security issues in K3s can be reported by sending an email to [security@k3s.io](mailto:security@k3s.io). Please do not file issues about security issues.
+Security issues in K3s can be reported by sending an email to [security@k3s.io](mailto:security@k3s.io).
+Please do not file issues about security issues.


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

This change will add a pipeline which implements [drone-skip-pipeline](https://github.com/joshdk/drone-skip-pipeline).
The purpose is to provide some mechanism to automatically skip pipelines which are not necessary due to the files that are being changed. For example, if a markdown file is the only file changed, then we don't need to run functional tests. This will reduce our integration time.

#### Types of Changes ####

No new code to k3s, all changes in .drone.yml

#### Verification ####

Unfortunately, Drone provides no way to test this outside of letting it run in your repo.


#### Linked Issues ####

This addresses #6980.

#### User-Facing Change ####
This has no user facing change.

#### Further Comments ####

There is [another plugin](https://github.com/fernandrone/drone-ignore-config) which may give us similar functionality, but is out of date and requires configuration on the drone server, I would like to try this one first to avoid the additional handoffs.
There is more than one way to implement this plugin, the way I have provided is the one with the fewest changes to existing steps, I am open to additional suggestions.