### PR TITLE
Tweaked order of ingress IPs in ServiceLB

### DIFF
--- a/pkg/cloudprovider/servicelb.go
+++ b/pkg/cloudprovider/servicelb.go
@@ -285,10 +285,6 @@ func (k *k3s) getStatus(svc *core.Service) (*core.LoadBalancerStatus, error) {
 		return nil, err
 	}
 
-	expectedIPs, err = filterByIPFamily(expectedIPs, svc)
-	if err != nil {
-		return nil, err
-	}
 
 	loadbalancer := &core.LoadBalancerStatus{}
 	for _, ip := range expectedIPs {

--- a/pkg/cloudprovider/servicelb.go
+++ b/pkg/cloudprovider/servicelb.go
@@ -285,7 +285,10 @@ func (k *k3s) getStatus(svc *core.Service) (*core.LoadBalancerStatus, error) {
 		return nil, err
 	}
 
-	sort.Strings(expectedIPs)
+	expectedIPs, err = filterByIPFamily(expectedIPs, svc)
+	if err != nil {
+		return nil, err
+	}
 
 	loadbalancer := &core.LoadBalancerStatus{}
 	for _, ip := range expectedIPs {
@@ -392,6 +395,9 @@ func filterByIPFamily(ips []string, svc *core.Service) ([]string, error) {
 			ipv6Addresses = append(ipv6Addresses, ip)
 		}
 	}
+
+	sort.Strings(ipv4Addresses)
+	sort.Strings(ipv6Addresses)
 
 	for _, ipFamily := range svc.Spec.IPFamilies {
 		switch ipFamily {

--- a/pkg/cloudprovider/servicelb.go
+++ b/pkg/cloudprovider/servicelb.go
@@ -285,7 +285,6 @@ func (k *k3s) getStatus(svc *core.Service) (*core.LoadBalancerStatus, error) {
 		return nil, err
 	}
 
-
 	loadbalancer := &core.LoadBalancerStatus{}
 	for _, ip := range expectedIPs {
 		loadbalancer.Ingress = append(loadbalancer.Ingress, core.LoadBalancerIngress{

--- a/pkg/cloudprovider/servicelb_test.go
+++ b/pkg/cloudprovider/servicelb_test.go
@@ -1,6 +1,7 @@
 package cloudprovider
 
 import (
+	"math/rand"
 	"reflect"
 	"testing"
 
@@ -8,8 +9,10 @@ import (
 )
 
 const (
-	addrv4 = "1.2.3.4"
-	addrv6 = "2001:db8::1"
+	addrv4   = "1.2.3.4"
+	addrv4_2 = "2.3.4.5"
+	addrv6   = "2001:db8::1"
+	addrv6_2 = "3001:db8::1"
 )
 
 func Test_UnitFilterByIPFamily(t *testing.T) {
@@ -87,5 +90,24 @@ func Test_UnitFilterByIPFamily(t *testing.T) {
 				t.Errorf("filterByIPFamily() = %+v\nWant = %+v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_UnitFilterByIPFamily_Ordering(t *testing.T) {
+	want := []string{addrv4, addrv4_2, addrv6, addrv6_2}
+	ips := []string{addrv4, addrv4_2, addrv6, addrv6_2}
+	rand.Shuffle(len(ips), func(i, j int) {
+		ips[i], ips[j] = ips[j], ips[i]
+	})
+	svc := &core.Service{
+		Spec: core.ServiceSpec{
+			IPFamilies: []core.IPFamily{core.IPv4Protocol, core.IPv6Protocol},
+		},
+	}
+
+	got, _ := filterByIPFamily(ips, svc)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("filterByIPFamily() = %+v\nWant = %+v", got, want)
 	}
 }


### PR DESCRIPTION
Previously, ingress IPs were only string-sorted when returned

Sorted by IP family and string-sorted in each family as part of filterByIPFamily method

#### Proposed Changes ####

Addresses https://github.com/k3s-io/k3s/issues/8704 with adjustment and use of `filterByIPFamily` as part of `servicelb.getStatus`

#### Types of Changes ####

Bugfix

#### Verification ####

Added new unit test to `servicelb_test.go`

#### Testing ####

See above

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8704

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Improved ingress IP ordering from ServiceLB
```

#### Further Comments ####

Hopefully my first PR of many. Great project

