### PR TITLE
Re-enable etcd endpoint auto-sync

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -681,6 +681,7 @@ func getClientConfig(ctx context.Context, control *config.Control, endpoints ...
 		DialTimeout:          defaultDialTimeout,
 		DialKeepAliveTime:    defaultKeepAliveTime,
 		DialKeepAliveTimeout: defaultKeepAliveTimeout,
+		AutoSyncInterval:     defaultKeepAliveTimeout,
 		PermitWithoutStream:  true,
 	}
 


### PR DESCRIPTION

#### Proposed Changes ####

Re-enable etcd endpoint auto-sync

Removing this in 002e6c43ee935583f4533d1347a04b658eee016b regressed control-plane-only nodes, as we rely on the etcd client to update its endpoint list internally so that we can use it to sync the load-balancer address list.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8672

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
