### PR TITLE
Support setting control server URL for Tailscale

### DIFF
--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -76,7 +76,7 @@ const (
 
 	tailscaledBackend = `{
 	"Type": "extension",
-	"PostStartupCommand": "tailscale up --accept-routes --advertise-routes=%Routes%",
+	"PostStartupCommand": "tailscale set --accept-routes --advertise-routes=%Routes%",
 	"ShutdownCommand": "tailscale down"
 }`
 

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -155,13 +155,13 @@ var (
 	}
 	VPNAuth = &cli.StringFlag{
 		Name:        "vpn-auth",
-		Usage:       "(agent/networking) (experimental) Credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>",
+		Usage:       "(agent/networking) (experimental) Credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>]",
 		EnvVar:      version.ProgramUpper + "_VPN_AUTH",
 		Destination: &AgentConfig.VPNAuth,
 	}
 	VPNAuthFile = &cli.StringFlag{
 		Name:        "vpn-auth-file",
-		Usage:       "(agent/networking) (experimental) File containing credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>",
+		Usage:       "(agent/networking) (experimental) File containing credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>]",
 		EnvVar:      version.ProgramUpper + "_VPN_AUTH_FILE",
 		Destination: &AgentConfig.VPNAuthFile,
 	}

--- a/pkg/vpn/vpn.go
+++ b/pkg/vpn/vpn.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/url"
 	"strings"
 
 	"github.com/k3s-io/k3s/pkg/util"
@@ -31,8 +32,9 @@ type VPNInfo struct {
 
 // vpnCliAuthInfo includes auth information of the VPN. It is a general struct in case we want to add more vpn integrations
 type vpnCliAuthInfo struct {
-	Name    string
-	JoinKey string
+	Name             string
+	JoinKey          string
+	ControlServerURL string
 }
 
 // StartVPN starts the VPN interface. General function in case we want to add more vpn integrations
@@ -45,7 +47,13 @@ func StartVPN(vpnAuthConfigFile string) error {
 	logrus.Infof("Starting VPN: %s", authInfo.Name)
 	switch authInfo.Name {
 	case "tailscale":
-		output, err := util.ExecCommand("tailscale", []string{"up", "--authkey", authInfo.JoinKey, "--reset"})
+		args := []string{
+			"up", "--authkey", authInfo.JoinKey, "--timeout=30s", "--reset",
+		}
+		if authInfo.ControlServerURL != "" {
+			args = append(args, "--login-server", authInfo.ControlServerURL)
+		}
+		output, err := util.ExecCommand("tailscale", args)
 		if err != nil {
 			return errors.Wrap(err, "tailscale up failed: "+output)
 		}
@@ -80,6 +88,8 @@ func getVPNAuthInfo(vpnAuth string) (vpnCliAuthInfo, error) {
 			authInfo.Name = vpnKeyValue[1]
 		case "joinKey":
 			authInfo.JoinKey = vpnKeyValue[1]
+		case "controlServerURL":
+			authInfo.ControlServerURL = vpnKeyValue[1]
 		default:
 			return vpnCliAuthInfo{}, fmt.Errorf("VPN Error. The passed VPN auth info includes an unknown parameter: %v", vpnKeyValue[0])
 		}
@@ -96,6 +106,11 @@ func isVPNConfigOK(authInfo vpnCliAuthInfo) error {
 	if authInfo.Name == "tailscale" {
 		if authInfo.JoinKey == "" {
 			return errors.New("VPN Error. Tailscale requires a JoinKey")
+		}
+		if authInfo.ControlServerURL != "" {
+			if _, err := url.Parse(authInfo.ControlServerURL); err != nil {
+				return fmt.Errorf("VPN Error. Invalid control server URL for Tailscale: %w", err)
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
This change enables the use of [Headscale](https://headscale.net) - open source implementation of the Tailscale control server.

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Pretty simple: Add `controlURL` parameter to `--vpn-auth`, which will be propagated to Tailscale as `--login-server` flag. This flag will only be set if `controlURL` parameter is preset, so it's backward-compatible.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

New Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

You'll need a Headscale instance for this, see [docs](https://headscale.net/running-headscale-linux/). Then add `controlURL=https://<your-headscale-server>` to the usual `--vpn-auth` parameter.

Verification can be done in a negative way: set `controlURL=https://example.com` for a valid Tailscale join key, and it should fail to join the network by hitting the wrong domain. See #7352 for a general Tailscale setup.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

1 - Install headscale in a separate VM by following [these instructions ](https://headscale.net/running-headscale-linux/#migrating-from-manual-install). 

2 - Edit the headscale config and set ` listen_addr: 0.0.0.0:8080`

3 - As explained in the headscale instructions, create a user and a pre authenticated key

4 - Deploy k3s with tailscale passing the extra config vpnServerURL=<url>, where url is `http://$IP_HEADSCALE:8080`

5 - Verify that tailscale interface gets an IPv4/IPv6 address

6 - In the headscale server, list the routes `sudo headscale routes list` and enable all of them (e.g. sudo headscale routes enable -r 1`)

7 - Verify you can ping between pods on different nodes

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/k3s-io/k3s/issues/7824

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support connecting tailscale to a separate server (e.g. headscale)
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
