### PR TITLE
Cleanup help messages

### DIFF
--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -102,7 +102,6 @@ var EtcdSnapshotFlags = []cli.Flag{
 func NewEtcdSnapshotCommands(delete, list, prune, save func(ctx *cli.Context) error) cli.Command {
 	return cli.Command{
 		Name:            EtcdSnapshotCommand,
-		Usage:           "Trigger an immediate etcd snapshot",
 		SkipFlagParsing: false,
 		SkipArgReorder:  true,
 		Subcommands: []cli.Command{

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -209,7 +209,7 @@ var ServerFlags = []cli.Flag{
 	ClusterDomain,
 	&cli.StringFlag{
 		Name:        "flannel-backend",
-		Usage:       "(networking) backend<=option1=val1,option2=val2> where backend is one of 'none', 'vxlan', 'ipsec' (deprecated), 'host-gw', 'wireguard-native', 'wireguard' (deprecated)",
+		Usage:       "(networking) Backend (valid values: 'none', 'vxlan', 'ipsec' (deprecated), 'host-gw', 'wireguard-native'",
 		Destination: &ServerConfig.FlannelBackend,
 		Value:       "vxlan",
 	},


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Cleanup deprecated help messages for v1.27.1
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Verification ####
```
$ ./dist/artifacts/k3s server -h | grep flannel-backend
   --flannel-backend value                    (networking) Backend networking (valid values: 'none', 'vxlan', 'ipsec' (deprecated), 'host-gw', 'wireguard-native' (default: "vxlan")
```

And
```
$ ./dist/artifacts/k3s etcd-snapshot
NAME:
   k3s etcd-snapshot - 

USAGE:
   k3s etcd-snapshot command [command options] [arguments...]
```

#### Types of Changes ####
CLI help messages
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/6598
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
