### PR TITLE
[release-1.25] Adding cli to custom klipper helm image

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -45,6 +45,7 @@ type Server struct {
 	DisableAgent             bool
 	KubeConfigOutput         string
 	KubeConfigMode           string
+	HelmJobImage             string
 	TLSSan                   cli.StringSlice
 	BindAddress              string
 	EnablePProf              bool
@@ -245,6 +246,11 @@ var ServerFlags = []cli.Flag{
 		Usage:       "(client) Write kubeconfig with this mode",
 		Destination: &ServerConfig.KubeConfigMode,
 		EnvVar:      version.ProgramUpper + "_KUBECONFIG_MODE",
+	},
+	&cli.StringFlag{
+		Name:        "helm-job-image",
+		Usage:       "(helm) Default image to use for helm jobs",
+		Destination: &ServerConfig.HelmJobImage,
 	},
 	ServerToken,
 	&cli.StringFlag{

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -133,6 +133,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.DataDir = cfg.DataDir
 	serverConfig.ControlConfig.KubeConfigOutput = cfg.KubeConfigOutput
 	serverConfig.ControlConfig.KubeConfigMode = cfg.KubeConfigMode
+	serverConfig.ControlConfig.HelmJobImage = cfg.HelmJobImage
 	serverConfig.ControlConfig.Rootless = cfg.Rootless
 	serverConfig.ControlConfig.ServiceLBNamespace = cfg.ServiceLBNamespace
 	serverConfig.ControlConfig.SANs = util.SplitStringSlice(cfg.TLSSan)

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -166,6 +166,7 @@ type Control struct {
 	ServiceNodePortRange     *utilnet.PortRange
 	KubeConfigOutput         string
 	KubeConfigMode           string
+	HelmJobImage             string
 	DataDir                  string
 	Datastore                endpoint.Config `json:"-"`
 	Disables                 map[string]bool

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -208,7 +208,9 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 	}
 
 	// apply SystemDefaultRegistry setting to Helm before starting controllers
-	if config.ControlConfig.SystemDefaultRegistry != "" {
+	if config.ControlConfig.HelmJobImage != "" {
+		helmchart.DefaultJobImage = config.ControlConfig.HelmJobImage
+	} else if config.ControlConfig.SystemDefaultRegistry != "" {
 		helmchart.DefaultJobImage = config.ControlConfig.SystemDefaultRegistry + "/" + helmchart.DefaultJobImage
 	}
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

A new cli flag for changing our klipper helm image that is default

#### Types of Changes ####

New feature

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/7912

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
the default helm-controller job image can now be overridden with the --helm-job-image CLI flag
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
