### PR TITLE
Remove kubelet credential provider support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,6 @@ replace (
 require (
 	github.com/Microsoft/hcsshim v0.11.1
 	github.com/Mirantis/cri-dockerd v0.0.0-00010101000000-000000000000
-	github.com/blang/semver/v4 v4.0.0
 	github.com/cloudnativelabs/kube-router/v2 v2.0.0-00010101000000-000000000000
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/cgroups v1.1.0
@@ -144,6 +143,7 @@ require (
 	go.etcd.io/etcd/server/v3 v3.5.9
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.15.0
+	golang.org/x/mod v0.11.0
 	golang.org/x/net v0.17.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/sys v0.14.0
@@ -194,6 +194,7 @@ require (
 	github.com/avast/retry-go/v4 v4.3.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bronze1man/goStrongswanVici v0.0.0-20201105010758-936f38b697fd // indirect
 	github.com/canonical/go-dqlite v1.5.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
@@ -385,7 +386,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230307190834-24139beb5833 // indirect
-	golang.org/x/mod v0.11.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -528,7 +528,6 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		nodeConfig.AgentConfig.RootDir = filepath.Join(envInfo.DataDir, "agent", "kubelet")
 	}
 	nodeConfig.AgentConfig.Snapshotter = envInfo.Snapshotter
-	nodeConfig.AgentConfig.IPSECPSK = controlConfig.IPSECPSK
 	nodeConfig.Containerd.Config = filepath.Join(envInfo.DataDir, "agent", "etc", "containerd", "config.toml")
 	nodeConfig.Containerd.Root = filepath.Join(envInfo.DataDir, "agent", "containerd")
 	nodeConfig.CRIDockerd.Root = filepath.Join(envInfo.DataDir, "agent", "cri-dockerd")

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -660,8 +660,6 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	nodeConfig.AgentConfig.ExtraKubeProxyArgs = envInfo.ExtraKubeProxyArgs
 	nodeConfig.AgentConfig.NodeTaints = envInfo.Taints
 	nodeConfig.AgentConfig.NodeLabels = envInfo.Labels
-	nodeConfig.AgentConfig.ImageCredProvBinDir = envInfo.ImageCredProvBinDir
-	nodeConfig.AgentConfig.ImageCredProvConfig = envInfo.ImageCredProvConfig
 	nodeConfig.AgentConfig.PrivateRegistry = envInfo.PrivateRegistry
 	nodeConfig.AgentConfig.DisableCCM = controlConfig.DisableCCM
 	nodeConfig.AgentConfig.DisableNPC = controlConfig.DisableNPC

--- a/pkg/cli/agent/agent.go
+++ b/pkg/cli/agent/agent.go
@@ -67,6 +67,11 @@ func Run(ctx *cli.Context) error {
 		cmds.AgentConfig.NodeIP.Set(ip)
 	}
 
+	// Handle command deprecation
+	if err := cmds.HandleDeprecated(ctx); err != nil {
+		return err
+	}
+
 	logrus.Info("Starting " + version.Program + " agent " + ctx.App.Version)
 
 	dataDir, err := datadir.LocalHome(cmds.AgentConfig.DataDir, cmds.AgentConfig.Rootless)

--- a/pkg/cli/cert/cert.go
+++ b/pkg/cli/cert/cert.go
@@ -288,7 +288,6 @@ func rotateCA(app *cli.Context, cfg *cmds.Server, sync *cmds.CertRotateCA) error
 
 	// Override these paths so that we don't get warnings when they don't exist, as the user is not expected to provide them.
 	tmpServer.Runtime.PasswdFile = "/dev/null"
-	tmpServer.Runtime.IPSECKey = "/dev/null"
 
 	buf := &bytes.Buffer{}
 	if err := bootstrap.ReadFromDisk(buf, &tmpServer.Runtime.ControlRuntimeBootstrap); err != nil {

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -47,8 +47,6 @@ type Agent struct {
 	ExtraKubeProxyArgs       cli.StringSlice
 	Labels                   cli.StringSlice
 	Taints                   cli.StringSlice
-	ImageCredProvBinDir      string
-	ImageCredProvConfig      string
 	AgentReady               chan<- struct{}
 	AgentShared
 }
@@ -198,16 +196,14 @@ var (
 		Value: &AgentConfig.Labels,
 	}
 	ImageCredProvBinDirFlag = &cli.StringFlag{
-		Name:        "image-credential-provider-bin-dir",
-		Usage:       "(agent/node) The path to the directory where credential provider plugin binaries are located",
-		Destination: &AgentConfig.ImageCredProvBinDir,
-		Value:       "/var/lib/rancher/credentialprovider/bin",
+		Name:   "image-credential-provider-bin-dir",
+		Usage:  "(agent/node) The path to the directory where credential provider plugin binaries are located",
+		Hidden: true,
 	}
 	ImageCredProvConfigFlag = &cli.StringFlag{
-		Name:        "image-credential-provider-config",
-		Usage:       "(agent/node) The path to the credential provider plugin config file",
-		Destination: &AgentConfig.ImageCredProvConfig,
-		Value:       "/var/lib/rancher/credentialprovider/config.yaml",
+		Name:   "image-credential-provider-config",
+		Usage:  "(agent/node) The path to the credential provider plugin config file",
+		Hidden: true,
 	}
 	DisableAgentLBFlag = &cli.BoolFlag{
 		Name:        "disable-apiserver-lb",
@@ -252,8 +248,6 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			WithNodeIDFlag,
 			NodeLabels,
 			NodeTaints,
-			ImageCredProvBinDirFlag,
-			ImageCredProvConfigFlag,
 			SELinuxFlag,
 			LBServerPortFlag,
 			ProtectKernelDefaultsFlag,
@@ -278,11 +272,13 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 				Destination: &AgentConfig.Rootless,
 			},
 			PreferBundledBin,
+			DisableAgentLBFlag,
 			// Deprecated/hidden below
 			DockerFlag,
 			VPNAuth,
 			VPNAuthFile,
-			DisableAgentLBFlag,
+			ImageCredProvBinDirFlag,
+			ImageCredProvConfigFlag,
 		},
 	}
 }

--- a/pkg/cli/cmds/deprecation.go
+++ b/pkg/cli/cmds/deprecation.go
@@ -1,0 +1,35 @@
+package cmds
+
+import (
+	"fmt"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+	"golang.org/x/mod/semver"
+)
+
+// Deprecation tracks flag removal
+type Deprecation struct {
+	Deprecated string
+	Removed    string
+}
+
+// Deprecations contains a list of deprecated/removed flags, and the version that they are deprecated/removed in.
+var Deprecations = map[string]Deprecation{
+	"image-credential-provider-bin-dir": {Deprecated: "v1.28", Removed: "v1.30"},
+	"image-credential-provider-config":  {Deprecated: "v1.28", Removed: "v1.30"},
+}
+
+// HandleDeprecated handles warning or raising errors for deprecated or removed CLI flags.
+func HandleDeprecated(ctx *cli.Context) error {
+	for flag, deprecation := range Deprecations {
+		if ctx.IsSet(flag) {
+			if semver.Compare(version.Version, deprecation.Removed) >= 0 {
+				return fmt.Errorf("The %s option was deprecated in %s and removed in %s", flag, deprecation.Deprecated, deprecation.Removed)
+			}
+			logrus.Warnf("The %s option was deprecated in %s and will be removed in %s", flag, deprecation.Deprecated, deprecation.Removed)
+		}
+	}
+	return nil
+}

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -471,6 +471,11 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		}
 	}
 
