### PR TITLE
Don't ignore assets in home dir if system assets exist

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -222,16 +222,20 @@ func getAssetAndDir(dataDir string) (string, string) {
 // extract checks for and if necessary unpacks the bindata archive, returning the unique path
 // to the extracted bindata asset.
 func extract(dataDir string) (string, error) {
-	// first look for global asset folder so we don't create a HOME version if not needed
-	_, dir := getAssetAndDir(datadir.DefaultDataDir)
+	// check if content already exists in requested data-dir
+	asset, dir := getAssetAndDir(dataDir)
 	if _, err := os.Stat(filepath.Join(dir, "bin", "k3s")); err == nil {
 		return dir, nil
 	}
 
-	asset, dir := getAssetAndDir(dataDir)
-	// check if target content already exists
-	if _, err := os.Stat(filepath.Join(dir, "bin", "k3s")); err == nil {
-		return dir, nil
+	// check if content exists in default path as a fallback, prior
+	// to extracting. This will prevent re-extracting into the user's home
+	// dir if the assets already exist in the default path.
+	if dataDir != datadir.DefaultDataDir {
+		_, defaultDir := getAssetAndDir(datadir.DefaultDataDir)
+		if _, err := os.Stat(filepath.Join(defaultDir, "bin", "k3s")); err == nil {
+			return defaultDir, nil
+		}
 	}
 
 	// acquire a data directory lock


### PR DESCRIPTION
#### Proposed Changes ####

Prefer user assets over system assets, if both exist

#### Types of Changes ####

bugfix

#### Verification ####

**On old release**
1. install K3s but do not start it.
2. Run `k3s check-config` as unprivileged user; note that assets are extracted out to `$HOME/.rancher/k3s/data` and checked
3. Run `k3s check-config` as root; note that assets are extracted out to `/var/lib/rancher/k3s/data` and checked
4. Run `k3s check-config` as unprivileged user again; note that this time the assets in `/var/lib/rancher/k3s/data` are checked, instead of the user assets.

**On new release**
Perform above steps, but in step 4, note that the assets in the home directory are still checked, even if system-level assets exist.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8403

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
