### PR TITLE
Handle multiple arguments with StringSlice flags

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -116,7 +116,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.KubeConfigMode = cfg.KubeConfigMode
 	serverConfig.ControlConfig.Rootless = cfg.Rootless
 	serverConfig.ControlConfig.ServiceLBNamespace = cfg.ServiceLBNamespace
-	serverConfig.ControlConfig.SANs = util.SplitSliceString(cfg.TLSSan)
+	serverConfig.ControlConfig.SANs = util.SplitStringSlice(cfg.TLSSan)
 	serverConfig.ControlConfig.BindAddress = cfg.BindAddress
 	serverConfig.ControlConfig.SupervisorPort = cfg.SupervisorPort
 	serverConfig.ControlConfig.HTTPSPort = cfg.HTTPSPort
@@ -247,7 +247,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		}
 		cmds.ServerConfig.ClusterCIDR.Set(clusterCIDR)
 	}
-	for _, cidr := range util.SplitSliceString(cmds.ServerConfig.ClusterCIDR) {
+	for _, cidr := range util.SplitStringSlice(cmds.ServerConfig.ClusterCIDR) {
 		_, parsed, err := net.ParseCIDR(cidr)
 		if err != nil {
 			return errors.Wrapf(err, "invalid cluster-cidr %s", cidr)
@@ -271,7 +271,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		}
 		cmds.ServerConfig.ServiceCIDR.Set(serviceCIDR)
 	}
-	for _, cidr := range util.SplitSliceString(cmds.ServerConfig.ServiceCIDR) {
+	for _, cidr := range util.SplitStringSlice(cmds.ServerConfig.ServiceCIDR) {
 		_, parsed, err := net.ParseCIDR(cidr)
 		if err != nil {
 			return errors.Wrapf(err, "invalid service-cidr %s", cidr)
@@ -311,7 +311,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		serverConfig.ControlConfig.ClusterDNS = clusterDNS
 		serverConfig.ControlConfig.ClusterDNSs = []net.IP{serverConfig.ControlConfig.ClusterDNS}
 	} else {
-		for _, ip := range util.SplitSliceString(cmds.ServerConfig.ClusterDNS) {
+		for _, ip := range util.SplitStringSlice(cmds.ServerConfig.ClusterDNS) {
 			parsed := net.ParseIP(ip)
 			if parsed == nil {
 				return fmt.Errorf("invalid cluster-dns address %s", ip)
@@ -343,7 +343,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 
 	serverConfig.ControlConfig.Skips = map[string]bool{}
 	serverConfig.ControlConfig.Disables = map[string]bool{}
-	for _, disable := range util.SplitSliceString(app.StringSlice("disable")) {
+	for _, disable := range util.SplitStringSlice(app.StringSlice("disable")) {
 		disable = strings.TrimSpace(disable)
 		serverConfig.ControlConfig.Skips[disable] = true
 		serverConfig.ControlConfig.Disables[disable] = true

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -247,14 +247,12 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		}
 		cmds.ServerConfig.ClusterCIDR.Set(clusterCIDR)
 	}
-	for _, cidr := range cmds.ServerConfig.ClusterCIDR {
-		for _, v := range strings.Split(cidr, ",") {
-			_, parsed, err := net.ParseCIDR(v)
-			if err != nil {
-				return errors.Wrapf(err, "invalid cluster-cidr %s", v)
-			}
-			serverConfig.ControlConfig.ClusterIPRanges = append(serverConfig.ControlConfig.ClusterIPRanges, parsed)
+	for _, cidr := range util.SplitSliceString(cmds.ServerConfig.ClusterCIDR) {
+		_, parsed, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return errors.Wrapf(err, "invalid cluster-cidr %s", cidr)
 		}
+		serverConfig.ControlConfig.ClusterIPRanges = append(serverConfig.ControlConfig.ClusterIPRanges, parsed)
 	}
 
 	// set ClusterIPRange to the first IPv4 block, for legacy clients
@@ -273,14 +271,12 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		}
 		cmds.ServerConfig.ServiceCIDR.Set(serviceCIDR)
 	}
-	for _, cidr := range cmds.ServerConfig.ServiceCIDR {
-		for _, v := range strings.Split(cidr, ",") {
-			_, parsed, err := net.ParseCIDR(v)
-			if err != nil {
-				return errors.Wrapf(err, "invalid service-cidr %s", v)
-			}
-			serverConfig.ControlConfig.ServiceIPRanges = append(serverConfig.ControlConfig.ServiceIPRanges, parsed)
+	for _, cidr := range util.SplitSliceString(cmds.ServerConfig.ServiceCIDR) {
+		_, parsed, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return errors.Wrapf(err, "invalid service-cidr %s", cidr)
 		}
+		serverConfig.ControlConfig.ServiceIPRanges = append(serverConfig.ControlConfig.ServiceIPRanges, parsed)
 	}
 
 	// set ServiceIPRange to the first IPv4 block, for legacy clients
@@ -315,14 +311,12 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		serverConfig.ControlConfig.ClusterDNS = clusterDNS
 		serverConfig.ControlConfig.ClusterDNSs = []net.IP{serverConfig.ControlConfig.ClusterDNS}
 	} else {
-		for _, ip := range cmds.ServerConfig.ClusterDNS {
-			for _, v := range strings.Split(ip, ",") {
-				parsed := net.ParseIP(v)
-				if parsed == nil {
-					return fmt.Errorf("invalid cluster-dns address %s", v)
-				}
-				serverConfig.ControlConfig.ClusterDNSs = append(serverConfig.ControlConfig.ClusterDNSs, parsed)
+		for _, ip := range util.SplitSliceString(cmds.ServerConfig.ClusterDNS) {
+			parsed := net.ParseIP(ip)
+			if parsed == nil {
+				return fmt.Errorf("invalid cluster-dns address %s", ip)
 			}
+			serverConfig.ControlConfig.ClusterDNSs = append(serverConfig.ControlConfig.ClusterDNSs, parsed)
 		}
 		// Set ClusterDNS to the first IPv4 address, for legacy clients
 		// unless only IPv6 range given
@@ -349,12 +343,10 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 
 	serverConfig.ControlConfig.Skips = map[string]bool{}
 	serverConfig.ControlConfig.Disables = map[string]bool{}
-	for _, disable := range app.StringSlice("disable") {
-		for _, v := range strings.Split(disable, ",") {
-			v = strings.TrimSpace(v)
-			serverConfig.ControlConfig.Skips[v] = true
-			serverConfig.ControlConfig.Disables[v] = true
-		}
+	for _, disable := range util.SplitSliceString(app.StringSlice("disable")) {
+		disable = strings.TrimSpace(disable)
+		serverConfig.ControlConfig.Skips[disable] = true
+		serverConfig.ControlConfig.Disables[disable] = true
 	}
 	if serverConfig.ControlConfig.Skips["servicelb"] {
 		serverConfig.ControlConfig.DisableServiceLB = true

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -116,7 +116,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.KubeConfigMode = cfg.KubeConfigMode
 	serverConfig.ControlConfig.Rootless = cfg.Rootless
 	serverConfig.ControlConfig.ServiceLBNamespace = cfg.ServiceLBNamespace
-	serverConfig.ControlConfig.SANs = cfg.TLSSan
+	serverConfig.ControlConfig.SANs = util.SplitSliceString(cfg.TLSSan)
 	serverConfig.ControlConfig.BindAddress = cfg.BindAddress
 	serverConfig.ControlConfig.SupervisorPort = cfg.SupervisorPort
 	serverConfig.ControlConfig.HTTPSPort = cfg.HTTPSPort

--- a/pkg/daemons/control/deps/deps_test.go
+++ b/pkg/daemons/control/deps/deps_test.go
@@ -1,0 +1,51 @@
+package deps
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	certutil "github.com/rancher/dynamiclistener/cert"
+)
+
+func Test_UnitAddSANs(t *testing.T) {
+	type args struct {
+		altNames *certutil.AltNames
+		sans     []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want certutil.AltNames
+	}{
+		{
+			name: "One IP, One DNS",
+			args: args{
+				altNames: &certutil.AltNames{},
+				sans:     []string{"192.168.205.10", "192.168.205.10.nip.io"},
+			},
+			want: certutil.AltNames{
+				IPs:      []net.IP{net.ParseIP("192.168.205.10")},
+				DNSNames: []string{"192.168.205.10.nip.io"},
+			},
+		},
+		{
+			name: "Two IP, No DNS",
+			args: args{
+				altNames: &certutil.AltNames{},
+				sans:     []string{"192.168.205.10", "10.168.21.15"},
+			},
+			want: certutil.AltNames{
+				IPs: []net.IP{net.ParseIP("192.168.205.10"), net.ParseIP("10.168.21.15")},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addSANs(tt.args.altNames, tt.args.sans)
+			if !reflect.DeepEqual(*tt.args.altNames, tt.want) {
+				t.Errorf("addSANs() = %v, want %v", *tt.args.altNames, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -30,10 +30,10 @@ func GetClientSet(file string) (clientset.Interface, error) {
 	return clientset.NewForConfig(restConfig)
 }
 
-// SplitSliceString is a helper function to handle StringSliceFlag containing mutliple values
+// SplitStringSlice is a helper function to handle StringSliceFlag containing multiple values
 // By default, StringSliceFlag only supports repeated values, not multiple values
 // e.g. --foo="bar,car" --foo=baz will result in []string{"bar", "car". "baz"}
-func SplitSliceString(ss []string) []string {
+func SplitStringSlice(ss []string) []string {
 	result := []string{}
 	for _, s := range ss {
 		result = append(result, strings.Split(s, ",")...)

--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -39,8 +39,6 @@ func SplitSliceString(flag cli.StringSlice) []string {
 	for _, s := range flag.Value() {
 		if strings.Contains(s, ",") {
 			result = append(result, strings.Split(s, ",")...)
-		} else if strings.Contains(s, " ") {
-			result = append(result, strings.Split(s, " ")...)
 		} else {
 			result = append(result, s)
 		}

--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/k3s-io/k3s/pkg/datadir"
-	"github.com/urfave/cli"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -34,14 +33,10 @@ func GetClientSet(file string) (clientset.Interface, error) {
 // SplitSliceString is a helper function to handle StringSliceFlag containing mutliple values
 // By default, StringSliceFlag only supports repeated values, not multiple values
 // e.g. --foo="bar,car" --foo=baz will result in []string{"bar", "car". "baz"}
-func SplitSliceString(flag cli.StringSlice) []string {
+func SplitSliceString(ss []string) []string {
 	result := []string{}
-	for _, s := range flag.Value() {
-		if strings.Contains(s, ",") {
-			result = append(result, strings.Split(s, ",")...)
-		} else {
-			result = append(result, s)
-		}
+	for _, s := range ss {
+		result = append(result, strings.Split(s, ",")...)
 	}
 	return result
 }

--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -1,7 +1,10 @@
 package util
 
 import (
+	"strings"
+
 	"github.com/k3s-io/k3s/pkg/datadir"
+	"github.com/urfave/cli"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -26,4 +29,21 @@ func GetClientSet(file string) (clientset.Interface, error) {
 	}
 
 	return clientset.NewForConfig(restConfig)
+}
+
+// SplitSliceString is a helper function to handle StringSliceFlag containing mutliple values
+// By default, StringSliceFlag only supports repeated values, not multiple values
+// e.g. --foo="bar,car" --foo=baz will result in []string{"bar", "car". "baz"}
+func SplitSliceString(flag cli.StringSlice) []string {
+	result := []string{}
+	for _, s := range flag.Value() {
+		if strings.Contains(s, ",") {
+			result = append(result, strings.Split(s, ",")...)
+		} else if strings.Contains(s, " ") {
+			result = append(result, strings.Split(s, " ")...)
+		} else {
+			result = append(result, s)
+		}
+	}
+	return result
 }

--- a/pkg/util/client_test.go
+++ b/pkg/util/client_test.go
@@ -14,13 +14,18 @@ func Test_UnitSplitSliceString(t *testing.T) {
 		want []string
 	}{
 		{
+			name: "Single Argument",
+			arg:  cli.StringSlice{"foo"},
+			want: []string{"foo"},
+		},
+		{
 			name: "Repeated Arguments",
 			arg:  cli.StringSlice{"foo", "bar", "baz"},
 			want: []string{"foo", "bar", "baz"},
 		},
 		{
 			name: "Multiple Arguments and Repeated Arguments",
-			arg:  cli.StringSlice{"foo,bar", "zoo clar", "baz"},
+			arg:  cli.StringSlice{"foo,bar", "zoo,clar", "baz"},
 			want: []string{"foo", "bar", "zoo", "clar", "baz"},
 		},
 	}

--- a/pkg/util/client_test.go
+++ b/pkg/util/client_test.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/urfave/cli"
+)
+
+func Test_UnitSplitSliceString(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  cli.StringSlice
+		want []string
+	}{
+		{
+			name: "Repeated Arguments",
+			arg:  cli.StringSlice{"foo", "bar", "baz"},
+			want: []string{"foo", "bar", "baz"},
+		},
+		{
+			name: "Multiple Arguments and Repeated Arguments",
+			arg:  cli.StringSlice{"foo,bar", "zoo clar", "baz"},
+			want: []string{"foo", "bar", "zoo", "clar", "baz"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SplitSliceString(tt.arg); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SplitSliceString() = %+v\nWant = %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/util/client_test.go
+++ b/pkg/util/client_test.go
@@ -31,7 +31,7 @@ func Test_UnitSplitSliceString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SplitSliceString(tt.arg); !reflect.DeepEqual(got, tt.want) {
+			if got := SplitStringSlice(tt.arg); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("SplitSliceString() = %+v\nWant = %+v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Adds a helper function `SplitSliceString` which allows SliceString flags like `--tls-san` to accept not only repeated arguments (e.g. `--tls-san=foo --tls-san=bar`) but also multliple comma separated args (e.g. `--tls-san="foo,bar"`)
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CLI
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
See linked issue.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
2 New unit tests
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/7365
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
