### PR TITLE
Fix error reporting

### DIFF
--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -93,7 +93,7 @@ func Run(ctx context.Context, cfg *config.Node) error {
 
 		addDeathSig(cmd)
 		if err := cmd.Run(); err != nil {
-			fmt.Fprintf(os.Stderr, "containerd: %s\n", err)
+			logrus.Errorf("containerd exited: %s", err)
 		}
 		os.Exit(1)
 	}()


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Use logrus to report the error instead of fmt to avoid an rke2 windows bug.

This fixes: https://github.com/rancher/rke2/issues/4693

To report stuff on Windows Event Logger, we are using a logrus hook, i.e. any log created by logrus, gets printed in the Event Tracing for Windows (EWT) (some sort of journalctl). However, anything else is dropped, e.g. fmt messages.

https://github.com/rancher/wins/blob/main/pkg/logs/etw.go#L125-L132

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Try breaking something in containerd/k3s and check that it gets reported correctly in journalctl

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->
The bug is in rke2

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/rancher/rke2/issues/4693
https://github.com/k3s-io/k3s/issues/8251

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
