### PR TITLE
Etcd snapshots retention when node name changes

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -1429,7 +1429,6 @@ func (e *ETCD) Snapshot(ctx context.Context, config *config.Control) error {
 		if err := e.addSnapshotData(*sf); err != nil {
 			return errors.Wrap(err, "failed to save local snapshot data to configmap")
 		}
-		
 		if err := snapshotRetention(e.config.EtcdSnapshotRetention, e.config.EtcdSnapshotName, snapshotDir); err != nil {
 			return errors.Wrap(err, "failed to apply local snapshot retention policy")
 		}
@@ -2049,6 +2048,7 @@ func snapshotRetention(retention int, snapshotPrefix string, snapshotDir string)
 	sort.Slice(snapshotFiles, func(i, j int) bool {
 		return snapshotFiles[i].Name() < snapshotFiles[j].Name()
 	})
+
 	delCount := len(snapshotFiles) - retention
 	for _, df := range snapshotFiles[:delCount] {
 		snapshotPath := filepath.Join(snapshotDir, df.Name())

--- a/pkg/etcd/s3.go
+++ b/pkg/etcd/s3.go
@@ -212,8 +212,7 @@ func (s *S3) Download(ctx context.Context) error {
 // snapshotPrefix returns the prefix used in the
 // naming of the snapshots.
 func (s *S3) snapshotPrefix() string {
-	nodeName := os.Getenv("NODE_NAME")
-	fullSnapshotPrefix := s.config.EtcdSnapshotName + "-" + nodeName
+	fullSnapshotPrefix := s.config.EtcdSnapshotName
 	var prefix string
 	if s.config.EtcdS3Folder != "" {
 		prefix = filepath.Join(s.config.EtcdS3Folder, fullSnapshotPrefix)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

* Delete the oldest snapshot files inside the node and s3 if the snapshot count is greater than the retention, regardless of the node name.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

* Fix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Need to create a cluster with etcd snapshots enabled and s3
```
k3s server --cluster-init --etcd-snapshot-schedule-cron "*/1 * * * *" --etcd-snapshot-retention 2 --etcd-s3 --etcd-s3-access-key --etcd-s3-secret-key --etcd-s3-bucket
```
Then you can see in the /var/lib/rancher/k3s/server/db/snapshots that will maintain the retention
```
ls /var/lib/rancher/server/db/snapshots
```

If you are using AWS, you can just reboot the machine to have another name, and just restarted the cluster, it will still delete the snapshot inside `/var/lib/rancher/server/db/snapshots` and maintain the retention

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

* https://github.com/rancher/rke2/issues/3714

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
