### PR TITLE
add: timezone info in image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.18 as base
-RUN apk add -U ca-certificates tar zstd
+RUN apk add -U ca-certificates tar zstd tzdata
 COPY build/out/data.tar.zst /
 RUN mkdir -p /image/etc/ssl/certs /image/run /image/var/run /image/tmp /image/lib/modules /image/lib/firmware && \
     tar -xa -C /image -f /data.tar.zst && \
@@ -8,6 +8,7 @@ RUN mkdir -p /image/etc/ssl/certs /image/run /image/var/run /image/tmp /image/li
 FROM scratch
 ARG VERSION="dev"
 COPY --from=base /image /
+COPY --from=base /usr/share/zoneinfo /usr/share/zoneinfo
 RUN mkdir -p /etc && \
     echo 'hosts: files dns' > /etc/nsswitch.conf && \
     echo "PRETTY_NAME=\"K3s ${VERSION}\"" > /etc/os-release && \


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

The K3s image is built `FROM scratch`, thus doesn't include a timezone database.
With K8s v1.27, the [timezone field on CronJobs is stable](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones), but cannot really be used with the K3s docker image, since it won't know the timezones except for UTC.
A workaround is to mount the file from the host system.

#### Types of Changes ####

New Feature

#### Verification ####

- Run the newly built image (e.g. with k3d) 
- create a CronJob with a timezone set:
	```yaml
	apiVersion: batch/v1
	kind: CronJob
	metadata:
	  name: my-job
	spec:
	  jobTemplate:
	    metadata:
	      name: my-job
	    spec:
	      template:
	        spec:
	          containers:
	            - image: busybox
	              name: my-job
	          restartPolicy: Never
	  schedule: '1 1 1 1 *'
	  timeZone: Europe/Berlin
	```
- See that it's applied correctly, whereas it would fail with `unknown time zone` before



#### Testing ####

 -

#### Linked Issues ####

- https://github.com/k3s-io/k3s/issues/8832
- https://github.com/k3d-io/k3d/issues/1083

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- new timezone info in Docker image allows the use of `spec.timeZone` in CronJobs
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
