### PR TITLE
Revert "Warn that v1.28 will deprecate reencrypt/prepare"

### DIFF
--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -16,7 +16,6 @@ import (
 	"github.com/k3s-io/k3s/pkg/server"
 	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"k8s.io/utils/pointer"
 )
@@ -152,7 +151,6 @@ func Prepare(app *cli.Context) error {
 	if err = cmds.InitLogging(); err != nil {
 		return err
 	}
-	logrus.Warnln("This command will be deprecated in v1.28, will be combined with rotate")
 	info, err := commandPrep(app, &cmds.ServerConfig)
 	if err != nil {
 		return err
@@ -198,7 +196,6 @@ func Reencrypt(app *cli.Context) error {
 	if err = cmds.InitLogging(); err != nil {
 		return err
 	}
-	logrus.Warnln("This command will be deprecated in v1.28, will be combined with rotate")
 	info, err := commandPrep(app, &cmds.ServerConfig)
 	if err != nil {
 		return err

--- a/pkg/server/secrets-encrypt.go
+++ b/pkg/server/secrets-encrypt.go
@@ -208,7 +208,6 @@ func encryptionPrepare(ctx context.Context, server *config.Control, force bool) 
 	if err := AppendNewEncryptionKey(&curKeys); err != nil {
 		return err
 	}
-	logrus.Warnln("prepare command will be deprecated in v1.28, will be combined with rotate")
 	logrus.Infoln("Adding secrets-encryption key: ", curKeys[len(curKeys)-1])
 
 	if err := secretsencrypt.WriteEncryptionConfig(server.Runtime, curKeys, true); err != nil {
@@ -276,7 +275,6 @@ func encryptionReencrypt(ctx context.Context, server *config.Control, force bool
 	if _, err = server.Runtime.Core.Core().V1().Node().Update(node); err != nil {
 		return err
 	}
-	logrus.Warnln("reencrypt command will be deprecated in v1.28, will be combined with rotate")
 	logrus.Debugf("encryption hash annotation set successfully on node: %s\n", node.ObjectMeta.Name)
 	return nil
 }


### PR DESCRIPTION
Reverts k3s-io/k3s#7848, as design discussion has push those dates out to far beyond 1.28