### PR TITLE
Pin golangci-lint version to v1.51.2

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -37,7 +37,7 @@ RUN GOPROXY=direct go install golang.org/x/tools/cmd/goimports@gopls/v0.11.0
 RUN rm -rf /go/src /go/pkg
 
 RUN if [ "$(go env GOARCH)" = "amd64" ]; then \
-    curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/v1.50.1/install.sh | sh -s -- v1.50.1;  \
+    curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/v1.51.2/install.sh | sh -s -- v1.51.2;  \
     fi
 
 ARG SELINUX=true

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -37,7 +37,7 @@ RUN GOPROXY=direct go install golang.org/x/tools/cmd/goimports@gopls/v0.11.0
 RUN rm -rf /go/src /go/pkg
 
 RUN if [ "$(go env GOARCH)" = "amd64" ]; then \
-    curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/v1.50.1/install.sh | sh -s;  \
+    curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/v1.50.1/install.sh | sh -s -- v1.50.1;  \
     fi
 
 ARG SELINUX=true


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

The golangci-lint installer downloads the latest GitHub tag. This PR passes a specified tag to the installer.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/k3s-io/k3s/pull/7114
https://github.com/k3s-io/k3s/pull/7115

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Since golangci-lint v1.52.0 was released, a lot of warnings from revive started to appear for these rules:
* unused-parameter
* redefines-builtin-id
* superfluous-else
* empty-block

They don't appear to be false positives, and it's not immediately clear what changed in the linter. An alternate solution is to fix all these violations now, or to add them all to the exclude list.