### PR TITLE
Add integration tests for etc-snapshot server flags and refactor /tests/integration/integration.go/K3sStartServer

### DIFF
--- a/tests/integration/custometcdargs/custometcdargs_int_test.go
+++ b/tests/integration/custometcdargs/custometcdargs_int_test.go
@@ -13,8 +13,9 @@ import (
 var customEtcdArgsServer *testutil.K3sServer
 var customEtcdArgsServerArgs = []string{
 	"--cluster-init",
-	"--etcd-arg quota-backend-bytes=858993459",
+	"--etcd-arg=quota-backend-bytes=858993459",
 }
+
 var testLock int
 
 var _ = BeforeSuite(func() {

--- a/tests/integration/dualstack/dualstack_int_test.go
+++ b/tests/integration/dualstack/dualstack_int_test.go
@@ -13,8 +13,8 @@ import (
 var dualStackServer *testutil.K3sServer
 var dualStackServerArgs = []string{
 	"--cluster-init",
-	"--cluster-cidr 10.42.0.0/16,2001:cafe:42:0::/56",
-	"--service-cidr 10.43.0.0/16,2001:cafe:42:1::/112",
+	"--cluster-cidr", "10.42.0.0/16,2001:cafe:42:0::/56",
+	"--service-cidr", "10.43.0.0/16,2001:cafe:42:1::/112",
 	"--disable-network-policy",
 }
 var testLock int

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -210,12 +210,8 @@ func K3sStartServer(inputArgs ...string) (*K3sServer, error) {
 		return nil, errors.New("integration tests must be run as sudo/root")
 	}
 
-	var cmdArgs []string
-	for _, arg := range inputArgs {
-		cmdArgs = append(cmdArgs, strings.Fields(arg)...)
-	}
 	k3sBin := findK3sExecutable()
-	k3sCmd := append([]string{"server"}, cmdArgs...)
+	k3sCmd := append([]string{"server"}, inputArgs...)
 	cmd := exec.Command(k3sBin, k3sCmd...)
 	// Give the server a new group id so we can kill it and its children later
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

This adds integration tests for the following flags: "--etcd-snapshot-name","--etcd-snapshot-dir","--etcd-snapshot-retention","--etcd-snapshot-schedule-cron" and "--etcd-snapshot-compress". It also refactors K3sStartServer to receive as argument a string slice instead of a variadic arg and stop applying strings.Fields() into inputArgs, so it can accept arguments that have space in their definition.


<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####


<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
`sudo -E env "PATH=$PATH" go test ./tests/integration/...`
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
#6057 
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
