### PR TITLE
Warn that v1.28 will deprecate reencrypt/prepare

### DIFF
--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -152,7 +152,7 @@ func Prepare(app *cli.Context) error {
 	if err = cmds.InitLogging(); err != nil {
 		return err
 	}
-	logrus.Warnln("This command will be deprecated in v1.28, rotate will subsume it")
+	logrus.Warnln("This command will be deprecated in v1.28, will be combined with rotate")
 	info, err := commandPrep(app, &cmds.ServerConfig)
 	if err != nil {
 		return err
@@ -198,7 +198,7 @@ func Reencrypt(app *cli.Context) error {
 	if err = cmds.InitLogging(); err != nil {
 		return err
 	}
-	logrus.Warnln("This command will be deprecated in v1.28, rotate will subsume it")
+	logrus.Warnln("This command will be deprecated in v1.28, will be combined with rotate")
 	info, err := commandPrep(app, &cmds.ServerConfig)
 	if err != nil {
 		return err

--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -16,6 +16,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/server"
 	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"k8s.io/utils/pointer"
 )
@@ -151,6 +152,7 @@ func Prepare(app *cli.Context) error {
 	if err = cmds.InitLogging(); err != nil {
 		return err
 	}
+	logrus.Warnln("This command will be deprecated in v1.28, rotate will subsume it")
 	info, err := commandPrep(app, &cmds.ServerConfig)
 	if err != nil {
 		return err
@@ -196,6 +198,7 @@ func Reencrypt(app *cli.Context) error {
 	if err = cmds.InitLogging(); err != nil {
 		return err
 	}
+	logrus.Warnln("This command will be deprecated in v1.28, rotate will subsume it")
 	info, err := commandPrep(app, &cmds.ServerConfig)
 	if err != nil {
 		return err

--- a/pkg/server/secrets-encrypt.go
+++ b/pkg/server/secrets-encrypt.go
@@ -208,6 +208,7 @@ func encryptionPrepare(ctx context.Context, server *config.Control, force bool) 
 	if err := AppendNewEncryptionKey(&curKeys); err != nil {
 		return err
 	}
+	logrus.Warnln("prepare command will be deprecated in v1.28, rotate will replace it")
 	logrus.Infoln("Adding secrets-encryption key: ", curKeys[len(curKeys)-1])
 
 	if err := secretsencrypt.WriteEncryptionConfig(server.Runtime, curKeys, true); err != nil {
@@ -275,6 +276,7 @@ func encryptionReencrypt(ctx context.Context, server *config.Control, force bool
 	if _, err = server.Runtime.Core.Core().V1().Node().Update(node); err != nil {
 		return err
 	}
+	logrus.Warnln("reencrypt command will be deprecated in v1.28, rotate will replace it")
 	logrus.Debugf("encryption hash annotation set successfully on node: %s\n", node.ObjectMeta.Name)
 	return nil
 }

--- a/pkg/server/secrets-encrypt.go
+++ b/pkg/server/secrets-encrypt.go
@@ -208,7 +208,7 @@ func encryptionPrepare(ctx context.Context, server *config.Control, force bool) 
 	if err := AppendNewEncryptionKey(&curKeys); err != nil {
 		return err
 	}
-	logrus.Warnln("prepare command will be deprecated in v1.28, rotate will replace it")
+	logrus.Warnln("prepare command will be deprecated in v1.28, will be combined with rotate")
 	logrus.Infoln("Adding secrets-encryption key: ", curKeys[len(curKeys)-1])
 
 	if err := secretsencrypt.WriteEncryptionConfig(server.Runtime, curKeys, true); err != nil {
@@ -276,7 +276,7 @@ func encryptionReencrypt(ctx context.Context, server *config.Control, force bool
 	if _, err = server.Runtime.Core.Core().V1().Node().Update(node); err != nil {
 		return err
 	}
-	logrus.Warnln("reencrypt command will be deprecated in v1.28, rotate will replace it")
+	logrus.Warnln("reencrypt command will be deprecated in v1.28, will be combined with rotate")
 	logrus.Debugf("encryption hash annotation set successfully on node: %s\n", node.ObjectMeta.Name)
 	return nil
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
The new secrets-encrypt rework (see https://github.com/k3s-io/k3s/issues/7760) will be introduced in v1.28, and the `prepare` and `reencrypt` will no longer be used (its all covered in the single `rotate` command). This adds warning to those 2 commands.  
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CLI Warning
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/7760
https://github.com/k3s-io/k3s/issues/7297
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
