### PR TITLE
[release-1.25] Fix etcd snapshot S3 issues

### DIFF
--- a/pkg/etcd/s3.go
+++ b/pkg/etcd/s3.go
@@ -360,9 +360,8 @@ func (s *S3) listSnapshots(ctx context.Context) (map[string]snapshotFile, error)
 	defer cancel()
 
 	opts := minio.ListObjectsOptions{
-		Prefix:       s.config.EtcdS3Folder,
-		Recursive:    true,
-		WithMetadata: true,
+		Prefix:    s.config.EtcdS3Folder,
+		Recursive: true,
 	}
 
 	objects := s.client.ListObjects(ctx, s.config.EtcdS3BucketName, opts)

--- a/pkg/etcd/s3.go
+++ b/pkg/etcd/s3.go
@@ -178,7 +178,7 @@ func (s *S3) upload(ctx context.Context, snapshot string, extraMetadata *v1.Conf
 	if _, err := s.uploadSnapshotMetadata(ctx, metadataKey, metadata); err != nil {
 		logrus.Warnf("Failed to upload snapshot metadata to S3: %v", err)
 	} else {
-		logrus.Infof("Uploaded snapshot metadata s3://%s/%s", s.config.EtcdS3BucketName, metadata)
+		logrus.Infof("Uploaded snapshot metadata s3://%s/%s", s.config.EtcdS3BucketName, metadataKey)
 	}
 	return sf, err
 }


### PR DESCRIPTION
#### Proposed Changes ####

*Backport of https://github.com/k3s-io/k3s/pull/8926*

* Don't apply s3 retention if S3 client failed to initialize
* Don't request metadata when listing objects  
   While some implementations may support it, it appears that most don't, and some may in fact return an error if it is requested. We already stat the object to get the metadata anyway, so this was unnecessary if harmless on most implementations.
* Print key instead of file path in snapshot metadata log message

#### Types of Changes ####

bugfix

#### Verification ####

See linked issues

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8929
* https://github.com/k3s-io/k3s/issues/8932
* https://github.com/k3s-io/k3s/issues/8935

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Don't apply S3 retention if S3 client failed to initialize
Don't request metadata when listing S3 snapshots
Print key instead of file path in snapshot metadata log message
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
