### PR TITLE
Fix: INSTALL_K3S_SKIP_ENABLE=true should start service for current session usage

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1001,10 +1001,10 @@ service_enable_and_start() {
         info 'Failed to find memory cgroup, you may need to add "cgroup_memory=1 cgroup_enable=memory" to your linux cmdline (/boot/cmdline.txt on a Raspberry Pi)'
     fi
 
-    [ "${INSTALL_K3S_SKIP_ENABLE}" = true ] && return
-
-    [ "${HAS_SYSTEMD}" = true ] && systemd_enable
-    [ "${HAS_OPENRC}" = true ] && openrc_enable
+    [ "${INSTALL_K3S_SKIP_ENABLE}" = true ] || {
+        [ "${HAS_SYSTEMD}" = true ] && systemd_enable
+        [ "${HAS_OPENRC}" = true ] && openrc_enable
+    }
 
     [ "${INSTALL_K3S_SKIP_START}" = true ] && return
 


### PR DESCRIPTION
#### Proposed Changes ####

* Reproduce this step:

```
$ curl -L https://get.k3s.io/ | STALL_K3S_SKIP_ENABLE=true INSTALL_K3S_VERSION="v1.20.8+k3s1" sh -x -
... ...
+ create_systemd_service_file
+ info 'systemd: Creating service file /etc/systemd/system/k3s.service'
+ echo '[INFO] ' 'systemd: Creating service file /etc/systemd/system/k3s.service'
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
+ tee /etc/systemd/system/k3s.service
+ '[' '' = true ']'
+ return 0
+ sleep 30
+ service_enable_and_start
+ '[' -f /proc/cgroups ']'
++ grep memory /proc/cgroups
++ read -r n n n enabled
++ echo 1
++ read -r n n n enabled
+ '[' 1 -eq 0 ']'
+ '[' true = true ']'
+ return
+ cleanup
+ code=0
+ set +e
+ trap - EXIT
+ rm -rf /tmp/k3s-install.ghww8Wsh1u
+ exit 0
$ systemctl status k3s
● k3s.service - Lightweight Kubernetes
   Loaded: loaded (/etc/systemd/system/k3s.service; disabled; vendor preset: disabled)
   Active: inactive (dead)
     Docs: https://k3s.io
```

From systemctl(1) manual page: `Enabling and starting units is orthogonal: units may be enabled without being started and started without being enabled.`

#### Types of Changes ####

Bugfix

#### Verification ####

```
... ...
+ service_enable_and_start
+ '[' -f /proc/cgroups ']'
++ grep memory /proc/cgroups
++ read -r n n n enabled
++ echo 1
++ read -r n n n enabled
+ '[' 1 -eq 0 ']'
+ '[' true = true ']'
+ '[' '' = true ']'
++ get_installed_hashes
++ sha256sum /usr/local/bin/k3s /etc/systemd/system/k3s.service /etc/systemd/system/k3s.service.env
+ POST_INSTALL_HASHES='07acd68c89c42ea5c15eca16b857d40fb5c13d4a943d550e780da3ebaa9561c2  /usr/local/bin/k3s
e846711e65b50662db45fa82f533a4033b191e5975957c2f0a22a2496b66f96d  /etc/systemd/system/k3s.service
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  /etc/systemd/system/k3s.service.env'
+ '[' 'sha256sum: /usr/local/bin/k3s: No such file or directory
sha256sum: /etc/systemd/system/k3s.service: No such file or directory
sha256sum: /etc/systemd/system/k3s.service.env: No such file or directory' = '07acd68c89c42ea5c15eca16b857d40fb5c13d4a943d550e780da3ebaa9561c2  /usr/local/bin/k3s
e846711e65b50662db45fa82f533a4033b191e5975957c2f0a22a2496b66f96d  /etc/systemd/system/k3s.service
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  /etc/systemd/system/k3s.service.env' ']'
+ command -v iptables-save
+ command -v iptables-restore
+ iptables-save
+ grep -v KUBE-
+ grep -iv flannel
+ iptables-restore
+ command -v ip6tables-save
+ command -v ip6tables-restore
+ ip6tables-save
+ grep -v KUBE-
+ grep -iv flannel
+ ip6tables-restore
+ '[' true = true ']'
+ systemd_start
+ info 'systemd: Starting k3s'
+ echo '[INFO] ' 'systemd: Starting k3s'
[INFO]  systemd: Starting k3s
+ systemctl restart k3s
+ '[' '' = true ']'
+ return 0
+ cleanup
+ code=0
+ set +e
+ trap - EXIT
+ rm -rf /tmp/k3s-install.Gh9lycx6xF
+ exit 0
$ systemctl is-enabled k3s
disabled
$ systemctl status k3s
● k3s.service - Lightweight Kubernetes
   Loaded: loaded (/etc/systemd/system/k3s.service; disabled; vendor preset: disabled)
   Active: active (running) since Thu 2023-08-03 16:41:44 CST; 24s ago
... ...
```

#### Testing ####

#### Linked Issues ####

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

