### PR TITLE
Pass SystemdCgroup setting through to nvidia runtime options

### DIFF
--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -125,6 +125,7 @@ enable_keychain = true
   runtime_type = "{{$v.RuntimeType}}"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."{{$k}}".options]
   BinaryName = "{{$v.BinaryName}}"
+  SystemdCgroup = {{ .SystemdCgroup }}
 {{end}}
 `
 


### PR DESCRIPTION
#### Proposed Changes ####

Pass SystemdCgroup setting through to nvidia runtime options.

This is apparently required by newer versions of the nvidia container runtime; something appears to periodically kill off pods using the nvidia runtime if they are not in the correct cgroup.
Ref: https://github.com/NVIDIA/nvidia-container-toolkit/issues/28#issuecomment-1201243587

#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* #7130

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed issue that would cause pods using nvidia container runtime to be killed after a few seconds, when using newer versions of nvidia-container-toolkit.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
