### PR TITLE
[release-1.24] Add new CLI flag to enable TLS SAN CN filtering

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	KubeConfigMode           string
 	HelmJobImage             string
 	TLSSan                   cli.StringSlice
+	TLSSanSecurity           bool
 	BindAddress              string
 	EnablePProf              bool
 	ExtraAPIArgs             cli.StringSlice
@@ -200,6 +201,11 @@ var ServerFlags = []cli.Flag{
 		Name:  "tls-san",
 		Usage: "(listener) Add additional hostnames or IPv4/IPv6 addresses as Subject Alternative Names on the server TLS cert",
 		Value: &ServerConfig.TLSSan,
+	},
+	&cli.BoolFlag{
+		Name:        "tls-san-security",
+		Usage:       "(listener) Protect the server TLS cert by refusing to add Subject Alternative Names not associated with the kubernetes apiserver service, server nodes, or values of the tls-san option (default: false)",
+		Destination: &ServerConfig.TLSSanSecurity,
 	},
 	DataDirFlag,
 	ClusterCIDR,

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -122,6 +122,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.Rootless = cfg.Rootless
 	serverConfig.ControlConfig.ServiceLBNamespace = cfg.ServiceLBNamespace
 	serverConfig.ControlConfig.SANs = util.SplitStringSlice(cfg.TLSSan)
+	serverConfig.ControlConfig.SANSecurity = cfg.TLSSanSecurity
 	serverConfig.ControlConfig.BindAddress = cfg.BindAddress
 	serverConfig.ControlConfig.SupervisorPort = cfg.SupervisorPort
 	serverConfig.ControlConfig.HTTPSPort = cfg.HTTPSPort

--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -52,8 +52,10 @@ func (c *Cluster) newListener(ctx context.Context) (net.Listener, http.Handler, 
 		return nil, nil, err
 	}
 	c.config.SANs = append(c.config.SANs, "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc."+c.config.ClusterDomain)
-	c.config.Runtime.ClusterControllerStarts["server-cn-filter"] = func(ctx context.Context) {
-		registerAddressHandlers(ctx, c)
+	if c.config.SANSecurity {
+		c.config.Runtime.ClusterControllerStarts["server-cn-filter"] = func(ctx context.Context) {
+			registerAddressHandlers(ctx, c)
+		}
 	}
 	storage := tlsStorage(ctx, c.config.DataDir, c.config.Runtime)
 	return wrapHandler(dynamiclistener.NewListenerWithChain(tcp, storage, certs, key, dynamiclistener.Config{

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -219,6 +219,7 @@ type Control struct {
 
 	BindAddress string
 	SANs        []string
+	SANSecurity bool
 	PrivateIP   string
 	Runtime     *ControlRuntime `json:"-"`
 }


### PR DESCRIPTION
#### Proposed Changes ####

Add new CLI flag to enable TLS SAN CN filtering.

Flag defaults to true on 1.28+, false on older branches.

#### Types of Changes ####

security, bugfix

#### Verification ####

See testing steps from https://github.com/k3s-io/k3s/issues/7312 - setting the flag to false should retain previous behavior.

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8256

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added a new `--tls-san-security` option. This flag defaults to false, but can be set to true to disable automatically adding SANs to the server's TLS certificate to satisfy any hostname requested by a client.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
