### PR TITLE
Fix nil map in full snapshot configmap reconcile

### DIFF
--- a/pkg/etcd/snapshot_controller.go
+++ b/pkg/etcd/snapshot_controller.go
@@ -252,6 +252,10 @@ func (e *etcdSnapshotHandler) reconcile() error {
 		}
 	}
 
+	if len(snapshots) > 0 && snapshotConfigMap.Data == nil {
+		snapshotConfigMap.Data = map[string]string{}
+	}
+
 	// Ensure keys for existing snapshots
 	for sfKey, esf := range snapshots {
 		sf := snapshotFile{}


### PR DESCRIPTION
#### Proposed Changes ####

If a full reconcile wins the race against sync of an individual snapshot resource, or someone intentionally deletes the configmap, the data map could be nil and cause a crash.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* #9047 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
