### PR TITLE
Disable helm CRD installation for disable-helm-controller

### DIFF
--- a/pkg/cli/etcdsnapshot/etcd_snapshot.go
+++ b/pkg/cli/etcdsnapshot/etcd_snapshot.go
@@ -86,7 +86,7 @@ func commandSetup(app *cli.Context, cfg *cmds.Server, config *server.Config) (*e
 		return nil, fmt.Errorf("etcd database not found in %s", config.ControlConfig.DataDir)
 	}
 
-	sc, err := server.NewContext(ctx, config.ControlConfig.Runtime.KubeConfigAdmin, false)
+	sc, err := server.NewContext(ctx, config, config.ControlConfig.Runtime.KubeConfigAdmin, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/etcdsnapshot/etcd_snapshot.go
+++ b/pkg/cli/etcdsnapshot/etcd_snapshot.go
@@ -86,7 +86,7 @@ func commandSetup(app *cli.Context, cfg *cmds.Server, config *server.Config) (*e
 		return nil, fmt.Errorf("etcd database not found in %s", config.ControlConfig.DataDir)
 	}
 
-	sc, err := server.NewContext(ctx, config, config.ControlConfig.Runtime.KubeConfigAdmin, false)
+	sc, err := server.NewContext(ctx, config, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/context.go
+++ b/pkg/server/context.go
@@ -87,7 +87,7 @@ func registerCrds(ctx context.Context, config *Config, restConfig *rest.Config) 
 
 func crds(config *Config) []crd.CRD {
 	defaultCrds := addoncrd.List()
-	if config == nil || !config.ControlConfig.DisableHelmController {
+	if !config.ControlConfig.DisableHelmController {
 		defaultCrds = append(defaultCrds, helmcrd.List()...)
 	}
 	return defaultCrds

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -97,7 +97,7 @@ func startOnAPIServerReady(ctx context.Context, config *Config) {
 func runControllers(ctx context.Context, config *Config) error {
 	controlConfig := &config.ControlConfig
 
-	sc, err := NewContext(ctx, config, controlConfig.Runtime.KubeConfigSupervisor, true)
+	sc, err := NewContext(ctx, config, true)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new server context")
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -97,7 +97,7 @@ func startOnAPIServerReady(ctx context.Context, config *Config) {
 func runControllers(ctx context.Context, config *Config) error {
 	controlConfig := &config.ControlConfig
 
-	sc, err := NewContext(ctx, controlConfig.Runtime.KubeConfigSupervisor, true)
+	sc, err := NewContext(ctx, config, controlConfig.Runtime.KubeConfigSupervisor, true)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new server context")
 	}


### PR DESCRIPTION
The NewContext package requires config as input which would require all third-party callers to update when the new go module is published.

This change only affects the behaviour of installation of helm CRDs. Existing helm crds installed in a cluster would not be removed when disable-helm-controller flag is set on the server.

Addresses #8701

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Disable helm CRD installation for disable-helm-controller
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Breaking Change (for sdk) not for k3s service
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
* #8701 

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Closes #8701