### PR TITLE
Fix the OTHER etcd snapshot s3 log message that prints the wrong variable

### DIFF
--- a/pkg/etcd/s3.go
+++ b/pkg/etcd/s3.go
@@ -139,7 +139,6 @@ func NewS3(ctx context.Context, config *config.Control) (*S3, error) {
 // upload uploads the given snapshot to the configured S3
 // compatible backend.
 func (s *S3) upload(ctx context.Context, snapshot string, extraMetadata *v1.ConfigMap, now time.Time) (*snapshotFile, error) {
-	logrus.Infof("Uploading snapshot to s3://%s/%s", s.config.EtcdS3BucketName, snapshot)
 	basename := filepath.Base(snapshot)
 	metadata := filepath.Join(filepath.Dir(snapshot), "..", metadataDir, basename)
 	snapshotKey := path.Join(s.config.EtcdS3Folder, basename)
@@ -166,6 +165,7 @@ func (s *S3) upload(ctx context.Context, snapshot string, extraMetadata *v1.Conf
 		nodeSource:     s.nodeName,
 	}
 
+	logrus.Infof("Uploading snapshot to s3://%s/%s", s.config.EtcdS3BucketName, snapshotKey)
 	uploadInfo, err := s.uploadSnapshot(ctx, snapshotKey, snapshot)
 	if err != nil {
 		sf.Status = failedSnapshotStatus


### PR DESCRIPTION

#### Proposed Changes ####

Fix the OTHER log message that prints the wrong variable

#### Types of Changes ####

bugfix

#### Verification ####

Check log message

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8925

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
