### PR TITLE
E2E Domain Drone Cleanup

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -752,7 +752,8 @@ steps:
   - mkdir -p dist/artifacts
   - cp /tmp/artifacts/* dist/artifacts/
   - docker stop registry && docker rm registry
-  # Cleanup any VMs running, happens if a previous test panics
+  # Cleanup VMs running, happens if a previous test panics
+  # Cleanup inactive domains, happens if previous test is canceled
   - |
     VMS=$(virsh list --name | grep '_server-\|_agent-' || true)
     if [ -n "$VMS" ]; then
@@ -760,6 +761,13 @@ steps:
       do
         virsh destroy $vm
         virsh undefine $vm --remove-all-storage
+      done
+    fi 
+    VMS=$(virsh list --name --inactive | grep '_server-\|_agent-' || true)
+    if [ -n "$VMS" ]; then
+      for vm in $VMS
+      do
+        virsh undefine $vm
       done
     fi 
   - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2

--- a/.drone.yml
+++ b/.drone.yml
@@ -710,6 +710,9 @@ platform:
 clone:
   retries: 3
 
+depends_on:
+- amd64
+
 steps:
 - name: skipfiles
   image: plugins/git


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Cleanup inactive VM domains before running E2E tests.
- Have E2E depend on successful amd64 pipeline
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Testing/CI
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
E2E passes, nothing to QA
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/8379
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
