### PR TITLE
Improve error message when CLI wrapper Exec fails

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -204,7 +204,10 @@ func stageAndRun(dataDir, cmd string, args []string) error {
 
 	logrus.Debugf("Running %s %v", cmd, args)
 
-	return syscall.Exec(cmd, args, os.Environ())
+	if err := syscall.Exec(cmd, args, os.Environ()); err != nil {
+		return errors.Wrapf(err, "exec %s failed", cmd)
+	}
+	return nil
 }
 
 // getAssetAndDir returns the name of the bindata asset, along with a directory path


### PR DESCRIPTION
#### Proposed Changes ####

Improve error message when CLI wrapper Exec fails

Right now if the k3s CLI wrapper fails to exec the extracted binaries (most frequently because /var is mounted noxec), it just prints a fairly hard to diagnose `FATA [0000] permission denied` error.

This wraps the exec error in some context showing what it was trying to exec, to assist with troubleshooting.

Perhaps we could also check to see if the filesystem is mounted noexec and return an even more meaningful error, but there doesn't seem to be a particularly graceful way to do that.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/7372

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
K3s now prints a more meaningful error when attempting to run from a filesystem mounted `noexec`.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
