### PR TITLE
add kube-* server flags integration tests

### DIFF
--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -212,13 +212,21 @@ func GetPersistentVolume(name string) (*corev1.PersistentVolume, error) {
 	return client.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
 }
 
-func FindStringInCmdAsync(scanner *bufio.Scanner, target string) bool {
+func SearchK3sLog(k3s *K3sServer, target string) (bool, error) {
+	file, err := os.Open(k3s.log.Name())
+	if err != nil {
+		return false, err
+	}
+	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		if strings.Contains(scanner.Text(), target) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	if scanner.Err() != nil {
+		return false, scanner.Err()
+	}
+	return false, nil
 }
 
 func K3sTestLock() (int, error) {

--- a/tests/integration/kubeflags/kubeflags_test.go
+++ b/tests/integration/kubeflags/kubeflags_test.go
@@ -1,0 +1,135 @@
+package kubeflags
+
+import (
+	"strings"
+	"testing"
+
+	testutil "github.com/k3s-io/k3s/tests/integration"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+)
+
+var server *testutil.K3sServer
+var serverArgs = []string{"--cluster-init",
+	"--kube-apiserver-arg", "advertise-port=1234",
+	"--kube-controller-manager-arg", "allocate-node-cidrs=false",
+	"--kube-scheduler-arg", "authentication-kubeconfig=test",
+	"--kube-cloud-controller-manager-arg", "allocate-node-cidrs=false",
+	"--kubelet-arg", "address=127.0.0.1",
+	"--kube-proxy-arg", "cluster-cidr=127.0.0.1/16",
+}
+var testLock int
+
+var _ = BeforeSuite(func() {
+	if !testutil.IsExistingServer() {
+		var err error
+		testLock, err = testutil.K3sTestLock()
+		Expect(err).ToNot(HaveOccurred())
+		server, err = testutil.K3sStartServer(serverArgs...)
+		Expect(err).ToNot(HaveOccurred())
+	}
+})
+
+var _ = Describe("create a new cluster with kube-* flags", Ordered, func() {
+	BeforeEach(func() {
+		if testutil.IsExistingServer() && !testutil.ServerArgsPresent(serverArgs) {
+			Skip("Test needs k3s server with: " + strings.Join(serverArgs, " "))
+		}
+	})
+	When("should print the args on the console", func() {
+		It("should find cloud-controller-manager starting", func() {
+			Eventually(func() error {
+				match, err := testutil.SearchK3sLog(server, "Running cloud-controller-manager --allocate-node-cidrs=false")
+				if err != nil {
+					return err
+				}
+				if match {
+					return nil
+				}
+				return errors.New("error finding cloud-controller-manager")
+			}, "30s", "2s").Should(Succeed())
+		})
+		It("should find kube-scheduler starting", func() {
+			Eventually(func() error {
+				match, err := testutil.SearchK3sLog(server, "Running kube-scheduler --authentication-kubeconfig=test")
+				if err != nil {
+					return err
+				}
+				if match {
+					return nil
+				}
+				return errors.New("error finding kube-scheduler")
+			}, "30s", "2s").Should(Succeed())
+		})
+		It("should find kube-apiserver starting", func() {
+			Eventually(func() error {
+				match, err := testutil.SearchK3sLog(server, "Running kube-apiserver --advertise-port=1234")
+				if err != nil {
+					return err
+				}
+				if match {
+					return nil
+				}
+				return errors.New("error finding kube-apiserver")
+			}, "30s", "2s").Should(Succeed())
+		})
+		It("should find kube-controller-manager starting", func() {
+			Eventually(func() error {
+				match, err := testutil.SearchK3sLog(server, "Running kube-controller-manager --allocate-node-cidrs=false")
+				if err != nil {
+					return err
+				}
+				if match {
+					return nil
+				}
+				return errors.New("error finding kube-controller-manager")
+			}, "30s", "2s").Should(Succeed())
+		})
+		It("should find kubelet starting", func() {
+			Eventually(func() error {
+				match, err := testutil.SearchK3sLog(server, "Running kubelet --address=127.0.0.1")
+				if err != nil {
+					return err
+				}
+				if match {
+					return nil
+				}
+				return errors.New("error finding kubelet")
+			}, "120s", "15s").Should(Succeed())
+		})
+		It("should find kube-proxy starting", func() {
+			Eventually(func() error {
+				match, err := testutil.SearchK3sLog(server, "Running kube-proxy --cluster-cidr=127.0.0.1/16")
+				if err != nil {
+					return err
+				}
+				if match {
+					return nil
+				}
+				return errors.New("error finding kube-proxy")
+			}, "120s", "15s").Should(Succeed())
+		})
+
+	})
+})
+
+var failed bool
+var _ = AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
+var _ = AfterSuite(func() {
+	if !testutil.IsExistingServer() {
+		if failed {
+			testutil.K3sSaveLog(server, false)
+		}
+		Expect(testutil.K3sKillServer(server)).To(Succeed())
+		Expect(testutil.K3sCleanup(testLock, "")).To(Succeed())
+	}
+})
+
+func Test_IntegrationEtcdSnapshot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Etcd Snapshot Suite")
+}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Adds an integration test to check if args passed by the flags are been consumed and used
```
"--kube-apiserver-arg"
"--kube-controller-manager-arg"
"--kube-scheduler-arg"
"--kube-cloud-controller-manager-arg"
"--kubelet-arg"
"--kube-proxy-arg"
```
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
#6057 
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
