### PR TITLE
Fix k3s-killall.sh to support Cilium CNI: preventing network host going down

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -738,9 +738,12 @@ ip link delete flannel-v6.1
 ip link delete kube-ipvs0
 ip link delete flannel-wg
 ip link delete flannel-wg-v6
+ip link delete cilium_host
+ip link delete cilium_net
+ip link delete cilium_vxlan
 rm -rf /var/lib/cni/
-iptables-save | grep -v KUBE- | grep -v CNI- | grep -iv flannel | iptables-restore
-ip6tables-save | grep -v KUBE- | grep -v CNI- | grep -iv flannel | ip6tables-restore
+iptables-save | grep -v KUBE- | grep -v CNI- | grep -iv flannel | grep -iv cilium | iptables-restore
+ip6tables-save | grep -v KUBE- | grep -v CNI- | grep -iv flannel | grep -iv cilium | ip6tables-restore
 EOF
     $SUDO chmod 755 ${KILLALL_K3S_SH}
     $SUDO chown root:root ${KILLALL_K3S_SH}


### PR DESCRIPTION
Fix k3s-killall.sh to support Cilium CNI preventing network host going down

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Context: you're using K3s and Cilium CNI instead of default CNI, Flannel.

Without this fix: everytime you issue `k3s-killall.sh` directly or indirectly through `k3s-uninstall.sh`, the host network hangs and you have to reboot your system.

#### Types of Changes ####

Bugfix on `k3s-killall.sh`

#### Verification ####

With this fix all works well, the iptables rules are correctly flushed and the iface are cleaned up.

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
