### PR TITLE
QoS-class resource configuration

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -558,6 +558,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	nodeConfig.Containerd.Debug = envInfo.Debug
 	applyContainerdStateAndAddress(nodeConfig)
 	applyCRIDockerdAddress(nodeConfig)
+	applyContainerdQoSClassConfigFileIfPresent(envInfo, nodeConfig)
 	nodeConfig.Containerd.Template = filepath.Join(envInfo.DataDir, "agent", "etc", "containerd", "config.toml.tmpl")
 	nodeConfig.Certificate = servingCert
 

--- a/pkg/agent/config/config_linux.go
+++ b/pkg/agent/config/config_linux.go
@@ -4,9 +4,13 @@
 package config
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/sirupsen/logrus"
 )
 
 func applyContainerdStateAndAddress(nodeConfig *config.Node) {
@@ -16,4 +20,22 @@ func applyContainerdStateAndAddress(nodeConfig *config.Node) {
 
 func applyCRIDockerdAddress(nodeConfig *config.Node) {
 	nodeConfig.CRIDockerd.Address = "unix:///run/k3s/cri-dockerd/cri-dockerd.sock"
+}
+
+func applyContainerdQoSClassConfigFileIfPresent(envInfo *cmds.Agent, nodeConfig *config.Node) {
+	blockioPath := filepath.Join(envInfo.DataDir, "agent", "etc", "containerd", "blockio_config.yaml")
+
+	// Set containerd config if file exists
+	if _, err := os.Stat(blockioPath); !errors.Is(err, os.ErrNotExist) {
+		logrus.Infof("BlockIO configuration file found")
+		nodeConfig.Containerd.BlockIOConfig = blockioPath
+	}
+
+	rdtPath := filepath.Join(envInfo.DataDir, "agent", "etc", "containerd", "rdt_config.yaml")
+
+	// Set containerd config if file exists
+	if _, err := os.Stat(rdtPath); !errors.Is(err, os.ErrNotExist) {
+		logrus.Infof("RDT configuration file found")
+		nodeConfig.Containerd.RDTConfig = rdtPath
+	}
 }

--- a/pkg/agent/config/config_windows.go
+++ b/pkg/agent/config/config_windows.go
@@ -6,6 +6,7 @@ package config
 import (
 	"path/filepath"
 
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 )
 
@@ -16,4 +17,8 @@ func applyContainerdStateAndAddress(nodeConfig *config.Node) {
 
 func applyCRIDockerdAddress(nodeConfig *config.Node) {
 	nodeConfig.CRIDockerd.Address = "npipe:////.pipe/cri-dockerd"
+}
+
+func applyContainerdQoSClassConfigFileIfPresent(envInfo *cmds.Agent, nodeConfig *config.Node) {
+	// QoS-class resource management not supported on windows.
 }

--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -82,6 +82,12 @@ enable_keychain = true
   conf_dir = "{{ .NodeConfig.AgentConfig.CNIConfDir }}"
 {{end}}
 
+{{- if or .NodeConfig.Containerd.BlockIOConfig .NodeConfig.Containerd.RDTConfig }}
+[plugins."io.containerd.service.v1.tasks-service"]
+  {{ if .NodeConfig.Containerd.BlockIOConfig }}blockio_config_file = "{{ .NodeConfig.Containerd.BlockIOConfig }}"{{end}}
+  {{ if .NodeConfig.Containerd.RDTConfig }}rdt_config_file = "{{ .NodeConfig.Containerd.RDTConfig }}"{{end}}
+{{end}}
+
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
   runtime_type = "io.containerd.runc.v2"
 

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -58,15 +58,17 @@ type Node struct {
 }
 
 type Containerd struct {
-	Address  string
-	Log      string
-	Root     string
-	State    string
-	Config   string
-	Opt      string
-	Template string
-	SELinux  bool
-	Debug    bool
+	Address       string
+	Log           string
+	Root          string
+	State         string
+	Config        string
+	Opt           string
+	Template      string
+	BlockIOConfig string
+	RDTConfig     string
+	SELinux       bool
+	Debug         bool
 }
 
 type CRIDockerd struct {


### PR DESCRIPTION
Problem:
Configuring qos-class features in containerd requres a custom containerd configuration template.

Solution:
Look for configuration files in default locations and configure containerd to use them if they exist.

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- If `rdt_config.yaml` and/or `blockio_config.yaml` exists, configure containerd to use them by specifying their paths in the generated containerd `config.toml` file.  
- The predefined file locations to check are (same directory as containerd configuration file):
  - `/var/lib/rancher/k3s/agent/etc/containerd/rdt_config.yaml`
  - `/var/lib/rancher/k3s/agent/etc/containerd/blockio_config.yaml`

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

- New Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

1. Ensure generated `config.toml` does not contain any line similar to any of:
  `[plugins."io.containerd.service.v1.tasks-service"]`, `rdt_config_file = "..."`, or `blockio_config_file = "..."`
2. `touch /var/lib/rancher/k3s/agent/etc/containerd/rdt_config.yaml`
3. Restart k3s
4. This should mean k3s fails to start, as containerd will exit due to an empty file not being a valid configuration.
5. Ensure the file reference exists in the `config.toml` file (in accordance with https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md)

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

Not covered

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- #8720 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Containerd may now be configured to use rdt or blockio configuration by defining `rdt_config.yaml` or `blockio_config.yaml` files.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
