### PR TITLE
[v1.28] Secrets Encryption V3

### DIFF
--- a/cmd/encrypt/main.go
+++ b/cmd/encrypt/main.go
@@ -22,6 +22,7 @@ func main() {
 			secretsencrypt.Prepare,
 			secretsencrypt.Rotate,
 			secretsencrypt.Reencrypt,
+			secretsencrypt.RotateKeys,
 		),
 	}
 

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -71,6 +71,7 @@ func main() {
 			secretsencryptCommand,
 			secretsencryptCommand,
 			secretsencryptCommand,
+			secretsencryptCommand,
 		),
 		cmds.NewCertCommand(
 			cmds.NewCertSubcommands(

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -68,6 +68,7 @@ func main() {
 			secretsencrypt.Prepare,
 			secretsencrypt.Rotate,
 			secretsencrypt.Reencrypt,
+			secretsencrypt.RotateKeys,
 		),
 		cmds.NewCertCommand(
 			cmds.NewCertSubcommands(

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ replace (
 
 require (
 	github.com/Mirantis/cri-dockerd v0.0.0-00010101000000-000000000000
+	github.com/blang/semver/v4 v4.0.0
 	github.com/cloudnativelabs/kube-router/v2 v2.0.0-00010101000000-000000000000
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/cgroups v1.1.0
@@ -110,7 +111,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/json-iterator/go v1.1.12
 	github.com/k3s-io/helm-controller v0.15.4
-	github.com/k3s-io/kine v0.10.2
+	github.com/k3s-io/kine v0.10.3-0.20230816194222-7f6ba014aa71
 	github.com/klauspost/compress v1.16.6
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.10.2
@@ -194,7 +195,6 @@ require (
 	github.com/avast/retry-go/v4 v4.3.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bronze1man/goStrongswanVici v0.0.0-20201105010758-936f38b697fd // indirect
 	github.com/canonical/go-dqlite v1.5.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
@@ -328,7 +328,7 @@ require (
 	github.com/nats-io/jsm.go v0.0.31-0.20220317133147-fe318f464eee // indirect
 	github.com/nats-io/jwt/v2 v2.4.1 // indirect
 	github.com/nats-io/nats-server/v2 v2.9.18 // indirect
-	github.com/nats-io/nats.go v1.27.1-0.20230619112143-ec00e662324e // indirect
+	github.com/nats-io/nats.go v1.27.1 // indirect
 	github.com/nats-io/nkeys v0.4.4 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -835,8 +835,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZ
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
 github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
 github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
-github.com/k3s-io/kine v0.10.2 h1:aN2taL3BUSPZ4D+36opCn4PGlNZ+lkduk5Oz+/ZYhqA=
-github.com/k3s-io/kine v0.10.2/go.mod h1:JDJpiaFlxltCNqqWCBrP+/pbAGzJqbG1Y1DsHqM3X9U=
+github.com/k3s-io/kine v0.10.3-0.20230816194222-7f6ba014aa71 h1:vfjgEzFWojbe1jD1zAhDNXhcGFhp3sNCV7fjOG3rk0M=
+github.com/k3s-io/kine v0.10.3-0.20230816194222-7f6ba014aa71/go.mod h1:hiOK3Gj89Py+AB11YK0fxEwkdWxBvNfaMt8PRWXqh6M=
 github.com/k3s-io/klog/v2 v2.100.1-k3s1 h1:xb/Ta8dpQuIZueQEw2YTZUYrKoILdBmPiITVkNmYPa0=
 github.com/k3s-io/klog/v2 v2.100.1-k3s1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 github.com/k3s-io/kube-router/v2 v2.0.1-0.20230508174102-b42e5faded1c h1:7IaKAByGXNvZAmhYlaHH2LiqOGWtPNVg8vKV1Xvlrek=
@@ -1057,8 +1057,8 @@ github.com/nats-io/nats-server/v2 v2.7.5-0.20220309212130-5c0d1999ff72/go.mod h1
 github.com/nats-io/nats-server/v2 v2.9.18 h1:00muGH0qu/7NAw1b/2eFcpIvdHcTghj6PFjUVhy8zEo=
 github.com/nats-io/nats-server/v2 v2.9.18/go.mod h1:aTb/xtLCGKhfTFLxP591CMWfkdgBmcUUSkiSOe5A3gw=
 github.com/nats-io/nats.go v1.13.1-0.20220308171302-2f2f6968e98d/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
-github.com/nats-io/nats.go v1.27.1-0.20230619112143-ec00e662324e h1:+JoNIXzRg65A/J5MeA011xAWRW/gx5EL9F3+9O0glTg=
-github.com/nats-io/nats.go v1.27.1-0.20230619112143-ec00e662324e/go.mod h1:XpbWUlOElGwTYbMR7imivs7jJj9GtK7ypv321Wp6pjc=
+github.com/nats-io/nats.go v1.27.1 h1:OuYnal9aKVSnOzLQIzf7554OXMCG7KbaTkCSBHRcSoo=
+github.com/nats-io/nats.go v1.27.1/go.mod h1:XpbWUlOElGwTYbMR7imivs7jJj9GtK7ypv321Wp6pjc=
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
 github.com/nats-io/nkeys v0.4.4 h1:xvBJ8d69TznjcQl9t6//Q5xXuVhyYiSos6RPtvQNTwA=
 github.com/nats-io/nkeys v0.4.4/go.mod h1:XUkxdLPTufzlihbamfzQ7mw/VGx6ObUs+0bN5sNvt64=

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 			secretsencrypt.Prepare,
 			secretsencrypt.Rotate,
 			secretsencrypt.Reencrypt,
+			secretsencrypt.RotateKeys,
 		),
 		cmds.NewCertCommand(
 			cmds.NewCertSubcommands(

--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -26,7 +26,7 @@ var (
 	}
 )
 
-func NewSecretsEncryptCommands(status, enable, disable, prepare, rotate, reencrypt func(ctx *cli.Context) error) cli.Command {
+func NewSecretsEncryptCommands(status, enable, disable, prepare, rotate, reencrypt, rotateKeys func(ctx *cli.Context) error) cli.Command {
 	return cli.Command{
 		Name:           SecretsEncryptCommand,
 		Usage:          "Control secrets encryption and keys rotation",
@@ -83,6 +83,13 @@ func NewSecretsEncryptCommands(status, enable, disable, prepare, rotate, reencry
 						Usage:       "Skip removing old key",
 						Destination: &ServerConfig.EncryptSkip,
 					}),
+			},
+			{
+				Name:           "rotate-keys",
+				Usage:          "Add, rotate and rencryption with a new encryption key",
+				SkipArgReorder: true,
+				Action:         rotateKeys,
+				Flags:          EncryptFlags,
 			},
 		},
 	}

--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -86,7 +86,7 @@ func NewSecretsEncryptCommands(status, enable, disable, prepare, rotate, reencry
 			},
 			{
 				Name:           "rotate-keys",
-				Usage:          "Add, rotate and rencryption with a new encryption key",
+				Usage:          "(experimental) Dynamically add a new secrets encryption key and re-encrypt secrets",
 				SkipArgReorder: true,
 				Action:         rotateKeys,
 				Flags:          EncryptFlags,

--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -156,7 +156,7 @@ func Prepare(app *cli.Context) error {
 		return err
 	}
 	b, err := json.Marshal(server.EncryptionRequest{
-		Stage: pointer.StringPtr(secretsencrypt.EncryptionPrepare),
+		Stage: pointer.String(secretsencrypt.EncryptionPrepare),
 		Force: cmds.ServerConfig.EncryptForce,
 	})
 	if err != nil {
@@ -178,7 +178,7 @@ func Rotate(app *cli.Context) error {
 		return err
 	}
 	b, err := json.Marshal(server.EncryptionRequest{
-		Stage: pointer.StringPtr(secretsencrypt.EncryptionRotate),
+		Stage: pointer.String(secretsencrypt.EncryptionRotate),
 		Force: cmds.ServerConfig.EncryptForce,
 	})
 	if err != nil {
@@ -201,7 +201,7 @@ func Reencrypt(app *cli.Context) error {
 		return err
 	}
 	b, err := json.Marshal(server.EncryptionRequest{
-		Stage: pointer.StringPtr(secretsencrypt.EncryptionReencryptActive),
+		Stage: pointer.String(secretsencrypt.EncryptionReencryptActive),
 		Force: cmds.ServerConfig.EncryptForce,
 		Skip:  cmds.ServerConfig.EncryptSkip,
 	})
@@ -212,5 +212,27 @@ func Reencrypt(app *cli.Context) error {
 		return wrapServerError(err)
 	}
 	fmt.Println("reencryption started")
+	return nil
+}
+
+func RotateKeys(app *cli.Context) error {
+	var err error
+	if err = cmds.InitLogging(); err != nil {
+		return err
+	}
+	info, err := commandPrep(app, &cmds.ServerConfig)
+	if err != nil {
+		return err
+	}
+	b, err := json.Marshal(server.EncryptionRequest{
+		Stage: pointer.String(secretsencrypt.EncryptionRotateKeys),
+	})
+	if err != nil {
+		return err
+	}
+	if err = info.Put("/v1-"+version.Program+"/encrypt/config", b); err != nil {
+		return wrapServerError(err)
+	}
+	fmt.Println("keys rotated, rencryption started")
 	return nil
 }

--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func commandPrep(app *cli.Context, cfg *cmds.Server) (*clientaccess.Info, error) {
+func commandPrep(cfg *cmds.Server) (*clientaccess.Info, error) {
 	// hide process arguments from ps output, since they may contain
 	// database credentials or other secrets.
 	gspt.SetProcTitle(os.Args[0] + " secrets-encrypt")
@@ -46,11 +46,10 @@ func wrapServerError(err error) error {
 }
 
 func Enable(app *cli.Context) error {
-	var err error
-	if err = cmds.InitLogging(); err != nil {
+	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	info, err := commandPrep(app, &cmds.ServerConfig)
+	info, err := commandPrep(&cmds.ServerConfig)
 	if err != nil {
 		return err
 	}
@@ -70,7 +69,7 @@ func Disable(app *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	info, err := commandPrep(app, &cmds.ServerConfig)
+	info, err := commandPrep(&cmds.ServerConfig)
 	if err != nil {
 		return err
 	}
@@ -89,7 +88,7 @@ func Status(app *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	info, err := commandPrep(app, &cmds.ServerConfig)
+	info, err := commandPrep(&cmds.ServerConfig)
 	if err != nil {
 		return err
 	}
@@ -147,11 +146,10 @@ func Status(app *cli.Context) error {
 }
 
 func Prepare(app *cli.Context) error {
-	var err error
-	if err = cmds.InitLogging(); err != nil {
+	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	info, err := commandPrep(app, &cmds.ServerConfig)
+	info, err := commandPrep(&cmds.ServerConfig)
 	if err != nil {
 		return err
 	}
@@ -173,7 +171,7 @@ func Rotate(app *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	info, err := commandPrep(app, &cmds.ServerConfig)
+	info, err := commandPrep(&cmds.ServerConfig)
 	if err != nil {
 		return err
 	}
@@ -192,11 +190,10 @@ func Rotate(app *cli.Context) error {
 }
 
 func Reencrypt(app *cli.Context) error {
-	var err error
-	if err = cmds.InitLogging(); err != nil {
+	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	info, err := commandPrep(app, &cmds.ServerConfig)
+	info, err := commandPrep(&cmds.ServerConfig)
 	if err != nil {
 		return err
 	}
@@ -216,11 +213,10 @@ func Reencrypt(app *cli.Context) error {
 }
 
 func RotateKeys(app *cli.Context) error {
-	var err error
-	if err = cmds.InitLogging(); err != nil {
+	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	info, err := commandPrep(app, &cmds.ServerConfig)
+	info, err := commandPrep(&cmds.ServerConfig)
 	if err != nil {
 		return err
 	}
@@ -233,6 +229,6 @@ func RotateKeys(app *cli.Context) error {
 	if err = info.Put("/v1-"+version.Program+"/encrypt/config", b); err != nil {
 		return wrapServerError(err)
 	}
-	fmt.Println("keys rotated, rencryption started")
+	fmt.Println("keys rotated, reencryption started")
 	return nil
 }

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -777,7 +777,7 @@ func genEncryptionConfigAndState(controlConfig *config.Control) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(runtime.EncryptionConfig, b, 0600); err != nil {
+	if err := util.AtomicWrite(runtime.EncryptionConfig, b, 0600); err != nil {
 		return err
 	}
 	encryptionConfigHash := sha256.Sum256(b)

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -214,6 +214,7 @@ func apiServer(ctx context.Context, cfg *config.Control) error {
 	}
 	if cfg.EncryptSecrets {
 		argsMap["encryption-provider-config"] = runtime.EncryptionConfig
+		argsMap["encryption-provider-config-automatic-reload"] = "true"
 	}
 	args := config.GetArgs(argsMap, cfg.ExtraAPIArgs)
 

--- a/pkg/secretsencrypt/config.go
+++ b/pkg/secretsencrypt/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/k3s-io/k3s/pkg/util"
 	"github.com/k3s-io/k3s/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 
@@ -106,7 +107,7 @@ func WriteEncryptionConfig(runtime *config.ControlRuntime, keys []apiserverconfi
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(runtime.EncryptionConfig, jsonfile, 0600)
+	return util.AtomicWrite(runtime.EncryptionConfig, jsonfile, 0600)
 }
 
 func GenEncryptionConfigHash(runtime *config.ControlRuntime) (string, error) {

--- a/pkg/secretsencrypt/config.go
+++ b/pkg/secretsencrypt/config.go
@@ -21,6 +21,7 @@ const (
 	EncryptionStart             string = "start"
 	EncryptionPrepare           string = "prepare"
 	EncryptionRotate            string = "rotate"
+	EncryptionRotateKeys        string = "rotate_keys"
 	EncryptionReencryptRequest  string = "reencrypt_request"
 	EncryptionReencryptActive   string = "reencrypt_active"
 	EncryptionReencryptFinished string = "reencrypt_finished"

--- a/pkg/server/secrets-encrypt.go
+++ b/pkg/server/secrets-encrypt.go
@@ -13,13 +13,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/k3s-io/k3s/pkg/cluster"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/secretsencrypt"
 	"github.com/k3s-io/k3s/pkg/util"
 	"github.com/rancher/wrangler/pkg/generated/controllers/core"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/mod/semver"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
@@ -390,9 +390,16 @@ func verifyRotateKeysSupport(core core.Interface) error {
 		return err
 	}
 	for _, node := range nodes.Items {
-		kubver := node.Status.NodeInfo.KubeletVersion
-		if semver.Compare(kubver, "v1.28.0") < 0 {
-			return fmt.Errorf("node %s is running k3s version %s that does not support rotate-keys", node.ObjectMeta.Name, kubver)
+		kubver, err := semver.ParseTolerant(node.Status.NodeInfo.KubeletVersion)
+		if err != nil {
+			return fmt.Errorf("failed to parse kubelet version %s: %v", node.Status.NodeInfo.KubeletVersion, err)
+		}
+		supportVer, err := semver.Make("1.28.0")
+		if err != nil {
+			return err
+		}
+		if kubver.LT(supportVer) {
+			return fmt.Errorf("node %s is running k3s version %s that does not support rotate-keys", node.ObjectMeta.Name, kubver.String())
 		}
 	}
 	return nil

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -36,4 +37,29 @@ func ReadFile(path string) (string, error) {
 	}
 
 	return "", errors.New("Timeout while trying to read the file")
+}
+
+// AtomicWrite firsts writes data to a temp file, then renames to the destination file.
+// This ensures that the destination file is never partially written.
+func AtomicWrite(fileName string, data []byte, perm os.FileMode) error {
+	f, err := os.CreateTemp(filepath.Dir(fileName), filepath.Base(fileName)+".tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := f.Name()
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Chmod(perm); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpName, fileName)
 }

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -47,6 +47,7 @@ func AtomicWrite(fileName string, data []byte, perm os.FileMode) error {
 		return err
 	}
 	tmpName := f.Name()
+	defer os.Remove(tmpName)
 	if _, err := f.Write(data); err != nil {
 		f.Close()
 		return err

--- a/tests/e2e/secretsencryption_old/Vagrantfile
+++ b/tests/e2e/secretsencryption_old/Vagrantfile
@@ -1,0 +1,77 @@
+ENV['VAGRANT_NO_PARALLEL'] = 'no'
+NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
+  ["server-0", "server-1", "server-2"])
+NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
+  ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
+GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
+RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
+GOCOVER = (ENV['E2E_GOCOVER'] || "")
+NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
+NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 2048).to_i
+# Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks 
+NETWORK_PREFIX = "10.10.10"
+install_type = ""
+
+def provision(vm, role, role_num, node_num)
+  vm.box = NODE_BOXES[node_num]
+  vm.hostname = role
+  # An expanded netmask is required to allow VM<-->VM communication, virtualbox defaults to /32
+  vm.network "private_network", ip: "#{NETWORK_PREFIX}.#{100+node_num}", netmask: "255.255.255.0"
+
+  vagrant_defaults = '../vagrantdefaults.rb'
+  load vagrant_defaults if File.exists?(vagrant_defaults)
+  
+  defaultOSConfigure(vm)
+  addCoverageDir(vm, role, GOCOVER)
+  install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
+  
+  vm.provision "shell", inline: "ping -c 2 k3s.io"
+  
+
+  if role.include?("server") && role_num == 0
+    vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+      k3s.args = %W[server --cluster-init --node-external-ip=#{NETWORK_PREFIX}.100 --flannel-iface=eth1 --secrets-encryption]
+      k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+  elsif role.include?("server") && role_num != 0
+    vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
+      k3s.args = %W[server --server https://#{NETWORK_PREFIX}.100:6443 --flannel-iface=eth1 --secrets-encryption]
+      k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+  end
+  if vm.box.to_s.include?("microos")
+    vm.provision 'k3s-reload', type: 'reload', run: 'once'
+  end
+end
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = ["vagrant-k3s", "vagrant-reload"]
+  # Default provider is libvirt, virtualbox is only provided as a backup
+  config.vm.provider "libvirt" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+  
+  if NODE_ROLES.kind_of?(String)
+    NODE_ROLES = NODE_ROLES.split(" ", -1)
+  end
+  if NODE_BOXES.kind_of?(String)
+    NODE_BOXES = NODE_BOXES.split(" ", -1)
+  end
+
+  # Must iterate on the index, vagrant does not understand iterating 
+  # over the node roles themselves
+  NODE_ROLES.length.times do |i|
+    name = NODE_ROLES[i]
+    role_num = name.split("-", -1).pop.to_i
+    config.vm.define name do |node|
+      provision(node.vm, name, role_num, i)
+    end
+  end
+end


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Implements https://github.com/k3s-io/k3s/blob/master/docs/adrs/secrets-encryption-v3.md, a new command `k3s secrets-encrypt rotate-keys` is now Experimental, and adds, rotates, and reencrypts secrets all in one command. 
- Adds additional protections around attempting to `k3s secrets-encrypt enable` on HA clusters that do not have `--secrets-encryption` server flags. 
- Makes a new E2E test with the old test called `secretsencryption_old` (likely will remove old test in future PR)
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Feature Improvement
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Use the new Secrets Encryption E2E test
OR
1) Start k3s cluster with `--secrets-encryption`
2) Make a bunch of secrets 
    ```
    echo "this is a file" > file.txt && for i in {1..500}; do echo test$i >> file.txt; kubectl create secret generic test$i --from-file=file.txt; done
    ```
3) Run `k3s secrets-encrypt rotate-keys`
4) Watch the server logs, or wait for `reencrypt_finished` to be the state in `k3s secrets-encrypt status`
5) Restart all servers
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
Changed existing E2E test
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/7760
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
