### PR TITLE
Add `nats` build tag from KINE for embedded support

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -62,7 +62,7 @@ fi
 STATIC="
     -extldflags '-static -lm -ldl -lz -lpthread'
 "
-TAGS="ctrd apparmor seccomp netcgo osusergo providerless urfave_cli_no_docs"
+TAGS="ctrd apparmor seccomp netcgo osusergo providerless urfave_cli_no_docs nats"
 RUNC_TAGS="apparmor seccomp"
 RUNC_STATIC="static"
 


### PR DESCRIPTION
#### Proposed Changes ####

Support embedded NATS by default.

#### Types of Changes ####

It will embed the NATS server as part of the k3s binary rather than require an external server.

#### Verification ####

NATS is already embedded within standalone KINE releases.

#### Testing ####

Current testing is done within KINE.

#### Linked Issues ####

#7451 

#### User-Facing Change ####

For existing deployments of k3s that used NATS (implying an external server/cluster), the `--datastore-endpoint=nats://...` CLI option must be updated with the `noEmbed` param to prevent running in embedded mode and expect to connect to an external server.

#### Further Comments ####

None.
