### PR TITLE
[release-1.25] Add --image-service-endpoint flag (#8279)

### DIFF
--- a/pkg/agent/run_linux.go
+++ b/pkg/agent/run_linux.go
@@ -37,5 +37,9 @@ func setupCriCtlConfig(cfg cmds.Agent, nodeConfig *config.Node) error {
 	}
 
 	crp := "runtime-endpoint: " + cre + "\n"
+	ise := nodeConfig.ImageServiceEndpoint
+	if ise != "" && ise != cre {
+		crp += "image-endpoint: " + cre + "\n"
+	}
 	return os.WriteFile(agentConfDir+"/crictl.yaml", []byte(crp), 0600)
 }

--- a/pkg/agent/run_windows.go
+++ b/pkg/agent/run_windows.go
@@ -39,5 +39,9 @@ func setupCriCtlConfig(cfg cmds.Agent, nodeConfig *config.Node) error {
 	}
 
 	crp := "runtime-endpoint: " + cre + "\n"
+	ise := nodeConfig.ImageServiceEndpoint
+	if ise != "" && ise != cre {
+		crp += "image-endpoint: " + cre + "\n"
+	}
 	return os.WriteFile(filepath.Join(agentConfDir, "crictl.yaml"), []byte(crp), 0600)
 }

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -28,6 +28,7 @@ type Agent struct {
 	Snapshotter              string
 	Docker                   bool
 	ContainerRuntimeEndpoint string
+	ImageServiceEndpoint     string
 	NoFlannel                bool
 	FlannelIface             string
 	FlannelConf              string
@@ -115,6 +116,11 @@ var (
 		Name:        "container-runtime-endpoint",
 		Usage:       "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path; when used with --docker this sets the docker socket path",
 		Destination: &AgentConfig.ContainerRuntimeEndpoint,
+	}
+	ImageServiceEndpointFlag = &cli.StringFlag{
+		Name:        "image-service-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd image service and use remote image service socket at the given path. If not specified, defaults to --container-runtime-endpoint.",
+		Destination: &AgentConfig.ImageServiceEndpoint,
 	}
 	PrivateRegistryFlag = &cli.StringFlag{
 		Name:        "private-registry",
@@ -271,6 +277,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			LBServerPortFlag,
 			ProtectKernelDefaultsFlag,
 			CRIEndpointFlag,
+			ImageServiceEndpointFlag,
 			PauseImageFlag,
 			SnapshotterFlag,
 			PrivateRegistryFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -491,6 +491,7 @@ var ServerFlags = []cli.Flag{
 	ImageCredProvConfigFlag,
 	DockerFlag,
 	CRIEndpointFlag,
+	ImageServiceEndpointFlag,
 	PauseImageFlag,
 	SnapshotterFlag,
 	PrivateRegistryFlag,

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -39,6 +39,7 @@ const (
 type Node struct {
 	Docker                   bool
 	ContainerRuntimeEndpoint string
+	ImageServiceEndpoint     string
 	NoFlannel                bool
 	SELinux                  bool
 	FlannelBackend           string


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Problem:
External container runtime can be set but image service endpoint is unchanged and also is not exposed as a flag. This is useful for using containerd snapshotters outside of the ones that have built-in support like stargz-snapshotter.

Solution:
Add a flag --image-service-endpoint and also default image service endpoint to container runtime endpoint if set.

#### Types of Changes ####

The `--image-service-endpoint` flag is a new feature but defaulting image-service-endpoint can be considered a bug fix as that's the behavior in most CRI related tool like `crictl`.

#### Verification ####

Use `--container-runtime-endpoint` to an external containerd instead of `--snapshotter` for any remote snapshotter setup like `stargz` or `nydus`. Optionally set `--image-service-endpoint` if the snapshotter also supports the image service GRPC server.

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8483

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add `--image-service-endpoint` flag to specify an external image service socket.
```
