### PR TITLE
Handle logging flags when parsing kube-proxy args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -161,6 +161,7 @@ require (
 	k8s.io/component-helpers v0.29.0
 	k8s.io/cri-api v0.29.0-alpha.0
 	k8s.io/klog/v2 v2.110.1
+	k8s.io/kube-proxy v0.0.0
 	k8s.io/kubectl v0.25.0
 	k8s.io/kubernetes v1.29.0
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
@@ -421,7 +422,6 @@ require (
 	k8s.io/kube-aggregator v0.29.0 // indirect
 	k8s.io/kube-controller-manager v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
-	k8s.io/kube-proxy v0.0.0 // indirect
 	k8s.io/kube-scheduler v0.0.0 // indirect
 	k8s.io/kubelet v0.0.0 // indirect
 	k8s.io/legacy-cloud-providers v0.0.0 // indirect

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -43,6 +43,8 @@ import (
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	toolswatch "k8s.io/client-go/tools/watch"
+	"k8s.io/component-base/cli/globalflag"
+	"k8s.io/component-base/logs"
 	app2 "k8s.io/kubernetes/cmd/kube-proxy/app"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	utilsnet "k8s.io/utils/net"
@@ -195,6 +197,7 @@ func getConntrackConfig(nodeConfig *daemonconfig.Node) (*kubeproxyconfig.KubePro
 	}
 
 	cmd := app2.NewProxyCommand()
+	globalflag.AddGlobalFlags(cmd.Flags(), cmd.Name(), logs.SkipLoggingConfigurationFlags())
 	if err := cmd.ParseFlags(daemonconfig.GetArgs(map[string]string{}, nodeConfig.AgentConfig.ExtraKubeProxyArgs)); err != nil {
 		return nil, err
 	}

--- a/pkg/agent/run_test.go
+++ b/pkg/agent/run_test.go
@@ -1,0 +1,99 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
+	v1alpha1 "k8s.io/kube-proxy/config/v1alpha1"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
+	kubeproxyconfigv1alpha1 "k8s.io/kubernetes/pkg/proxy/apis/config/v1alpha1"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+func Test_UnitGetConntrackConfig(t *testing.T) {
+	// There are only helpers to default the typed config, so we have to set defaults on the typed config,
+	// then convert it to the internal config representation in order to use it for tests.
+	typedConfig := &v1alpha1.KubeProxyConfiguration{}
+	defaultConfig := &kubeproxyconfig.KubeProxyConfiguration{}
+	kubeproxyconfigv1alpha1.SetDefaults_KubeProxyConfiguration(typedConfig)
+	if err := kubeproxyconfigv1alpha1.Convert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguration(typedConfig, defaultConfig, nil); err != nil {
+		t.Fatalf("Failed to generate default KubeProxyConfiguration: %v", err)
+	}
+
+	customConfig := defaultConfig.DeepCopy()
+	customConfig.Conntrack.Min = utilpointer.Int32Ptr(100)
+	customConfig.Conntrack.TCPCloseWaitTimeout.Duration = 42 * time.Second
+
+	type args struct {
+		nodeConfig *daemonconfig.Node
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *kubeproxyconfig.KubeProxyConntrackConfiguration
+		wantErr bool
+	}{
+		{
+			name: "Default args",
+			args: args{
+				nodeConfig: &daemonconfig.Node{
+					AgentConfig: daemonconfig.Agent{
+						ExtraKubeProxyArgs: []string{},
+					},
+				},
+			},
+			want:    &defaultConfig.Conntrack,
+			wantErr: false,
+		},
+		{
+			name: "Logging args",
+			args: args{
+				nodeConfig: &daemonconfig.Node{
+					AgentConfig: daemonconfig.Agent{
+						ExtraKubeProxyArgs: []string{"v=9"},
+					},
+				},
+			},
+			want:    &defaultConfig.Conntrack,
+			wantErr: false,
+		},
+		{
+			name: "Invalid args",
+			args: args{
+				nodeConfig: &daemonconfig.Node{
+					AgentConfig: daemonconfig.Agent{
+						ExtraKubeProxyArgs: []string{"conntrack-tcp-timeout-close-wait=invalid", "bogus=true"},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Conntrack args",
+			args: args{
+				nodeConfig: &daemonconfig.Node{
+					AgentConfig: daemonconfig.Agent{
+						ExtraKubeProxyArgs: []string{"conntrack-tcp-timeout-close-wait=42s", "conntrack-min=100"},
+					},
+				},
+			},
+			want:    &customConfig.Conntrack,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getConntrackConfig(tt.args.nodeConfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getConntrackConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getConntrackConfig() = %+v\nWant = %+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Proposed Changes ####

Handle logging flags when parsing kube-proxy args

Also adds a test to ensure this continues to work.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8915

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
