### PR TITLE
[release-1.26] Enable netpol controller metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.25
 	github.com/Mirantis/cri-dockerd => github.com/k3s-io/cri-dockerd v0.3.4-k3s1 // k3s/release-1.27
-	github.com/cloudnativelabs/kube-router/v2 => github.com/brandond/kube-router/v2 v2.0.0-20230914231636-f157365f4bc9
+	github.com/cloudnativelabs/kube-router/v2 => github.com/brandond/kube-router/v2 v2.0.0-20230915164328-567753b41cea
 	github.com/containerd/containerd => github.com/k3s-io/containerd v1.7.3-k3s1
 	github.com/containerd/stargz-snapshotter => github.com/k3s-io/stargz-snapshotter v0.14.3-k3s1
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.25
 	github.com/Mirantis/cri-dockerd => github.com/k3s-io/cri-dockerd v0.3.4-k3s1 // k3s/release-1.27
-	github.com/cloudnativelabs/kube-router/v2 => github.com/brandond/kube-router/v2 v2.0.0-20230914060203-079f06df7f5d
+	github.com/cloudnativelabs/kube-router/v2 => github.com/brandond/kube-router/v2 v2.0.0-20230914231636-f157365f4bc9
 	github.com/containerd/containerd => github.com/k3s-io/containerd v1.7.3-k3s1
 	github.com/containerd/stargz-snapshotter => github.com/k3s-io/stargz-snapshotter v0.14.3-k3s1
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
@@ -124,7 +124,6 @@ require (
 	github.com/opencontainers/selinux v1.11.0
 	github.com/otiai10/copy v1.7.0
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.14.0
 	github.com/rancher/dynamiclistener v0.3.6-rc2
 	github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc
 	github.com/rancher/remotedialer v0.3.0
@@ -345,6 +344,7 @@ require (
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
+	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.39.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.25
 	github.com/Mirantis/cri-dockerd => github.com/k3s-io/cri-dockerd v0.3.4-k3s1 // k3s/release-1.27
-	github.com/cloudnativelabs/kube-router/v2 => github.com/k3s-io/kube-router/v2 v2.0.1-0.20230508174102-b42e5faded1c
+	github.com/cloudnativelabs/kube-router/v2 => github.com/brandond/kube-router/v2 v2.0.0-20230914060203-079f06df7f5d
 	github.com/containerd/containerd => github.com/k3s-io/containerd v1.7.3-k3s1
 	github.com/containerd/stargz-snapshotter => github.com/k3s-io/stargz-snapshotter v0.14.3-k3s1
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
@@ -124,6 +124,7 @@ require (
 	github.com/opencontainers/selinux v1.11.0
 	github.com/otiai10/copy v1.7.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.14.0
 	github.com/rancher/dynamiclistener v0.3.6-rc2
 	github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc
 	github.com/rancher/remotedialer v0.3.0
@@ -344,7 +345,6 @@ require (
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.39.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
-github.com/brandond/kube-router/v2 v2.0.0-20230914060203-079f06df7f5d h1:tx/zTZC9S8yWMNan4I0tf+IPMfNOCULxKtdfZVRr4fg=
-github.com/brandond/kube-router/v2 v2.0.0-20230914060203-079f06df7f5d/go.mod h1:zhLSRTL1M+0BqeDTRzT42ZtlFJH/d9xaGvXGQR4c2Gc=
+github.com/brandond/kube-router/v2 v2.0.0-20230914231636-f157365f4bc9 h1:3QpeNkHso5RoezvzvQRHdtGSqUOK+EuD+nEF/YmgZ00=
+github.com/brandond/kube-router/v2 v2.0.0-20230914231636-f157365f4bc9/go.mod h1:zhLSRTL1M+0BqeDTRzT42ZtlFJH/d9xaGvXGQR4c2Gc=
 github.com/bronze1man/goStrongswanVici v0.0.0-20201105010758-936f38b697fd h1:qn6a8rGrW+7p4ghypmYHZUKewXURuUDYxKqZxEoFjPc=
 github.com/bronze1man/goStrongswanVici v0.0.0-20201105010758-936f38b697fd/go.mod h1:fWUtBEPt2yjrr3WFhOqvajM8JSEU8bEeBcoeSCsKRpc=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
-github.com/brandond/kube-router/v2 v2.0.0-20230914231636-f157365f4bc9 h1:3QpeNkHso5RoezvzvQRHdtGSqUOK+EuD+nEF/YmgZ00=
-github.com/brandond/kube-router/v2 v2.0.0-20230914231636-f157365f4bc9/go.mod h1:zhLSRTL1M+0BqeDTRzT42ZtlFJH/d9xaGvXGQR4c2Gc=
+github.com/brandond/kube-router/v2 v2.0.0-20230915164328-567753b41cea h1:eEcnSZ3hMKCLNYszzDQEhnQc02wf9n5I9/St+xLl7O8=
+github.com/brandond/kube-router/v2 v2.0.0-20230915164328-567753b41cea/go.mod h1:zhLSRTL1M+0BqeDTRzT42ZtlFJH/d9xaGvXGQR4c2Gc=
 github.com/bronze1man/goStrongswanVici v0.0.0-20201105010758-936f38b697fd h1:qn6a8rGrW+7p4ghypmYHZUKewXURuUDYxKqZxEoFjPc=
 github.com/bronze1man/goStrongswanVici v0.0.0-20201105010758-936f38b697fd/go.mod h1:fWUtBEPt2yjrr3WFhOqvajM8JSEU8bEeBcoeSCsKRpc=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/brandond/kube-router/v2 v2.0.0-20230914060203-079f06df7f5d h1:tx/zTZC9S8yWMNan4I0tf+IPMfNOCULxKtdfZVRr4fg=
+github.com/brandond/kube-router/v2 v2.0.0-20230914060203-079f06df7f5d/go.mod h1:zhLSRTL1M+0BqeDTRzT42ZtlFJH/d9xaGvXGQR4c2Gc=
 github.com/bronze1man/goStrongswanVici v0.0.0-20201105010758-936f38b697fd h1:qn6a8rGrW+7p4ghypmYHZUKewXURuUDYxKqZxEoFjPc=
 github.com/bronze1man/goStrongswanVici v0.0.0-20201105010758-936f38b697fd/go.mod h1:fWUtBEPt2yjrr3WFhOqvajM8JSEU8bEeBcoeSCsKRpc=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
@@ -626,8 +628,6 @@ github.com/k3s-io/klog v1.0.0-k3s2 h1:yyvD2bQbxG7m85/pvNctLX2bUDmva5kOBvuZ77tTGB
 github.com/k3s-io/klog v1.0.0-k3s2/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 github.com/k3s-io/klog/v2 v2.80.1-k3s1 h1:mGMXURxxmabQurmtRhXuQTJ9jC0pvIhESSxRSymepS8=
 github.com/k3s-io/klog/v2 v2.80.1-k3s1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
-github.com/k3s-io/kube-router/v2 v2.0.1-0.20230508174102-b42e5faded1c h1:7IaKAByGXNvZAmhYlaHH2LiqOGWtPNVg8vKV1Xvlrek=
-github.com/k3s-io/kube-router/v2 v2.0.1-0.20230508174102-b42e5faded1c/go.mod h1:zhLSRTL1M+0BqeDTRzT42ZtlFJH/d9xaGvXGQR4c2Gc=
 github.com/k3s-io/kubernetes v1.26.8-k3s1 h1:d0I9SEQCe2vilxiS9JXz8p1HNB9vB8lhr9u7G/YTgj4=
 github.com/k3s-io/kubernetes v1.26.8-k3s1/go.mod h1:EBE8dfGfk2sZ3yzZVQjr1wQ/k28/wwaajL/1+77Cjmg=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/api v1.26.8-k3s1 h1:gS4kucc+D21BKul2s3YiBpRr7dfTmNxmFbaXSfk8EW0=

--- a/pkg/agent/netpol/netpol.go
+++ b/pkg/agent/netpol/netpol.go
@@ -65,7 +65,7 @@ func Run(ctx context.Context, nodeConfig *config.Node) error {
 	krConfig.EnableIPv6 = nodeConfig.AgentConfig.EnableIPv6
 	krConfig.NodePortRange = strings.ReplaceAll(nodeConfig.AgentConfig.ServiceNodePortRange.String(), "-", ":")
 	krConfig.HostnameOverride = nodeConfig.AgentConfig.NodeName
-	krConfig.MetricsEnabled = false
+	krConfig.MetricsEnabled = true
 	krConfig.RunFirewall = true
 	krConfig.RunRouter = false
 	krConfig.RunServiceProxy = false

--- a/pkg/agent/netpol/netpol.go
+++ b/pkg/agent/netpol/netpol.go
@@ -50,6 +50,10 @@ func Run(ctx context.Context, nodeConfig *config.Node) error {
 		return err
 	}
 
+	// Override default rate limits to prevent long delays in policy setup
+	restConfig.QPS = 100
+	restConfig.Burst = 150
+
 	client, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return err

--- a/pkg/agent/netpol/netpol.go
+++ b/pkg/agent/netpol/netpol.go
@@ -11,7 +11,9 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/cloudnativelabs/kube-router/v2/pkg/metrics"
 	"github.com/cloudnativelabs/kube-router/v2/pkg/version"
 
 	"github.com/cloudnativelabs/kube-router/v2/pkg/controllers/netpol"
@@ -26,7 +28,14 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/component-base/metrics/legacyregistry"
 )
+
+func init() {
+	// ensure that kube-router exposes metrics through the same registry used by Kubernetes components
+	metrics.DefaultRegisterer = legacyregistry.Registerer()
+	metrics.DefaultGatherer = legacyregistry.DefaultGatherer
+}
 
 // Run creates and starts a new instance of the kube-router network policy controller
 // The code in this function is cribbed from the upstream controller at:
@@ -118,22 +127,31 @@ func Run(ctx context.Context, nodeConfig *config.Node) error {
 		ipSetHandlers[v1core.IPv6Protocol] = ipset
 	}
 
-	// Start kube-router healthcheck server. Netpol requires it
+	// Start kube-router healthcheck controller; netpol requires it
 	hc, err := healthcheck.NewHealthController(krConfig)
 	if err != nil {
 		return err
 	}
 
-	// Initialize all healthcheck timers. Otherwise, the system reports incorrect heartbeat missing messages
+	// Start kube-router metrics controller to avoid complaints about metrics heartbeat missing
+	mc, err := metrics.NewMetricsController(krConfig)
+	if err != nil {
+		return nil
+	}
+
+	// Initialize all healthcheck timers. Otherwise, the system reports heartbeat missing messages
 	hc.SetAlive()
 
 	wg.Add(1)
 	go hc.RunCheck(healthCh, stopCh, &wg)
 
+	wg.Add(1)
+	go metricsRunCheck(mc, healthCh, stopCh, &wg)
+
 	npc, err := netpol.NewNetworkPolicyController(client, krConfig, podInformer, npInformer, nsInformer, &sync.Mutex{},
 		iptablesCmdHandlers, ipSetHandlers)
 	if err != nil {
-		return errors.Wrap(err, "unable to initialize Network Policy Controller")
+		return errors.Wrap(err, "unable to initialize network policy controller")
 	}
 
 	podInformer.AddEventHandler(npc.PodEventHandler)
@@ -141,8 +159,29 @@ func Run(ctx context.Context, nodeConfig *config.Node) error {
 	npInformer.AddEventHandler(npc.NetworkPolicyEventHandler)
 
 	wg.Add(1)
-	logrus.Infof("Starting the netpol controller version %s, built on %s, %s", version.Version, version.BuildDate, runtime.Version())
+	logrus.Infof("Starting network policy controller version %s, built on %s, %s", version.Version, version.BuildDate, runtime.Version())
 	go npc.Run(healthCh, stopCh, &wg)
 
 	return nil
+}
+
+// metricsRunCheck is a stub version of mc.Run() that doesn't start up a dedicated http server.
+func metricsRunCheck(mc *metrics.Controller, healthChan chan<- *healthcheck.ControllerHeartbeat, stopCh <-chan struct{}, wg *sync.WaitGroup) {
+	t := time.NewTicker(3 * time.Second)
+	defer wg.Done()
+
+	// register metrics for this controller
+	metrics.BuildInfo.WithLabelValues(runtime.Version(), version.Version).Set(1)
+	metrics.DefaultRegisterer.MustRegister(metrics.BuildInfo)
+
+	for {
+		healthcheck.SendHeartBeat(healthChan, "MC")
+		select {
+		case <-stopCh:
+			t.Stop()
+			return
+		case <-t.C:
+			logrus.Debugf("Kube-router network policy controller metrics tick")
+		}
+	}
 }

--- a/scripts/build
+++ b/scripts/build
@@ -14,7 +14,7 @@ PKG_CRICTL="github.com/kubernetes-sigs/cri-tools/pkg"
 PKG_K8S_BASE="k8s.io/component-base"
 PKG_K8S_CLIENT="k8s.io/client-go/pkg"
 PKG_CNI_PLUGINS="github.com/containernetworking/plugins"
-PKG_KUBE_ROUTER="github.com/cloudnativelabs/kube-router"
+PKG_KUBE_ROUTER="github.com/cloudnativelabs/kube-router/v2"
 PKG_CRI_DOCKERD="github.com/Mirantis/cri-dockerd"
 PKG_ETCD="go.etcd.io/etcd"
 


### PR DESCRIPTION

#### Proposed Changes ####

Enable metrics support within the network policy controller

#### Types of Changes ####

new feature

#### Verification ####

See linked issue

Check for metrics:
```
kube_router_controller_iptables_sync_time
kube_router_controller_policy_chains_sync_time
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Metrics are now available for network policy controller sync loop timing
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
