### PR TITLE
Adjust default kubeconfig file permissions

### DIFF
--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -88,16 +88,12 @@ func KubeConfig(dest, url, caCert, clientCert, clientKey string) error {
 		ClientKey:  clientKey,
 	}
 
-	output, err := os.Create(dest)
+	// cis-1.24 and newer require kubeconfigs to be 0600
+	output, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
 	defer output.Close()
-
-	// cis-1.24 and newer require kubeconfigs to be 0600
-	if err := output.Chmod(0600); err != nil {
-		return err
-	}
 
 	return kubeconfigTemplate.Execute(output, &data)
 }

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -94,6 +94,11 @@ func KubeConfig(dest, url, caCert, clientCert, clientKey string) error {
 	}
 	defer output.Close()
 
+	// cis-1.24 and newer require kubeconfigs to be 0600
+	if err := output.Chmod(0600); err != nil {
+		return err
+	}
+
 	return kubeconfigTemplate.Execute(output, &data)
 }
 


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
cis-1.24 and newer (the upcoming cis-1.7, yes the name is weird) have moved to a more restrictive kubeconfig default. As the folder `var/lib/rancher/k3s/server/cred` containing these files is restricted to root users only, further restricting the files to read only for root does not present a huge change in file access. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- Start k3s
- `root $ stat -c "%a %n" /var/lib/rancher/k3s/server/cred/* ` 
All `.kubeconfig` files should be 600 permissions
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/7975
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
