### PR TITLE
Update Kube-router ACCEPT rule insertion and install script to clean rules before start 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.22
 	github.com/Mirantis/cri-dockerd => github.com/k3s-io/cri-dockerd v0.3.2-0.20230123224936-bcd78c2d21d8 // k3s/release-1.26
-	github.com/cloudnativelabs/kube-router/v2 => github.com/k3s-io/kube-router/v2 v2.0.1-0.20230405162624-e18008d495ef
+	github.com/cloudnativelabs/kube-router/v2 => github.com/k3s-io/kube-router/v2 v2.0.1-0.20230411195838-cced939a8ba1
 	github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
 	github.com/containerd/containerd => github.com/k3s-io/containerd v1.5.18-k3s1
 	github.com/containerd/stargz-snapshotter => github.com/k3s-io/stargz-snapshotter v0.13.0-k3s1

--- a/go.sum
+++ b/go.sum
@@ -596,8 +596,8 @@ github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGB
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 github.com/k3s-io/klog/v2 v2.80.1-k3s1 h1:mGMXURxxmabQurmtRhXuQTJ9jC0pvIhESSxRSymepS8=
 github.com/k3s-io/klog/v2 v2.80.1-k3s1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
-github.com/k3s-io/kube-router/v2 v2.0.1-0.20230405162624-e18008d495ef h1:2bTqV/V8rvkijGZ3CBQ05GLFl2XTqbKdMnaxqonvrus=
-github.com/k3s-io/kube-router/v2 v2.0.1-0.20230405162624-e18008d495ef/go.mod h1:zhLSRTL1M+0BqeDTRzT42ZtlFJH/d9xaGvXGQR4c2Gc=
+github.com/k3s-io/kube-router/v2 v2.0.1-0.20230411195838-cced939a8ba1 h1:TyefGfus6NkbJKWmEBft0NSb3/D7dYGx9cMkERjdQxc=
+github.com/k3s-io/kube-router/v2 v2.0.1-0.20230411195838-cced939a8ba1/go.mod h1:zhLSRTL1M+0BqeDTRzT42ZtlFJH/d9xaGvXGQR4c2Gc=
 github.com/k3s-io/kubernetes v1.26.3-k3s1 h1:TGJRkXakMp9i6Xx9c2i0ZTth5W9QVebyONJq0Ifgj00=
 github.com/k3s-io/kubernetes v1.26.3-k3s1/go.mod h1:NxzR7U7mS+OGa3J/qweI86Pek//mlfHqDgt6NNGdz8g=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/api v1.26.3-k3s1 h1:Ss3lqvwEnFnlCfFOtV7jg71dC1TAGXldOzgY5W5cnTk=

--- a/install.sh
+++ b/install.sh
@@ -967,6 +967,15 @@ service_enable_and_start() {
         return
     fi
 
+    if command -v iptables-save &> /dev/null && command -v iptables-restore &> /dev/null
+    then
+	    $SUDO iptables-save | grep -v KUBE- | grep -v CNI- | grep -iv flannel | $SUDO iptables-restore
+    fi
+    if command -v ip6tables-save &> /dev/null && command -v ip6tables-restore &> /dev/null
+    then
+	    $SUDO ip6tables-save | grep -v KUBE- | grep -v CNI- | grep -iv flannel | $SUDO ip6tables-restore
+    fi
+
     [ "${HAS_SYSTEMD}" = true ] && systemd_start
     [ "${HAS_OPENRC}" = true ] && openrc_start
     return 0


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Updated Kube-router version to add the default `ACCEPT` iptables rules right after the latest kubernetes rules to fix setup where a firewall that adds `DROP` rules is enabled.
Updated `install.sh` script to clean the iptables rules before K3s start.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
#7203 #7244 #7251

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The embedded kube-router controller has been updated to fix a regression that caused traffic from pods to be blocked by any default drop/deny rules present on the host. Users should still confirm that any externally-managed firewall rules explicitly allow traffic to/from pod and service networks, but this returns the old behavior that was relied upon by some users.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
