### PR TITLE
[Release 1.26] Remove unused libvirt config

### DIFF
--- a/tests/e2e/dualstack/Vagrantfile
+++ b/tests/e2e/dualstack/Vagrantfile
@@ -21,8 +21,6 @@ def provision(vm, roles, role_num, node_num)
   vm.network "private_network", 
     :ip => node_ip4,
     :netmask => "255.255.255.0",
-    :libvirt__dhcp_enabled => false,
-    :libvirt__forward_mode => "none",
     :libvirt__guest_ipv6 => "yes",
     :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
     :libvirt__ipv6_prefix => "64"

--- a/tests/e2e/externalip/Vagrantfile
+++ b/tests/e2e/externalip/Vagrantfile
@@ -16,16 +16,8 @@ def provision(vm, roles, role_num, node_num)
   vm.hostname = "#{roles[0]}-#{role_num}"
   node_ip4 = "#{NETWORK4_PREFIX}.#{100+node_num}"
   node_ip4_public = "#{PUBLIC_NETWORK4_PREFIX}.#{100+node_num}"
-  vm.network "private_network", 
-    :ip => node_ip4,
-    :netmask => "255.255.255.0",
-    :libvirt__dhcp_enabled => false,
-    :libvirt__forward_mode => "none"
-  vm.network "private_network", 
-    :ip => node_ip4_public,
-    :netmask => "255.255.255.0",
-    :libvirt__dhcp_enabled => false,
-    :libvirt__forward_mode => "none"
+  vm.network "private_network", :ip => node_ip4, :netmask => "255.255.255.0"
+  vm.network "private_network", :ip => node_ip4_public, :netmask => "255.255.255.0"
     
   scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
   vagrant_defaults = File.exists?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"

--- a/tests/e2e/multiclustercidr/Vagrantfile
+++ b/tests/e2e/multiclustercidr/Vagrantfile
@@ -22,8 +22,6 @@ def provision(vm, roles, role_num, node_num)
   vm.network "private_network",
     :ip => node_ip4,
     :netmask => "255.255.255.0",
-    :libvirt__dhcp_enabled => false,
-    :libvirt__forward_mode => "none",
     :libvirt__guest_ipv6 => "yes",
     :libvirt__ipv6_address => "#{NETWORK6_PREFIX}::1",
     :libvirt__ipv6_prefix => "64"


### PR DESCRIPTION
Backport: https://github.com/k3s-io/k3s/pull/7745
Issue: https://github.com/k3s-io/k3s/issues/7754