### PR TITLE
WIP: Add riscv64 support

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-ARG GOLANG=golang:1.19.7-alpine3.17
+ARG GOLANG=brandond/golang:1.19.7-alpine
 FROM ${GOLANG}
 
 ARG http_proxy=$http_proxy
@@ -11,10 +11,13 @@ ENV no_proxy=$no_proxy
 RUN apk -U --no-cache add bash git gcc musl-dev docker vim less file curl wget ca-certificates jq linux-headers \
     zlib-dev tar zip squashfs-tools npm coreutils python3 py3-pip openssl-dev libffi-dev libseccomp libseccomp-dev \
     libseccomp-static make libuv-static sqlite-dev sqlite-static libselinux libselinux-dev zlib-dev zlib-static \
-    zstd pigz alpine-sdk binutils-gold btrfs-progs-dev btrfs-progs-static gawk yq \
+    zstd pigz alpine-sdk btrfs-progs-dev btrfs-progs-static gawk yq \
     && \
     if [ "$(go env GOARCH)" = "amd64" ]; then \
     apk -U --no-cache add mingw-w64-gcc; \
+    fi \
+    && if [ "$(go env GOARCH)" != "riscv64" ]; then \
+    apk -U --no-cache add binutils-gold; \
     fi
 
 RUN python3 -m pip install awscli

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 TARGETS := $(shell ls scripts | grep -v \\.sh)
 
 .dapper:
-	@echo Downloading dapper
-	@curl -sL https://releases.rancher.com/dapper/v0.6.0/dapper-$$(uname -s)-$$(uname -m) > .dapper.tmp
-	@@chmod +x .dapper.tmp
-	@./.dapper.tmp -v
-	@mv .dapper.tmp .dapper
+	@if command -v dapper; then \
+			ln -s $$(command -v dapper) .dapper; \
+		else \
+			echo Downloading dapper; \
+			curl -sLfo .dapper.tmp https://releases.rancher.com/dapper/v0.6.0/dapper-$$(uname -s)-$$(uname -m) \
+			chmod +x .dapper.tmp; \
+			./.dapper.tmp -v; \
+			mv .dapper.tmp .dapper; \
+		fi
 
 $(TARGETS): .dapper
 	./.dapper $@

