### PR TITLE
Bump helm-controller version for repo auth/ca support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ replace (
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.6
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.10.1
+	github.com/rancher/wrangler => github.com/rancher/wrangler v1.1.1-0.20230425173236-39a4707f0689
 	go.etcd.io/etcd/api/v3 => github.com/k3s-io/etcd/api/v3 v3.5.7-k3s1
 	go.etcd.io/etcd/client/pkg/v3 => github.com/k3s-io/etcd/client/pkg/v3 v3.5.7-k3s1
 	go.etcd.io/etcd/client/v2 => github.com/k3s-io/etcd/client/v2 v2.305.7-k3s1
@@ -104,7 +105,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/json-iterator/go v1.1.12
-	github.com/k3s-io/helm-controller v0.13.3
+	github.com/k3s-io/helm-controller v0.14.0
 	github.com/k3s-io/kine v0.10.1
 	github.com/klauspost/compress v1.16.5
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000
@@ -122,7 +123,7 @@ require (
 	github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc
 	github.com/rancher/remotedialer v0.3.0
 	github.com/rancher/wharfie v0.5.3
-	github.com/rancher/wrangler v1.1.1-0.20230419173538-80fdf092be3b
+	github.com/rancher/wrangler v1.1.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rootless-containers/rootlesskit v1.0.1
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -624,8 +624,8 @@ github.com/k3s-io/etcd/raft/v3 v3.5.7-k3s1 h1:C2FlzI9JcwUhxoT7KSvxcK3aLyzy9bMM5z
 github.com/k3s-io/etcd/raft/v3 v3.5.7-k3s1/go.mod h1:TflkAb/8Uy6JFBxcRaH2Fr6Slm9mCPVdI2efzxY96yU=
 github.com/k3s-io/etcd/server/v3 v3.5.7-k3s1 h1:T4VGL9jq4WvxAd7Jiilt7f3ZBPkqPTqa0GZD9t5j50A=
 github.com/k3s-io/etcd/server/v3 v3.5.7-k3s1/go.mod h1:gxBgT84issUVBRpZ3XkW1T55NjOb4vZZRI4wVvNhf4A=
-github.com/k3s-io/helm-controller v0.13.3 h1:zlJkqZtKJNt1e738G77t5MN0X2RCIYr9PPU5KAuJHzs=
-github.com/k3s-io/helm-controller v0.13.3/go.mod h1:I6EYR7hCs4rcNv/KRWYU5CUgpCP+jn4PZ88j+eXYsMU=
+github.com/k3s-io/helm-controller v0.14.0 h1:jVJtfNIBFvK98oHBjySIxPSP/Hr/iN6LXG0mZVkaTQI=
+github.com/k3s-io/helm-controller v0.14.0/go.mod h1:Y8hkgBc37wKWOQBIpFNEJ9/UVGrnEKFaPHpaPwV6cBA=
 github.com/k3s-io/kine v0.10.1 h1:HdpG84WaZvIYYzFB+kT8grNhtlsGzLLYN/MohV+r7+U=
 github.com/k3s-io/kine v0.10.1/go.mod h1:TU8mr4oByeEPKChQBUpSdGc1mZk+Txr2yZhRY+Jch1Q=
 github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGBA=
@@ -989,8 +989,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/wharfie v0.5.3 h1:6hiO26H7YTgChbLAE6JppxFRjaH3tbKfMItv/LqV0Q0=
 github.com/rancher/wharfie v0.5.3/go.mod h1:Ebpai7digxegLroBseeC54XRBt5we3DgFS6kAE2ho+o=
-github.com/rancher/wrangler v1.1.1-0.20230419173538-80fdf092be3b h1:rs3WYld8iaRcSzCmM/CrCIVz9uVgfd96o7FsufIdoVI=
-github.com/rancher/wrangler v1.1.1-0.20230419173538-80fdf092be3b/go.mod h1:D6Tu6oVX8aGtCHsMCtYaysgVK3ad920MTSeAu7rzb5U=
+github.com/rancher/wrangler v1.1.1-0.20230425173236-39a4707f0689 h1:otb4OjgXH2b8a4C9g76jCDuTF3opjaYffZ55SiVe7KU=
+github.com/rancher/wrangler v1.1.1-0.20230425173236-39a4707f0689/go.mod h1:D6Tu6oVX8aGtCHsMCtYaysgVK3ad920MTSeAu7rzb5U=
 github.com/rasky/go-xdr v0.0.0-20170217172119-4930550ba2e2/go.mod h1:Nfe4efndBz4TibWycNE+lqyJZiMX4ycx+QKV8Ta0f/o=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -223,7 +223,8 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 			sc.Batch.Batch().V1().Job().Cache(),
 			sc.Auth.Rbac().V1().ClusterRoleBinding(),
 			sc.Core.Core().V1().ServiceAccount(),
-			sc.Core.Core().V1().ConfigMap())
+			sc.Core.Core().V1().ConfigMap(),
+			sc.Core.Core().V1().Secret())
 	}
 
 	if config.ControlConfig.EncryptSecrets {

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,4 +1,4 @@
-docker.io/rancher/klipper-helm:v0.7.7-build20230403
+docker.io/rancher/klipper-helm:v0.8.0-build20230510
 docker.io/rancher/klipper-lb:v0.4.3
 docker.io/rancher/local-path-provisioner:v0.0.24
 docker.io/rancher/mirrored-coredns-coredns:1.10.1


### PR DESCRIPTION
#### Proposed Changes ####

Bump helm-controller version for repo auth/ca support

#### Types of Changes ####

enhancement

#### Verification ####

See linked issue, and example in https://github.com/k3s-io/helm-controller/pull/192#issuecomment-1540862200

#### Testing ####


#### Linked Issues ####

* #7517 
* 
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The embedded Helm controller now supports authenticating to chart repositories via credentials stored in a Secret, as well as passing repo CAs via ConfigMap.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
