### PR TITLE
Fix coreos multiple installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -604,7 +604,7 @@ EOF
             ${transactional_update_run} mkdir -p /var/lib/rpm-state
             ;;
         coreos)
-            rpm_installer="rpm-ostree"
+            rpm_installer="rpm-ostree --idempotent"
             # rpm_install_extra_args="--apply-live"
             : "${INSTALL_K3S_SKIP_START:=true}"
             ;;


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Add --idempotent flag to the rpm-os-tree installer in coreos systems 

#### Types of Changes ####

Bugfix

#### Verification ####

- run the install script twice on the same coreos machine

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

- https://github.com/k3s-io/k3s/issues/8078

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
