### PR TITLE
Allow setting default-runtime on servers

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -497,6 +497,7 @@ var ServerFlags = []cli.Flag{
 	ImageCredProvConfigFlag,
 	DockerFlag,
 	CRIEndpointFlag,
+	DefaultRuntimeFlag,
 	ImageServiceEndpointFlag,
 	PauseImageFlag,
 	SnapshotterFlag,


### PR DESCRIPTION

#### Proposed Changes ####

Fix missing agent flag on server CLI

#### Types of Changes ####

bugfix

#### Verification ####

`k3s server --help`

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8700
* 
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
