### PR TITLE
Skip initial datastore reconcile during cluster-reset

### DIFF
--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -31,7 +31,7 @@ import (
 // Bootstrap attempts to load a managed database driver, if one has been initialized or should be created/joined.
 // It then checks to see if the cluster needs to load bootstrap data, and if so, loads data into the
 // ControlRuntimeBoostrap struct, either via HTTP or from the datastore.
-func (c *Cluster) Bootstrap(ctx context.Context, snapshot bool) error {
+func (c *Cluster) Bootstrap(ctx context.Context, clusterReset bool) error {
 	if err := c.assignManagedDriver(ctx); err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func (c *Cluster) Bootstrap(ctx context.Context, snapshot bool) error {
 	c.shouldBootstrap = shouldBootstrap
 
 	if c.managedDB != nil {
-		if !snapshot {
+		if !clusterReset {
 			isHTTP := c.config.JoinURL != "" && c.config.Token != ""
 			// For secondary servers, we attempt to connect and reconcile with the datastore.
 			// If that fails we fallback to the local etcd cluster start

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -262,7 +262,7 @@ func prepare(ctx context.Context, config *config.Control) error {
 
 	cluster := cluster.New(config)
 
-	if err := cluster.Bootstrap(ctx, false); err != nil {
+	if err := cluster.Bootstrap(ctx, config.ClusterReset); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### Proposed Changes ####

Skip initial datastore reconcile during cluster-reset

Due to prior refactoring, there are no longer any other callers of `cluster.Bootstrap`, and the `snapshot` flag was unused. It does what we want when resetting/restoring though.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8497

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
