### PR TITLE
[release-1.26] Backports for 2023-07 release

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -140,6 +140,20 @@ func getNodeNamedCrt(nodeName string, nodeIPs []net.IP, nodePasswordFile string)
 		}
 		defer resp.Body.Close()
 
+		// If we got a 401 Unauthorized response when using client certs, try again without client cert auth.
+		// This allows us to fall back from node identity to token when the node resource is deleted.
+		if resp.StatusCode == http.StatusUnauthorized {
+			if transport, ok := client.Transport.(*http.Transport); ok && transport.TLSClientConfig != nil && len(transport.TLSClientConfig.Certificates) != 0 {
+				logrus.Infof("Node authorization rejected, retrying without client certificate authentication")
+				transport.TLSClientConfig.Certificates = []tls.Certificate{}
+				resp, err = client.Do(req)
+				if err != nil {
+					return nil, err
+				}
+				defer resp.Body.Close()
+			}
+		}
+
 		if resp.StatusCode == http.StatusForbidden {
 			return nil, fmt.Errorf("Node password rejected, duplicate hostname or contents of '%s' may not match server node-passwd entry, try enabling a unique node name with the --with-node-id flag", nodePasswordFile)
 		}

--- a/pkg/cli/cmds/certs.go
+++ b/pkg/cli/cmds/certs.go
@@ -36,6 +36,11 @@ var (
 			Destination: &ServerConfig.ServerURL,
 		},
 		cli.StringFlag{
+			Name:        "data-dir,d",
+			Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
+			Destination: &ServerConfig.DataDir,
+		},
+		cli.StringFlag{
 			Name:        "path",
 			Usage:       "Path to directory containing new CA certificates",
 			Destination: &CertRotateCAConfig.CACertPath,

--- a/pkg/clientaccess/token.go
+++ b/pkg/clientaccess/token.go
@@ -367,7 +367,7 @@ func getCACerts(u url.URL) ([]byte, error) {
 	return cacerts, nil
 }
 
-// get makes a request to a url using a provided client, username, and password,
+// get makes a request to a url using a provided client and credentials,
 // returning the response body.
 func get(u string, client *http.Client, username, password, token string) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodGet, u, nil)
@@ -394,7 +394,7 @@ func get(u string, client *http.Client, username, password, token string) ([]byt
 	return io.ReadAll(resp.Body)
 }
 
-// put makes a request to a url using a provided client, username, and password
+// put makes a request to a url using a provided client and credentials,
 // only an error is returned
 func put(u string, body []byte, client *http.Client, username, password, token string) error {
 	req, err := http.NewRequest(http.MethodPut, u, bytes.NewBuffer(body))


### PR DESCRIPTION
#### Proposed Changes ####

Backport fixes

#### Types of Changes ####

backport, bugfix

#### Verification ####

See linked issues

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/7902
* https://github.com/k3s-io/k3s/issues/7905

#### User-Facing Change ####
```release-note
Resolved an issue that caused agents joined with kubeadm-style bootstrap tokens to fail to rejoin the cluster when their node object is deleted.
The `k3s certificate rotate-ca` command now supports the data-dir flag.
```

#### Further Comments ####
