### PR TITLE
Fix CloudDualStackNodeIPs feature-gate inconsistency

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -313,6 +313,7 @@ func cloudControllerManager(ctx context.Context, cfg *config.Control) error {
 		"authentication-kubeconfig":    runtime.KubeConfigCloudController,
 		"node-status-update-frequency": "1m0s",
 		"bind-address":                 cfg.Loopback(false),
+		"feature-gates":                "CloudDualStackNodeIPs=true",
 	}
 	if cfg.NoLeaderElect {
 		argsMap["leader-elect"] = "false"

--- a/tests/integration/kubeflags/kubeflags_test.go
+++ b/tests/integration/kubeflags/kubeflags_test.go
@@ -148,11 +148,12 @@ var _ = Describe("create a new cluster with kube-* flags", Ordered, func() {
 			It("should find cloud-controller-manager starting with"+
 				"\"--cloud-node,--cloud-node-lifecycle,--secure-port=0\" flags ", func() {
 				Eventually(func() error {
-					match, err := testutil.SearchK3sLog(server, "Running cloud-controller-manager --allocate-node-cidrs=true"+
-						" --authentication-kubeconfig=/var/lib/rancher/k3s/server/cred/cloud-controller.kubeconfig"+
-						" --authorization-kubeconfig=/var/lib/rancher/k3s/server/cred/cloud-controller.kubeconfig --bind-address=127.0.0.1 "+
+					match, err := testutil.SearchK3sLog(server, "Running cloud-controller-manager --allocate-node-cidrs=true "+
+						"--authentication-kubeconfig=/var/lib/rancher/k3s/server/cred/cloud-controller.kubeconfig "+
+						"--authorization-kubeconfig=/var/lib/rancher/k3s/server/cred/cloud-controller.kubeconfig --bind-address=127.0.0.1 "+
 						"--cloud-config=/var/lib/rancher/k3s/server/etc/cloud-config.yaml --cloud-provider=k3s --cluster-cidr=10.42.0.0/16 "+
-						"--configure-cloud-routes=false --controllers=*,-route,-cloud-node,-cloud-node-lifecycle --kubeconfig=/var/lib/rancher/k3s/server/cred/cloud-controller.kubeconfig "+
+						"--configure-cloud-routes=false --controllers=*,-route,-cloud-node,-cloud-node-lifecycle "+
+						"--feature-gates=CloudDualStackNodeIPs=true --kubeconfig=/var/lib/rancher/k3s/server/cred/cloud-controller.kubeconfig "+
 						"--leader-elect-resource-name=k3s-cloud-controller-manager --node-status-update-frequency=1m0s --profiling=false --secure-port=0")
 					if err != nil {
 						return err


### PR DESCRIPTION

#### Proposed Changes ####

Fix CloudDualStackNodeIPs feature-gate inconsistency

Enable the feature-gate for both kubelet and cloud-controller-manager. Enabling it on only one side breaks RKE2, where feature-gates are not shared due to kubelet and ccm running in different processes.

Fixes RKE2 regression introduced by https://github.com/k3s-io/k3s/pull/8581

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8666

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
