### PR TITLE
fix(sec): upgrade github.com/containerd/containerd to 1.6.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/Mirantis/cri-dockerd v0.0.0-00010101000000-000000000000
 	github.com/cloudnativelabs/kube-router v0.0.0-00010101000000-000000000000
 	github.com/containerd/cgroups v1.0.3
-	github.com/containerd/containerd v1.6.10
+	github.com/containerd/containerd v1.6.18
 	github.com/containerd/fuse-overlayfs-snapshotter v1.0.5
 	github.com/containerd/stargz-snapshotter v0.13.0
 	github.com/coreos/go-iptables v0.6.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in github.com/containerd/containerd v1.6.10
- [CVE-2023-25173](https://www.oscs1024.com/hd/CVE-2023-25173)


### What did I do？
Upgrade github.com/containerd/containerd from v1.6.10 to 1.6.18 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.
