### PR TITLE
Disable HTTP on main etcd client port

### DIFF
--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -37,6 +37,7 @@ type ETCDConfig struct {
 	InitialOptions                  `json:",inline"`
 	Name                            string      `json:"name,omitempty"`
 	ListenClientURLs                string      `json:"listen-client-urls,omitempty"`
+	ListenClientHTTPURLs            string      `json:"listen-client-http-urls,omitempty"`
 	ListenMetricsURLs               string      `json:"listen-metrics-urls,omitempty"`
 	ListenPeerURLs                  string      `json:"listen-peer-urls,omitempty"`
 	AdvertiseClientURLs             string      `json:"advertise-client-urls,omitempty"`

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -834,6 +834,14 @@ func (e *ETCD) listenMetricsURLs(reset bool) string {
 	return metricsURLs
 }
 
+// listenClientHTTPURLs returns a list of URLs to bind to for http client connections.
+// This should no longer be used, but we must set it in order to free the listen URLs
+// for dedicated use by GRPC.
+// Ref: https://github.com/etcd-io/etcd/issues/15402
+func (e *ETCD) listenClientHTTPURLs() string {
+	return fmt.Sprintf("https://%s:2382", e.config.Loopback(true))
+}
+
 // cluster calls the executor to start etcd running with the provided configuration.
 func (e *ETCD) cluster(ctx context.Context, reset bool, options executor.InitialOptions) error {
 	ctx, e.cancel = context.WithCancel(ctx)
@@ -864,6 +872,7 @@ func (e *ETCD) cluster(ctx context.Context, reset bool, options executor.Initial
 		Logger:                          "zap",
 		LogOutputs:                      []string{"stderr"},
 		ExperimentalInitialCorruptCheck: true,
+		ListenClientHTTPURLs:            e.listenClientHTTPURLs(),
 	}, e.config.ExtraEtcdArgs)
 }
 
@@ -885,7 +894,13 @@ func (e *ETCD) StartEmbeddedTemporary(ctx context.Context) error {
 
 	endpoints := getEndpoints(e.config)
 	clientURL := endpoints[0]
+	// peer URL is usually 1 more than client
 	peerURL, err := addPort(endpoints[0], 1)
+	if err != nil {
+		return err
+	}
+	// client http URL is usually 3 more than client, after peer and metrics
+	clientHTTPURL, err := addPort(endpoints[0], 3)
 	if err != nil {
 		return err
 	}
@@ -898,6 +913,7 @@ func (e *ETCD) StartEmbeddedTemporary(ctx context.Context) error {
 		ForceNewCluster:                 true,
 		AdvertiseClientURLs:             clientURL,
 		ListenClientURLs:                clientURL,
+		ListenClientHTTPURLs:            clientHTTPURL,
 		ListenPeerURLs:                  peerURL,
 		Logger:                          "zap",
 		HeartbeatInterval:               500,


### PR DESCRIPTION
#### Proposed Changes ####

Disable HTTP on main etcd client port. Only etcd v2 API used http, all v3 clients (etcdctl and kubernetes) use GRPC.

Fixes performance issue under load, ref: 
* https://github.com/etcd-io/etcd/issues/15402
* https://github.com/kubernetes/kubernetes/pull/118460

Fixes warning in logs on etcd nodes:
```
Sep 22 05:37:58 systemd-node-1 k3s[25599]: {"level":"warn","ts":"2023-09-22T05:37:58.756955Z","caller":"embed/config.go:673","msg":"Running http and grpc server on single port. This is not recommended for production."}
```

#### Types of Changes ####

bugfix

#### Verification ####

Check for absence of warning message.

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8415
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Embedded etcd no longer serves http requests on the client port, only grpc. This addresses a performance issue that could cause watch stream starvation under load. For more information, see https://github.com/etcd-io/etcd/issues/15402
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
