### PR TITLE
Generation of certificates and keys for etcd gated if etcd is disabled.

### DIFF
--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -433,6 +433,7 @@ func genServerCerts(config *config.Control) error {
 }
 
 func genETCDCerts(config *config.Control) error {
+
 	runtime := config.Runtime
 	regen, err := createSigningCertKey("etcd-server", runtime.ETCDServerCA, runtime.ETCDServerCAKey)
 	if err != nil {
@@ -441,13 +442,6 @@ func genETCDCerts(config *config.Control) error {
 
 	altNames := &certutil.AltNames{}
 	addSANs(altNames, config.SANs)
-
-	if _, err := createClientCertKey(regen, "etcd-server", nil,
-		altNames, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
-		runtime.ETCDServerCA, runtime.ETCDServerCAKey,
-		runtime.ServerETCDCert, runtime.ServerETCDKey); err != nil {
-		return err
-	}
 
 	if _, err := createClientCertKey(regen, "etcd-client", nil,
 		nil, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
@@ -465,6 +459,17 @@ func genETCDCerts(config *config.Control) error {
 		altNames, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		runtime.ETCDPeerCA, runtime.ETCDPeerCAKey,
 		runtime.PeerServerClientETCDCert, runtime.PeerServerClientETCDKey); err != nil {
+		return err
+	}
+
+	if config.DisableETCD {
+		return nil
+	}
+
+	if _, err := createClientCertKey(regen, "etcd-server", nil,
+		altNames, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		runtime.ETCDServerCA, runtime.ETCDServerCAKey,
+		runtime.ServerETCDCert, runtime.ServerETCDKey); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Problem:
When support for `etcd` was added in 3957142, the generation of certificates and keys for `etcd` was not gated behind the use of managed `etcd`. Keys are generated and distributed across servers even if managed `etcd` is not enabled.

Solution:
Allow generation of certificates and keys only if managed etc is enabled. Check config.DisableETCD flag.

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Gate generating ETCD Certificates by checking `config.DisableETCD` flag.

#### Types of Changes ####

Bugfix

#### Verification ####

When running `k3s server` provide `--disable-etcd` flag

#### Testing ####

There are no unit tests present. 

#### Linked Issues ####

[Related issue](https://github.com/k3s-io/k3s/issues/3404)

#### User-Facing Change ####

No user-facing changes in that PR.

#### Further Comments ####

Trivial change. 
