### PR TITLE
Remove GA feature-gates

### DIFF
--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -165,7 +165,6 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 
 	if ImageCredProvAvailable(cfg) {
 		logrus.Infof("Kubelet image credential provider bin dir and configuration file found.")
-		argsMap["feature-gates"] = util.AddFeatureGate(argsMap["feature-gates"], "KubeletCredentialProviders=true")
 		argsMap["image-credential-provider-bin-dir"] = cfg.ImageCredProvBinDir
 		argsMap["image-credential-provider-config"] = cfg.ImageCredProvConfig
 	}

--- a/pkg/daemons/agent/agent_windows.go
+++ b/pkg/daemons/agent/agent_windows.go
@@ -114,7 +114,6 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 
 	if ImageCredProvAvailable(cfg) {
 		logrus.Infof("Kubelet image credential provider bin dir and configuration file found.")
-		argsMap["feature-gates"] = util.AddFeatureGate(argsMap["feature-gates"], "KubeletCredentialProviders=true")
 		argsMap["image-credential-provider-bin-dir"] = cfg.ImageCredProvBinDir
 		argsMap["image-credential-provider-config"] = cfg.ImageCredProvConfig
 	}

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -92,7 +92,6 @@ func controllerManager(ctx context.Context, cfg *config.Control) error {
 	runtime := cfg.Runtime
 	argsMap := map[string]string{
 		"controllers":                      "*,tokencleaner",
-		"feature-gates":                    "JobTrackingWithFinalizers=true",
 		"kubeconfig":                       runtime.KubeConfigController,
 		"authorization-kubeconfig":         runtime.KubeConfigController,
 		"authentication-kubeconfig":        runtime.KubeConfigController,
@@ -153,9 +152,7 @@ func scheduler(ctx context.Context, cfg *config.Control) error {
 
 func apiServer(ctx context.Context, cfg *config.Control) error {
 	runtime := cfg.Runtime
-	argsMap := map[string]string{
-		"feature-gates": "JobTrackingWithFinalizers=true",
-	}
+	argsMap := map[string]string{}
 
 	setupStorageBackend(argsMap, cfg)
 


### PR DESCRIPTION
#### Proposed Changes ####

Remove KubeletCredentialProviders and JobTrackingWithFinalizers feature-gates, both of which are GA since 1.26 and cannot be disabled.

#### Types of Changes ####

upstream tracking

#### Verification ####

See linked issues

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8941
* https://github.com/k3s-io/k3s/issues/8969

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
