### PR TITLE
Drone Pipelines enhancement

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,6 +6,11 @@ platform:
   os: linux
   arch: amd64
 
+trigger:
+  event:
+    exclude:
+    - cron
+
 steps:
 - name: skipfiles
   image: plugins/git
@@ -194,6 +199,11 @@ platform:
   os: linux
   arch: arm64
 
+trigger:
+  event:
+    exclude:
+    - cron
+
 steps:
 - name: skipfiles
   image: plugins/git
@@ -295,6 +305,11 @@ name: arm
 platform:
   os: linux
   arch: arm
+
+trigger:
+  event:
+    exclude:
+    - cron
 
 steps:
 - name: skipfiles
@@ -401,6 +416,11 @@ platform:
 # Hack needed for s390x: https://gist.github.com/colstrom/c2f359f72658aaabb44150ac20b16d7c#gistcomment-3858388
 node:
   arch: s390x
+
+trigger:
+  event:
+    exclude:
+    - cron
 
 clone:
   disable: true
@@ -518,6 +538,11 @@ platform:
   os: linux
   arch: amd64
 
+trigger:
+  event:
+    exclude:
+    - cron
+
 steps:
 - name: skipfiles
   image: plugins/git
@@ -598,7 +623,10 @@ trigger:
   - refs/head/master
   - refs/tags/*
   event:
-  - tag
+    include:
+    - tag
+    exclude:
+      - cron
 
 depends_on:
 - amd64

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,6 @@ steps:
     fi;
   when:
     event:
-    - push
     - pull_request
 
 - name: build
@@ -218,7 +217,6 @@ steps:
     fi;
   when:
     event:
-    - push
     - pull_request
 
 - name: build
@@ -325,7 +323,6 @@ steps:
     fi;
   when:
     event:
-    - push
     - pull_request
 
 - name: build
@@ -446,7 +443,6 @@ steps:
     fi;
   when:
     event:
-    - push
     - pull_request
 
 - name: build


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- This should prevent all the pipelines from triggering during the nightly conformance testing. We really just want the `conformance` and `e2e` pipelines to run. 
- Don't run Skipfiles step on pushes to master for the 4 Architecture pipelines (amd64, arm.arm64, s390x). We still want each commit to be available for testing via AWS bucket.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

See https://drone-pr.k3s.io/k3s-io/k3s/5972 for the current problem we face when running nightly. Notice that all the pipelines tried to run.

See https://drone-publish.k3s.io/k3s-io/k3s/1265/1/6 for the issue with not publishing commits to AWS.

#### Types of Changes ####
Drone CI
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
