### PR TITLE
[release-1.25] backport containerd bump and and test fixes

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -9,7 +9,6 @@ GO=${GO-go}
 
 PKG="github.com/k3s-io/k3s"
 PKG_CONTAINERD="github.com/containerd/containerd"
-PKG_K3S_CONTAINERD="github.com/k3s-io/containerd"
 PKG_CRICTL="github.com/kubernetes-sigs/cri-tools/pkg"
 PKG_K8S_BASE="k8s.io/component-base"
 PKG_K8S_CLIENT="k8s.io/client-go/pkg"
@@ -36,7 +35,7 @@ VERSIONFLAGS="
     -X ${PKG_CRICTL}/version.Version=${VERSION_CRICTL}
 
     -X ${PKG_CONTAINERD}/version.Version=${VERSION_CONTAINERD}
-    -X ${PKG_CONTAINERD}/version.Package=${PKG_K3S_CONTAINERD}
+    -X ${PKG_CONTAINERD}/version.Package=${PKG_CONTAINERD_K3S}
 
     -X ${PKG_CNI_PLUGINS}/pkg/utils/buildversion.BuildVersion=${VERSION_CNIPLUGINS}
     -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Program=flannel

--- a/scripts/download
+++ b/scripts/download
@@ -24,7 +24,7 @@ curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${VE
 
 git clone --single-branch --branch=${VERSION_RUNC} --depth=1 https://github.com/opencontainers/runc ${RUNC_DIR}
 
-git clone --single-branch --branch=${VERSION_CONTAINERD} --depth=1 https://github.com/k3s-io/containerd ${CONTAINERD_DIR}
+git clone --single-branch --branch=${VERSION_CONTAINERD} --depth=1 https://${PKG_CONTAINERD_K3S} ${CONTAINERD_DIR}
 
 for CHART_FILE in $(grep -rlF HelmChart manifests/ | xargs yq eval --no-doc .spec.chart | xargs -n1 basename); do
   CHART_NAME=$(echo $CHART_FILE | grep -oE '^(-*[a-z])+')

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -534,8 +534,8 @@ cleanup-test-env(){
       export SERVER_ARGS=''
       export WAIT_SERVICES="${all_services[*]}"
 
-      unset AGENT_1_ARGS AGENT_2_ARGS AGENT_3_ARGS AGENT_DOCKER_ARGS
-      unset SERVER_1_ARGS SERVER_2_ARGS SERVER_3_ARGS SERVER_DOCKER_ARGS
+      unset AGENT_1_ARGS AGENT_2_ARGS AGENT_3_ARGS AGENT_DOCKER_ARGS K3S_IMAGE_AGENT
+      unset SERVER_1_ARGS SERVER_2_ARGS SERVER_3_ARGS SERVER_DOCKER_ARGS K3S_IMAGE_SERVER
 
       unset -f server-pre-hook server-post-hook agent-pre-hook agent-post-hook cluster-pre-hook cluster-post-hook test-post-hook test-cleanup-hook
 }

--- a/scripts/test-run-upgrade
+++ b/scripts/test-run-upgrade
@@ -22,6 +22,7 @@ server-pre-hook(){
     local testID=$(basename $TEST_DIR)
     export SERVER_DOCKER_ARGS="\
         --mount type=volume,src=k3s-server-$1-${testID,,}-rancher,dst=/var/lib/rancher/k3s \
+        --mount type=volume,src=k3s-server-$1-${testID,,}-log,dst=/var/log \
         --mount type=volume,src=k3s-server-$1-${testID,,}-etc,dst=/etc/rancher"
 }
 export -f server-pre-hook
@@ -30,6 +31,7 @@ agent-pre-hook(){
     local testID=$(basename $TEST_DIR)
     export AGENT_DOCKER_ARGS="\
         --mount type=volume,src=k3s-agent-$1-${testID,,}-rancher,dst=/var/lib/rancher/k3s \
+        --mount type=volume,src=k3s-agent-$1-${testID,,}-log,dst=/var/log \
         --mount type=volume,src=k3s-agent-$1-${testID,,}-etc,dst=/etc/rancher"
 }
 export -f agent-pre-hook
@@ -66,8 +68,15 @@ start-test() {
 
     # Confirm that the nodes are running the current build and that the pod we created earlier is still there
     . ./scripts/version.sh || true
-    kubectl get node -o wide | grep -F $VERSION
+
+    verify-valid-versions $(cat $TEST_DIR/servers/1/metadata/name)
+
     kubectl get pod -n kube-system volume-test -o wide
+
+    if ! kubectl get node -o wide | grep -qF $VERSION; then
+      echo "Expected version $VERSION not found in node list"
+      return 1
+    fi
 }
 export -f start-test
 

--- a/scripts/test-run-upgrade
+++ b/scripts/test-run-upgrade
@@ -41,9 +41,11 @@ start-test() {
     kubectl get node -o wide
     kubectl create -f scripts/airgap/volume-test.yaml
 
-    # Add post-hook sleeps to give the kubelet time to update the version after startup
+    # Add post-hook sleeps to give the kubelet time to update the version after startup.
+    # Server gets an extra 60 seconds to handle the metrics-server service being unavailable:
+    # https://github.com/kubernetes/kubernetes/issues/120739
     server-post-hook(){
-        sleep 15
+        sleep 75
     }
     export -f server-post-hook
     agent-post-hook(){

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -26,9 +26,14 @@ get-module-version(){
   go list -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' $1
 }
 
-# We're building k3s against containerd 1.5 in go.mod because 1.6 has dependency
-# conflicts with Kubernetes, but we still need to bundle containerd 1.6.
-VERSION_CONTAINERD="v1.7.3-k3s1"
+get-module-path(){
+  go list -m -f '{{if .Replace}}{{.Replace.Path}}{{else}}{{.Path}}{{end}}' $1
+}
+
+# We're building k3s against containerd 1.5 in go.mod because newer releases have
+# dependency conflicts with Kubernetes, but we still need to bundle containerd 1.7
+VERSION_CONTAINERD="v1.7.6-k3s1"
+PKG_CONTAINERD_K3S=$(get-module-path github.com/containerd/containerd)
 
 VERSION_CRICTL=$(get-module-version github.com/kubernetes-sigs/cri-tools)
 if [ -z "$VERSION_CRICTL" ]; then


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to v1.7.6-k3s1

#### Types of Changes ####

version bump
test

#### Verification ####

See linked issue

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8389

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump embedded containerd to v1.7.6
Bump embedded stargz-snapshotter plugin to latest
Fixed intermittent drone CI failures due to race conditions in test environment setup scripts
Fixed CI failures due to changes to api discovery changes in Kubernetes 1.28
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
