### PR TITLE
Fix token startup test

### DIFF
--- a/tests/e2e/startup/startup_test.go
+++ b/tests/e2e/startup/startup_test.go
@@ -257,7 +257,9 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			tokenYAML := "token: aaaaaa.bbbbbbbbbbbbbbbb"
 			err := StartK3sCluster(append(serverNodeNames, agentNodeNames...), tokenYAML, tokenYAML)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(ContainSubstring("failed to normalize server token"))
+			logs, err := e2e.GetJournalLogs(serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logs).To(ContainSubstring("failed to normalize server token"))
 		})
 		It("Kills the cluster", func() {
 			err := KillK3sCluster(append(serverNodeNames, agentNodeNames...))


### PR DESCRIPTION


#### Proposed Changes ####

Fix startup e2e test

#### Types of Changes ####

bugfix, testing

#### Verification ####

Check CI logs

#### Testing ####

yes

#### Linked Issues ####


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

Fixes e2e failure:
```
• [FAILED] [6.012 seconds]
Various Startup Configurations Verify server fails to start with bootstrap token [It] Fails to start with a meaningful error
/drone/src/tests/e2e/startup/startup_test.go:256

  [FAILED] ContainSubstring matcher requires a string or stringer.  Got:
      <*e2e.NodeError | 0xc000111d10>: 
      failed creating cluster: sudo systemctl start k3s: failed to run command: sudo systemctl start k3s on node server-0: Job for k3s.service failed because the control process exited with error code.
      See "systemctl status k3s.service" and "journalctl -xe" for details.
      , exit status 1
      {
          Node: "server-0",
          Cmd: "sudo systemctl start k3s",
          Err: <*errors.errorString | 0xc0001e47f0>{
              s: "failed to run command: sudo systemctl start k3s on node server-0: Job for k3s.service failed because the control process exited with error code.\nSee \"systemctl status k3s.service\" and \"journalctl -xe\" for details.\n, exit status 1",
          },
      }
```
