### PR TITLE
[Release-1.25] E2E Domain Drone Cleanup

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -579,6 +579,12 @@ platform:
   os: linux
   arch: amd64
 
+clone:
+  retries: 3
+
+depends_on:
+- amd64
+
 steps:
 - name: build-e2e-image
   image: rancher/dapper:v0.5.0
@@ -604,7 +610,8 @@ steps:
   - mkdir -p dist/artifacts
   - cp /tmp/artifacts/* dist/artifacts/
   - docker stop registry && docker rm registry
-  # Cleanup any VMs running, happens if a previous test panics
+  # Cleanup VMs running, happens if a previous test panics
+  # Cleanup inactive domains, happens if previous test is canceled
   - |
     VMS=$(virsh list --name | grep '_server-\|_agent-' || true)
     if [ -n "$VMS" ]; then
@@ -612,6 +619,13 @@ steps:
       do
         virsh destroy $vm
         virsh undefine $vm --remove-all-storage
+      done
+    fi 
+    VMS=$(virsh list --name --inactive | grep '_server-\|_agent-' || true)
+    if [ -n "$VMS" ]; then
+      for vm in $VMS
+      do
+        virsh undefine $vm
       done
     fi 
   - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2

--- a/.github/workflows/cgroup.yaml
+++ b/.github/workflows/cgroup.yaml
@@ -57,6 +57,9 @@ jobs:
         run: vagrant plugin install vagrant-k3s vagrant-reload
       - name: "Vagrant Up"
         run: vagrant up
+      - name: On Failure, Validate VMs deployed
+        if: ${{ failure() }}
+        run: vboxmanage list vms
       - name: "K3s Prepare"
         run: vagrant provision --provision-with=k3s-prepare
       - name: ⏬ "K3s Install"

--- a/.github/workflows/cgroup.yaml
+++ b/.github/workflows/cgroup.yaml
@@ -59,7 +59,7 @@ jobs:
         run: vagrant up
       - name: On Failure, Validate VMs deployed
         if: ${{ failure() }}
-        run: vboxmanage list vms
+        run: vboxmanage list vms --long
       - name: "K3s Prepare"
         run: vagrant provision --provision-with=k3s-prepare
       - name: ⏬ "K3s Install"

--- a/.github/workflows/cgroup.yaml
+++ b/.github/workflows/cgroup.yaml
@@ -57,9 +57,11 @@ jobs:
         run: vagrant plugin install vagrant-k3s vagrant-reload
       - name: "Vagrant Up"
         run: vagrant up
-      - name: On Failure, Validate VMs deployed
+      - name: On Failure, Dump VM logs
         if: ${{ failure() }}
-        run: vboxmanage list vms --long
+        run: |
+          logsDir=$(vboxmanage list vms --long | grep Logs | awk '{print $3" "$4}')
+          cat "$logsDir"/VBox.log
       - name: "K3s Prepare"
         run: vagrant provision --provision-with=k3s-prepare
       - name: ⏬ "K3s Install"

--- a/.github/workflows/snapshotter.yaml
+++ b/.github/workflows/snapshotter.yaml
@@ -59,6 +59,11 @@ jobs:
         run: vagrant plugin install vagrant-k3s
       - name: "Vagrant Up ⏩ Install K3s"
         run: vagrant up
+      - name: On Failure, Dump VM logs
+        if: ${{ failure() }}
+        run: |
+          logsDir=$(vboxmanage list vms --long | grep Logs | awk '{print $3" "$4}')
+          cat "$logsDir"/VBox.log
       - name: "⏳ Node"
         run: vagrant provision --provision-with=k3s-wait-for-node
       - name: "⏳ CoreDNS"

--- a/docs/adrs/add-dual-stack-support-to-netpol-agent.md
+++ b/docs/adrs/add-dual-stack-support-to-netpol-agent.md
@@ -36,7 +36,7 @@ The motivation behind keeping a fork is that:
 
 * upstream might ask for implementing dual-stack in all kube-router
   components (which would be understandable)
-* acceepting a solution upstream might take long time
+* accepting a solution upstream might take long time
 
 Our fork of kube-router is going to be used as a vendored library inside k3s
 code. And the currently copied code in k3s in `pkg/agent/netpol` is going to


### PR DESCRIPTION
Backport https://github.com/k3s-io/k3s/pull/8579
* Cleanup inactive vm domains
* Have e2e depend on amd64 pipeline

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/8379
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
