### PR TITLE
Clean E2E VMs before testing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -702,27 +702,29 @@ steps:
   environment:
     E2E_REGISTRY: 'true'
   commands:
-  # - mkdir -p dist/artifacts
-  # - cp /tmp/artifacts/* dist/artifacts/
-  # - docker stop registry && docker rm registry
-  # - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
-  # - cd tests/e2e/validatecluster
-  # - vagrant destroy -f
-  # - go test -v -timeout=45m ./validatecluster_test.go -ci -local
-  # - cd ../secretsencryption
-  # - vagrant destroy -f
-  # - go test -v -timeout=30m ./secretsencryption_test.go -ci -local
-  # - cd ../upgradecluster
-  # - E2E_RELEASE_CHANNEL="latest" go test -v -timeout=45m ./upgradecluster_test.go  -ci -local
-  # - docker stop registry && docker rm registry
-  # Cleanup any VMs still running, happens if a test panics
-  - VMS=$(virsh list --name | grep '_server-\|_agent-' || true)
+  - mkdir -p dist/artifacts
+  - cp /tmp/artifacts/* dist/artifacts/
+  - docker stop registry && docker rm registry
+  # Cleanup any VMs running, happens if a previous test panics
   - |
-    for vm in $VMS
-    do
-      virsh destroy $vm
-      virsh undefine $vm --remove-all-storage
-    done
+    VMS=$(virsh list --name | grep '_server-\|_agent-' || true)
+    if [ -n "$VMS" ]; then
+      for vm in $VMS
+      do
+        virsh destroy $vm
+        virsh undefine $vm --remove-all-storage
+      done
+    fi 
+  - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
+  - cd tests/e2e/validatecluster
+  - vagrant destroy -f
+  - go test -v -timeout=45m ./validatecluster_test.go -ci -local
+  - cd ../secretsencryption
+  - vagrant destroy -f
+  - go test -v -timeout=30m ./secretsencryption_test.go -ci -local
+  - cd ../upgradecluster
+  - E2E_RELEASE_CHANNEL="latest" go test -v -timeout=45m ./upgradecluster_test.go  -ci -local
+  - docker stop registry && docker rm registry
 
   volumes:
   - name: libvirt

--- a/.drone.yml
+++ b/.drone.yml
@@ -702,19 +702,19 @@ steps:
   environment:
     E2E_REGISTRY: 'true'
   commands:
-  - mkdir -p dist/artifacts
-  - cp /tmp/artifacts/* dist/artifacts/
-  - docker stop registry && docker rm registry
-  - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
-  - cd tests/e2e/validatecluster
-  - vagrant destroy -f
-  - go test -v -timeout=45m ./validatecluster_test.go -ci -local
-  - cd ../secretsencryption
-  - vagrant destroy -f
-  - go test -v -timeout=30m ./secretsencryption_test.go -ci -local
-  - cd ../upgradecluster
-  - E2E_RELEASE_CHANNEL="latest" go test -v -timeout=45m ./upgradecluster_test.go  -ci -local
-  - docker stop registry && docker rm registry
+  # - mkdir -p dist/artifacts
+  # - cp /tmp/artifacts/* dist/artifacts/
+  # - docker stop registry && docker rm registry
+  # - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
+  # - cd tests/e2e/validatecluster
+  # - vagrant destroy -f
+  # - go test -v -timeout=45m ./validatecluster_test.go -ci -local
+  # - cd ../secretsencryption
+  # - vagrant destroy -f
+  # - go test -v -timeout=30m ./secretsencryption_test.go -ci -local
+  # - cd ../upgradecluster
+  # - E2E_RELEASE_CHANNEL="latest" go test -v -timeout=45m ./upgradecluster_test.go  -ci -local
+  # - docker stop registry && docker rm registry
   # Cleanup any VMs still running, happens if a test panics
   - VMS=$(virsh list --name | grep '_server-\|_agent-' || true)
   - |


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Detect if any lingering `server` or `agent` VMs are still around and clean them up manually before proceeding with E2E testing.
- This addresses an issue where a Drone run would get cancelled or core dump fail, preventing the cleanup at the end from running. Now we run it at the beginning to ensure clean test runs.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI now passes. 
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
