### PR TITLE
Make apiserver egress args conditional on egress-selector-mode

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -178,8 +178,10 @@ func apiServer(ctx context.Context, cfg *config.Control) error {
 	} else {
 		argsMap["bind-address"] = cfg.APIServerBindAddress
 	}
-	argsMap["enable-aggregator-routing"] = "true"
-	argsMap["egress-selector-config-file"] = runtime.EgressSelectorConfig
+	if cfg.EgressSelectorMode != config.EgressSelectorModeDisabled {
+		argsMap["enable-aggregator-routing"] = "true"
+		argsMap["egress-selector-config-file"] = runtime.EgressSelectorConfig
+	}
 	argsMap["tls-cert-file"] = runtime.ServingKubeAPICert
 	argsMap["tls-private-key-file"] = runtime.ServingKubeAPIKey
 	argsMap["service-account-key-file"] = runtime.ServiceKey


### PR DESCRIPTION
#### Proposed Changes ####

Make apiserver egress args conditional on egress-selector-mode

Only configure enable-aggregator-routing and egress-selector-config-file if required by egress-selector-mode.

#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/7971

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
K3s no longer enables the apiserver's `enable-aggregator-routing` flag when the egress proxy is not being used to route connections to in-cluster endpoints.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
