### PR TITLE
Drone: Cleanup E2E VMs on test panic

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -665,6 +665,22 @@ platform:
   arch: amd64
 
 steps:
+- name: skipfiles
+  image: plugins/git
+  commands:
+  - export NAME=$(test $DRONE_BUILD_EVENT = pull_request && echo remotes/origin/${DRONE_COMMIT_BRANCH:-master} || echo ${DRONE_COMMIT_SHA}~)
+  - export DIFF=$(git --no-pager diff --name-only $NAME | grep -v -f .droneignore);
+  - if [ -z "$DIFF" ]; then
+        echo "All files in PR are on ignore list";
+        exit 78;
+    else
+        echo "Some files in PR are not ignored, $DIFF";
+    fi;
+  when:
+    event:
+    - push
+    - pull_request
+
 - name: build-e2e-image
   image: rancher/dapper:v0.5.0
   commands:
@@ -686,19 +702,19 @@ steps:
   environment:
     E2E_REGISTRY: 'true'
   commands:
-  # - mkdir -p dist/artifacts
-  # - cp /tmp/artifacts/* dist/artifacts/
-  # - docker stop registry && docker rm registry
-  # - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
-  # - cd tests/e2e/validatecluster
-  # - vagrant destroy -f
-  # - go test -v -timeout=45m ./validatecluster_test.go -ci -local
-  # - cd ../secretsencryption
-  # - vagrant destroy -f
-  # - go test -v -timeout=30m ./secretsencryption_test.go -ci -local
-  # - cd ../upgradecluster
-  # - E2E_RELEASE_CHANNEL="latest" go test -v -timeout=45m ./upgradecluster_test.go  -ci -local
-  # - docker stop registry && docker rm registry
+  - mkdir -p dist/artifacts
+  - cp /tmp/artifacts/* dist/artifacts/
+  - docker stop registry && docker rm registry
+  - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
+  - cd tests/e2e/validatecluster
+  - vagrant destroy -f
+  - go test -v -timeout=45m ./validatecluster_test.go -ci -local
+  - cd ../secretsencryption
+  - vagrant destroy -f
+  - go test -v -timeout=30m ./secretsencryption_test.go -ci -local
+  - cd ../upgradecluster
+  - E2E_RELEASE_CHANNEL="latest" go test -v -timeout=45m ./upgradecluster_test.go  -ci -local
+  - docker stop registry && docker rm registry
   # Cleanup any VMs still running, happens if a test panics
   - VMS=$(virsh list --name | grep '_server-\|_agent-')
   - |

--- a/.drone.yml
+++ b/.drone.yml
@@ -716,7 +716,7 @@ steps:
   - E2E_RELEASE_CHANNEL="latest" go test -v -timeout=45m ./upgradecluster_test.go  -ci -local
   - docker stop registry && docker rm registry
   # Cleanup any VMs still running, happens if a test panics
-  - VMS=$(virsh list --name | grep '_server-\|_agent-')
+  - VMS=$(virsh list --name | grep '_server-\|_agent-' || true)
   - |
     for vm in $VMS
     do

--- a/.drone.yml
+++ b/.drone.yml
@@ -686,19 +686,28 @@ steps:
   environment:
     E2E_REGISTRY: 'true'
   commands:
-  - mkdir -p dist/artifacts
-  - cp /tmp/artifacts/* dist/artifacts/
-  - docker stop registry && docker rm registry
-  - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
-  - cd tests/e2e/validatecluster
-  - vagrant destroy -f
-  - go test -v -timeout=30m ./validatecluster_test.go -ci -local
-  - cd ../secretsencryption
-  - vagrant destroy -f
-  - go test -v -timeout=30m ./secretsencryption_test.go -ci -local
-  - cd ../upgradecluster
-  - E2E_RELEASE_CHANNEL="latest" go test -v -timeout=45m ./upgradecluster_test.go  -ci -local
-  - docker stop registry && docker rm registry
+  # - mkdir -p dist/artifacts
+  # - cp /tmp/artifacts/* dist/artifacts/
+  # - docker stop registry && docker rm registry
+  # - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
+  # - cd tests/e2e/validatecluster
+  # - vagrant destroy -f
+  # - go test -v -timeout=45m ./validatecluster_test.go -ci -local
+  # - cd ../secretsencryption
+  # - vagrant destroy -f
+  # - go test -v -timeout=30m ./secretsencryption_test.go -ci -local
+  # - cd ../upgradecluster
+  # - E2E_RELEASE_CHANNEL="latest" go test -v -timeout=45m ./upgradecluster_test.go  -ci -local
+  # - docker stop registry && docker rm registry
+  # Cleanup any VMs still running, happens if a test panics
+  - VMS=$(virsh list --name | grep '_server-\|_agent-')
+  - |
+    for vm in $VMS
+    do
+      virsh destroy $vm
+      virsh undefine $vm --remove-all-storage
+    done
+
   volumes:
   - name: libvirt
     path: /var/run/libvirt/


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- force cleanup any lingering VMs at the end of the E2E pipeline. Previously, if a `go test` panics (e.g. test timeout), it would not cleanup up its VMs.
- Add skipfiles step to E2E pipeline
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CI Fix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI now passes
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
