### PR TITLE
[Release-1.27] Cluster reset from non boostrap nodes

### DIFF
--- a/tests/e2e/snapshotrestore/Vagrantfile
+++ b/tests/e2e/snapshotrestore/Vagrantfile
@@ -28,8 +28,6 @@ def provision(vm, role, role_num, node_num)
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
   
   vm.provision "shell", inline: "ping -c 2 k3s.io"
-  
-  db_type = getDBType(role, role_num, vm)
 
   if role.include?("server") && role_num == 0
     vm.provision 'k3s-primary-server', type: 'k3s', run: 'once' do |k3s|

--- a/tests/e2e/snapshotrestore/snapshotrestore_test.go
+++ b/tests/e2e/snapshotrestore/snapshotrestore_test.go
@@ -124,6 +124,7 @@ var _ = Describe("Verify snapshots and cluster restores work", Ordered, func() {
 		})
 
 	})
+	
 	Context("Cluster is reset normally", func() {
 		It("Resets the cluster", func() {
 			for _, nodeName := range serverNodeNames {
@@ -142,6 +143,17 @@ var _ = Describe("Verify snapshots and cluster restores work", Ordered, func() {
 
 			cmd = "systemctl start k3s"
 			Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Error().NotTo(HaveOccurred())
+		})
+
+		It("Resets non boostrap nodes", func() {
+			for _, nodeName := range serverNodeNames {
+				if nodeName != serverNodeNames[0] {
+					cmd := "k3s server --cluster-reset"
+					response, err := e2e.RunCmdOnNode(cmd, nodeName)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(response).Should(ContainSubstring("Managed etcd cluster membership has been reset, restart without --cluster-reset flag now"))
+				}
+			}
 		})
 
 		It("Checks that other servers are not ready", func() {
@@ -209,6 +221,7 @@ var _ = Describe("Verify snapshots and cluster restores work", Ordered, func() {
 		})
 
 	})
+
 	Context("Cluster restores from snapshot", func() {
 		It("Restores the snapshot", func() {
 			//Stop k3s on all nodes

--- a/tests/e2e/snapshotrestore/snapshotrestore_test.go
+++ b/tests/e2e/snapshotrestore/snapshotrestore_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Verify snapshots and cluster restores work", Ordered, func() {
 		})
 
 	})
-	
+
 	Context("Cluster is reset normally", func() {
 		It("Resets the cluster", func() {
 			for _, nodeName := range serverNodeNames {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Resets all cluster members in the test

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

- Test
- Backport

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

```bash
go test -timeout=15m ./tests/e2e/snapshotrestore/... -run E2E
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

* https://github.com/k3s-io/k3s/issues/8450

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