+	// Handle command deprecation
+	if err := cmds.HandleDeprecated(app); err != nil {
+		return err
+	}
+
 	logrus.Info("Starting " + version.Program + " " + app.App.Version)
 
 	notifySocket := os.Getenv("NOTIFY_SOCKET")

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"math/rand"
-	"os"
 	"time"
 
 	"github.com/k3s-io/k3s/pkg/agent/config"
@@ -51,18 +50,4 @@ func startKubelet(ctx context.Context, cfg *daemonconfig.Agent) error {
 	logrus.Infof("Running kubelet %s", daemonconfig.ArgString(args))
 
 	return executor.Kubelet(ctx, args)
-}
-
-// ImageCredProvAvailable checks to see if the kubelet image credential provider bin dir and config
-// files exist and are of the correct types. This is exported so that it may be used by downstream projects.
-func ImageCredProvAvailable(cfg *daemonconfig.Agent) bool {
-	if info, err := os.Stat(cfg.ImageCredProvBinDir); err != nil || !info.IsDir() {
-		logrus.Debugf("Kubelet image credential provider bin directory check failed: %v", err)
-		return false
-	}
-	if info, err := os.Stat(cfg.ImageCredProvConfig); err != nil || info.IsDir() {
-		logrus.Debugf("Kubelet image credential provider config file check failed: %v", err)
-		return false
-	}
-	return true
 }

