### PR TITLE
fix etcd-snapshot delete when etcd-s3 is true

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -1704,21 +1704,26 @@ func (e *ETCD) DeleteSnapshots(ctx context.Context, snapshots []string) error {
 			}
 		}()
 
-		for {
-			select {
-			case <-ctx.Done():
-				logrus.Errorf("Unable to delete snapshot: %v", ctx.Err())
-				return e.ReconcileSnapshotData(ctx)
-			case <-time.After(time.Millisecond * 100):
-				continue
-			case err, ok := <-e.s3.client.RemoveObjects(ctx, e.config.EtcdS3BucketName, objectsCh, minio.RemoveObjectsOptions{}):
-				if err.Err != nil {
-					logrus.Errorf("Unable to delete snapshot: %v", err.Err)
-				}
-				if !ok {
+		err = func() error {
+			for {
+				select {
+				case <-ctx.Done():
+					logrus.Errorf("Unable to delete snapshot: %v", ctx.Err())
 					return e.ReconcileSnapshotData(ctx)
+				case <-time.After(time.Millisecond * 100):
+					continue
+				case err, ok := <-e.s3.client.RemoveObjects(ctx, e.config.EtcdS3BucketName, objectsCh, minio.RemoveObjectsOptions{}):
+					if err.Err != nil {
+						logrus.Errorf("Unable to delete snapshot: %v", err.Err)
+					}
+					if !ok {
+						return e.ReconcileSnapshotData(ctx)
+					}
 				}
 			}
+		}()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/tests/e2e/s3/s3_test.go
+++ b/tests/e2e/s3/s3_test.go
@@ -114,6 +114,18 @@ var _ = Describe("Verify Create", Ordered, func() {
 			Expect(res).To(ContainSubstring("special-2-server-0"))
 			Expect(res).To(ContainSubstring("special-3-server-0"))
 		})
+		It("delete first on-demand s3 snapshot", func() {
+			_, err := e2e.RunCmdOnNode("sudo k3s etcd-snapshot ls >> ./snapshotname.txt", serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred())
+			snapshotName, err := e2e.RunCmdOnNode("grep -Eo 'on-demand-server-0-([0-9]+)' ./snapshotname.txt | sed 's/^/on-demand-server-0-/'| head -1", serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred())
+			res, err := e2e.RunCmdOnNode("sudo k3s etcd-snapshot delete "+snapshotName, serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(ContainSubstring("Removing the given etcd snapshot(s) from S3"))
+			Expect(res).To(ContainSubstring("Reconciliation of snapshot data in k3s-etcd-snapshots ConfigMap complete"))
+			Expect(res).To(ContainSubstring("Removing the given locally stored etcd snapshot(s)"))
+		})
+
 		// TODO, there is currently a bug that prevents pruning on s3 snapshots that are not prefixed with "on-demand"
 		// https://github.com/rancher/rke2/issues/3714
 		// Once fixed, ensure that the snapshots list are actually reduced to 2

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -507,7 +507,7 @@ func GetCoverageReport(nodeNames []string) error {
 		}
 	}
 	coverageFile := "coverage.out"
-	cmd := "go tool covdata textfmt -i " + strings.Join(covDirs, ",") + " -o " + coverageFile
+	cmd := "go tool covdata textfmt -i=" + strings.Join(covDirs, ",") + " -o=" + coverageFile
 	if out, err := RunCommand(cmd); err != nil {
 		return fmt.Errorf("failed to generate coverage report: %s, %v", out, err)
 	}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
This fix SURE-6362, `k3s etcd-snapshot save --etcd-s3 ...` is creating a local snapshot and uploading it to s3 while `k3s etcd-snapshot delete --etcd-s3 ...` was deleting the snapshot only on s3 buckets, this commit change the behavior of delete to do it locally and on s3

there was a select with a return statement that was returning the function and skipping the local delete logic, i put it in an anonymous function and returning only if error occurs now.

fixes https://github.com/k3s-io/k3s/issues/8137
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
