### PR TITLE
[release-1.26] Update kube-router package in build script

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -13,7 +13,7 @@ PKG_CRICTL="github.com/kubernetes-sigs/cri-tools/pkg"
 PKG_K8S_BASE="k8s.io/component-base"
 PKG_K8S_CLIENT="k8s.io/client-go/pkg"
 PKG_CNI_PLUGINS="github.com/containernetworking/plugins"
-PKG_KUBE_ROUTER="github.com/cloudnativelabs/kube-router"
+PKG_KUBE_ROUTER="github.com/cloudnativelabs/kube-router/v2"
 PKG_CRI_DOCKERD="github.com/Mirantis/cri-dockerd"
 PKG_ETCD="go.etcd.io/etcd"
 


### PR DESCRIPTION
#### Proposed Changes ####

Package was changed in version script in bc332ac6671 but we missed changing it here as well.

Both should have been changed when we updated kube-router to v2 for dual-stack support.

#### Types of Changes ####

bugfix

#### Verification ####

```
INFO[0016] Starting the netpol controller version v2.0.0-20230925161250-364f994b140b, built on 2023-10-13T19:55:29Z, go1.20.8
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8632

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
