### PR TITLE
Fix issues with `--disable-agent` and `--egress-selector-mode=pod|cluster`

### DIFF
--- a/pkg/agent/cridockerd/cridockerd.go
+++ b/pkg/agent/cridockerd/cridockerd.go
@@ -34,7 +34,7 @@ func Run(ctx context.Context, cfg *config.Node) error {
 	go func() {
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.Fatalf("cri-dockerd panic: %s", debug.Stack())
+				logrus.WithField("stack", string(debug.Stack())).Fatalf("cri-dockerd panic: %v", err)
 			}
 		}()
 		logrus.Fatalf("cri-dockerd exited: %v", command.ExecuteContext(ctx))

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -530,8 +530,11 @@ func validateNetworkConfiguration(serverConfig server.Config) error {
 	}
 
 	switch serverConfig.ControlConfig.EgressSelectorMode {
-	case config.EgressSelectorModeAgent, config.EgressSelectorModeCluster,
-		config.EgressSelectorModeDisabled, config.EgressSelectorModePod:
+	case config.EgressSelectorModeCluster, config.EgressSelectorModePod:
+	case config.EgressSelectorModeAgent, config.EgressSelectorModeDisabled:
+		if serverConfig.DisableAgent {
+			logrus.Warn("Webhooks and apiserver aggregation may not function properly without an agent; please set egress-selector-mode to 'cluster' or 'pod'")
+		}
 	default:
 		return fmt.Errorf("invalid egress-selector-mode %s", serverConfig.ControlConfig.EgressSelectorMode)
 	}

--- a/pkg/daemons/executor/embed.go
+++ b/pkg/daemons/executor/embed.go
@@ -57,7 +57,7 @@ func (e *Embedded) Kubelet(ctx context.Context, args []string) error {
 	go func() {
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.WithField("stack", debug.Stack()).Fatalf("kubelet panic: %v", err)
+				logrus.WithField("stack", string(debug.Stack())).Fatalf("kubelet panic: %v", err)
 			}
 		}()
 		// The embedded executor doesn't need the kubelet to come up to host any components, and
@@ -79,7 +79,7 @@ func (*Embedded) KubeProxy(ctx context.Context, args []string) error {
 	go func() {
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.WithField("stack", debug.Stack()).Fatalf("kube-proxy panic: %v", err)
+				logrus.WithField("stack", string(debug.Stack())).Fatalf("kube-proxy panic: %v", err)
 			}
 		}()
 		logrus.Fatalf("kube-proxy exited: %v", command.ExecuteContext(ctx))
@@ -101,7 +101,7 @@ func (*Embedded) APIServer(ctx context.Context, etcdReady <-chan struct{}, args 
 		<-etcdReady
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.WithField("stack", debug.Stack()).Fatalf("apiserver panic: %v", err)
+				logrus.WithField("stack", string(debug.Stack())).Fatalf("apiserver panic: %v", err)
 			}
 		}()
 		logrus.Fatalf("apiserver exited: %v", command.ExecuteContext(ctx))
@@ -130,7 +130,7 @@ func (e *Embedded) Scheduler(ctx context.Context, apiReady <-chan struct{}, args
 		}
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.WithField("stack", debug.Stack()).Fatalf("scheduler panic: %v", err)
+				logrus.WithField("stack", string(debug.Stack())).Fatalf("scheduler panic: %v", err)
 			}
 		}()
 		logrus.Fatalf("scheduler exited: %v", command.ExecuteContext(ctx))
@@ -147,7 +147,7 @@ func (*Embedded) ControllerManager(ctx context.Context, apiReady <-chan struct{}
 		<-apiReady
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.WithField("stack", debug.Stack()).Fatalf("controller-manager panic: %v", err)
+				logrus.WithField("stack", string(debug.Stack())).Fatalf("controller-manager panic: %v", err)
 			}
 		}()
 		logrus.Fatalf("controller-manager exited: %v", command.ExecuteContext(ctx))
@@ -180,7 +180,7 @@ func (*Embedded) CloudControllerManager(ctx context.Context, ccmRBACReady <-chan
 		<-ccmRBACReady
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.WithField("stack", debug.Stack()).Fatalf("cloud-controller-manager panic: %v", err)
+				logrus.WithField("stack", string(debug.Stack())).Fatalf("cloud-controller-manager panic: %v", err)
 			}
 		}()
 		logrus.Errorf("cloud-controller-manager exited: %v", command.ExecuteContext(ctx))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -168,8 +168,11 @@ func apiserverControllers(ctx context.Context, sc *Context, config *Config) {
 			panic(errors.Wrapf(err, "failed to start %s leader controller", util.GetFunctionName(controller)))
 		}
 	}
+
+	// Re-run context startup after core and leader-elected controllers have started. Additional
+	// informer caches may need to start for the newly added OnChange callbacks.
 	if err := sc.Start(ctx); err != nil {
-		panic(err)
+		panic(errors.Wrap(err, "failed to start wranger controllers"))
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -181,7 +181,7 @@ func apiserverControllers(ctx context.Context, sc *Context, config *Config) {
 func runOrDie(ctx context.Context, name string, cb leader.Callback) {
 	defer func() {
 		if err := recover(); err != nil {
-			logrus.WithField("stack", debug.Stack()).Fatalf("%s controller panic: %v", name, err)
+			logrus.WithField("stack", string(debug.Stack())).Fatalf("%s controller panic: %v", name, err)
 		}
 	}()
 	cb(ctx)

--- a/tests/e2e/rotateca/rotateca_test.go
+++ b/tests/e2e/rotateca/rotateca_test.go
@@ -1,4 +1,4 @@
-package secretsencryption
+package rotateca
 
 import (
 	"flag"


### PR DESCRIPTION
#### Proposed Changes ####

Improve egress selector handling on agentless servers

* Add an e2e test for agentless servers
* Don't set up the agent tunnel authorizer on agentless servers, and warn when agentless servers won't have a way to reach in-cluster endpoints.
* Fix a regression in the (non-default) cluster and pod egress-selector-modes

#### Types of Changes ####

bugfix

#### Verification ####

See linked issues

#### Testing ####

Yes, added one

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/7329
* https://github.com/k3s-io/k3s/issues/7332


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
* Servers started with the (experimental) --disable-agent flag no longer attempt to run the tunnel authorizer agent component.
* Fixed an regression that prevented the pod and cluster egress-selector modes from working properly.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
