### PR TITLE
Consistently use constant-time comparison of password hashes instead of bare password strings

### DIFF
--- a/pkg/authenticator/passwordfile/passwordfile.go
+++ b/pkg/authenticator/passwordfile/passwordfile.go
@@ -18,13 +18,13 @@ package passwordfile
 
 import (
 	"context"
-	"crypto/subtle"
 	"encoding/csv"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/k3s-io/k3s/pkg/nodepassword"
 	"k8s.io/klog/v2"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
@@ -37,8 +37,8 @@ type PasswordAuthenticator struct {
 }
 
 type userPasswordInfo struct {
-	info     *user.DefaultInfo
-	password string
+	info *user.DefaultInfo
+	hash string
 }
 
 // NewCSV returns a PasswordAuthenticator, populated from a CSV file.
@@ -65,9 +65,13 @@ func NewCSV(path string) (*PasswordAuthenticator, error) {
 		if len(record) < 3 {
 			return nil, fmt.Errorf("password file '%s' must have at least 3 columns (password, user name, user uid), found %d", path, len(record))
 		}
+		hash, err := nodepassword.Hasher.CreateHash(record[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to hash password for username '%s' in password file '%s': %v", record[1], path, err)
+		}
 		obj := &userPasswordInfo{
-			info:     &user.DefaultInfo{Name: record[1], UID: record[2]},
-			password: record[0],
+			info: &user.DefaultInfo{Name: record[1], UID: record[2]},
+			hash: hash,
 		}
 		if len(record) >= 4 {
 			obj.info.Groups = strings.Split(record[3], ",")
@@ -88,7 +92,7 @@ func (a *PasswordAuthenticator) AuthenticatePassword(ctx context.Context, userna
 	if !ok {
 		return nil, false, nil
 	}
-	if subtle.ConstantTimeCompare([]byte(user.password), []byte(password)) == 0 {
+	if err := nodepassword.Hasher.VerifyHash(user.hash, password); err != nil {
 		return nil, false, nil
 	}
 	return &authenticator.Response{User: user.info}, true, nil

--- a/pkg/nodepassword/nodepassword.go
+++ b/pkg/nodepassword/nodepassword.go
@@ -18,8 +18,8 @@ import (
 )
 
 var (
-	// hasher provides the algorithm for generating and verifying hashes
-	hasher = hash.NewSCrypt()
+	// Hasher provides the algorithm for generating and verifying hashes
+	Hasher = hash.NewSCrypt()
 )
 
 func getSecretName(nodeName string) string {
@@ -33,7 +33,7 @@ func verifyHash(secretClient coreclient.SecretClient, nodeName, pass string) err
 		return err
 	}
 	if hash, ok := secret.Data["hash"]; ok {
-		if err := hasher.VerifyHash(string(hash), pass); err != nil {
+		if err := Hasher.VerifyHash(string(hash), pass); err != nil {
 			return errors.Wrapf(err, "unable to verify hash for node '%s'", nodeName)
 		}
 		return nil
@@ -47,7 +47,7 @@ func Ensure(secretClient coreclient.SecretClient, nodeName, pass string) error {
 		return err
 	}
 
-	hash, err := hasher.CreateHash(pass)
+	hash, err := Hasher.CreateHash(pass)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create hash for node '%s'", nodeName)
 	}

--- a/pkg/passwd/passwd.go
+++ b/pkg/passwd/passwd.go
@@ -60,14 +60,6 @@ func Read(file string) (*Passwd, error) {
 	return result, nil
 }
 
-func (p *Passwd) Check(name, pass string) (matches bool, exists bool) {
-	e, ok := p.names[name]
-	if !ok {
-		return false, false
-	}
-	return e.pass == pass, true
-}
-
 func (p *Passwd) EnsureUser(name, role, passwd string) error {
 	tokenPrefix := "::" + name + ":"
 	idx := strings.Index(passwd, tokenPrefix)

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -483,8 +483,12 @@ func verifyLocalPassword(ctx context.Context, config *Config, mu *sync.Mutex, de
 		return "", http.StatusInternalServerError, errors.Wrap(err, "unable to read node password file")
 	}
 
-	password := strings.TrimSpace(string(passBytes))
-	if password != node.Password {
+	passHash, err := nodepassword.Hasher.CreateHash(strings.TrimSpace(string(passBytes)))
+	if err != nil {
+		return "", http.StatusInternalServerError, errors.Wrap(err, "unable to hash node password file")
+	}
+
+	if err := nodepassword.Hasher.VerifyHash(passHash, node.Password); err != nil {
 		return "", http.StatusForbidden, errors.Wrapf(err, "unable to verify local password for node '%s'", node.Name)
 	}
 


### PR DESCRIPTION
#### Proposed Changes ####

Consistently use constant-time comparison of password hashes

As per https://github.com/golang/go/issues/47001 even subtle.ConstantTimeCompare should never be used with variable-length inputs, as it will return 0 if the lengths do not match. Switch to consistently using constant-time comparisons of hashes for password checks to avoid any possible side-channel leaks that could be combined with other vectors to discover password lengths.

The `passwordfile` misuse of `subtle.ConstantTimeCompare` comes from upstream Kubernetes:
https://github.com/kubernetes/kubernetes/blob/release-1.18/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile/passwordfile.go

#### Types of Changes ####

bugfix

#### Verification ####

Normal CI and release testing (no visible user impact)

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/7456

#### User-Facing Change ####
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
