### PR TITLE
Don't use zgrep in `check-config` if apparmor porfile is enforced

### DIFF
--- a/contrib/util/check-config.sh
+++ b/contrib/util/check-config.sh
@@ -25,7 +25,7 @@ if [ $# -gt 0 ]; then
   CONFIG="$1"
 fi
 
-if ! command -v zgrep >/dev/null 2>&1; then
+if ! command -v zgrep >/dev/null 2>&1 || eval "cat /sys/kernel/security/apparmor/profiles | grep -q 'zgrep (enforce)'"; then
   zgrep() {
     zcat "$2" | grep "$1"
   }

--- a/tests/e2e/secretsencryption/secretsencryption_test.go
+++ b/tests/e2e/secretsencryption/secretsencryption_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 			cmd = "k3s secrets-encrypt status"
 			Eventually(func() (string, error) {
 				return e2e.RunCmdOnNode(cmd, serverNodeNames[0])
-			}, "180s", "5s").Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
+			}, "240s", "10s").Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
 
 			for _, nodeName := range serverNodeNames[1:] {
 				res, err := e2e.RunCmdOnNode(cmd, nodeName)
@@ -219,7 +219,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 					g.Expect(res).Should(ContainSubstring("Encryption Status: Enabled"))
 					g.Expect(res).Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
 					g.Expect(res).Should(ContainSubstring("Server Encryption Hashes: All hashes match"))
-				}, "420s", "2s").Should(Succeed())
+				}, "420s", "5s").Should(Succeed())
 			}
 		})
 	})
@@ -237,7 +237,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 			cmd = "k3s secrets-encrypt status"
 			Eventually(func() (string, error) {
 				return e2e.RunCmdOnNode(cmd, serverNodeNames[0])
-			}, "180s", "5s").Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
+			}, "240s", "10s").Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
 
 			for i, nodeName := range serverNodeNames {
 				Eventually(func(g Gomega) {


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Bypass zgrep on opensuse 15.4+, with an apparmor profile for zgrep due to [CVE-2022-1271](https://www.suse.com/security/cve/CVE-2022-1271.html).
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
1) Setup opensuse-leap vm (Just use the tests/e2e/validatecluster )and call: 
`E2E_NODE_BOXES="opensuse/Leap-15.4.x86_64" vagrant up server-0 --no-provision`
2) Run `zypper in apparmor-utils`
3) Run `aa-enforce zgrep`
4) Install K3s
5) Run `k3s check-config`

Check config should pass with no issues

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/6278
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
