### PR TITLE
Use JSONPatch to update node labels and annotations

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -354,12 +354,9 @@ func configureNode(ctx context.Context, nodeConfig *daemonconfig.Node, nodes typ
 			return false, err
 		}
 
-		if patch.Len() > 0 {
-			b, err := patch.Marshal()
-			if err != nil {
-				return false, err
-			}
-
+		if b, err := patch.Marshal(); err != nil {
+			return false, err
+		} else if b != nil {
 			if _, err := nodes.Patch(ctx, node.Name, types.JSONPatchType, b, metav1.PatchOptions{}); err != nil {
 				logrus.Infof("Failed to set annotations and labels on node %s: %v", agentConfig.NodeName, err)
 				return false, nil

--- a/pkg/etcd/metadata_controller.go
+++ b/pkg/etcd/metadata_controller.go
@@ -101,11 +101,9 @@ func (m *metadataHandler) handleSelf(node *v1.Node) (*v1.Node, error) {
 		ls = labels.Set(node.Labels)
 		patch.WithPath("metadata", "labels").
 			RemoveIfHas(ls, util.ETCDRoleLabelKey)
-		if patch.Len() > 0 {
-			b, err := patch.Marshal()
-			if err != nil {
-				return node, err
-			}
+		if b, err := patch.Marshal(); err != nil {
+			return node, err
+		} else if b != nil {
 			return m.nodeController.Patch(node.Name, types.JSONPatchType, b)
 		}
 		return node, nil
@@ -121,11 +119,9 @@ func (m *metadataHandler) handleSelf(node *v1.Node) (*v1.Node, error) {
 	ls = labels.Set(node.Labels)
 	patch.WithPath("metadata", "labels").
 		AddIfNotEqual(ls, util.ETCDRoleLabelKey, "true")
-	if patch.Len() > 0 {
-		b, err := patch.Marshal()
-		if err != nil {
-			return node, err
-		}
+	if b, err := patch.Marshal(); err != nil {
+		return node, err
+	} else if b != nil {
 		return m.nodeController.Patch(node.Name, types.JSONPatchType, b)
 	}
 	return node, nil

--- a/pkg/etcd/snapshot.go
+++ b/pkg/etcd/snapshot.go
@@ -879,12 +879,14 @@ func (e *ETCD) ReconcileSnapshotData(ctx context.Context) error {
 	if e.config.EtcdS3 {
 		patch.Add(now, "metadata", "annotations", annotationS3Reconciled)
 	}
-	b, err := patch.Marshal()
-	if err != nil {
+	if b, err := patch.Marshal(); err != nil {
 		return err
+	} else if b != nil {
+		if _, err = nodes.Patch(nodeNames[0], types.JSONPatchType, b); err != nil {
+			return err
+		}
 	}
-	_, err = nodes.Patch(nodeNames[0], types.JSONPatchType, b)
-	return err
+	return nil
 }
 
 // setSnapshotFunction schedules snapshots at the configured interval.

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/k3s-io/k3s/pkg/configfilearg"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/k3s-io/k3s/pkg/util/jsonpatch"
 	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 var (
@@ -74,57 +76,45 @@ func getNodeEnv() (string, error) {
 // environment variables as annotations on the node object. It also stores a
 // hash of the combined args + variables. These are used by other components
 // to determine if the node configuration has been changed.
-func SetNodeConfigAnnotations(nodeConfig *config.Node, node *corev1.Node) (bool, error) {
+func SetNodeConfigAnnotations(nodeConfig *config.Node, node *corev1.Node, patch jsonpatch.PatchBuilder) error {
+	ls := labels.Set(node.Annotations)
+	patch = patch.WithPath("metadata", "annotations")
 	nodeArgs, err := getNodeArgs()
 	if err != nil {
-		return false, err
+		return err
 	}
 	nodeEnv, err := getNodeEnv()
 	if err != nil {
-		return false, err
+		return err
 	}
 	h := sha256.New()
 	_, err = h.Write([]byte(nodeArgs + nodeEnv))
 	if err != nil {
-		return false, fmt.Errorf("Failed to hash the node config: %v", err)
-	}
-	if node.Annotations == nil {
-		node.Annotations = make(map[string]string)
+		return fmt.Errorf("Failed to hash the node config: %v", err)
 	}
 	configHash := h.Sum(nil)
 	encoded := base32.StdEncoding.EncodeToString(configHash[:])
-	if node.Annotations[NodeConfigHashAnnotation] == encoded {
-		return false, nil
-	}
 
-	node.Annotations[NodeEnvAnnotation] = nodeEnv
-	node.Annotations[NodeArgsAnnotation] = nodeArgs
-	node.Annotations[NodeConfigHashAnnotation] = encoded
-	return true, nil
+	patch.AddIfNotEqual(ls, NodeEnvAnnotation, nodeEnv)
+	patch.AddIfNotEqual(ls, NodeArgsAnnotation, nodeArgs)
+	patch.AddIfNotEqual(ls, NodeConfigHashAnnotation, encoded)
+	return nil
 }
 
 // SetNodeConfigLabels adds labels for functionality flags
 // that may not be present on down-level or up-level nodes.
 // These labels are used by other components to determine whether
 // or not a node supports particular functionality.
-func SetNodeConfigLabels(nodeConfig *config.Node, node *corev1.Node) (bool, error) {
-	if node.Labels == nil {
-		node.Labels = make(map[string]string)
-	}
-	_, hasLabel := node.Labels[ClusterEgressLabel]
+func SetNodeConfigLabels(nodeConfig *config.Node, node *corev1.Node, patch jsonpatch.PatchBuilder) error {
+	ls := labels.Set(node.Labels)
+	patch = patch.WithPath("metadata", "labels")
 	switch nodeConfig.EgressSelectorMode {
 	case config.EgressSelectorModeCluster, config.EgressSelectorModePod:
-		if !hasLabel {
-			node.Labels[ClusterEgressLabel] = "true"
-			return true, nil
-		}
+		patch.AddIfNotEqual(ls, ClusterEgressLabel, "true")
 	default:
-		if hasLabel {
-			delete(node.Labels, ClusterEgressLabel)
-			return true, nil
-		}
+		patch.RemoveIfHas(ls, ClusterEgressLabel)
 	}
-	return false, nil
+	return nil
 }
 
 func isSecret(key string) bool {

--- a/pkg/nodeconfig/nodeconfig_test.go
+++ b/pkg/nodeconfig/nodeconfig_test.go
@@ -78,7 +78,7 @@ func Test_UnitSetNodeConfigAnnotations(t *testing.T) {
 				node:   FakeNodeWithAnnotation,
 				osArgs: []string{version.Program, "server", "--flannel-backend=none"},
 			},
-			wantPatch: `[]`,
+			wantPatch: ``,
 		},
 		{
 			name: "Set NodeConfigAnnotations to different values",

--- a/pkg/nodeconfig/nodeconfig_test.go
+++ b/pkg/nodeconfig/nodeconfig_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/k3s-io/k3s/pkg/util/jsonpatch"
 	"github.com/k3s-io/k3s/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +31,7 @@ var FakeNodeWithAnnotation = &corev1.Node{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "fakeNode-with-annotation",
 		Annotations: map[string]string{
-			NodeArgsAnnotation:       `["server","--flannel-backend=none"]`,
+			NodeArgsAnnotation:       `["server","--flannel-backend","none"]`,
 			NodeEnvAnnotation:        `{"` + TestEnvName + `":"fakeNode-with-annotation"}`,
 			NodeConfigHashAnnotation: "5E6GSWFRVCOEB3BFFVXKWVD7IQEVJFJAALHPOTCLV7SL33N6SIYA====",
 		},
@@ -41,12 +42,13 @@ func Test_UnitSetExistingNodeConfigAnnotations(t *testing.T) {
 	// adding same config
 	os.Args = []string{version.Program, "server", "--flannel-backend=none"}
 	os.Setenv(version.ProgramUpper+"_NODE_NAME", "fakeNode-with-annotation")
-	nodeUpdated, err := SetNodeConfigAnnotations(FakeNodeConfig, FakeNodeWithAnnotation)
+	patch := jsonpatch.NewBuilder()
+	err := SetNodeConfigAnnotations(FakeNodeConfig, FakeNodeWithAnnotation, patch)
 	if err != nil {
 		t.Fatalf("Failed to set node config annotation: %v", err)
 	}
-	if nodeUpdated {
-		t.Errorf("Test_UnitSetExistingNodeConfigAnnotations() expected false")
+	if patch.Len() != 0 {
+		t.Errorf("Test_UnitSetExistingNodeConfigAnnotations() expected no patches, got %v", string(patch.MustMarshal()))
 	}
 }
 
@@ -56,70 +58,61 @@ func Test_UnitSetNodeConfigAnnotations(t *testing.T) {
 		node   *corev1.Node
 		osArgs []string
 	}
-	setup := func(osArgs []string) error {
+	setup := func(osArgs []string, nodeName string) error {
 		os.Args = osArgs
-		return os.Setenv(TestEnvName, "fakeNode-with-no-annotation")
+		return os.Setenv(TestEnvName, nodeName)
 	}
 	teardown := func() error {
 		return os.Unsetenv(TestEnvName)
 	}
 	tests := []struct {
-		name               string
-		args               args
-		want               bool
-		wantErr            bool
-		wantNodeArgs       string
-		wantNodeEnv        string
-		wantNodeConfigHash string
+		name      string
+		args      args
+		wantErr   bool
+		wantPatch string
 	}{
 		{
-			name: "Set empty NodeConfigAnnotations",
+			name: "Set NodeConfigAnnotations to same values",
 			args: args{
 				config: FakeNodeConfig,
 				node:   FakeNodeWithAnnotation,
 				osArgs: []string{version.Program, "server", "--flannel-backend=none"},
 			},
-			want:               true,
-			wantNodeArgs:       `["server","--flannel-backend","none"]`,
-			wantNodeEnv:        `{"` + TestEnvName + `":"fakeNode-with-no-annotation"}`,
-			wantNodeConfigHash: "DRWW63TXZZGSKLARSFZLNSJ3RZ6VR7LQ46WPKZMSLTSGNI2J42WA====",
+			wantPatch: `[]`,
 		},
 		{
-			name: "Set args with equal",
+			name: "Set NodeConfigAnnotations to different values",
 			args: args{
 				config: FakeNodeConfig,
-				node:   FakeNodeWithNoAnnotation,
+				node:   FakeNodeWithAnnotation,
 				osArgs: []string{version.Program, "server", "--flannel-backend=none", "--write-kubeconfig-mode=777"},
 			},
-			want:         true,
-			wantNodeArgs: `["server","--flannel-backend","none","--write-kubeconfig-mode","777"]`,
-			wantNodeEnv:  `{"` + TestEnvName + `":"fakeNode-with-no-annotation"}`,
+			wantPatch: `[` +
+				`{"op":"add","path":"/metadata/annotations/k3s.io~1node-args","value":"[\"server\",\"--flannel-backend\",\"none\",\"--write-kubeconfig-mode\",\"777\"]"},` +
+				`{"op":"add","path":"/metadata/annotations/k3s.io~1node-config-hash","value":"HG5SBLM6J7NNQ55XTG3HJ46UHNTA4AQOVCVEBME4SVNKG7RXBCTQ===="}` +
+				`]`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer teardown()
-			if err := setup(tt.args.osArgs); err != nil {
+			if err := setup(tt.args.osArgs, tt.args.node.Name); err != nil {
 				t.Errorf("Setup for SetNodeConfigAnnotations() failed = %v", err)
 				return
 			}
-			got, err := SetNodeConfigAnnotations(tt.args.config, tt.args.node)
+			patch := jsonpatch.NewBuilder()
+			err := SetNodeConfigAnnotations(tt.args.config, tt.args.node, patch)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SetNodeConfigAnnotations() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("SetNodeConfigAnnotations() = %+v\nWantRes = %+v", got, tt.want)
+			b, err := patch.Marshal()
+			if err != nil {
+				t.Errorf("patch.Marshal() error = %v", err)
+				return
 			}
-			nodeAnn := tt.args.node.Annotations
-			if nodeAnn[NodeArgsAnnotation] != tt.wantNodeArgs {
-				t.Errorf("SetNodeConfigAnnotations() = %+v\nWantAnn.nodeArgs = %+v", nodeAnn[NodeArgsAnnotation], tt.wantNodeArgs)
-			}
-			if nodeAnn[NodeEnvAnnotation] != tt.wantNodeEnv {
-				t.Errorf("SetNodeConfigAnnotations() = %+v\nWantAnn.nodeEnv = %+v", nodeAnn[NodeEnvAnnotation], tt.wantNodeEnv)
-			}
-			if tt.wantNodeConfigHash != "" && nodeAnn[NodeConfigHashAnnotation] != tt.wantNodeConfigHash {
-				t.Errorf("SetNodeConfigAnnotations() = %+v\nWantAnn.nodeConfigHash = %+v", nodeAnn[NodeConfigHashAnnotation], tt.wantNodeConfigHash)
+			if p := string(b); p != tt.wantPatch {
+				t.Errorf("Wanted patch: %s\nGot: %s", tt.wantPatch, p)
 			}
 		})
 	}

--- a/pkg/secretsencrypt/config.go
+++ b/pkg/secretsencrypt/config.go
@@ -168,11 +168,9 @@ func WriteEncryptionHashAnnotation(runtime *config.ControlRuntime, node *corev1.
 	}
 	ann := stage + "-" + encryptionConfigHash
 	patch := jsonpatch.NewBuilder("metadata", "annotations").AddIfNotEqual(labels.Set(node.Annotations), EncryptionHashAnnotation, ann)
-	if patch.Len() > 0 {
-		b, err := patch.Marshal()
-		if err != nil {
-			return err
-		}
+	if b, err := patch.Marshal(); err != nil {
+		return err
+	} else if b != nil {
 		if _, err = runtime.Core.Core().V1().Node().Patch(node.Name, types.JSONPatchType, b); err != nil {
 			return err
 		}

--- a/pkg/server/secrets-encrypt.go
+++ b/pkg/server/secrets-encrypt.go
@@ -284,12 +284,12 @@ func encryptionReencrypt(ctx context.Context, server *config.Control, force bool
 
 	ann := secretsencrypt.EncryptionReencryptRequest + "-" + reencryptHash
 	patch := jsonpatch.NewBuilder("metadata", "annotations").Add(ann, secretsencrypt.EncryptionHashAnnotation)
-	b, err := patch.Marshal()
-	if err != nil {
+	if b, err := patch.Marshal(); err != nil {
 		return err
-	}
-	if _, err = server.Runtime.Core.Core().V1().Node().Patch(nodeName, types.JSONPatchType, b); err != nil {
-		return err
+	} else if b != nil {
+		if _, err = server.Runtime.Core.Core().V1().Node().Patch(nodeName, types.JSONPatchType, b); err != nil {
+			return err
+		}
 	}
 	logrus.Debugf("encryption hash annotation set successfully on node: %s\n", nodeName)
 	return nil
@@ -345,12 +345,12 @@ func setReencryptAnnotation(server *config.Control) error {
 
 	ann := secretsencrypt.EncryptionReencryptRequest + "-" + reencryptHash
 	patch := jsonpatch.NewBuilder("metadata", "annotations").Add(ann, secretsencrypt.EncryptionHashAnnotation)
-	b, err := patch.Marshal()
-	if err != nil {
+	if b, err := patch.Marshal(); err != nil {
 		return err
-	}
-	if _, err = server.Runtime.Core.Core().V1().Node().Patch(nodeName, types.JSONPatchType, b); err != nil {
-		return err
+	} else if b != nil {
+		if _, err = server.Runtime.Core.Core().V1().Node().Patch(nodeName, types.JSONPatchType, b); err != nil {
+			return err
+		}
 	}
 	logrus.Debugf("encryption hash annotation set successfully on node: %s\n", nodeName)
 	return nil

--- a/pkg/server/secrets-encrypt.go
+++ b/pkg/server/secrets-encrypt.go
@@ -18,10 +18,12 @@ import (
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/secretsencrypt"
 	"github.com/k3s-io/k3s/pkg/util"
+	"github.com/k3s-io/k3s/pkg/util/jsonpatch"
 	"github.com/rancher/wrangler/pkg/generated/controllers/core"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
@@ -274,21 +276,22 @@ func encryptionReencrypt(ctx context.Context, server *config.Control, force bool
 	server.EncryptForce = force
 	server.EncryptSkip = skip
 	nodeName := os.Getenv("NODE_NAME")
-	node, err := server.Runtime.Core.Core().V1().Node().Get(nodeName, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
 
 	reencryptHash, err := secretsencrypt.GenReencryptHash(server.Runtime, secretsencrypt.EncryptionReencryptRequest)
 	if err != nil {
 		return err
 	}
+
 	ann := secretsencrypt.EncryptionReencryptRequest + "-" + reencryptHash
-	node.Annotations[secretsencrypt.EncryptionHashAnnotation] = ann
-	if _, err = server.Runtime.Core.Core().V1().Node().Update(node); err != nil {
+	patch := jsonpatch.NewBuilder("metadata", "annotations").Add(ann, secretsencrypt.EncryptionHashAnnotation)
+	b, err := patch.Marshal()
+	if err != nil {
 		return err
 	}
-	logrus.Debugf("encryption hash annotation set successfully on node: %s\n", node.ObjectMeta.Name)
+	if _, err = server.Runtime.Core.Core().V1().Node().Patch(nodeName, types.JSONPatchType, b); err != nil {
+		return err
+	}
+	logrus.Debugf("encryption hash annotation set successfully on node: %s\n", nodeName)
 	return nil
 }
 
@@ -334,21 +337,22 @@ func encryptionRotateKeys(ctx context.Context, server *config.Control) error {
 
 func setReencryptAnnotation(server *config.Control) error {
 	nodeName := os.Getenv("NODE_NAME")
-	node, err := server.Runtime.Core.Core().V1().Node().Get(nodeName, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
 
 	reencryptHash, err := secretsencrypt.GenReencryptHash(server.Runtime, secretsencrypt.EncryptionReencryptRequest)
 	if err != nil {
 		return err
 	}
+
 	ann := secretsencrypt.EncryptionReencryptRequest + "-" + reencryptHash
-	node.Annotations[secretsencrypt.EncryptionHashAnnotation] = ann
-	if _, err = server.Runtime.Core.Core().V1().Node().Update(node); err != nil {
+	patch := jsonpatch.NewBuilder("metadata", "annotations").Add(ann, secretsencrypt.EncryptionHashAnnotation)
+	b, err := patch.Marshal()
+	if err != nil {
 		return err
 	}
-	logrus.Debugf("encryption hash annotation set successfully on node: %s\n", node.ObjectMeta.Name)
+	if _, err = server.Runtime.Core.Core().V1().Node().Patch(nodeName, types.JSONPatchType, b); err != nil {
+		return err
+	}
+	logrus.Debugf("encryption hash annotation set successfully on node: %s\n", nodeName)
 	return nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -595,12 +595,9 @@ func setNodeLabelsAndAnnotations(ctx context.Context, nodes v1.NodeClient, confi
 			}
 		}
 
-		if patch.Len() > 0 {
-			b, err := patch.Marshal()
-			if err != nil {
-				return false, err
-			}
-
+		if b, err := patch.Marshal(); err != nil {
+			return false, err
+		} else if b != nil {
 			if _, err := nodes.Patch(nodeName, types.JSONPatchType, b); err != nil {
 				logrus.Errorf("Failed to set server annotations and labels on node %s: %v", nodeName, err)
 				return false, nil

--- a/pkg/util/jsonpatch/jsonpatch.go
+++ b/pkg/util/jsonpatch/jsonpatch.go
@@ -110,6 +110,9 @@ func (p *patch) WithPath(path ...string) PatchBuilder {
 }
 
 func (p *patch) Marshal() ([]byte, error) {
+	if p.Len() == 0 {
+		return nil, nil
+	}
 	return json.Marshal(p.ops)
 }
 

--- a/pkg/util/jsonpatch/jsonpatch.go
+++ b/pkg/util/jsonpatch/jsonpatch.go
@@ -1,0 +1,135 @@
+package jsonpatch
+
+import (
+	"encoding/json"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// PatchBuilder is an interface for building a set of changes to a JSON document.
+type PatchBuilder interface {
+	Add(value interface{}, path ...string) PatchBuilder
+	Remove(path ...string) PatchBuilder
+	Replace(value interface{}, path ...string) PatchBuilder
+	Copy(from []string, path ...string) PatchBuilder
+	Move(from []string, path ...string) PatchBuilder
+	Test(value interface{}, path ...string) PatchBuilder
+
+	AddIfNotEqual(ls labels.Set, key, value string) PatchBuilder
+	RemoveIfHas(ls labels.Set, key string) PatchBuilder
+
+	WithPath(path ...string) PatchBuilder
+
+	Marshal() ([]byte, error)
+	MustMarshal() []byte
+
+	Len() int
+}
+
+type operation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+	From  string      `json:"from,omitempty"`
+}
+
+type patch struct {
+	ops  *[]operation
+	base []string
+}
+
+// Explicit interface check
+var _ PatchBuilder = &patch{}
+
+// NewBuilder returns a new builder that can be used to create a chain of operations.
+func NewBuilder(path ...string) PatchBuilder {
+	return &patch{
+		ops:  &[]operation{},
+		base: append([]string{""}, path...),
+	}
+}
+
+func (p *patch) Add(value interface{}, path ...string) PatchBuilder {
+	path = append(p.base, path...)
+	*p.ops = append(*p.ops, operation{Op: "add", Value: value, Path: encodePath(path)})
+	return p
+}
+
+func (p *patch) Remove(path ...string) PatchBuilder {
+	path = append(p.base, path...)
+	*p.ops = append(*p.ops, operation{Op: "remove", Path: encodePath(path)})
+	return p
+}
+
+func (p *patch) Replace(value interface{}, path ...string) PatchBuilder {
+	path = append(p.base, path...)
+	*p.ops = append(*p.ops, operation{Op: "replace", Value: value, Path: encodePath(path)})
+	return p
+}
+
+func (p *patch) Copy(from []string, path ...string) PatchBuilder {
+	from = append(p.base, from...)
+	path = append(p.base, path...)
+	*p.ops = append(*p.ops, operation{Op: "copy", From: encodePath(from), Path: encodePath(path)})
+	return p
+}
+
+func (p *patch) Move(from []string, path ...string) PatchBuilder {
+	from = append(p.base, from...)
+	path = append(p.base, path...)
+	*p.ops = append(*p.ops, operation{Op: "move", From: encodePath(from), Path: encodePath(path)})
+	return p
+}
+
+func (p *patch) Test(value interface{}, path ...string) PatchBuilder {
+	path = append(p.base, path...)
+	*p.ops = append(*p.ops, operation{Op: "test", Value: value, Path: encodePath(path)})
+	return p
+}
+
+func (p *patch) AddIfNotEqual(ls labels.Set, key, value string) PatchBuilder {
+	if ls.Get(key) != value {
+		p.Add(value, key)
+	}
+	return p
+}
+
+func (p *patch) RemoveIfHas(ls labels.Set, key string) PatchBuilder {
+	if ls.Has(key) {
+		p.Remove(key)
+	}
+	return p
+}
+
+func (p *patch) WithPath(path ...string) PatchBuilder {
+	return &patch{
+		ops:  p.ops,
+		base: append(p.base, path...),
+	}
+}
+
+func (p *patch) Marshal() ([]byte, error) {
+	return json.Marshal(p.ops)
+}
+
+func (p *patch) MustMarshal() []byte {
+	b, err := p.Marshal()
+	if err != nil {
+		panic("Failed to marshal JSON patch: " + err.Error())
+	}
+	return b
+}
+
+func (p *patch) Len() int {
+	return len(*p.ops)
+}
+
+// encodePath encodes the two characters reserved by RFC6901, and joins the path components together.
+func encodePath(path []string) string {
+	for i := range path {
+		path[i] = strings.ReplaceAll(path[i], "~", "~0")
+		path[i] = strings.ReplaceAll(path[i], "/", "~1")
+	}
+	return strings.Join(path, "/")
+}

--- a/pkg/util/jsonpatch/jsonpatch_test.go
+++ b/pkg/util/jsonpatch/jsonpatch_test.go
@@ -20,7 +20,7 @@ func Test_JSONPath(t *testing.T) {
 			name: "empty patch",
 			args: args{
 				wantLen:   0,
-				wantPatch: `[]`,
+				wantPatch: ``,
 				addOperations: func(patch PatchBuilder) {
 				},
 			},
@@ -109,7 +109,7 @@ func Test_JSONPath_With_Base(t *testing.T) {
 			name: "empty patch",
 			args: args{
 				wantLen:   0,
-				wantPatch: `[]`,
+				wantPatch: ``,
 				addOperations: func(patch PatchBuilder) {
 				},
 			},

--- a/pkg/util/jsonpatch/jsonpatch_test.go
+++ b/pkg/util/jsonpatch/jsonpatch_test.go
@@ -1,0 +1,217 @@
+package jsonpatch
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func Test_JSONPath(t *testing.T) {
+	type args struct {
+		wantLen       int
+		wantPatch     string
+		addOperations func(patch PatchBuilder)
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "empty patch",
+			args: args{
+				wantLen:   0,
+				wantPatch: `[]`,
+				addOperations: func(patch PatchBuilder) {
+				},
+			},
+		},
+		{
+			name: "add and remove",
+			args: args{
+				wantLen: 3,
+				wantPatch: `[` +
+					`{"op":"add","path":"/a/b","value":1},` +
+					`{"op":"add","path":"/b/c","value":["hello","world"]},` +
+					`{"op":"remove","path":"/d/e"}` +
+					`]`,
+				addOperations: func(patch PatchBuilder) {
+					patch.Add(1, "a", "b")
+					patch.Add([]string{"hello", "world"}, "b", "c")
+					patch.Remove("d", "e")
+				},
+			},
+		},
+		{
+			name: "nested wrapped paths",
+			args: args{
+				wantLen: 4,
+				wantPatch: `[` +
+					`{"op":"add","path":"/a","value":{"b":[1]}},` +
+					`{"op":"add","path":"/a/b","value":2},` +
+					`{"op":"add","path":"/a/b","value":3},` +
+					`{"op":"add","path":"/a/b","value":4}` +
+					`]`,
+				addOperations: func(patch PatchBuilder) {
+					v := map[string][]int{
+						"b": []int{1},
+					}
+					patch.Add(v, "a")
+					patch.WithPath("a", "b").Add(2).Add(3)
+					patch.WithPath("a").WithPath("b").Add(4)
+				},
+			},
+		},
+		{
+			name: "path escaping",
+			args: args{
+				wantLen: 4,
+				wantPatch: `[` +
+					`{"op":"add","path":"/metadata/labels/example.com~1label1","value":"true"},` +
+					`{"op":"remove","path":"/metadata/labels/example.com~1label2"},` +
+					`{"op":"add","path":"/metadata/annotations/example.com~1annotation1","value":"abc"},` +
+					`{"op":"add","path":"/spec/example/~0bar~0","value":"foo"}` +
+					`]`,
+				addOperations: func(patch PatchBuilder) {
+					patch.WithPath("metadata", "labels").Add("true", "example.com/label1").Remove("example.com/label2")
+					patch.WithPath("metadata", "annotations").Add("abc", "example.com/annotation1")
+					patch.WithPath("spec", "example").Add("foo", "~bar~")
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		patch := NewBuilder()
+		t.Run(tt.name, func(t *testing.T) {
+			tt.args.addOperations(patch)
+			if l := patch.Len(); l != tt.args.wantLen {
+				t.Errorf("Wanted patch length: %d, got %d", tt.args.wantLen, l)
+			}
+
+			res := string(patch.MustMarshal())
+			if res != tt.args.wantPatch {
+				t.Errorf("Wanted patch: %s\ngot: %s", tt.args.wantPatch, res)
+			}
+		})
+	}
+}
+
+func Test_JSONPath_With_Base(t *testing.T) {
+	type args struct {
+		wantLen       int
+		wantPatch     string
+		addOperations func(patch PatchBuilder)
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "empty patch",
+			args: args{
+				wantLen:   0,
+				wantPatch: `[]`,
+				addOperations: func(patch PatchBuilder) {
+				},
+			},
+		},
+		{
+			name: "add and remove",
+			args: args{
+				wantLen: 3,
+				wantPatch: `[` +
+					`{"op":"add","path":"/root/path/a/b","value":1},` +
+					`{"op":"add","path":"/root/path/b/c","value":["hello","world"]},` +
+					`{"op":"remove","path":"/root/path/d/e"}` +
+					`]`,
+				addOperations: func(patch PatchBuilder) {
+					patch.Add(1, "a", "b")
+					patch.Add([]string{"hello", "world"}, "b", "c")
+					patch.Remove("d", "e")
+				},
+			},
+		},
+		{
+			name: "nested wrapped paths",
+			args: args{
+				wantLen: 4,
+				wantPatch: `[` +
+					`{"op":"add","path":"/root/path/a","value":{"b":[1]}},` +
+					`{"op":"add","path":"/root/path/a/b","value":2},` +
+					`{"op":"add","path":"/root/path/a/b","value":3},` +
+					`{"op":"add","path":"/root/path/a/b","value":4}` +
+					`]`,
+				addOperations: func(patch PatchBuilder) {
+					v := map[string][]int{
+						"b": []int{1},
+					}
+					patch.Add(v, "a")
+					patch.WithPath("a", "b").Add(2).Add(3)
+					patch.WithPath("a").WithPath("b").Add(4)
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		patch := NewBuilder("root", "path")
+		t.Run(tt.name, func(t *testing.T) {
+			tt.args.addOperations(patch)
+			if l := patch.Len(); l != tt.args.wantLen {
+				t.Errorf("Wanted patch length: %d, got %d", tt.args.wantLen, l)
+			}
+
+			res := string(patch.MustMarshal())
+			if res != tt.args.wantPatch {
+				t.Errorf("Wanted patch: %s\ngot: %s", tt.args.wantPatch, res)
+			}
+		})
+	}
+}
+
+func Test_JSONPath_LabelSet(t *testing.T) {
+	type args struct {
+		wantLen       int
+		wantPatch     string
+		labelSet      labels.Set
+		addOperations func(ls labels.Set, patch PatchBuilder)
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "add and remove",
+			args: args{
+				wantLen: 2,
+				labelSet: labels.Set{
+					"example.com/label1": "true",
+					"example.com/label2": "1234",
+					"example.com/label3": "0000",
+				},
+				wantPatch: `[` +
+					`{"op":"remove","path":"/metadata/labels/example.com~1label1"},` +
+					`{"op":"add","path":"/metadata/labels/example.com~1label2","value":"5678"}` +
+					`]`,
+				addOperations: func(ls labels.Set, patch PatchBuilder) {
+					patch = patch.WithPath("metadata", "labels")
+					patch.RemoveIfHas(ls, "example.com/label1")
+					patch.AddIfNotEqual(ls, "example.com/label2", "5678")
+					patch.AddIfNotEqual(ls, "example.com/label3", "0000")
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		patch := NewBuilder()
+		t.Run(tt.name, func(t *testing.T) {
+			tt.args.addOperations(tt.args.labelSet, patch)
+			if l := patch.Len(); l != tt.args.wantLen {
+				t.Errorf("Wanted patch length: %d, got %d", tt.args.wantLen, l)
+			}
+
+			res := string(patch.MustMarshal())
+			if res != tt.args.wantPatch {
+				t.Errorf("Wanted patch: %s\ngot: %s", tt.args.wantPatch, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Proposed Changes ####

We spend a fair bit of time during startup with multiple controllers trying to update node labels and annotations. Each of these has to retry if they race with another controller to make changes.

Switching to Patch instead of Get/Update should speed this up, as Patch is atomic on the server side and cannot conflict as it has no preconditions.

#### Types of Changes ####

enhancement

#### Verification ####

Note startup time improvements

#### Testing ####


#### Linked Issues ####


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

This doesn't seem to have made much of an actual impact on startup times for the first run of a single sqlite server. A 10 run sample:

Before:
```
 INFO[0019] Running flannel backend.
 INFO[0017] Running flannel backend.
 INFO[0017] Running flannel backend.
 INFO[0018] Running flannel backend.
 INFO[0018] Running flannel backend.
 INFO[0018] Running flannel backend.
 INFO[0019] Running flannel backend.
 INFO[0017] Running flannel backend.
 INFO[0018] Running flannel backend.
 INFO[0018] Running flannel backend.
 ```
 
 After:
 ```
 INFO[0018] Running flannel backend.
 INFO[0018] Running flannel backend.
 INFO[0019] Running flannel backend.
 INFO[0019] Running flannel backend.
 INFO[0018] Running flannel backend.
 INFO[0018] Running flannel backend.
 INFO[0017] Running flannel backend.
 INFO[0018] Running flannel backend.
 INFO[0018] Running flannel backend.
 INFO[0018] Running flannel backend.
 ```
 
 Adding an agent also takes 3 seconds both before and after this change. So maybe it's not worth the additional code, even if I do think it's cool.