### PR TITLE
Remove useless libvirt config

### DIFF
--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -21,8 +21,6 @@ def provision(vm, roles, role_num, node_num)
   vm.network "private_network", 
     :ip => node_ip4,
     :netmask => "255.255.255.0",
-    :libvirt__dhcp_enabled => false,
-    :libvirt__forward_mode => "none",
     :libvirt__guest_ipv6 => "yes",
     :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
     :libvirt__ipv6_prefix => "64"

--- a/tests/e2e/externalip/Vagrantfile
+++ b/tests/e2e/externalip/Vagrantfile
@@ -16,16 +16,8 @@ def provision(vm, roles, role_num, node_num)
   vm.hostname = "#{roles[0]}-#{role_num}"
   node_ip4 = "#{NETWORK4_PREFIX}.#{100+node_num}"
   node_ip4_public = "#{PUBLIC_NETWORK4_PREFIX}.#{100+node_num}"
-  vm.network "private_network", 
-    :ip => node_ip4,
-    :netmask => "255.255.255.0",
-    :libvirt__dhcp_enabled => false,
-    :libvirt__forward_mode => "none"
-  vm.network "private_network", 
-    :ip => node_ip4_public,
-    :netmask => "255.255.255.0",
-    :libvirt__dhcp_enabled => false,
-    :libvirt__forward_mode => "none"
+  vm.network "private_network", :ip => node_ip4, :netmask => "255.255.255.0"
+  vm.network "private_network", :ip => node_ip4_public, :netmask => "255.255.255.0"
     
   scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
   vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"

--- a/tests/e2e/multiclustercidr/Vagrantfile
+++ b/tests/e2e/multiclustercidr/Vagrantfile
@@ -22,8 +22,6 @@ def provision(vm, roles, role_num, node_num)
   vm.network "private_network",
     :ip => node_ip4,
     :netmask => "255.255.255.0",
-    :libvirt__dhcp_enabled => false,
-    :libvirt__forward_mode => "none",
     :libvirt__guest_ipv6 => "yes",
     :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
     :libvirt__ipv6_prefix => "64"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

We were changing the default Vagrant config without any need because test works well too. @dereknola , our e2e test guru, pointed that out in this comment https://github.com/k3s-io/k3s/pull/7352#discussion_r1223929926 and I thought it is worth removing the unnecessary extra changes, to avoid future confusion. This config is:
```
    :libvirt__dhcp_enabled => false,
    :libvirt__forward_mode => "none",
 ```

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Simplification

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Just verify that e2e tests are still working

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/7744

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
