### PR TITLE
v1.27.1 CLI Deprectation

### DIFF
--- a/cmd/etcdsnapshot/main.go
+++ b/cmd/etcdsnapshot/main.go
@@ -16,7 +16,6 @@ func main() {
 	app := cmds.NewApp()
 	app.Commands = []cli.Command{
 		cmds.NewEtcdSnapshotCommands(
-			etcdsnapshot.Run,
 			etcdsnapshot.Delete,
 			etcdsnapshot.List,
 			etcdsnapshot.Prune,

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -63,7 +63,6 @@ func main() {
 			etcdsnapshotCommand,
 			etcdsnapshotCommand,
 			etcdsnapshotCommand,
-			etcdsnapshotCommand,
 		),
 		cmds.NewSecretsEncryptCommands(
 			secretsencryptCommand,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -56,7 +56,6 @@ func main() {
 			token.List,
 		),
 		cmds.NewEtcdSnapshotCommands(
-			etcdsnapshot.Run,
 			etcdsnapshot.Delete,
 			etcdsnapshot.List,
 			etcdsnapshot.Prune,

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ func main() {
 		cmds.NewKubectlCommand(kubectl.Run),
 		cmds.NewCRICTL(crictl.Run),
 		cmds.NewEtcdSnapshotCommands(
-			etcdsnapshot.Run,
 			etcdsnapshot.Delete,
 			etcdsnapshot.List,
 			etcdsnapshot.Prune,

--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -201,16 +200,7 @@ func createFlannelConf(nodeConfig *config.Node) error {
 	backend := parts[0]
 	backendOptions := make(map[string]string)
 	if len(parts) > 1 {
-		logrus.Warnf("The additional options through flannel-backend are deprecated and will be removed in k3s v1.27, use flannel-conf instead")
-		options := strings.Split(parts[1], ",")
-		for _, o := range options {
-			p := strings.SplitN(o, "=", 2)
-			if len(p) == 1 {
-				backendOptions[p[0]] = ""
-			} else {
-				backendOptions[p[0]] = p[1]
-			}
-		}
+		logrus.Fatalf("The additional options through flannel-backend are deprecated and were removed in k3s v1.27, use flannel-conf instead")
 	}
 
 	switch backend {
@@ -219,11 +209,7 @@ func createFlannelConf(nodeConfig *config.Node) error {
 	case config.FlannelBackendHostGW:
 		backendConf = hostGWBackend
 	case config.FlannelBackendIPSEC:
-		backendConf = strings.ReplaceAll(ipsecBackend, "%psk%", nodeConfig.AgentConfig.IPSECPSK)
-		if _, err := exec.LookPath("swanctl"); err != nil {
-			return errors.Wrap(err, "k3s no longer includes strongswan - please install strongswan's swanctl and charon packages on your host")
-		}
-		logrus.Warnf("The ipsec backend is deprecated and will be removed in k3s v1.27; please switch to wireguard-native. Check our docs for information on how to migrate.")
+		logrus.Fatal("The ipsec backend is deprecated and was removed in k3s v1.27; please switch to wireguard-native. Check our docs for information on how to migrate.")
 	case config.FlannelBackendWireguardNative:
 		mode, ok := backendOptions["Mode"]
 		if !ok {

--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -224,8 +224,6 @@ func createFlannelConf(nodeConfig *config.Node) error {
 			return errors.Wrap(err, "k3s no longer includes strongswan - please install strongswan's swanctl and charon packages on your host")
 		}
 		logrus.Warnf("The ipsec backend is deprecated and will be removed in k3s v1.27; please switch to wireguard-native. Check our docs for information on how to migrate.")
-	case config.FlannelBackendWireguard:
-		logrus.Fatalf("The wireguard backend was deprecated in K3s v1.26, please switch to wireguard-native. Check our docs at docs.k3s.io/installation/network-options for information about how to migrate.")
 	case config.FlannelBackendWireguardNative:
 		mode, ok := backendOptions["Mode"]
 		if !ok {

--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -99,14 +99,21 @@ var EtcdSnapshotFlags = []cli.Flag{
 	},
 }
 
-func NewEtcdSnapshotCommands(run, delete, list, prune, save func(ctx *cli.Context) error) cli.Command {
+func NewEtcdSnapshotCommands(delete, list, prune, save func(ctx *cli.Context) error) cli.Command {
 	return cli.Command{
 		Name:            EtcdSnapshotCommand,
 		Usage:           "Trigger an immediate etcd snapshot",
 		SkipFlagParsing: false,
 		SkipArgReorder:  true,
-		Action:          run,
 		Subcommands: []cli.Command{
+			{
+				Name:            "save",
+				Usage:           "Trigger an immediate etcd snapshot",
+				SkipFlagParsing: false,
+				SkipArgReorder:  true,
+				Action:          save,
+				Flags:           EtcdSnapshotFlags,
+			},
 			{
 				Name:            "delete",
 				Usage:           "Delete given snapshot(s)",
@@ -140,14 +147,6 @@ func NewEtcdSnapshotCommands(run, delete, list, prune, save func(ctx *cli.Contex
 					Destination: &ServerConfig.EtcdSnapshotRetention,
 					Value:       defaultSnapshotRentention,
 				}),
-			},
-			{
-				Name:            "save",
-				Usage:           "Trigger an immediate etcd snapshot",
-				SkipFlagParsing: false,
-				SkipArgReorder:  true,
-				Action:          save,
-				Flags:           EtcdSnapshotFlags,
 			},
 		},
 		Flags: EtcdSnapshotFlags,

--- a/pkg/cli/etcdsnapshot/etcd_snapshot.go
+++ b/pkg/cli/etcdsnapshot/etcd_snapshot.go
@@ -69,12 +69,6 @@ func commandSetup(app *cli.Context, cfg *cmds.Server, sc *server.Config) error {
 	return nil
 }
 
-// Run was an alias for Save
-func Run(app *cli.Context) error {
-	cli.ShowAppHelp(app)
-	return fmt.Errorf("saving with etcd-snapshot was deprecated in v1.26, use \"etcd-snapshot save\" instead")
-}
-
 // Save triggers an on-demand etcd snapshot operation
 func Save(app *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -24,7 +24,6 @@ const (
 	FlannelBackendVXLAN           = "vxlan"
 	FlannelBackendHostGW          = "host-gw"
 	FlannelBackendIPSEC           = "ipsec"
-	FlannelBackendWireguard       = "wireguard"
 	FlannelBackendWireguardNative = "wireguard-native"
 	EgressSelectorModeAgent       = "agent"
 	EgressSelectorModeCluster     = "cluster"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
 Completely remove flags from k3s and docs. 
- `wireguard` backend
- `k3s etcd-snapshot` will no longer save a snapshot, it is now prints the help message.

Marks the following flags with a fatal error:
- `ipsec` backend
- Additional options of `flannel-backend`
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CLI Deprecation
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/6598
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`--flannel-backed=wireguard`: replaced completely with `--flannel-backend=wireguard-native`
The `k3s etcd-snapshot` command will now print a help message, to save a snapshot use `k3s etcd-snapshot save`
The following flags will now cause a fatal errors (with full removal coming in v1.28.0):
- `--flannel-backed=ipsec`: replaced with `--flannel-backend=wireguard-native` [see docs for more info.](https://docs.k3s.io/installation/network-options#migrating-from-wireguard-or-ipsec-to-wireguard-native)
- supplying multiple `--flannel-backend` values. Use `--flannel-conf` instead.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
