### PR TITLE
Make LB image configurable when compiling k3s

### DIFF
--- a/pkg/cloudprovider/servicelb.go
+++ b/pkg/cloudprovider/servicelb.go
@@ -41,8 +41,11 @@ var (
 )
 
 const (
-	Ready          = condition.Cond("Ready")
-	DefaultLBNS    = meta.NamespaceSystem
+	Ready       = condition.Cond("Ready")
+	DefaultLBNS = meta.NamespaceSystem
+)
+
+var (
 	DefaultLBImage = "rancher/klipper-lb:v0.4.4"
 )
 


### PR DESCRIPTION
It is no way we can configure the lb image because it is a const value. It would be better that we make it variable value and we can override the value like the `helm-controller` job image when compiling k3s/rke2

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Make `DefaultLBImage` as a variable value instead of const value.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
New Feature
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
N/A

#### Testing ####
Basically there is nothing changed after the PR merge as the variable name is not changed but I think we should test the service LB function in k3s cluster after merge. 

#### Linked Issues ####

Issue: https://github.com/k3s-io/k3s/issues/7625
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
No

#### Further Comments ####

No
