### PR TITLE
Add support for using base template in etc/containerd/config.toml.tmpl

### DIFF
--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -131,6 +131,7 @@ enable_keychain = true
 func ParseTemplateFromConfig(templateBuffer string, config interface{}) (string, error) {
 	out := new(bytes.Buffer)
 	t := template.Must(template.New("compiled_template").Parse(templateBuffer))
+	template.Must(t.New("base").Parse(ContainerdConfigTemplate))
 	if err := t.Execute(out, config); err != nil {
 		return "", err
 	}

--- a/pkg/agent/templates/templates_windows.go
+++ b/pkg/agent/templates/templates_windows.go
@@ -179,6 +179,7 @@ func ParseTemplateFromConfig(templateBuffer string, config interface{}) (string,
 		},
 	}
 	t := template.Must(template.New("compiled_template").Funcs(funcs).Parse(templateBuffer))
+	template.Must(t.New("base").Parse(ContainerdConfigTemplate))
 	if err := t.Execute(out, config); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Right now you need copy-paste the default containerd config template from [github](https://github.com/skirsten/k3s/blob/f78a66b44e2ecbef64122be99a9aa9118a49d7e9/pkg/agent/templates/templates_linux.go#L10) into `config.toml.tmpl` only to add a few lines.

This PR allows to do :point_down: instead which is much cleaner and removes the need to keep the base template up-to-date from :point_up: :

##### /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
```
{{ template "base" . }}

[plugins."io.containerd.grpc.v1.cri".containerd.runtimes."custom"]
  runtime_type = "io.containerd.runc.v2"
[plugins."io.containerd.grpc.v1.cri".containerd.runtimes."custom".options]
  BinaryName = "/usr/bin/custom-container-runtime"
```

#### Types of Changes ####

The PR adds the base template to the template list, so that it can be used.

#### Verification ####

- Build
- Use above config.toml.tmpl
- `cat config.toml`

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
* #7992

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
User-provided containerd config templates may now use `{{ template "base" . }}` to include the default K3s template content. This makes it easier to maintain user configuration if the only need is to add additional sections to the file.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
