### PR TITLE
Bump k3s-root for aarch64 page size fix

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -59,7 +59,7 @@ if [ -z "$VERSION_KUBE_ROUTER" ]; then
     VERSION_KUBE_ROUTER="v0.0.0"
 fi
 
-VERSION_ROOT="v0.12.1"
+VERSION_ROOT="v0.12.2"
 
 if [[ -n "$GIT_TAG" ]]; then
     if [[ ! "$GIT_TAG" =~ ^"$VERSION_K8S"[+-] ]]; then


### PR DESCRIPTION
#### Proposed Changes ####

Bump k3s-root

#### Types of Changes ####

bugfix

#### Verification ####

Run k3s on aarch64 with page size != 4k

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/7335
* 
#### User-Facing Change ####
```release-note
K3s once again supports aarch64 nodes with page size > 4k
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
