### PR TITLE
Switch build target from main.go to a package.

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -133,7 +133,7 @@ if [ ! -x ${INSTALLBIN}/cni ]; then
 fi
 
 echo Building k3s
-CGO_ENABLED=1 "${GO}" build $BLDFLAGS -tags "$TAGS" -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s ./cmd/server
+CGO_ENABLED=1 "${GO}" build $BLDFLAGS -tags "$TAGS" -buildvcs=false -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s ./cmd/server
 ln -s k3s ./bin/containerd
 ln -s k3s ./bin/crictl
 ln -s k3s ./bin/ctr

--- a/scripts/build
+++ b/scripts/build
@@ -133,7 +133,7 @@ if [ ! -x ${INSTALLBIN}/cni ]; then
 fi
 
 echo Building k3s
-CGO_ENABLED=1 "${GO}" build $BLDFLAGS -tags "$TAGS" -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s ./cmd/server/main.go
+CGO_ENABLED=1 "${GO}" build $BLDFLAGS -tags "$TAGS" -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s ./cmd/server
 ln -s k3s ./bin/containerd
 ln -s k3s ./bin/crictl
 ln -s k3s ./bin/ctr


### PR DESCRIPTION
#### Proposed Changes ####

This changes the way go embeds versions in the binary. Today, Grype can't determine which k3s version is used in k3s itself because it's built with the file. Here's what a scan looks like:

```
NAME                   INSTALLED  FIXED-IN  TYPE       VULNERABILITY        SEVERITY
github.com/k3s-io/k3s  (devel)    1.24.17   go-module  GHSA-m4hf-6vgr-75r2  High
```

If you make this switch, the scanner can correctly determine the version instead of (devel).

#### Types of Changes ####

Bugfix

#### Verification ####

Build k3s and scan it.

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8618

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
