### PR TITLE
Enable FindString to search dotD config files

### DIFF
--- a/pkg/configfilearg/parser.go
+++ b/pkg/configfilearg/parser.go
@@ -98,7 +98,7 @@ func (p *Parser) stripInvalidFlags(command string, args []string) ([]string, err
 
 func (p *Parser) FindString(args []string, target string) (string, error) {
 	configFile, isSet := p.findConfigFileFlag(args)
-	var last_val string
+	var lastVal string
 	if configFile != "" {
 
 		_, err := os.Stat(configFile)
@@ -129,15 +129,15 @@ func (p *Parser) FindString(args []string, target string) (string, error) {
 				k = strings.TrimSuffix(k, "+")
 				if k == target {
 					if isAppend {
-						last_val = last_val + "," + v
+						lastVal = lastVal + "," + v
 					} else {
-						last_val = v
+						lastVal = v
 					}
 				}
 			}
 		}
 	}
-	return last_val, nil
+	return lastVal, nil
 }
 
 func (p *Parser) findConfigFileFlag(args []string) (string, bool) {

--- a/pkg/configfilearg/parser.go
+++ b/pkg/configfilearg/parser.go
@@ -129,7 +129,7 @@ func (p *Parser) FindString(args []string, target string) (string, error) {
 				k = strings.TrimSuffix(k, "+")
 				if k == target {
 					if isAppend {
-						last_val = last_val + v
+						last_val = last_val + "," + v
 					} else {
 						last_val = v
 					}

--- a/pkg/configfilearg/parser.go
+++ b/pkg/configfilearg/parser.go
@@ -98,6 +98,7 @@ func (p *Parser) stripInvalidFlags(command string, args []string) ([]string, err
 
 func (p *Parser) FindString(args []string, target string) (string, error) {
 	configFile, isSet := p.findConfigFileFlag(args)
+	var last_val string
 	if configFile != "" {
 
 		_, err := os.Stat(configFile)
@@ -122,17 +123,21 @@ func (p *Parser) FindString(args []string, target string) (string, error) {
 			if err := yaml.Unmarshal(bytes, &data); err != nil {
 				return "", err
 			}
-
 			for _, i := range data {
 				k, v := convert.ToString(i.Key), convert.ToString(i.Value)
+				isAppend := strings.HasSuffix(k, "+")
+				k = strings.TrimSuffix(k, "+")
 				if k == target {
-					return v, nil
+					if isAppend {
+						last_val = last_val + v
+					} else {
+						last_val = v
+					}
 				}
 			}
 		}
 	}
-
-	return "", nil
+	return last_val, nil
 }
 
 func (p *Parser) findConfigFileFlag(args []string) (string, bool) {

--- a/pkg/configfilearg/parser_test.go
+++ b/pkg/configfilearg/parser_test.go
@@ -376,7 +376,7 @@ func Test_UnitParser_FindString(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "A custom config yaml exists, target exists",
+			name: "A custom config exists, target exists",
 			fields: fields{
 				FlagNames:     []string{"-c", "--config"},
 				EnvName:       "_TEST_ENV",
@@ -389,7 +389,7 @@ func Test_UnitParser_FindString(t *testing.T) {
 			want: "baz",
 		},
 		{
-			name: "A custom config yaml exists, target does not exist",
+			name: "A custom config exists, target does not exist",
 			fields: fields{
 				FlagNames:     []string{"-c", "--config"},
 				EnvName:       "_TEST_ENV",
@@ -400,6 +400,19 @@ func Test_UnitParser_FindString(t *testing.T) {
 				target: "tls",
 			},
 			want: "",
+		},
+		{
+			name: "Multiple custom configs exist, target exists in a secondary config",
+			fields: fields{
+				FlagNames:     []string{"-c", "--config"},
+				EnvName:       "_TEST_ENV",
+				DefaultConfig: "./testdata/data.yaml",
+			},
+			args: args{
+				osArgs: []string{"-c", "./testdata/data.yaml"},
+				target: "b-string",
+			},
+			want: "one",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/configfilearg/parser_test.go
+++ b/pkg/configfilearg/parser_test.go
@@ -384,9 +384,9 @@ func Test_UnitParser_FindString(t *testing.T) {
 			},
 			args: args{
 				osArgs: []string{"-c", "./testdata/data.yaml"},
-				target: "foo-bar",
+				target: "alice",
 			},
-			want: "baz",
+			want: "bob",
 		},
 		{
 			name: "A custom config exists, target does not exist",
@@ -410,9 +410,35 @@ func Test_UnitParser_FindString(t *testing.T) {
 			},
 			args: args{
 				osArgs: []string{"-c", "./testdata/data.yaml"},
+				target: "f-string",
+			},
+			want: "beta",
+		},
+		{
+			name: "Multiple custom configs exist, multiple targets exist in multiple secondary config, replacement",
+			fields: fields{
+				FlagNames:     []string{"-c", "--config"},
+				EnvName:       "_TEST_ENV",
+				DefaultConfig: "./testdata/data.yaml",
+			},
+			args: args{
+				osArgs: []string{"-c", "./testdata/data.yaml"},
+				target: "foo-bar",
+			},
+			want: "bar-foo",
+		},
+		{
+			name: "Multiple custom configs exist, multiple targets exist in multiple secondary config, appending",
+			fields: fields{
+				FlagNames:     []string{"-c", "--config"},
+				EnvName:       "_TEST_ENV",
+				DefaultConfig: "./testdata/data.yaml",
+			},
+			args: args{
+				osArgs: []string{"-c", "./testdata/data.yaml"},
 				target: "b-string",
 			},
-			want: "one",
+			want: "onetwo",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/configfilearg/parser_test.go
+++ b/pkg/configfilearg/parser_test.go
@@ -221,6 +221,7 @@ func Test_UnitParser_findConfigFileFlag(t *testing.T) {
 func Test_UnitParser_Parse(t *testing.T) {
 	testDataOutput := []string{
 		"--foo-bar=bar-foo",
+		"--alice=bob",
 		"--a-slice=1",
 		"--a-slice=1.5",
 		"--a-slice=2",
@@ -237,6 +238,7 @@ func Test_UnitParser_Parse(t *testing.T) {
 		"--c-slice=three",
 		"--d-slice=three",
 		"--d-slice=four",
+		"--f-string=beta",
 		"--e-slice=one",
 		"--e-slice=two",
 	}

--- a/pkg/configfilearg/parser_test.go
+++ b/pkg/configfilearg/parser_test.go
@@ -438,7 +438,7 @@ func Test_UnitParser_FindString(t *testing.T) {
 				osArgs: []string{"-c", "./testdata/data.yaml"},
 				target: "b-string",
 			},
-			want: "onetwo",
+			want: "one,two",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/configfilearg/testdata/data.yaml
+++ b/pkg/configfilearg/testdata/data.yaml
@@ -1,3 +1,4 @@
+foo-bar: baz
 alice: bob
 a-slice:
 - 1

--- a/pkg/configfilearg/testdata/data.yaml
+++ b/pkg/configfilearg/testdata/data.yaml
@@ -1,4 +1,4 @@
-foo-bar: baz
+alice: bob
 a-slice:
 - 1
 - "2"

--- a/pkg/configfilearg/testdata/data.yaml.d/01-data.yml
+++ b/pkg/configfilearg/testdata/data.yaml.d/01-data.yml
@@ -12,3 +12,4 @@ c-slice:
 d-slice:
 - one
 - two
+f-string: beta


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- `FindString` now correctly searches for a CLI argument inside of the `config.yaml.d` folder
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CLI Bug Fix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Create a config folder setup:
- `/etc/rancher/k3s/config.yaml` and `/etc/rancher/k3s/config.yaml.d/test.yaml`
- In`test.yaml` fill with `prefer-bundled-bin: true`
- Start K3s, check arguments passed to server
```
$ kubectl get nodes -o jsonpath='{.items[0].metadata.annotations.k3s\.io/node-args}{"\n"}'
["server","--token","********","--node-external-ip","10.10.10.100","--flannel-iface","eth1","--prefer-bundled-bin","true"]
```
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
New Unit test clause
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/7316
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
