### PR TITLE
[release-1.27] Add etcd-only/control-plane-only server test and fix control-plane-only server crash

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -1372,8 +1372,17 @@ func (e *ETCD) GetMembersNames(ctx context.Context) ([]string, error) {
 	return memberNames, nil
 }
 
-// RemoveSelf will remove the member if it exists in the cluster
+// RemoveSelf will remove the member if it exists in the cluster.  This should
+// only be called on a node that may have previously run etcd, but will not
+// currently run etcd, to ensure that it is not a member of the cluster.
+// This is also called by tests to do cleanup between runs.
 func (e *ETCD) RemoveSelf(ctx context.Context) error {
+	if e.client == nil {
+		if err := e.startClient(ctx); err != nil {
+			return err
+		}
+	}
+
 	if err := e.RemovePeer(ctx, e.name, e.address, true); err != nil {
 		return err
 	}

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -430,7 +430,7 @@ provision-cluster() {
         provision-server
         timeout --foreground 120s bash -c "wait-for-kubeconfig $i"
     done
-    export KUBECONFIG=$TEST_DIR/servers/1/kubeconfig.yaml
+    export KUBECONFIG=$TEST_DIR/servers/${KUBECONFIG_SERVER:-1}/kubeconfig.yaml
 
     if [ $NUM_AGENTS -gt 0 ]; then
         for _ in $(seq 1 $NUM_AGENTS); do

--- a/scripts/test-run-etcd
+++ b/scripts/test-run-etcd
@@ -38,6 +38,17 @@ LABEL="ETCD-JOIN-BASIC" SERVER_ARGS="" run-test
 # --- create a basic cluster to test joining a managed etcd cluster with --agent-token set
 LABEL="ETCD-JOIN-AGENTTOKEN" SERVER_ARGS="--agent-token ${RANDOM}${RANDOM}${RANDOM}" run-test
 
+# --- create a cluster with one etcd-only server, one control-plane-only server, and one agent
+server-post-hook() {
+  if [ $1 -eq 1 ]; then
+    local url=$(cat $TEST_DIR/servers/1/metadata/url)
+    export SERVER_ARGS="${SERVER_ARGS} --server $url"
+  fi
+}
+export -f server-post-hook
+LABEL="ETCD-SPLIT-ROLE" NUM_AGENTS=1 KUBECONFIG_SERVER=2 SERVER_1_ARGS="--cluster-init --disable-apiserver --disable-controller-manager --disable-scheduler" SERVER_2_ARGS="--disable-etcd" run-test
+
+
 # The following tests deploy clusters of mixed versions. The traefik helm chart may not deploy
 # correctly until all servers have been upgraded to the same release, so don't wait for it.
 all_services=(


### PR DESCRIPTION
#### Proposed Changes ####

Add a test, fix what's broken

#### Types of Changes ####

bugfix, test

#### Verification ####

#### Testing ####

Adds a test

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8639
* 
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
