### PR TITLE
Add ServiceLB support for PodHostIPs FeatureGate

### DIFF
--- a/pkg/cloudprovider/servicelb.go
+++ b/pkg/cloudprovider/servicelb.go
@@ -24,9 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/util/retry"
 	ccmapp "k8s.io/cloud-provider/app"
 	servicehelper "k8s.io/cloud-provider/service/helpers"
+	"k8s.io/kubernetes/pkg/features"
 	utilsnet "k8s.io/utils/net"
 	utilpointer "k8s.io/utils/pointer"
 )
@@ -47,7 +49,7 @@ const (
 )
 
 var (
-	DefaultLBImage = "rancher/klipper-lb:v0.4.4"
+	DefaultLBImage = "rancher/klipper-lb:v0.4.5"
 )
 
 func (k *k3s) Register(ctx context.Context,
@@ -435,10 +437,11 @@ func (k *k3s) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 	name := generateName(svc)
 	oneInt := intstr.FromInt(1)
 	localTraffic := servicehelper.RequestsOnlyLocalTraffic(svc)
-	sourceRanges, err := servicehelper.GetLoadBalancerSourceRanges(svc)
+	sourceRangesSet, err := servicehelper.GetLoadBalancerSourceRanges(svc)
 	if err != nil {
 		return nil, err
 	}
+	sourceRanges := strings.Join(sourceRangesSet.StringSlice(), ",")
 
 	var sysctls []core.Sysctl
 	for _, ipFamily := range svc.Spec.IPFamilies {
@@ -447,6 +450,11 @@ func (k *k3s) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 			sysctls = append(sysctls, core.Sysctl{Name: "net.ipv4.ip_forward", Value: "1"})
 		case core.IPv6Protocol:
 			sysctls = append(sysctls, core.Sysctl{Name: "net.ipv6.conf.all.forwarding", Value: "1"})
+			// The upstream default load-balancer source range only includes IPv4, even if the service is IPv6-only or dual-stack.
+			// If using the default range, and IPv6 is enabled, also allow IPv6.
+			if sourceRanges == "0.0.0.0/0" {
+				sourceRanges += ",::/0"
+			}
 		}
 	}
 
@@ -532,7 +540,7 @@ func (k *k3s) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 				},
 				{
 					Name:  "SRC_RANGES",
-					Value: strings.Join(sourceRanges.StringSlice(), " "),
+					Value: sourceRanges,
 				},
 				{
 					Name:  "DEST_PROTO",
@@ -558,7 +566,7 @@ func (k *k3s) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 					Name: "DEST_IPS",
 					ValueFrom: &core.EnvVarSource{
 						FieldRef: &core.ObjectFieldSelector{
-							FieldPath: "status.hostIP",
+							FieldPath: getHostIPsFieldPath(),
 						},
 					},
 				},
@@ -571,7 +579,7 @@ func (k *k3s) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 				},
 				core.EnvVar{
 					Name:  "DEST_IPS",
-					Value: strings.Join(svc.Spec.ClusterIPs, " "),
+					Value: strings.Join(svc.Spec.ClusterIPs, ","),
 				},
 			)
 		}
@@ -702,4 +710,11 @@ func ingressToString(ingresses []core.LoadBalancerIngress) []string {
 		}
 	}
 	return parts
+}
+
+func getHostIPsFieldPath() string {
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodHostIPs) {
+		return "status.hostIPs"
+	}
+	return "status.hostIP"
 }

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,5 +1,5 @@
 docker.io/rancher/klipper-helm:v0.8.2-build20230815
-docker.io/rancher/klipper-lb:v0.4.4
+docker.io/rancher/klipper-lb:v0.4.5
 docker.io/rancher/local-path-provisioner:v0.0.24
 docker.io/rancher/mirrored-coredns-coredns:1.10.1
 docker.io/rancher/mirrored-library-busybox:1.36.1


### PR DESCRIPTION
#### Proposed Changes ####

Add ServiceLB support for PodHostIPs FeatureGate

If the feature-gate is enabled, use status.hostIPs for dual-stack externalTrafficPolicy=Local support.

At the moment, we are only able to advertise the address of the primary address family for services with `externalTrafficPolicy=Local`, as the downwards API does not expose both dual-stack host addresses.

Waiting on:
* [ ] https://github.com/k3s-io/klipper-lb/pull/60

#### Types of Changes ####

Enhancement

#### Verification ####

Start dual-stack k3s server with:
```bash
k3s server \
  --cluster-cidr=10.42.0.0/16,2001:cafe:42::/56 \
  --service-cidr=10.43.0.0/16,2001:cafe:43::/112 \
  --kubelet-arg=feature-gates=CloudDualStackNodeIPs=true,PodHostIPs=true \
  --kube-apiserver-arg=feature-gates=CloudDualStackNodeIPs=true,PodHostIPs=true \
  --controller-manager-arg=feature-gates=CloudDualStackNodeIPs=true,PodHostIPs=true \
  --kube-cloud-controller-manager-arg=feature-gates=CloudDualStackNodeIPs=true,PodHostIPs=true
```

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8823

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
