### PR TITLE
[1.30] Remove depracated `pod-infra-container-image` kubelet flag

### DIFF
--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -112,9 +112,6 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 			argsMap["container-runtime-endpoint"] = socketPrefix + cfg.RuntimeSocket
 		}
 	}
-	if cfg.PauseImage != "" {
-		argsMap["pod-infra-container-image"] = cfg.PauseImage
-	}
 	if cfg.ImageServiceSocket != "" {
 		if strings.HasPrefix(cfg.ImageServiceSocket, socketPrefix) {
 			argsMap["image-service-endpoint"] = cfg.ImageServiceSocket

--- a/pkg/daemons/agent/agent_windows.go
+++ b/pkg/daemons/agent/agent_windows.go
@@ -81,9 +81,6 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 			argsMap["container-runtime-endpoint"] = socketPrefix + cfg.RuntimeSocket
 		}
 	}
-	if cfg.PauseImage != "" {
-		argsMap["pod-infra-container-image"] = cfg.PauseImage
-	}
 	if cfg.ListenAddress != "" {
 		argsMap["address"] = cfg.ListenAddress
 	}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Stops passing pause image to kubelet as a flag (deprecated in v1.29.0)
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CLI
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Start k3s with `--pause-image=rancher/mirrored-pause:3.5` and check the logs for the kubelet command. Should see no complaints from kubelet. 
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/7408
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
