### PR TITLE
Fail to validate server tokens that use bootstrap id/secret format

### DIFF
--- a/pkg/clientaccess/token.go
+++ b/pkg/clientaccess/token.go
@@ -165,9 +165,13 @@ func hashCA(b []byte) (string, error) {
 
 // ParseUsernamePassword returns the username and password portion of a token string,
 // along with a bool indicating if the token was successfully parsed.
+// Kubeadm-style tokens have ID/Secret not Username/Password and therefore will return false (invalid).
 func ParseUsernamePassword(token string) (string, string, bool) {
 	info, err := parseToken(token)
 	if err != nil {
+		return "", "", false
+	}
+	if info.BootstrapTokenString != nil {
 		return "", "", false
 	}
 	return info.Username, info.Password, true

--- a/pkg/clientaccess/token_test.go
+++ b/pkg/clientaccess/token_test.go
@@ -294,6 +294,7 @@ func Test_UnitUserPass(t *testing.T) {
 		{"K10XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX::username:password", "username", "password", true},
 		{"password", "", "password", true},
 		{"K10X::x", "", "", false},
+		{"aaaaaa.bbbbbbbbbbbbbbbb", "", "", false},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -271,7 +271,7 @@ func readTokenFromFile(serverToken, certs, dataDir string) (string, error) {
 func normalizeToken(token string) (string, error) {
 	_, password, ok := clientaccess.ParseUsernamePassword(token)
 	if !ok {
-		return password, errors.New("failed to normalize token; must be in format K10<CA-HASH>::<USERNAME>:<PASSWORD> or <PASSWORD>")
+		return password, errors.New("failed to normalize server token; must be in format K10<CA-HASH>::<USERNAME>:<PASSWORD> or <PASSWORD>")
 	}
 
 	return password, nil
@@ -286,7 +286,7 @@ func migrateOldTokens(ctx context.Context, bootstrapList []client.Value, storage
 	for _, bootstrapKV := range bootstrapList {
 		// checking for empty string bootstrap key
 		if string(bootstrapKV.Key) == emptyStringKey {
-			logrus.Warn("bootstrap data encrypted with empty string, deleting and resaving with token")
+			logrus.Warn("Bootstrap data encrypted with empty string, deleting and resaving with token")
 			if err := doMigrateToken(ctx, storageClient, bootstrapKV, "", emptyStringKey, token, tokenKey); err != nil {
 				return err
 			}

--- a/tests/e2e/startup/startup_test.go
+++ b/tests/e2e/startup/startup_test.go
@@ -246,6 +246,18 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
+	Context("Verify server fails to start with bootstrap token", func() {
+		It("Fails to start with a meaningful error", func() {
+			tokenYAML := "token: aaaaaa.bbbbbbbbbbbbbbbb"
+			err := StartK3sCluster(append(serverNodeNames, agentNodeNames...), tokenYAML, tokenYAML)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(ContainSubstring("failed to normalize server token"))
+		})
+		It("Kills the cluster", func() {
+			err := KillK3sCluster(append(serverNodeNames, agentNodeNames...))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
 })
 
 var failed bool


### PR DESCRIPTION
#### Proposed Changes ####
Fail to validate server tokens that use bootstrap id/secret format

Exit out with a proper `failed to normalize server token; must be in format K10<CA-HASH>::<USERNAME>:<PASSWORD> or <PASSWORD>` error instead of failing later on when the bootstrap save code notices that the password is an empty string.

#### Types of Changes ####

bugfix

#### Verification ####

Start a k3s server with a --token value that uses the bootstrap token format.

#### Testing ####

Yes

#### Linked Issues ####

* #7313

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
K3s now exits with a proper error message when the server token uses a bootstrap token `id.secret` format.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
