### PR TITLE
Bump cni plugins to v1.2.0-k3s1

### DIFF
--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -40,6 +40,12 @@ const (
       "capabilities":{
         "portMappings":true
       }
+    },
+    {
+      "type":"bandwidth",
+      "capabilities":{
+        "bandwidth":true
+      }
     }
   ]
 }

--- a/scripts/package-cli
+++ b/scripts/package-cli
@@ -12,7 +12,7 @@ for i in crictl kubectl k3s-agent k3s-server k3s-token k3s-etcd-snapshot k3s-sec
     ln -s k3s bin/$i
 done
 
-for i in bridge flannel host-local loopback portmap; do
+for i in bandwidth bridge firewall flannel host-local loopback portmap; do
     rm -f bin/$i
     ln -s cni bin/$i
 done

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -53,7 +53,7 @@ if [ -z "$VERSION_CRI_DOCKERD" ]; then
   VERSION_CRI_DOCKERD="v0.0.0"
 fi
 
-VERSION_CNIPLUGINS="v1.1.1-k3s1"
+VERSION_CNIPLUGINS="v1.2.0-k3s1"
 
 VERSION_KUBE_ROUTER=$(grep github.com/k3s-io/kube-router go.mod | head -n1 | awk '{print $4}')
 if [ -z "$VERSION_KUBE_ROUTER" ]; then


### PR DESCRIPTION
#### Proposed Changes ####

Bump cni plugins to v1.2.0-k3s1

Also add bandwidth and firewall plugins. The bandwidth plugin is automatically registered with the appropriate capability, but the firewall plugin must be configured by the user if they want to use it.

Bandwidth ref: https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-ingress-bandwidth
Firewall ref: https://www.cni.dev/plugins/current/meta/firewall/

#### Types of Changes ####

version bump, enhancement

#### Verification ####

* Check cni binary versions using cli
* Check that bandwidth annotations on pods work properly

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* #7424 
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The bundled CNI plugins have been upgraded to v1.2.0-k3s1. The bandwidth and firewall plugins are now included in the bundle.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
