### PR TITLE
[Release-1.25] add format command on Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,3 +88,18 @@ Signed-off-by: Jane Smith <jane.smith@example.com>
 
 In most cases, you can add this signoff to your commit automatically with the
 `-s` flag to `git commit`. Please use your real name and a reachable email address.
+
+
+## Golangci-lint ##
+
+There is a CI check for formatting on our code, you'll need to install `goimports` to be able to attend this check, you can do it by running the command:
+
+```
+go install golang.org/x/tools/cmd/goimports@latest
+```
+
+then run:
+
+```
+make format
+```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 TARGETS := $(shell ls scripts | grep -v \\.sh)
+GO_FILES ?= $$(find . -name '*.go' | grep -v generated)
+
 
 .dapper:
 	@echo Downloading dapper
@@ -12,7 +14,6 @@ $(TARGETS): .dapper
 
 .PHONY: deps
 deps:
-	go mod vendor
 	go mod tidy
 
 release:
@@ -32,3 +33,7 @@ binary-size-check:
 .PHONY: image-scan
 image-scan:
 	scripts/image_scan.sh $(IMAGE)
+
+format:
+	gofmt -s -l -w $(GO_FILES)
+	goimports -w $(GO_FILES)


### PR DESCRIPTION
This commit adds the format command to make it easier to be compliant to golangci-lint issues

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
backport for #7437 
closes #7766 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
