### PR TITLE
[Release 1.25] Fixed the etcd retention to delete orphaned snapshots based on the date

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -2047,10 +2047,12 @@ func snapshotRetention(retention int, snapshotPrefix string, snapshotDir string)
 	if len(snapshotFiles) <= retention {
 		return nil
 	}
-	sort.Slice(snapshotFiles, func(i, j int) bool {
-		return snapshotFiles[i].Name() < snapshotFiles[j].Name()
+	sort.Slice(snapshotFiles, func(firstSnapshot, secondSnapshot int) bool {
+		// it takes the name from the snapshot file ex: etcd-snapshot-example-{date}, makes the split using "-" to find the date, takes the date and sort by date
+		firstSnapshotName, secondSnapshotName := strings.Split(snapshotFiles[firstSnapshot].Name(), "-"), strings.Split(snapshotFiles[secondSnapshot].Name(), "-")
+		firstSnapshotDate, secondSnapshotDate := firstSnapshotName[len(firstSnapshotName)-1], secondSnapshotName[len(secondSnapshotName)-1]
+		return firstSnapshotDate < secondSnapshotDate
 	})
-
 	delCount := len(snapshotFiles) - retention
 	for _, df := range snapshotFiles[:delCount] {
 		snapshotPath := filepath.Join(snapshotDir, df.Name())

--- a/pkg/etcd/s3.go
+++ b/pkg/etcd/s3.go
@@ -249,8 +249,11 @@ func (s *S3) snapshotRetention(ctx context.Context) error {
 		return nil
 	}
 
-	sort.Slice(snapshotFiles, func(i, j int) bool {
-		return snapshotFiles[i].Key < snapshotFiles[j].Key
+	sort.Slice(snapshotFiles, func(firstSnapshot, secondSnapshot int) bool {
+		// it takes the key from the snapshot file ex: etcd-snapshot-example-{date}, makes the split using "-" to find the date, takes the date and sort by date
+		firstSnapshotName, secondSnapshotName := strings.Split(snapshotFiles[firstSnapshot].Key, "-"), strings.Split(snapshotFiles[secondSnapshot].Key, "-")
+		firstSnapshotDate, secondSnapshotDate := firstSnapshotName[len(firstSnapshotName)-1], secondSnapshotName[len(secondSnapshotName)-1]
+		return firstSnapshotDate < secondSnapshotDate
 	})
 
 	delCount := len(snapshotFiles) - s.config.EtcdSnapshotRetention


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

* Delete the oldest snapshot files inside the node and s3 if the snapshot count is greater than the retention, regardless of the node name.

* The delete will occur based on the the date in the name of the file.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

* backports from https://github.com/k3s-io/k3s/pull/8177

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Need to create a cluster with etcd snapshots enabled and s3
```
k3s server --cluster-init --etcd-snapshot-schedule-cron "*/1 * * * *" --etcd-snapshot-retention 2 --etcd-s3 --etcd-s3-access-key --etcd-s3-secret-key --etcd-s3-bucket
```
Then you can see in the /var/lib/rancher/k3s/server/db/snapshots that will maintain the retention
```
ls /var/lib/rancher/server/db/snapshots
```

If you are using AWS, you can just reboot the machine to have another name, and just restarted the cluster, it will still delete the snapshot inside `/var/lib/rancher/server/db/snapshots` and maintain the retention

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

* https://github.com/rancher/rke2/issues/4537

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

* This fix was found in the Issue Validations from QA