### PR TITLE
check variant before version to decide rpm target and packager closes #7666

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -514,6 +514,10 @@ setup_selinux() {
             rpm_site_infix=slemicro
             package_installer=zypper
         fi
+    elif [ "${ID_LIKE:-}" = coreos ] || [ "${VARIANT_ID:-}" = coreos ]; then
+        rpm_target=coreos
+        rpm_site_infix=coreos
+        package_installer=rpm-ostree
     elif [ "${VERSION_ID%%.*}" = "7" ]; then
         rpm_target=el7
         rpm_site_infix=centos/7
@@ -522,10 +526,6 @@ setup_selinux() {
         rpm_target=el8
         rpm_site_infix=centos/8
         package_installer=yum
-    elif [ "${ID_LIKE:-}" = coreos ] || [ "${VARIANT_ID:-}" = coreos ]; then
-        rpm_target=coreos
-        rpm_site_infix=coreos
-        package_installer=rpm-ostree
     else
         rpm_target=el9
         rpm_site_infix=centos/9


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Check the ID and VARIANT_ID before relying on just the VERSION_ID from /etc/os-release.  This is needed to disambiguate fedora from fedora coreos, where the VERSION_IDs (from /etc/os-release) will be the same, but if it's the coreos variant it should use rpm-ostree instead of yum.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
I tested this change on fcos 38, as listed in #7666, and it fixed the problem.  I did not retest on other distros, but it makes sense that having the id/variant check take precedence over the version would not impact the other distros, as non-coreos distros will still fall thru to the subsequent conditionals.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/k3s-io/k3s/issues/7666

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

small change
