### PR TITLE
Fix error logging in tailscale

### DIFF
--- a/pkg/vpn/vpn.go
+++ b/pkg/vpn/vpn.go
@@ -2,13 +2,13 @@ package vpn
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"strings"
 
 	"github.com/k3s-io/k3s/pkg/util"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -44,11 +44,11 @@ func StartVPN(vpnAuthConfigFile string) error {
 	logrus.Infof("Starting VPN: %s", authInfo.Name)
 	switch authInfo.Name {
 	case "tailscale":
-		outpt, err := util.ExecCommand("tailscale", []string{"up", "--authkey", authInfo.JoinKey, "--reset"})
+		output, err := util.ExecCommand("tailscale", []string{"up", "--authkey", authInfo.JoinKey, "--reset"})
 		if err != nil {
-			return err
+			return errors.Wrap(err, "tailscale up failed: "+output)
 		}
-		logrus.Debugf("Output from tailscale up: %v", outpt)
+		logrus.Debugf("Output from tailscale up: %v", output)
 		return nil
 	default:
 		return fmt.Errorf("Requested VPN: %s is not supported. We currently only support tailscale", authInfo.Name)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Return the output of the command instead of the error. Error will say nothing useful, just "exit 1/2", whereas the output (which is cmd.Stderr) will provide more useful information

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Start VPN with a wrong joinKey. Now you should see a useful error saying:
```
invalid key: unable to validate API key
```
Before, you'd only see `exit 1`

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/7771

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
