### PR TITLE
[Release 1.24] - Fix for cluster-reset backup from s3 when etcd snapshots are disabled

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -157,7 +157,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.EtcdExposeMetrics = cfg.EtcdExposeMetrics
 	serverConfig.ControlConfig.EtcdDisableSnapshots = cfg.EtcdDisableSnapshots
 
-	if !cfg.EtcdDisableSnapshots {
+	if !cfg.EtcdDisableSnapshots || cfg.ClusterReset {
 		serverConfig.ControlConfig.EtcdSnapshotCompress = cfg.EtcdSnapshotCompress
 		serverConfig.ControlConfig.EtcdSnapshotName = cfg.EtcdSnapshotName
 		serverConfig.ControlConfig.EtcdSnapshotCron = cfg.EtcdSnapshotCron


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

If `cluster-reset` was called with `etcd-disable-snapshots` , k3s will verify if the user have `etcd-s3` and then restore the snapshot from S3.

#### Types of Changes ####

- Backport from https://github.com/k3s-io/k3s/pull/8155

#### Verification ####

Create a config.yaml in the `/etc/rancher/k3s` with this flags
```yaml
cluster-init: true
etcd-disable-snapshots: true
etcd-s3: true
etcd-s3-access-key: 'secretKey'
etcd-s3-secret-key: 'secretKey'
etcd-s3-bucket: 'bucketName'
etcd-s3-region: 'awsRegion'
etcd-s3-timeout: '90s'
```

Now you can create the server
```bash
k3s server 
```

Then you need to save the snapshot, that will backup to s3 
```bash
k3s etcd-snapshot save
```

Turn off the k3s and then
```bash
k3s server --cluster-reset --cluster-reset-restore-path="s3SnapshotName"
```

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- https://github.com/k3s-io/k3s/issues/8167

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

With this change, users can now manage and backup their own snapshots on demand from S3.