### PR TITLE
Shortcircuit commands with version or help flags

### DIFF
--- a/pkg/configfilearg/defaultparser.go
+++ b/pkg/configfilearg/defaultparser.go
@@ -9,7 +9,7 @@ import (
 
 var DefaultParser = &Parser{
 	After:         []string{"server", "agent", "etcd-snapshot:1"},
-	FlagNames:     []string{"--config", "-c"},
+	ConfigFlags:   []string{"--config", "-c"},
 	EnvName:       version.ProgramUpper + "_CONFIG_FILE",
 	DefaultConfig: "/etc/rancher/" + version.Program + "/config.yaml",
 	ValidFlags:    map[string][]cli.Flag{"server": cmds.ServerFlags, "etcd-snapshot": cmds.EtcdSnapshotFlags},
@@ -25,8 +25,7 @@ func MustParse(args []string) []string {
 
 func MustFindString(args []string, target string) string {
 	parser := &Parser{
-		After:         []string{},
-		FlagNames:     []string{},
+		OverrideFlags: []string{"--help", "-h", "--version", "-v"},
 		EnvName:       version.ProgramUpper + "_CONFIG_FILE",
 		DefaultConfig: "/etc/rancher/" + version.Program + "/config.yaml",
 	}

--- a/pkg/configfilearg/parser_test.go
+++ b/pkg/configfilearg/parser_test.go
@@ -199,7 +199,7 @@ func Test_UnitParser_findConfigFileFlag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Parser{
-				FlagNames:     []string{"--config", "-c"},
+				ConfigFlags:   []string{"--config", "-c"},
 				EnvName:       "_TEST_FLAG_ENV",
 				DefaultConfig: tt.fields.DefaultConfig,
 			}
@@ -328,7 +328,7 @@ func Test_UnitParser_Parse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Parser{
 				After:         tt.fields.After,
-				FlagNames:     tt.fields.FlagNames,
+				ConfigFlags:   tt.fields.FlagNames,
 				EnvName:       tt.fields.EnvName,
 				DefaultConfig: tt.fields.DefaultConfig,
 			}
@@ -447,7 +447,7 @@ func Test_UnitParser_FindString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Parser{
 				After:         tt.fields.After,
-				FlagNames:     tt.fields.FlagNames,
+				ConfigFlags:   tt.fields.FlagNames,
 				EnvName:       tt.fields.EnvName,
 				DefaultConfig: tt.fields.DefaultConfig,
 			}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Before attempting to open config files, we check if the arguments provided contain a `--version, -v, --help, -h` flag. If so, we shortcircuit the search. As `-h` and `-v` flags always override the given command anyway, this enables users who do not have permission to access `/etc/rancher/k3s/config.yaml` or other root guarded files to still run these basic commands.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
1) Create a config file: `touch /etc/rancher/k3s/config.yaml`
2) Change the permissions so only root can read it: `sudo chmod 700 /etc/rancher/k3s/config.yaml`
3) Call `k3s --help`, `k3s --version`, `k3s -h`, `k3s server -h`. Note that these commands now complete successfully.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/4321
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Non root users can now call `k3s --help` and `k3s --version` commands without running into permission errors over the default config file.
```

#### Further Comments ####
This change is injected into `FindString` because this function is called when attemtping to find `data-dir` or `prefer-bundled-bin` arguments  before running a command. `FindString` in turn attempts to open the default config file (`/etc/rancher/k3s/config.yaml`), and if permission is not given on that file, the whole process will fail. 
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
