### PR TITLE
Bump helm-controller/klipper-helm versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,7 +108,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/json-iterator/go v1.1.12
-	github.com/k3s-io/helm-controller v0.15.2
+	github.com/k3s-io/helm-controller v0.15.4
 	github.com/k3s-io/kine v0.10.2
 	github.com/klauspost/compress v1.16.6
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/k3s-io/etcd/raft/v3 v3.5.9-k3s1 h1:nlix2+EM1UDofoHgp/X2VHzMvJW7oYbZbE
 github.com/k3s-io/etcd/raft/v3 v3.5.9-k3s1/go.mod h1:WnFkqzFdZua4LVlVXQEGhmooLeyS7mqzS4Pf4BCVqXg=
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZe8rfaBPfbXo=
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
-github.com/k3s-io/helm-controller v0.15.2 h1:H5OWiNPhp9ZoyZOldt0ewq7wTy4UnU9j7DHdb7swi0Q=
-github.com/k3s-io/helm-controller v0.15.2/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
+github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
+github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
 github.com/k3s-io/kine v0.10.2 h1:aN2taL3BUSPZ4D+36opCn4PGlNZ+lkduk5Oz+/ZYhqA=
 github.com/k3s-io/kine v0.10.2/go.mod h1:JDJpiaFlxltCNqqWCBrP+/pbAGzJqbG1Y1DsHqM3X9U=
 github.com/k3s-io/klog/v2 v2.90.1-k3s1 h1:QOJ/1xi4ERgpPGmSI3n1f989XjII+OvPdgdiMOKqV9s=

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,4 +1,4 @@
-docker.io/rancher/klipper-helm:v0.8.0-build20230510
+docker.io/rancher/klipper-helm:v0.8.2-build20230815
 docker.io/rancher/klipper-lb:v0.4.4
 docker.io/rancher/local-path-provisioner:v0.0.24
 docker.io/rancher/mirrored-coredns-coredns:1.10.1


### PR DESCRIPTION
#### Proposed Changes ####

Bump helm-controller/klipper-helm versions

* https://github.com/k3s-io/klipper-helm/pull/68

> Updates helm to v3.12.3, and plugins to versions that also use helm v3.12.3 and fixed versions of client-go.
>
> Pulls in fix for https://github.com/helm/helm/issues/12061: crash in kubernetes client libraries when older releases of prometheus-adapter's `v1beta1.custom.metrics.k8s.io` APIService is present in the cluster.

#### Types of Changes ####

version bump; bugfix

#### Verification ####

check image version

#### Testing ####

#### Linked Issues ####

* 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The version of `helm` used by the bundled helm controller's job image has been updated to v3.12.3
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