--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -163,13 +163,6 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 		argsMap["cloud-provider"] = "external"
 	}
 
-	if ImageCredProvAvailable(cfg) {
-		logrus.Infof("Kubelet image credential provider bin dir and configuration file found.")
-		argsMap["feature-gates"] = util.AddFeatureGate(argsMap["feature-gates"], "KubeletCredentialProviders=true")
-		argsMap["image-credential-provider-bin-dir"] = cfg.ImageCredProvBinDir
-		argsMap["image-credential-provider-config"] = cfg.ImageCredProvConfig
-	}
-
 	if cfg.Rootless {
 		createRootlessConfig(argsMap, controllers)
 	}

--- a/pkg/daemons/agent/agent_windows.go
+++ b/pkg/daemons/agent/agent_windows.go
@@ -112,13 +112,6 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 		argsMap["cloud-provider"] = "external"
 	}
 
-	if ImageCredProvAvailable(cfg) {
-		logrus.Infof("Kubelet image credential provider bin dir and configuration file found.")
-		argsMap["feature-gates"] = util.AddFeatureGate(argsMap["feature-gates"], "KubeletCredentialProviders=true")
-		argsMap["image-credential-provider-bin-dir"] = cfg.ImageCredProvBinDir
-		argsMap["image-credential-provider-config"] = cfg.ImageCredProvConfig
-	}
-
 	if cfg.ProtectKernelDefaults {
 		argsMap["protect-kernel-defaults"] = "true"
 	}

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -115,8 +115,6 @@ type Agent struct {
 	CNIPlugin               bool
 	NodeTaints              []string
 	NodeLabels              []string
-	ImageCredProvBinDir     string
-	ImageCredProvConfig     string
 	IPSECPSK                string
 	FlannelCniConfFile      string
 	PrivateRegistry         string

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -115,7 +115,6 @@ type Agent struct {
 	CNIPlugin               bool
 	NodeTaints              []string
 	NodeLabels              []string
-	IPSECPSK                string
 	FlannelCniConfFile      string
 	PrivateRegistry         string
 	SystemDefaultRegistry   string
@@ -187,7 +186,6 @@ type Control struct {
 	ExtraSchedulerAPIArgs    []string
 	NoLeaderElect            bool
 	JoinURL                  string
-	IPSECPSK                 string
 	DefaultLocalStoragePath  string
 	Skips                    map[string]bool
 	SystemDefaultRegistry    string
@@ -273,7 +271,6 @@ type ControlRuntimeBootstrap struct {
 	PasswdFile         string
 	RequestHeaderCA    string
 	RequestHeaderCAKey string
-	IPSECKey           string
 	EncryptionConfig   string
 	EncryptionHash     string
 }


### PR DESCRIPTION
#### Proposed Changes ####

* Remove image-credential-provider code  
  Feature-gate has been removed from upstream in 1.28.0
* Remove fields for IPSec  
  IPSec flannel backend has been removed for several minor versions, no need to keep the fields around.

#### Types of Changes ####

deprecation

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8941

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The image-credential-provider-related options have been deprecated, as the feature-gate has been removed from Kubernetes in 1.28
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