--- a/conformance/Dockerfile
+++ b/conformance/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM riscv64/alpine:edge
 ENV SONOBUOY_VERSION 0.56.14
 RUN apk add curl tar gzip
 RUN curl -sfL https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz | tar xvzf - -C /usr/bin

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ replace (
 	github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.1.1
 	github.com/juju/errors => github.com/k3s-io/nocode v0.0.0-20200630202308-cb097102c09f
 	github.com/kubernetes-sigs/cri-tools => github.com/k3s-io/cri-tools v1.26.0-rc.0-k3s1
-	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.5
+	github.com/opencontainers/runc => github.com/brandond/runc v1.1.6-k3s1
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.10.1
 	go.etcd.io/etcd/api/v3 => github.com/k3s-io/etcd/api/v3 v3.5.7-k3s1
@@ -140,9 +140,9 @@ require (
 	go.etcd.io/etcd/server/v3 v3.5.7
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.5.0
-	golang.org/x/net v0.7.0
+	golang.org/x/net v0.8.0
 	golang.org/x/sync v0.1.0
-	golang.org/x/sys v0.5.0
+	golang.org/x/sys v0.6.0
 	google.golang.org/grpc v1.51.0
 	gopkg.in/yaml.v2 v2.4.0
 	inet.af/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/brandond/runc v1.1.6-k3s1 h1:oa7L2wBnbQPMvxei00Wjfq6Auig0tfl4isjcVoQJ8pI=
+github.com/brandond/runc v1.1.6-k3s1/go.mod h1:CbUumNnWCuTGFukNXahoo/RFBZvDAgRh/smNYNOhA50=
 github.com/bronze1man/goStrongswanVici v0.0.0-20201105010758-936f38b697fd h1:qn6a8rGrW+7p4ghypmYHZUKewXURuUDYxKqZxEoFjPc=
 github.com/bronze1man/goStrongswanVici v0.0.0-20201105010758-936f38b697fd/go.mod h1:fWUtBEPt2yjrr3WFhOqvajM8JSEU8bEeBcoeSCsKRpc=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
@@ -853,8 +855,6 @@ github.com/opencontainers/image-spec v1.0.2-0.20210730191737-8e42a01fb1b7/go.mod
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 h1:rc3tiVYb5z54aKaDfakKn0dDjIyPpTtszkjuMzyt7ec=
 github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/runc v1.1.5 h1:L44KXEpKmfWDcS02aeGm8QNTFXTo2D+8MYGDIJ/GDEs=
-github.com/opencontainers/runc v1.1.5/go.mod h1:1J5XiS+vdZ3wCyZybsuxXZWGrgSr8fFJHLXuG2PsnNg=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.10.1 h1:09LIPVRP3uuZGQvgR+SgMSNBd1Eb3vlRbGqQpoHsF8w=

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.17 as base
+FROM riscv64/alpine:edge as base
 RUN apk add -U ca-certificates tar zstd
 COPY build/out/data.tar.zst /
 RUN mkdir -p /image/etc/ssl/certs /image/run /image/var/run /image/tmp /image/lib/modules /image/lib/firmware && \
     tar -xa -C /image -f /data.tar.zst && \
     cp /etc/ssl/certs/ca-certificates.crt /image/etc/ssl/certs/ca-certificates.crt
 
-FROM scratch
+FROM riscv64/alpine:edge
 ARG VERSION="dev"
 COPY --from=base /image /
 RUN mkdir -p /etc && \

--- a/scripts/download
+++ b/scripts/download
@@ -20,9 +20,11 @@ rm -rf ${CONTAINERD_DIR}
 mkdir -p ${CHARTS_DIR}
 mkdir -p ${DATA_DIR}
 
-curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${VERSION_ROOT}/k3s-root-${ARCH}.tar | tar xf -
+if [ "${ARCH}" != "riscv64" ]; then
+  curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${VERSION_ROOT}/k3s-root-${ARCH}.tar | tar xf -
+fi
 
-git clone --single-branch --branch=${VERSION_RUNC} --depth=1 https://github.com/opencontainers/runc ${RUNC_DIR}
+git clone --single-branch --branch=${VERSION_RUNC} --depth=1 https://github.com/brandond/runc ${RUNC_DIR}
 
 git clone --single-branch --branch=${VERSION_CONTAINERD} --depth=1 https://github.com/k3s-io/containerd ${CONTAINERD_DIR}
 

--- a/scripts/image_scan.sh
+++ b/scripts/image_scan.sh
@@ -9,8 +9,7 @@ fi
 
 ARCH=$2
 
-# skipping image scan for s390x since trivy doesn't support s390x arch yet
-if [ "${ARCH}" == "s390x" ]; then
+if [ "${ARCH}" == "s390x" ] || [ "${ARCH}" == "riscv64" ]; then
     exit 0
 fi
 

--- a/scripts/package-cli
+++ b/scripts/package-cli
@@ -35,7 +35,7 @@ mkdir -p dist/artifacts
     set -x
 )
 
-tar cvf ./build/out/data.tar ./bin ./etc
+tar cvf ./build/out/data.tar ./bin 
 zstd --no-progress -T0 -16 -f --long=25 --rm ./build/out/data.tar -o ./build/out/data.tar.zst
 HASH=$(sha256sum ./build/out/data.tar.zst | awk '{print $1}')
 


### PR DESCRIPTION
#### Proposed Changes ####

Get K3s working on riscv64

#### Types of Changes ####

hack

#### Verification ####


#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/7151
* 
#### User-Facing Change ####
<!--
-->
```release-note
NONE
```

#### Further Comments ####

Lots of caveats:
* Only tested this on VisionFive2
* Requires a custom kernel, as the one shipped by StarFive is missing pretty much everything - cgroups, iptables, vxlan, and so on. It is easy enough to rebuild a custom kernel and pack it into a flattened image tree that can be dropped in place of the existing one on the boot partition, using the sources at https://github.com/starfive-tech/VisionFive2 
* Don't have a static buildroot for riscv64 yet; at the moment I'm just using the `riscv64/alpine:edge` base image.