### PR TITLE
[release-1.25] Wait for kubelet port to be ready before setting

### DIFF
--- a/pkg/agent/tunnel/tunnel.go
+++ b/pkg/agent/tunnel/tunnel.go
@@ -160,7 +160,12 @@ func (a *agentTunnel) setKubeletPort(ctx context.Context, apiServerReady <-chan 
 			logrus.Debugf("Tunnel authorizer failed to get Kubelet Port: %v", err)
 			return false, nil
 		}
-		a.kubeletPort = strconv.FormatInt(int64(node.Status.DaemonEndpoints.KubeletEndpoint.Port), 10)
+		kubeletPort := strconv.FormatInt(int64(node.Status.DaemonEndpoints.KubeletEndpoint.Port), 10)
+		if kubeletPort == "0" {
+			logrus.Debugf("Waiting for the kubelet port to be populated")
+			return false, nil
+		}
+		a.kubeletPort = kubeletPort
 		logrus.Infof("Tunnel authorizer set Kubelet Port %s", a.kubeletPort)
 		return true, nil
 	})

--- a/pkg/agent/tunnel/tunnel.go
+++ b/pkg/agent/tunnel/tunnel.go
@@ -41,6 +41,7 @@ type agentTunnel struct {
 	ports       map[string]bool
 	mode        string
 	kubeletPort string
+	startTime   time.Time
 }
 
 // explicit interface check
@@ -72,12 +73,12 @@ func Setup(ctx context.Context, config *daemonconfig.Node, proxy proxy.Proxy) er
 	}
 
 	tunnel := &agentTunnel{
-		client: client,
-		cidrs:  cidranger.NewPCTrieRanger(),
-		ports:  map[string]bool{},
-		mode:   config.EgressSelectorMode,
-
+		client:      client,
+		cidrs:       cidranger.NewPCTrieRanger(),
+		ports:       map[string]bool{},
+		mode:        config.EgressSelectorMode,
 		kubeletPort: fmt.Sprint(ports.KubeletPort),
+		startTime:   time.Now().Truncate(time.Second),
 	}
 
 	apiServerReady := make(chan struct{})
@@ -154,15 +155,25 @@ func (a *agentTunnel) setKubeletPort(ctx context.Context, apiServerReady <-chan 
 	<-apiServerReady
 
 	wait.PollImmediateWithContext(ctx, time.Second, util.DefaultAPIServerReadyTimeout, func(ctx context.Context) (bool, error) {
+		var readyTime metav1.Time
 		nodeName := os.Getenv("NODE_NAME")
 		node, err := a.client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			logrus.Debugf("Tunnel authorizer failed to get Kubelet Port: %v", err)
 			return false, nil
 		}
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == v1.NodeReady && cond.Status == v1.ConditionTrue {
+				readyTime = cond.LastHeartbeatTime
+			}
+		}
+		if readyTime.Time.Before(a.startTime) {
+			logrus.Debugf("Waiting for Ready condition to be updated for Kubelet Port assignment")
+			return false, nil
+		}
 		kubeletPort := strconv.FormatInt(int64(node.Status.DaemonEndpoints.KubeletEndpoint.Port), 10)
 		if kubeletPort == "0" {
-			logrus.Debugf("Waiting for the kubelet port to be populated")
+			logrus.Debugf("Waiting for Kubelet Port to be set")
 			return false, nil
 		}
 		a.kubeletPort = kubeletPort


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

When using k3s with karpenter, we have been seeing issues that we are not able to exec and log into pods that lands into karpenter nodes.

When digging further, we have found out that every time we made exec and log requests, k3s agent returns the following log

```
Tunnel authorizer checking dial request for 127.0.0.1:10250"
Mar 09 17:36:42 ip-10-0-0-125 k3s[15315]: time="2023-03-09T17:36:42Z" level=error msg="Remotedialer proxy error" error="connect not allowed"
```

When k3s-agent starts, we've seen that it was setting kubelet port to 0, which is not correct.

```
Tunnel authorizer set Kubelet Port 0
```

I think what's happening in here is that when using k3s agent with karpenter, the node resource was precreated by karpenter. So agent boots up, it already sees the node but at this point the kubelet port might not be populated back since k3s-agent is still starting. So it just sets the zero port. 

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

In order to solve this bug, we need to make sure the we only set the port when port is ready(great than 0). This will prevent k3s agent from validating the wrong port and rejecting exec and log request.

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Testing this with aws-karpenter

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/7054

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The agent tunnel authorizer now waits for the kubelet to be ready before reading the kubelet port from the node object.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
