### PR TITLE
Check if we are on ipv4, ipv6 or dualStack when doing tailscale

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -390,15 +390,24 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		if err != nil {
 			return nil, err
 		}
-		if len(vpnInfo.IPs) != 0 {
-			logrus.Infof("Node-ip changed to %v due to VPN", vpnInfo.IPs)
+
+		var vpnIPs []net.IP
+		if vpnInfo.IPv4Address != nil {
+			vpnIPs = append(vpnIPs, vpnInfo.IPv4Address)
+		}
+		if vpnInfo.IPv6Address != nil {
+			vpnIPs = append(vpnIPs, vpnInfo.IPv6Address)
+		}
+
+		if len(vpnIPs) != 0 {
+			logrus.Infof("Node-ip changed to %v due to VPN", vpnIPs)
 			if len(envInfo.NodeIP) != 0 {
 				logrus.Warn("VPN provider overrides configured node-ip parameter")
 			}
 			if len(envInfo.NodeExternalIP) != 0 {
 				logrus.Warn("VPN provider overrides node-external-ip parameter")
 			}
-			nodeIPs = vpnInfo.IPs
+			nodeIPs = vpnIPs
 			flannelIface, err = net.InterfaceByName(vpnInfo.VPNInterface)
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to find vpn interface: %s", vpnInfo.VPNInterface)

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -228,12 +228,27 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		if err != nil {
 			return err
 		}
-		if len(vpnInfo.IPs) != 0 {
-			logrus.Infof("Advertise-address changed to %v due to VPN", vpnInfo.IPs)
-			if serverConfig.ControlConfig.AdvertiseIP != "" {
-				logrus.Warn("Conflict in the config detected. VPN integration overwrites advertise-address but the config is setting the advertise-address parameter")
+		// If we are in ipv6-only mode, we should pass the ipv6 address. Otherwise, ipv4
+		if utilsnet.IsIPv6CIDRString(util.JoinIPNets(serverConfig.ControlConfig.ClusterIPRanges)) {
+			if vpnInfo.IPv6Address != nil {
+				logrus.Infof("Advertise-address changed to %v due to VPN", vpnInfo.IPv6Address)
+				if serverConfig.ControlConfig.AdvertiseIP != "" {
+					logrus.Warn("Conflict in the config detected. VPN integration overwrites advertise-address but the config is setting the advertise-address parameter")
+				}
+				serverConfig.ControlConfig.AdvertiseIP = vpnInfo.IPv6Address.String()
+			} else {
+				return errors.New("tailscale does not provide an ipv6 address")
 			}
-			serverConfig.ControlConfig.AdvertiseIP = vpnInfo.IPs[0].String()
+		} else {
+			if vpnInfo.IPv4Address != nil {
+				logrus.Infof("Advertise-address changed to %v due to VPN", vpnInfo.IPv4Address)
+				if serverConfig.ControlConfig.AdvertiseIP != "" {
+					logrus.Warn("Conflict in the config detected. VPN integration overwrites advertise-address but the config is setting the advertise-address parameter")
+				}
+				serverConfig.ControlConfig.AdvertiseIP = vpnInfo.IPv4Address.String()
+			} else {
+				return errors.New("tailscale does not provide an ipv4 address")
+			}
 		}
 		logrus.Warn("Etcd IP (PrivateIP) remains the local IP. Running etcd traffic over VPN is not recommended due to performance issues")
 	} else {

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	apinet "k8s.io/apimachinery/pkg/util/net"
+	netutils "k8s.io/utils/net"
 )
 
 // JoinIPs stringifies and joins a list of IP addresses with commas.
@@ -85,10 +86,9 @@ func JoinIP4Nets(elems []*net.IPNet) string {
 // If no IPv6 addresses are found, an error is raised.
 func GetFirst6(elems []net.IP) (net.IP, error) {
 	for _, elem := range elems {
-		if elem == nil || elem.To16() == nil {
-			continue
+		if elem != nil && netutils.IsIPv6(elem) {
+			return elem, nil
 		}
-		return elem, nil
 	}
 	return nil, errors.New("no IPv6 address found")
 }
@@ -97,10 +97,9 @@ func GetFirst6(elems []net.IP) (net.IP, error) {
 // If no IPv6 addresses are found, an error is raised.
 func GetFirst6Net(elems []*net.IPNet) (*net.IPNet, error) {
 	for _, elem := range elems {
-		if elem == nil || elem.IP.To16() == nil {
-			continue
+		if elem != nil && netutils.IsIPv6(elem.IP) {
+			return elem, nil
 		}
-		return elem, nil
 	}
 	return nil, errors.New("no IPv6 CIDRs found")
 }
@@ -125,7 +124,7 @@ func GetFirst6String(elems []string) (string, error) {
 func JoinIP6Nets(elems []*net.IPNet) string {
 	var strs []string
 	for _, elem := range elems {
-		if elem != nil && elem.IP.To4() == nil {
+		if elem != nil && netutils.IsIPv6(elem.IP) {
 			strs = append(strs, elem.String())
 		}
 	}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Instead of listing the IPs of the tailscale interface in the variable `IPs []net.IP`, separate the ipv4 and ipv6 address that are always assigned to the tailscale interface:
```
	IPv4Address  net.IP
	IPv6Address  net.IP
```
That way we can easily control what address to use in kube-api depending on the configured mode in k3s.

Also a bug in utils/net.go was fixed:
```
elem.To16() == nil
```
is not a correct way to check if an IP is ipv6. It works for both ipv4 and ipv6!

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Verify that this works in:
Deploy k3s in three modes:
* ipv6-only
* ipv4-only
* dualStack

And check what IP is used for kubeapi-server in the flag `advertised-ip`. It should be ipv4 for ipv4-only and dual-stack mode. Whereas it should be ipv6 for ipv6-only mode.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/7831

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
