### PR TITLE
[release-1.26] Backport etcd fixes

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -681,6 +681,7 @@ func getClientConfig(ctx context.Context, control *config.Control, endpoints ...
 		DialTimeout:          defaultDialTimeout,
 		DialKeepAliveTime:    defaultKeepAliveTime,
 		DialKeepAliveTimeout: defaultKeepAliveTimeout,
+		AutoSyncInterval:     defaultKeepAliveTimeout,
 		PermitWithoutStream:  true,
 	}
 


### PR DESCRIPTION

#### Proposed Changes ####

Backports:
* https://github.com/k3s-io/k3s/pull/8675
* https://github.com/k3s-io/k3s/pull/8683

#### Types of Changes ####
bugfix

#### Verification ####
See linked issues
#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8685
* https://github.com/k3s-io/k3s/issues/8688


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Re-enable etcd endpoint auto-sync 
Manually requeue configmap reconcile when no nodes have reconciled snapshots
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
