### PR TITLE
Add a k3s data directory location specified by the cli

### DIFF
--- a/pkg/cli/cmds/certs.go
+++ b/pkg/cli/cmds/certs.go
@@ -36,6 +36,11 @@ var (
 			Destination: &ServerConfig.ServerURL,
 		},
 		cli.StringFlag{
+			Name:        "data-dir,d",
+			Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
+			Destination: &ServerConfig.DataDir,
+		},
+		cli.StringFlag{
 			Name:        "path",
 			Usage:       "Path to directory containing new CA certificates",
 			Destination: &CertRotateCAConfig.CACertPath,


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Add a cli to specify the self-holding of the k3s certificate rotate-ca command for the k3s custom data directory


#### Types of Changes ####

Just add a cli to cert.go, specifying the k3s data directory location with the --data-dir parameter

#### Verification ####

Because the installation and compilation process of the compilation environment took too long, I only chose to compile and test on the server of amd64. The test results are as follows:

```
[root@leilei:/opt/leilei-test/k3s 15:23 $]k3s certificate rotate-ca --help
NAME:
   k3s certificate rotate-ca - Write updated k3s CA certificates to the datastore

USAGE:
   k3s certificate rotate-ca [command options] [arguments...]

OPTIONS:
   --server value, -s value    (cluster) Server to connect to (default: "https://127.0.0.1:6443") [$K3S_URL]
   --data-dir value, -d value  (data) Folder to hold state default /var/lib/rancher/k3s or ${HOME}/.rancher/k3s if not root
   --path value                Path to directory containing new CA certificates
   --force                     Force certificate replacement, even if consistency checks fail
```
```
[root@leilei:/opt/leilei-test/k3s/dist/artifacts 11:42 $]k3s certificate rotate-ca --path=/data/k3s/server/rotate-ca
INFO[0000] Acquiring lock file /var/lib/rancher/k3s/data/.lock
INFO[0000] Preparing data dir /var/lib/rancher/k3s/data/2d10fa8a16a4bc82af6f81ae09d24f83a2cb4449c9848485d59ac2826518119f
FATA[0000] open /var/lib/rancher/k3s/server/token: no such file or directory
```
```
[root@leilei:/opt/leilei-test/k3s/dist/artifacts 11:43 $]k3s certificate rotate-ca --path=/data/k3s/server/rotate-ca --data-dir=/data/k3s
certificates saved to datastore
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/7774

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
If the k3s data directory is customized, you need to use the --data-dir parameter
```
example:
k3s certificate rotate-ca --path=/data/k3s/server/rotate-ca --data-dir=/data/k3s
```

#### Further Comments ####

I don't know much about golang, so I just looked for the logic of rotating certificates, not sure if there are other problems
