### PR TITLE
Server Token Rotation

### DIFF
--- a/cmd/cert/main.go
+++ b/cmd/cert/main.go
@@ -15,11 +15,9 @@ import (
 func main() {
 	app := cmds.NewApp()
 	app.Commands = []cli.Command{
-		cmds.NewCertCommand(
-			cmds.NewCertSubcommands(
-				cert.Rotate,
-				cert.RotateCA,
-			),
+		cmds.NewCertCommands(
+			cert.Rotate,
+			cert.RotateCA,
 		),
 	}
 

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -73,11 +73,9 @@ func main() {
 			secretsencryptCommand,
 			secretsencryptCommand,
 		),
-		cmds.NewCertCommand(
-			cmds.NewCertSubcommands(
-				certCommand,
-				certCommand,
-			),
+		cmds.NewCertCommands(
+			certCommand,
+			certCommand,
 		),
 		cmds.NewCompletionCommand(internalCLIAction(version.Program+"-completion", dataDir, os.Args)),
 	}

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -57,6 +57,7 @@ func main() {
 			tokenCommand,
 			tokenCommand,
 			tokenCommand,
+			tokenCommand,
 		),
 		cmds.NewEtcdSnapshotCommands(
 			etcdsnapshotCommand,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -70,11 +70,9 @@ func main() {
 			secretsencrypt.Reencrypt,
 			secretsencrypt.RotateKeys,
 		),
-		cmds.NewCertCommand(
-			cmds.NewCertSubcommands(
-				cert.Rotate,
-				cert.RotateCA,
-			),
+		cmds.NewCertCommands(
+			cert.Rotate,
+			cert.RotateCA,
 		),
 		cmds.NewCompletionCommand(completion.Run),
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -54,6 +54,7 @@ func main() {
 			token.Delete,
 			token.Generate,
 			token.List,
+			token.Rotate,
 		),
 		cmds.NewEtcdSnapshotCommands(
 			etcdsnapshot.Delete,

--- a/cmd/token/main.go
+++ b/cmd/token/main.go
@@ -20,6 +20,7 @@ func main() {
 			token.Delete,
 			token.Generate,
 			token.List,
+			token.Rotate,
 		),
 	}
 

--- a/main.go
+++ b/main.go
@@ -47,11 +47,9 @@ func main() {
 			secretsencrypt.Reencrypt,
 			secretsencrypt.RotateKeys,
 		),
-		cmds.NewCertCommand(
-			cmds.NewCertSubcommands(
-				cert.Rotate,
-				cert.RotateCA,
-			),
+		cmds.NewCertCommands(
+			cert.Rotate,
+			cert.RotateCA,
 		),
 		cmds.NewCompletionCommand(completion.Run),
 	}

--- a/pkg/cli/cmds/certs.go
+++ b/pkg/cli/cmds/certs.go
@@ -54,33 +54,29 @@ var (
 	}
 )
 
-func NewCertCommand(subcommands []cli.Command) cli.Command {
+func NewCertCommands(rotate, rotateCA func(ctx *cli.Context) error) cli.Command {
 	return cli.Command{
 		Name:            CertCommand,
 		Usage:           "Manage K3s certificates",
 		SkipFlagParsing: false,
 		SkipArgReorder:  true,
-		Subcommands:     subcommands,
-	}
-}
-
-func NewCertSubcommands(rotate, rotateCA func(ctx *cli.Context) error) []cli.Command {
-	return []cli.Command{
-		{
-			Name:            "rotate",
-			Usage:           "Rotate " + version.Program + " component certificates on disk",
-			SkipFlagParsing: false,
-			SkipArgReorder:  true,
-			Action:          rotate,
-			Flags:           CertRotateCommandFlags,
-		},
-		{
-			Name:            "rotate-ca",
-			Usage:           "Write updated " + version.Program + " CA certificates to the datastore",
-			SkipFlagParsing: false,
-			SkipArgReorder:  true,
-			Action:          rotateCA,
-			Flags:           CertRotateCACommandFlags,
+		Subcommands: []cli.Command{
+			{
+				Name:            "rotate",
+				Usage:           "Rotate " + version.Program + " component certificates on disk",
+				SkipFlagParsing: false,
+				SkipArgReorder:  true,
+				Action:          rotate,
+				Flags:           CertRotateCommandFlags,
+			},
+			{
+				Name:            "rotate-ca",
+				Usage:           "Write updated " + version.Program + " CA certificates to the datastore",
+				SkipFlagParsing: false,
+				SkipArgReorder:  true,
+				Action:          rotateCA,
+				Flags:           CertRotateCACommandFlags,
+			},
 		},
 	}
 }

--- a/pkg/cli/cmds/token.go
+++ b/pkg/cli/cmds/token.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"time"
 
+	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/urfave/cli"
 )
 
@@ -12,6 +13,7 @@ const TokenCommand = "token"
 type Token struct {
 	Description string
 	Kubeconfig  string
+	ServerURL   string
 	Token       string
 	Output      string
 	Groups      cli.StringSlice
@@ -32,7 +34,7 @@ var (
 	}
 )
 
-func NewTokenCommands(create, delete, generate, list func(ctx *cli.Context) error) cli.Command {
+func NewTokenCommands(create, delete, generate, list, rotate func(ctx *cli.Context) error) cli.Command {
 	return cli.Command{
 		Name:            TokenCommand,
 		Usage:           "Manage bootstrap tokens",
@@ -91,6 +93,27 @@ func NewTokenCommands(create, delete, generate, list func(ctx *cli.Context) erro
 				SkipFlagParsing: false,
 				SkipArgReorder:  true,
 				Action:          list,
+			},
+			{
+				Name:  "rotate",
+				Usage: "Rotate original server token with a new bootstrap token",
+				Flags: append(TokenFlags,
+					&cli.StringFlag{
+						Name:        "token,t",
+						Usage:       "(cluster) Shared secret used to join a server or agent to a cluster",
+						Destination: &TokenConfig.Token,
+						EnvVar:      version.ProgramUpper + "_TOKEN",
+					},
+					&cli.StringFlag{
+						Name:        "server, s",
+						Usage:       "(cluster) Server to connect to",
+						Destination: &TokenConfig.ServerURL,
+						EnvVar:      version.ProgramUpper + "_URL",
+						Value:       "https://127.0.0.1:6443",
+					}),
+				SkipFlagParsing: false,
+				SkipArgReorder:  true,
+				Action:          rotate,
 			},
 		},
 	}

--- a/pkg/cli/cmds/token.go
+++ b/pkg/cli/cmds/token.go
@@ -15,6 +15,7 @@ type Token struct {
 	Kubeconfig  string
 	ServerURL   string
 	Token       string
+	NewToken    string
 	Output      string
 	Groups      cli.StringSlice
 	Usages      cli.StringSlice
@@ -100,7 +101,7 @@ func NewTokenCommands(create, delete, generate, list, rotate func(ctx *cli.Conte
 				Flags: append(TokenFlags,
 					&cli.StringFlag{
 						Name:        "token,t",
-						Usage:       "(cluster) Shared secret used to join a server or agent to a cluster",
+						Usage:       "Existing token used to join a server or agent to a cluster",
 						Destination: &TokenConfig.Token,
 						EnvVar:      version.ProgramUpper + "_TOKEN",
 					},
@@ -110,6 +111,11 @@ func NewTokenCommands(create, delete, generate, list, rotate func(ctx *cli.Conte
 						Destination: &TokenConfig.ServerURL,
 						EnvVar:      version.ProgramUpper + "_URL",
 						Value:       "https://127.0.0.1:6443",
+					},
+					&cli.StringFlag{
+						Name:        "new-token",
+						Usage:       "New token that replaces existing token",
+						Destination: &TokenConfig.NewToken,
 					}),
 				SkipFlagParsing: false,
 				SkipArgReorder:  true,

--- a/pkg/cli/cmds/token.go
+++ b/pkg/cli/cmds/token.go
@@ -116,10 +116,6 @@ func NewTokenCommands(create, delete, generate, list, rotate func(ctx *cli.Conte
 						Name:        "new-token",
 						Usage:       "New token that replaces existing token",
 						Destination: &TokenConfig.NewToken,
-					},
-					&cli.BoolFlag{
-						Name:  "f,force",
-						Usage: "Bypass user prompt warnings",
 					}),
 				SkipFlagParsing: false,
 				SkipArgReorder:  true,

--- a/pkg/cli/cmds/token.go
+++ b/pkg/cli/cmds/token.go
@@ -116,6 +116,10 @@ func NewTokenCommands(create, delete, generate, list, rotate func(ctx *cli.Conte
 						Name:        "new-token",
 						Usage:       "New token that replaces existing token",
 						Destination: &TokenConfig.NewToken,
+					},
+					&cli.BoolFlag{
+						Name:  "f,force",
+						Usage: "Bypass user prompt warnings",
 					}),
 				SkipFlagParsing: false,
 				SkipArgReorder:  true,

--- a/pkg/cli/token/token.go
+++ b/pkg/cli/token/token.go
@@ -153,7 +153,11 @@ func Rotate(app *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	b, err := json.Marshal(server.ServerTokenRequest{Action: pointer.String("rotate")})
+	b, err := json.Marshal(server.ServerTokenRequest{
+		Action:   pointer.String("rotate"),
+		NewToken: pointer.String(cmds.TokenConfig.NewToken),
+	})
+	fmt.Println(cmds.TokenConfig.NewToken)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/token/token.go
+++ b/pkg/cli/token/token.go
@@ -153,11 +153,11 @@ func Rotate(app *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	b, err := json.Marshal(server.ServerTokenRequest{Rotate: pointer.String("rotate")})
+	b, err := json.Marshal(server.ServerTokenRequest{Action: pointer.String("rotate")})
 	if err != nil {
 		return err
 	}
-	if err = info.Put("/v1-"+version.Program+"/token/rotate", b); err != nil {
+	if err = info.Put("/v1-"+version.Program+"/token", b); err != nil {
 		return err
 	}
 	fmt.Println("rotating token")

--- a/pkg/cli/token/token.go
+++ b/pkg/cli/token/token.go
@@ -1,7 +1,6 @@
 package token
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -20,7 +19,6 @@ import (
 	"github.com/k3s-io/k3s/pkg/util"
 	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -151,13 +149,7 @@ func Rotate(app *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	if !app.Bool("force") {
-		warning := fmt.Sprint("\033[33mWARNING\033[0m: This will replace the existing token with a new one.",
-			"Recommend keeping a record of the old token. If restoring from a snapshot, you must use the token associated with that snapshot.")
-		if !askContinue(warning) {
-			return nil
-		}
-	}
+	fmt.Println("\033[33mWARNING\033[0m: Recommended to keep a record of the old token. If restoring from a snapshot, you must use the token associated with that snapshot.")
 	info, err := serverAccess(&cmds.TokenConfig)
 	if err != nil {
 		return err
@@ -176,26 +168,6 @@ func Rotate(app *cli.Context) error {
 	time.Sleep(1 * time.Second)
 	fmt.Println("Token rotated, restart k3s with new token")
 	return nil
-}
-
-func askContinue(prefix string) bool {
-	reader := bufio.NewReader(os.Stdin)
-
-	for i := 0; i < 3; i++ {
-		fmt.Printf("%s Continue: [y/n]: \n", prefix)
-
-		resp, err := reader.ReadString('\n')
-		if err != nil {
-			logrus.Fatal(err)
-		}
-		resp = strings.ToLower(strings.TrimSpace(resp))
-		if resp == "y" || resp == "yes" {
-			return true
-		} else if resp == "n" || resp == "no" {
-			return false
-		}
-	}
-	return false
 }
 
 func serverAccess(cfg *cmds.Token) (*clientaccess.Info, error) {

--- a/pkg/cli/token/token.go
+++ b/pkg/cli/token/token.go
@@ -154,8 +154,7 @@ func Rotate(app *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	b, err := json.Marshal(server.ServerTokenRequest{
-		Action:   pointer.String("rotate"),
+	b, err := json.Marshal(server.TokenRotateRequest{
 		NewToken: pointer.String(cmds.TokenConfig.NewToken),
 	})
 	if err != nil {

--- a/pkg/cli/token/token.go
+++ b/pkg/cli/token/token.go
@@ -164,7 +164,8 @@ func Rotate(app *cli.Context) error {
 	if err = info.Put("/v1-"+version.Program+"/token", b); err != nil {
 		return err
 	}
-	fmt.Println("rotating token")
+	time.Sleep(1 * time.Second)
+	fmt.Println("token rotated, restart k3s with new token")
 	return nil
 }
 

--- a/pkg/cli/token/token.go
+++ b/pkg/cli/token/token.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -19,6 +20,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/util"
 	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -149,6 +151,13 @@ func Rotate(app *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
+	if !app.Bool("force") {
+		warning := fmt.Sprint("\033[33mWARNING\033[0m: This will replace the existing token with a new one.",
+			"Recommend keeping a record of the old token. If restoring from a snapshot, you must use the token associated with that snapshot.")
+		if !askContinue(warning) {
+			return nil
+		}
+	}
 	info, err := serverAccess(&cmds.TokenConfig)
 	if err != nil {
 		return err
@@ -165,8 +174,28 @@ func Rotate(app *cli.Context) error {
 	}
 	// wait for etcd db propagation delay
 	time.Sleep(1 * time.Second)
-	fmt.Println("token rotated, restart k3s with new token")
+	fmt.Println("Token rotated, restart k3s with new token")
 	return nil
+}
+
+func askContinue(prefix string) bool {
+	reader := bufio.NewReader(os.Stdin)
+
+	for i := 0; i < 3; i++ {
+		fmt.Printf("%s Continue: [y/n]: \n", prefix)
+
+		resp, err := reader.ReadString('\n')
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		resp = strings.ToLower(strings.TrimSpace(resp))
+		if resp == "y" || resp == "yes" {
+			return true
+		} else if resp == "n" || resp == "no" {
+			return false
+		}
+	}
+	return false
 }
 
 func serverAccess(cfg *cmds.Token) (*clientaccess.Info, error) {

--- a/pkg/cli/token/token.go
+++ b/pkg/cli/token/token.go
@@ -157,13 +157,13 @@ func Rotate(app *cli.Context) error {
 		Action:   pointer.String("rotate"),
 		NewToken: pointer.String(cmds.TokenConfig.NewToken),
 	})
-	fmt.Println(cmds.TokenConfig.NewToken)
 	if err != nil {
 		return err
 	}
 	if err = info.Put("/v1-"+version.Program+"/token", b); err != nil {
 		return err
 	}
+	// wait for etcd db propagation delay
 	time.Sleep(1 * time.Second)
 	fmt.Println("token rotated, restart k3s with new token")
 	return nil

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -105,7 +105,7 @@ func Save(ctx context.Context, config *config.Control, override bool) error {
 	if err != nil {
 		return err
 	}
-	// I think I need to inject a new token via Save
+
 	// If there's an empty bootstrap key, then we've locked it and can override.
 	if currentKey != nil && len(currentKey.Data) == 0 {
 		logrus.Info("Bootstrap key lock is held")
@@ -282,7 +282,7 @@ func getBootstrapKeyFromStorage(ctx context.Context, storageClient client.Client
 	}
 	for _, bootstrapKV := range bootstrapList {
 		// ensure bootstrap is stored in the current token's key
-		logrus.Infof("checking bootstrap key %s against %s", string(bootstrapKV.Key), tokenKey)
+		logrus.Debugf("checking bootstrap key %s against %s", string(bootstrapKV.Key), tokenKey)
 		if string(bootstrapKV.Key) == tokenKey {
 			return &bootstrapKV, false, nil
 		}
@@ -330,9 +330,9 @@ func normalizeToken(token string) (string, error) {
 func migrateOldTokens(ctx context.Context, bootstrapList []client.Value, storageClient client.Client, emptyStringKey, tokenKey, token, oldToken string) error {
 	oldTokenKey := storageKey(oldToken)
 
-	logrus.Info("migrateOldTokens: t: ", token, " tK: ", tokenKey, " ot: ", oldToken, " otK: ", oldTokenKey)
 	for _, bootstrapKV := range bootstrapList {
 		// checking for empty string bootstrap key
+		logrus.Debug("Comparing ", string(bootstrapKV.Key), " to ", oldTokenKey)
 		if string(bootstrapKV.Key) == emptyStringKey {
 			logrus.Warn("Bootstrap data encrypted with empty string, deleting and resaving with token")
 			if err := doMigrateToken(ctx, storageClient, bootstrapKV, "", emptyStringKey, token, tokenKey); err != nil {
@@ -344,7 +344,6 @@ func migrateOldTokens(ctx context.Context, bootstrapList []client.Value, storage
 				return err
 			}
 		}
-		logrus.Info("Comparing ", string(bootstrapKV.Key), " to ", oldTokenKey)
 	}
 
 	return nil

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -22,19 +22,13 @@ import (
 const maxBootstrapWaitAttempts = 5
 
 func RotateBootstrapToken(ctx context.Context, config *config.Control, oldToken string) error {
-	logrus.Info("Rotating bootstrap token")
 
-	token := config.Token
-	logrus.Info("SAVE")
-	logrus.Info("Using token: ", token)
-	if token == "" {
-		tokenFromFile, err := readTokenFromFile(config.Runtime.ServerToken, config.Runtime.ServerCA, config.DataDir)
-		if err != nil {
-			return err
-		}
-		token = tokenFromFile
-		logrus.Info("Token from file: ", token)
+	logrus.Info("RotateBootstrapToken")
+	token, err := readTokenFromFile(config.Runtime.ServerToken, config.Runtime.ServerCA, config.DataDir)
+	if err != nil {
+		return err
 	}
+	logrus.Info("Token from file: ", token)
 	normalizedToken, err := normalizeToken(token)
 	if err != nil {
 		return err

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -45,9 +45,6 @@ func RotateBootstrapToken(ctx context.Context, config *config.Control, oldToken 
 	if err := wait.PollImmediateUntilWithContext(ctx, 5*time.Second, func(ctx context.Context) (bool, error) {
 		bootstrapList, err = storageClient.List(ctx, "/bootstrap", 0)
 		if err != nil {
-			if errors.Is(err, rpctypes.ErrGPRCNotSupportedForLearner) {
-				return false, nil
-			}
 			return false, err
 		}
 		return true, nil
@@ -59,7 +56,7 @@ func RotateBootstrapToken(ctx context.Context, config *config.Control, oldToken 
 	if err != nil {
 		return err
 	}
-	// resuse the existing migration function to reencrypt bootstrap data with new token
+	// reuse the existing migration function to reencrypt bootstrap data with new token
 	if err := migrateTokens(ctx, bootstrapList, storageClient, "", tokenKey, normalizedToken, normalizedOldToken); err != nil {
 		return err
 	}

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -239,8 +239,6 @@ func genUsers(config *config.Control) error {
 		return err
 	}
 
-	logrus.Info("HELP ", passwd)
-
 	if err := migratePassword(passwd); err != nil {
 		return err
 	}
@@ -250,11 +248,8 @@ func genUsers(config *config.Control) error {
 	if err != nil {
 		return err
 	}
-	logrus.Info("HELP 1 ", serverPass)
 
 	nodePass := getNodePass(config, serverPass)
-
-	logrus.Info("HELP 2 ", nodePass)
 
 	if err := passwd.EnsureUser("node", version.Program+":agent", nodePass); err != nil {
 		return err

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -239,16 +239,22 @@ func genUsers(config *config.Control) error {
 		return err
 	}
 
+	logrus.Info("HELP ", passwd)
+
 	if err := migratePassword(passwd); err != nil {
 		return err
 	}
 
+	// if no token is provided on bootstrap, we generate a random token
 	serverPass, err := getServerPass(passwd, config)
 	if err != nil {
 		return err
 	}
+	logrus.Info("HELP 1 ", serverPass)
 
 	nodePass := getNodePass(config, serverPass)
+
+	logrus.Info("HELP 2 ", nodePass)
 
 	if err := passwd.EnsureUser("node", version.Program+":agent", nodePass); err != nil {
 		return err

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -85,6 +85,7 @@ func router(ctx context.Context, config *Config, cfg *cmds.Server) http.Handler 
 	serverAuthed.Path(prefix + "/cert/cacerts").Handler(caCertReplaceHandler(serverConfig))
 	serverAuthed.Path("/db/info").Handler(nodeAuthed)
 	serverAuthed.Path(prefix + "/server-bootstrap").Handler(bootstrapHandler(serverConfig.Runtime))
+	serverAuthed.Path(prefix + "/token").Handler(tokenRequestHandler(ctx, serverConfig))
 
 	systemAuthed := mux.NewRouter().SkipClean(true)
 	systemAuthed.NotFoundHandler = serverAuthed

--- a/pkg/server/token.go
+++ b/pkg/server/token.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
 
 	"github.com/k3s-io/k3s/pkg/cluster"
@@ -65,7 +64,6 @@ func tokenRotate(ctx context.Context, server *config.Control, newToken string) e
 		return err
 	}
 
-	logrus.Info("BEFORE ", passwd)
 	if err != nil {
 		return err
 	}
@@ -83,28 +81,15 @@ func tokenRotate(ctx context.Context, server *config.Control, newToken string) e
 	// if err := passwd.EnsureUser("server", version.Program+":server", newToken); err != nil {
 	// 	return err
 	// }
-	// logrus.Info("AFTER ", passwd)
 
 	if err := passwd.Write(server.Runtime.PasswdFile); err != nil {
 		return err
 	}
 
 	serverTokenFile := filepath.Join(server.DataDir, "token")
-	b, err := os.ReadFile(serverTokenFile)
-	if err != nil {
-		return err
-	}
-	logrus.Debug("Old Token File: ", string(b))
-
 	if err := writeToken("server:"+newToken, serverTokenFile, server.Runtime.ServerCA); err != nil {
 		return err
 	}
-
-	b, err = os.ReadFile(serverTokenFile)
-	if err != nil {
-		return err
-	}
-	logrus.Debug("New Token File: ", string(b))
 
 	if err := cluster.RotateBootstrapToken(ctx, server, oldToken); err != nil {
 		return err

--- a/pkg/server/token.go
+++ b/pkg/server/token.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/k3s-io/k3s/pkg/cluster"
+	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/k3s-io/k3s/pkg/passwd"
+	"github.com/k3s-io/k3s/pkg/util"
+	"github.com/sirupsen/logrus"
+)
+
+type ServerTokenRequest struct {
+	Action *string `json:"stage,omitempty"`
+}
+
+func getServerTokenRequest(req *http.Request) (ServerTokenRequest, error) {
+	b, err := io.ReadAll(req.Body)
+	if err != nil {
+		return ServerTokenRequest{}, err
+	}
+	result := ServerTokenRequest{}
+	err = json.Unmarshal(b, &result)
+	return result, err
+}
+
+func tokenRequestHandler(ctx context.Context, server *config.Control) http.Handler {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		if req.TLS == nil || req.Method != http.MethodPut {
+			resp.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		logrus.Info("Received token request")
+		var err error
+		b := []byte{}
+		var token string
+		sTokenReq, err := getServerTokenRequest(req)
+		if err != nil {
+			resp.WriteHeader(http.StatusBadRequest)
+			resp.Write([]byte(err.Error()))
+			return
+		}
+
+		if *sTokenReq.Action == "rotate" {
+			token, err = tokenRotate(ctx, server)
+			b = []byte(token)
+		} else {
+			err = fmt.Errorf("unknown action %s requested", *sTokenReq.Action)
+		}
+
+		if err != nil {
+			genErrorMessage(resp, http.StatusInternalServerError, err, "token")
+			return
+		}
+		resp.WriteHeader(http.StatusOK)
+		resp.Write(b)
+	})
+}
+
+func tokenRotate(ctx context.Context, server *config.Control) (string, error) {
+	passwd, err := passwd.Read(server.Runtime.PasswdFile)
+	if err != nil {
+		return "", err
+	}
+
+	logrus.Info("BEFORE ", passwd)
+	if err != nil {
+		return "", err
+	}
+	oldToken, found := passwd.Pass("server")
+	if !found {
+		return "", fmt.Errorf("server token not found")
+	}
+	newToken, err := util.Random(16)
+	if err != nil {
+		return "", err
+	}
+	// if err := passwd.EnsureUser("server", version.Program+":server", newToken); err != nil {
+	// 	return "", err
+	// }
+	// logrus.Info("AFTER ", passwd)
+
+	// if err := passwd.Write(server.Runtime.PasswdFile); err != nil {
+	// 	return "", err
+	// }
+
+	serverTokenFile := filepath.Join(server.DataDir, "token")
+	b, err := os.ReadFile(serverTokenFile)
+	if err != nil {
+		return "", err
+	}
+	logrus.Info("OLD TOKEN ", string(b))
+	if err := writeToken("server:"+newToken, serverTokenFile, server.Runtime.ServerCA); err != nil {
+		return "", err
+	}
+
+	b, err = os.ReadFile(serverTokenFile)
+	if err != nil {
+		return "", err
+	}
+	logrus.Info("NEW TOKEN ", string(b))
+
+	cluster.RotateBootstrapToken(ctx, server, oldToken)
+	// if err := cluster.Save(ctx, server, true); err != nil {
+	// 	return "", err
+	// }
+	return newToken, nil
+}

--- a/pkg/server/token.go
+++ b/pkg/server/token.go
@@ -16,17 +16,16 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type ServerTokenRequest struct {
-	Action   *string `json:"stage,omitempty"`
+type TokenRotateRequest struct {
 	NewToken *string `json:"newToken,omitempty"`
 }
 
-func getServerTokenRequest(req *http.Request) (ServerTokenRequest, error) {
+func getServerTokenRequest(req *http.Request) (TokenRotateRequest, error) {
 	b, err := io.ReadAll(req.Body)
 	if err != nil {
-		return ServerTokenRequest{}, err
+		return TokenRotateRequest{}, err
 	}
-	result := ServerTokenRequest{}
+	result := TokenRotateRequest{}
 	err = json.Unmarshal(b, &result)
 	return result, err
 }
@@ -45,13 +44,7 @@ func tokenRequestHandler(ctx context.Context, server *config.Control) http.Handl
 			resp.Write([]byte(err.Error()))
 			return
 		}
-		if *sTokenReq.Action == "rotate" {
-			err = tokenRotate(ctx, server, *sTokenReq.NewToken)
-		} else {
-			err = fmt.Errorf("unknown action %s requested", *sTokenReq.Action)
-		}
-
-		if err != nil {
+		if err = tokenRotate(ctx, server, *sTokenReq.NewToken); err != nil {
 			genErrorMessage(resp, http.StatusInternalServerError, err, "token")
 			return
 		}

--- a/tests/e2e/token/Vagrantfile
+++ b/tests/e2e/token/Vagrantfile
@@ -1,6 +1,6 @@
 ENV['VAGRANT_NO_PARALLEL'] = 'no'
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
-  ["server-0", "server-1", "server-2", "agent-0", "agent-1" ])
+  ["server-0", "server-1", "server-2", "agent-0", "agent-1"])
 NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
   ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
 GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")

--- a/tests/e2e/token/Vagrantfile
+++ b/tests/e2e/token/Vagrantfile
@@ -1,6 +1,6 @@
 ENV['VAGRANT_NO_PARALLEL'] = 'no'
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
-  ["server-0", "agent-0", "agent-1" ])
+  ["server-0", "server-1", "server-2", "agent-0", "agent-1" ])
 NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
   ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
 GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
@@ -34,6 +34,18 @@ def provision(vm, roles, role_num, node_num)
       k3s.args = "server "
       k3s.config = <<~YAML
         cluster-init: true
+        token: vagrant
+        node-external-ip: #{node_ip}
+        flannel-iface: eth1
+      YAML
+      k3s.env = ["K3S_KUBECONFIG_MODE=0644", install_type]
+    end
+  elsif roles.include?("server") && role_num != 0
+    vm.provision 'k3s-secondary-server', type: 'k3s', run: 'once' do |k3s|
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      k3s.args = "server"
+      k3s.config = <<~YAML
+        server: "https://#{NETWORK_PREFIX}.100:6443"
         token: vagrant
         node-external-ip: #{node_ip}
         flannel-iface: eth1

--- a/tests/e2e/token/token_test.go
+++ b/tests/e2e/token/token_test.go
@@ -3,7 +3,6 @@ package snapshotrestore
 import (
 	"flag"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -17,7 +16,7 @@ import (
 // generic/ubuntu2004, generic/centos7, generic/rocky8, opensuse/Leap-15.4.x86_64
 
 var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
-var serverCount = flag.Int("serverCount", 1, "number of server nodes")
+var serverCount = flag.Int("serverCount", 3, "number of server nodes")
 var agentCount = flag.Int("agentCount", 2, "number of agent nodes")
 var ci = flag.Bool("ci", false, "running on CI")
 var local = flag.Bool("local", false, "deploy a locally built K3s binary")
@@ -42,7 +41,7 @@ var _ = ReportAfterEach(e2e.GenReport)
 
 var _ = Describe("Use the token CLI to create and join agents", Ordered, func() {
 	Context("Agent joins with permanent token:", func() {
-		It("Starts up with no issues", func() {
+		FIt("Starts up with no issues", func() {
 			var err error
 			if *local {
 				serverNodeNames, agentNodeNames, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
@@ -58,7 +57,7 @@ var _ = Describe("Use the token CLI to create and join agents", Ordered, func() 
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Checks Node and Pod Status", func() {
+		FIt("Checks Node and Pod Status", func() {
 			fmt.Printf("\nFetching node status\n")
 			Eventually(func(g Gomega) {
 				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
@@ -163,7 +162,7 @@ var _ = AfterSuite(func() {
 		fmt.Println("FAILED!")
 	} else {
 		Expect(e2e.GetCoverageReport(append(serverNodeNames, agentNodeNames...))).To(Succeed())
-		Expect(e2e.DestroyCluster()).To(Succeed())
-		Expect(os.Remove(kubeConfigFile)).To(Succeed())
+		// Expect(e2e.DestroyCluster()).To(Succeed())
+		// Expect(os.Remove(kubeConfigFile)).To(Succeed())
 	}
 })

--- a/tests/e2e/token/token_test.go
+++ b/tests/e2e/token/token_test.go
@@ -154,8 +154,8 @@ var _ = Describe("Use the token CLI to create and join agents", Ordered, func() 
 	Context("Rotate server bootstrap token", func() {
 		serverToken := "1234"
 		It("Creates a new server token", func() {
-			Expect(e2e.RunCmdOnNode("k3s token rotate -t vagrant --new-token="+serverToken, serverNodeNames[0])).
-				To(ContainSubstring("token rotated, restart k3s with new token"))
+			Expect(e2e.RunCmdOnNode("k3s token rotate -f -t vagrant --new-token="+serverToken, serverNodeNames[0])).
+				To(ContainSubstring("Token rotated, restart k3s with new token"))
 		})
 		It("Restarts servers with the new token", func() {
 			cmd := fmt.Sprintf("sed -i 's/token:.*/token: %s/' /etc/rancher/k3s/config.yaml", serverToken)

--- a/tests/e2e/token/token_test.go
+++ b/tests/e2e/token/token_test.go
@@ -154,7 +154,7 @@ var _ = Describe("Use the token CLI to create and join agents", Ordered, func() 
 	Context("Rotate server bootstrap token", func() {
 		serverToken := "1234"
 		It("Creates a new server token", func() {
-			Expect(e2e.RunCmdOnNode("k3s token rotate -f -t vagrant --new-token="+serverToken, serverNodeNames[0])).
+			Expect(e2e.RunCmdOnNode("k3s token rotate -t vagrant --new-token="+serverToken, serverNodeNames[0])).
 				To(ContainSubstring("Token rotated, restart k3s with new token"))
 		})
 		It("Restarts servers with the new token", func() {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Adds a new subcommand `k3s token rotate` which enables a user to rotate the initial server token.
- Expands existing E2E token test to include this new command
- Compact CertCommand functions
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
New Feature
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Single node:
- Start k3s with token `1234`
- if root, with access to `/var/lib/rancher/k3s/server/token` run: `k3s token rotate --new-token=6789`
- if not root, or non access, run: `k3s token rotate --token 1234 --new-token=6789`
- Restart k3s with new token `6789`

HA:
- Start k3s servers with token `1234`
- `k3s token rotate --new-token=6789`
- Restart all k3s servers with new token `6789`
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
New Testlets in E2E test
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/8264
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
