### PR TITLE
[Release-1.26] Server Token Rotation

### DIFF
--- a/cmd/cert/main.go
+++ b/cmd/cert/main.go
@@ -15,11 +15,9 @@ import (
 func main() {
 	app := cmds.NewApp()
 	app.Commands = []cli.Command{
-		cmds.NewCertCommand(
-			cmds.NewCertSubcommands(
-				cert.Rotate,
-				cert.RotateCA,
-			),
+		cmds.NewCertCommands(
+			cert.Rotate,
+			cert.RotateCA,
 		),
 	}
 

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -57,6 +57,7 @@ func main() {
 			tokenCommand,
 			tokenCommand,
 			tokenCommand,
+			tokenCommand,
 		),
 		cmds.NewEtcdSnapshotCommands(
 			etcdsnapshotCommand,
@@ -73,11 +74,9 @@ func main() {
 			secretsencryptCommand,
 			secretsencryptCommand,
 		),
-		cmds.NewCertCommand(
-			cmds.NewCertSubcommands(
-				certCommand,
-				certCommand,
-			),
+		cmds.NewCertCommands(
+			certCommand,
+			certCommand,
 		),
 		cmds.NewCompletionCommand(internalCLIAction(version.Program+"-completion", dataDir, os.Args)),
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -54,6 +54,7 @@ func main() {
 			token.Delete,
 			token.Generate,
 			token.List,
+			token.Rotate,
 		),
 		cmds.NewEtcdSnapshotCommands(
 			etcdsnapshot.Run,
@@ -70,11 +71,9 @@ func main() {
 			secretsencrypt.Rotate,
 			secretsencrypt.Reencrypt,
 		),
-		cmds.NewCertCommand(
-			cmds.NewCertSubcommands(
-				cert.Rotate,
-				cert.RotateCA,
-			),
+		cmds.NewCertCommands(
+			cert.Rotate,
+			cert.RotateCA,
 		),
 		cmds.NewCompletionCommand(completion.Run),
 	}

--- a/cmd/token/main.go
+++ b/cmd/token/main.go
@@ -20,6 +20,7 @@ func main() {
 			token.Delete,
 			token.Generate,
 			token.List,
+			token.Rotate,
 		),
 	}
 

--- a/main.go
+++ b/main.go
@@ -47,11 +47,9 @@ func main() {
 			secretsencrypt.Rotate,
 			secretsencrypt.Reencrypt,
 		),
-		cmds.NewCertCommand(
-			cmds.NewCertSubcommands(
-				cert.Rotate,
-				cert.RotateCA,
-			),
+		cmds.NewCertCommands(
+			cert.Rotate,
+			cert.RotateCA,
 		),
 		cmds.NewCompletionCommand(completion.Run),
 	}

--- a/pkg/cli/cmds/certs.go
+++ b/pkg/cli/cmds/certs.go
@@ -54,33 +54,29 @@ var (
 	}
 )
 
-func NewCertCommand(subcommands []cli.Command) cli.Command {
+func NewCertCommands(rotate, rotateCA func(ctx *cli.Context) error) cli.Command {
 	return cli.Command{
 		Name:            CertCommand,
 		Usage:           "Manage K3s certificates",
 		SkipFlagParsing: false,
 		SkipArgReorder:  true,
-		Subcommands:     subcommands,
-	}
-}
-
-func NewCertSubcommands(rotate, rotateCA func(ctx *cli.Context) error) []cli.Command {
-	return []cli.Command{
-		{
-			Name:            "rotate",
-			Usage:           "Rotate " + version.Program + " component certificates on disk",
-			SkipFlagParsing: false,
-			SkipArgReorder:  true,
-			Action:          rotate,
-			Flags:           CertRotateCommandFlags,
-		},
-		{
-			Name:            "rotate-ca",
-			Usage:           "Write updated " + version.Program + " CA certificates to the datastore",
-			SkipFlagParsing: false,
-			SkipArgReorder:  true,
-			Action:          rotateCA,
-			Flags:           CertRotateCACommandFlags,
+		Subcommands: []cli.Command{
+			{
+				Name:            "rotate",
+				Usage:           "Rotate " + version.Program + " component certificates on disk",
+				SkipFlagParsing: false,
+				SkipArgReorder:  true,
+				Action:          rotate,
+				Flags:           CertRotateCommandFlags,
+			},
+			{
+				Name:            "rotate-ca",
+				Usage:           "Write updated " + version.Program + " CA certificates to the datastore",
+				SkipFlagParsing: false,
+				SkipArgReorder:  true,
+				Action:          rotateCA,
+				Flags:           CertRotateCACommandFlags,
+			},
 		},
 	}
 }

--- a/pkg/cli/cmds/token.go
+++ b/pkg/cli/cmds/token.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"time"
 
+	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/urfave/cli"
 )
 
@@ -12,7 +13,9 @@ const TokenCommand = "token"
 type Token struct {
 	Description string
 	Kubeconfig  string
+	ServerURL   string
 	Token       string
+	NewToken    string
 	Output      string
 	Groups      cli.StringSlice
 	Usages      cli.StringSlice
@@ -32,7 +35,7 @@ var (
 	}
 )
 
-func NewTokenCommands(create, delete, generate, list func(ctx *cli.Context) error) cli.Command {
+func NewTokenCommands(create, delete, generate, list, rotate func(ctx *cli.Context) error) cli.Command {
 	return cli.Command{
 		Name:            TokenCommand,
 		Usage:           "Manage bootstrap tokens",
@@ -91,6 +94,32 @@ func NewTokenCommands(create, delete, generate, list func(ctx *cli.Context) erro
 				SkipFlagParsing: false,
 				SkipArgReorder:  true,
 				Action:          list,
+			},
+			{
+				Name:  "rotate",
+				Usage: "Rotate original server token with a new bootstrap token",
+				Flags: append(TokenFlags,
+					&cli.StringFlag{
+						Name:        "token,t",
+						Usage:       "Existing token used to join a server or agent to a cluster",
+						Destination: &TokenConfig.Token,
+						EnvVar:      version.ProgramUpper + "_TOKEN",
+					},
+					&cli.StringFlag{
+						Name:        "server, s",
+						Usage:       "(cluster) Server to connect to",
+						Destination: &TokenConfig.ServerURL,
+						EnvVar:      version.ProgramUpper + "_URL",
+						Value:       "https://127.0.0.1:6443",
+					},
+					&cli.StringFlag{
+						Name:        "new-token",
+						Usage:       "New token that replaces existing token",
+						Destination: &TokenConfig.NewToken,
+					}),
+				SkipFlagParsing: false,
+				SkipArgReorder:  true,
+				Action:          rotate,
 			},
 		},
 	}

--- a/pkg/cli/token/token.go
+++ b/pkg/cli/token/token.go
@@ -1,18 +1,23 @@
 package token
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
 
+	"github.com/erikdubbelboer/gspt"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	"github.com/k3s-io/k3s/pkg/clientaccess"
 	"github.com/k3s-io/k3s/pkg/kubeadm"
+	"github.com/k3s-io/k3s/pkg/server"
 	"github.com/k3s-io/k3s/pkg/util"
+	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v2"
@@ -22,6 +27,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
+	"k8s.io/utils/pointer"
 )
 
 func Create(app *cli.Context) error {
@@ -137,6 +143,50 @@ func generate(app *cli.Context, cfg *cmds.Token) error {
 	}
 	fmt.Println(token)
 	return nil
+}
+
+func Rotate(app *cli.Context) error {
+	if err := cmds.InitLogging(); err != nil {
+		return err
+	}
+	fmt.Println("\033[33mWARNING\033[0m: Recommended to keep a record of the old token. If restoring from a snapshot, you must use the token associated with that snapshot.")
+	info, err := serverAccess(&cmds.TokenConfig)
+	if err != nil {
+		return err
+	}
+	b, err := json.Marshal(server.TokenRotateRequest{
+		NewToken: pointer.String(cmds.TokenConfig.NewToken),
+	})
+	if err != nil {
+		return err
+	}
+	if err = info.Put("/v1-"+version.Program+"/token", b); err != nil {
+		return err
+	}
+	// wait for etcd db propagation delay
+	time.Sleep(1 * time.Second)
+	fmt.Println("Token rotated, restart k3s with new token")
+	return nil
+}
+
+func serverAccess(cfg *cmds.Token) (*clientaccess.Info, error) {
+	// hide process arguments from ps output, since they likely contain tokens.
+	gspt.SetProcTitle(os.Args[0] + " token")
+
+	dataDir, err := server.ResolveDataDir("")
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.Token == "" {
+		fp := filepath.Join(dataDir, "token")
+		tokenByte, err := os.ReadFile(fp)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Token = string(bytes.TrimRight(tokenByte, "\n"))
+	}
+	return clientaccess.ParseAndValidateToken(cfg.ServerURL, cfg.Token, clientaccess.WithUser("server"))
 }
 
 func List(app *cli.Context) error {

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -243,6 +243,7 @@ func genUsers(config *config.Control) error {
 		return err
 	}
 
+	// if no token is provided on bootstrap, we generate a random token
 	serverPass, err := getServerPass(passwd, config)
 	if err != nil {
 		return err

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -85,6 +85,7 @@ func router(ctx context.Context, config *Config, cfg *cmds.Server) http.Handler 
 	serverAuthed.Path(prefix + "/cert/cacerts").Handler(caCertReplaceHandler(serverConfig))
 	serverAuthed.Path("/db/info").Handler(nodeAuthed)
 	serverAuthed.Path(prefix + "/server-bootstrap").Handler(bootstrapHandler(serverConfig.Runtime))
+	serverAuthed.Path(prefix + "/token").Handler(tokenRequestHandler(ctx, serverConfig))
 
 	systemAuthed := mux.NewRouter().SkipClean(true)
 	systemAuthed.NotFoundHandler = serverAuthed

--- a/pkg/server/token.go
+++ b/pkg/server/token.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+
+	"github.com/k3s-io/k3s/pkg/cluster"
+	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/k3s-io/k3s/pkg/passwd"
+	"github.com/k3s-io/k3s/pkg/util"
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/sirupsen/logrus"
+)
+
+type TokenRotateRequest struct {
+	NewToken *string `json:"newToken,omitempty"`
+}
+
+func getServerTokenRequest(req *http.Request) (TokenRotateRequest, error) {
+	b, err := io.ReadAll(req.Body)
+	if err != nil {
+		return TokenRotateRequest{}, err
+	}
+	result := TokenRotateRequest{}
+	err = json.Unmarshal(b, &result)
+	return result, err
+}
+
+func tokenRequestHandler(ctx context.Context, server *config.Control) http.Handler {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		if req.TLS == nil || req.Method != http.MethodPut {
+			resp.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var err error
+		sTokenReq, err := getServerTokenRequest(req)
+		logrus.Debug("Received token request")
+		if err != nil {
+			resp.WriteHeader(http.StatusBadRequest)
+			resp.Write([]byte(err.Error()))
+			return
+		}
+		if err = tokenRotate(ctx, server, *sTokenReq.NewToken); err != nil {
+			genErrorMessage(resp, http.StatusInternalServerError, err, "token")
+			return
+		}
+		resp.WriteHeader(http.StatusOK)
+	})
+}
+
+func tokenRotate(ctx context.Context, server *config.Control, newToken string) error {
+	passwd, err := passwd.Read(server.Runtime.PasswdFile)
+	if err != nil {
+		return err
+	}
+
+	if err != nil {
+		return err
+	}
+	oldToken, found := passwd.Pass("server")
+	if !found {
+		return fmt.Errorf("server token not found")
+	}
+	if newToken == "" {
+		newToken, err = util.Random(16)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := passwd.EnsureUser("server", version.Program+":server", newToken); err != nil {
+		return err
+	}
+
+	// If the agent token is the same a server, we need to change both
+	if agentToken, found := passwd.Pass("node"); found && agentToken == oldToken && server.AgentToken == "" {
+		if err := passwd.EnsureUser("node", version.Program+":agent", newToken); err != nil {
+			return err
+		}
+	}
+
+	if err := passwd.Write(server.Runtime.PasswdFile); err != nil {
+		return err
+	}
+
+	serverTokenFile := filepath.Join(server.DataDir, "token")
+	if err := writeToken("server:"+newToken, serverTokenFile, server.Runtime.ServerCA); err != nil {
+		return err
+	}
+
+	if err := cluster.RotateBootstrapToken(ctx, server, oldToken); err != nil {
+		return err
+	}
+	server.Token = newToken
+	return cluster.Save(ctx, server, true)
+}

--- a/tests/e2e/token/Vagrantfile
+++ b/tests/e2e/token/Vagrantfile
@@ -1,6 +1,6 @@
 ENV['VAGRANT_NO_PARALLEL'] = 'no'
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
-  ["server-0", "agent-0", "agent-1" ])
+  ["server-0", "server-1", "server-2", "agent-0", "agent-1"])
 NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
   ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
 GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
@@ -34,6 +34,18 @@ def provision(vm, roles, role_num, node_num)
       k3s.args = "server "
       k3s.config = <<~YAML
         cluster-init: true
+        token: vagrant
+        node-external-ip: #{node_ip}
+        flannel-iface: eth1
+      YAML
+      k3s.env = ["K3S_KUBECONFIG_MODE=0644", install_type]
+    end
+  elsif roles.include?("server") && role_num != 0
+    vm.provision 'k3s-secondary-server', type: 'k3s', run: 'once' do |k3s|
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      k3s.args = "server"
+      k3s.config = <<~YAML
+        server: "https://#{NETWORK_PREFIX}.100:6443"
         token: vagrant
         node-external-ip: #{node_ip}
         flannel-iface: eth1


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Backport https://github.com/k3s-io/k3s/pull/8265
* Consolidate NewCertCommands
* Add support for user defined new token
* Add E2E testlets
* Ensure agent token also changes

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/8298
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users can now rotate the server token using `k3s token rotate -t <OLD_TOKEN> --new-token <NEW_TOKEN>`. After command succeeds, all server nodes must be restarted with the new token.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
