### PR TITLE
Enable containerd aufs/devmapper/zfs snapshotter plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,10 +89,12 @@ replace (
 require (
 	github.com/Mirantis/cri-dockerd v0.0.0-00010101000000-000000000000
 	github.com/cloudnativelabs/kube-router/v2 v2.0.0-00010101000000-000000000000
+	github.com/containerd/aufs v1.0.0
 	github.com/containerd/cgroups v1.1.0
 	github.com/containerd/containerd v1.6.10
 	github.com/containerd/fuse-overlayfs-snapshotter v1.0.5
 	github.com/containerd/stargz-snapshotter v0.14.3
+	github.com/containerd/zfs v1.0.0
 	github.com/coreos/go-iptables v0.6.0
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/docker/docker v23.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,7 @@ github.com/container-orchestrated-devices/container-device-interface v0.5.4 h1:P
 github.com/container-orchestrated-devices/container-device-interface v0.5.4/go.mod h1:DjE95rfPiiSmG7uVXtg0z6MnPm/Lx4wxKCIts0ZE0vg=
 github.com/container-storage-interface/spec v1.7.0 h1:gW8eyFQUZWWrMWa8p1seJ28gwDoN5CVJ4uAbQ+Hdycw=
 github.com/container-storage-interface/spec v1.7.0/go.mod h1:JYuzLqr9VVNoDJl44xp/8fmCOvWPDKzuGTwCoklhuqk=
+github.com/containerd/aufs v1.0.0 h1:2oeJiwX5HstO7shSrPZjrohJZLzK36wvpdmzDRkL/LY=
 github.com/containerd/aufs v1.0.0/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=
 github.com/containerd/btrfs/v2 v2.0.0 h1:FN4wsx7KQrYoLXN7uLP0vBV4oVWHOIKDRQ1G2Z0oL5M=
 github.com/containerd/btrfs/v2 v2.0.0/go.mod h1:swkD/7j9HApWpzl8OHfrHNxppPd9l44DFZdF94BUj9k=
@@ -227,6 +228,7 @@ github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY
 github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcDZXTn6oPz9s=
 github.com/containerd/typeurl/v2 v2.1.1 h1:3Q4Pt7i8nYwy2KmQWIw2+1hTvwTE/6w9FqcttATPO/4=
 github.com/containerd/typeurl/v2 v2.1.1/go.mod h1:IDp2JFvbwZ31H8dQbEIY7sDl2L3o3HZj1hsSQlywkQ0=
+github.com/containerd/zfs v1.0.0 h1:cXLJbx+4Jj7rNsTiqVfm6i+RNLx6FFA2fMmDlEf+Wm8=
 github.com/containerd/zfs v1.0.0/go.mod h1:m+m51S1DvAP6r3FcmYCp54bQ34pyOwTieQDNRIRHsFY=
 github.com/containernetworking/cni v1.1.1/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ=

--- a/pkg/containerd/builtins_linux.go
+++ b/pkg/containerd/builtins_linux.go
@@ -20,13 +20,16 @@
 package containerd
 
 import (
+	_ "github.com/containerd/aufs/plugin"
 	_ "github.com/containerd/containerd/metrics"
 	_ "github.com/containerd/containerd/metrics/cgroups"
 	_ "github.com/containerd/containerd/metrics/cgroups/v2"
 	_ "github.com/containerd/containerd/runtime/v2/runc/options"
 	_ "github.com/containerd/containerd/snapshots/btrfs/plugin"
+	_ "github.com/containerd/containerd/snapshots/devmapper/plugin"
 	_ "github.com/containerd/containerd/snapshots/native/plugin"
 	_ "github.com/containerd/containerd/snapshots/overlay/plugin"
 	_ "github.com/containerd/fuse-overlayfs-snapshotter/plugin"
 	_ "github.com/containerd/stargz-snapshotter/service/plugin"
+	_ "github.com/containerd/zfs/plugin"
 )


### PR DESCRIPTION
#### Proposed Changes ####

Enable containerd aufs/devmapper/zfs snapshotter plugins

These were unintentionally dropped when moving containerd back into the main multicall binary

#### Types of Changes ####

bugfix

#### Verification ####

1. Start K3s
2. `grep type=io.containerd.snapshotter.v1 /var/lib/rancher/k3s/agent/containerd/containerd.log`. Check for plugins:
```
time="2023-06-01T16:16:29.774504348Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.aufs\"..." type=io.containerd.snapshotter.v1
time="2023-06-01T16:16:29.777739321Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.btrfs\"..." type=io.containerd.snapshotter.v1
time="2023-06-01T16:16:29.777919781Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.devmapper\"..." type=io.containerd.snapshotter.v1
time="2023-06-01T16:16:29.777953832Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.native\"..." type=io.containerd.snapshotter.v1
time="2023-06-01T16:16:29.778025248Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.overlayfs\"..." type=io.containerd.snapshotter.v1
time="2023-06-01T16:16:29.778248703Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.fuse-overlayfs\"..." type=io.containerd.snapshotter.v1
time="2023-06-01T16:16:29.778323197Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.stargz\"..." type=io.containerd.snapshotter.v1
time="2023-06-01T16:16:29.782237739Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.zfs\"..." type=io.containerd.snapshotter.v1
```

#### Testing ####



#### Linked Issues ####

* #7660
* #3980 (zfs was unintentionally enabled when we stopped building containerd into the main multicall binary a while back, but apparently no-one noticed)
 
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The bundled containerd's aufs/devmapper/zfs snapshotter plugins have been restored. These were unintentionally omitted when moving contaienrd back into the k3s multicall binary in the previous release.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
