### PR TITLE
Add runtime checking of golang version

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -14,7 +14,7 @@ ENTRYPOINT ["/bin/test-mods"]
 
 FROM test-base as test-k3s
 
-RUN apk -U --no-cache add git gcc musl-dev docker curl coreutils python3 openssl py3-pip procps findutils
+RUN apk -U --no-cache add git gcc musl-dev docker curl coreutils python3 openssl py3-pip procps findutils yq
 
 RUN python3 -m pip install awscli
 

--- a/pkg/cli/agent/agent.go
+++ b/pkg/cli/agent/agent.go
@@ -20,6 +20,9 @@ import (
 )
 
 func Run(ctx *cli.Context) error {
+	// Validate build env
+	cmds.MustValidateGolang()
+
 	// hide process arguments from ps output, since they may contain
 	// database credentials or other secrets.
 	gspt.SetProcTitle(os.Args[0] + " agent")

--- a/pkg/cli/cmds/golang.go
+++ b/pkg/cli/cmds/golang.go
@@ -1,0 +1,27 @@
+package cmds
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/sirupsen/logrus"
+)
+
+func ValidateGolang() error {
+	k8sVersion, _, _ := strings.Cut(version.Version, "+")
+	if version.UpstreamGolang == "" {
+		return fmt.Errorf("kubernetes golang build version not set - see 'golang: upstream version' in https://github.com/kubernetes/kubernetes/blob/%s/build/dependencies.yaml", k8sVersion)
+	}
+	if v, _, _ := strings.Cut(runtime.Version(), " "); version.UpstreamGolang != v {
+		return fmt.Errorf("incorrect golang build version - kubernetes %s should be built with %s, runtime version is %s", k8sVersion, version.UpstreamGolang, v)
+	}
+	return nil
+}
+
+func MustValidateGolang() {
+	if err := ValidateGolang(); err != nil {
+		logrus.Fatalf("Failed to validate golang version: %v", err)
+	}
+}

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -49,6 +49,8 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	var (
 		err error
 	)
+	// Validate build env
+	cmds.MustValidateGolang()
 
 	// hide process arguments from ps output, since they may contain
 	// database credentials or other secrets.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,4 +7,6 @@ var (
 	ProgramUpper = strings.ToUpper(Program)
 	Version      = "dev"
 	GitCommit    = "HEAD"
+
+	UpstreamGolang = ""
 )

--- a/scripts/build
+++ b/scripts/build
@@ -22,6 +22,7 @@ buildDate=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 VERSIONFLAGS="
     -X ${PKG}/pkg/version.Version=${VERSION}
     -X ${PKG}/pkg/version.GitCommit=${COMMIT:0:8}
+    -X ${PKG}/pkg/version.UpstreamGolang=${VERSION_GOLANG}
 
     -X ${PKG_K8S_CLIENT}/version.gitVersion=${VERSION}
     -X ${PKG_K8S_CLIENT}/version.gitCommit=${COMMIT}

--- a/scripts/validate
+++ b/scripts/validate
@@ -29,10 +29,8 @@ if [ -n "$DIRTY" ]; then
 fi
 
 echo Running: go version
-DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${VERSION_K8S}/build/dependencies.yaml"
-GOLANG_VERSION=$(curl -sL "${DEPENDENCIES_URL}" | yq e '.dependencies[] | select(.name == "golang: upstream version").version' -)
-if ! go version | grep -s "go version go${GOLANG_VERSION} "; then
-  echo "Unexpected $(go version) - Kubernetes ${VERSION_K8S} should be built with go version go${GOLANG_VERSION}"
+if ! go version | grep -s "go version ${VERSION_GOLANG} "; then
+  echo "Unexpected $(go version) - Kubernetes ${VERSION_K8S} should be built with go version ${VERSION_GOLANG}"
   exit 1
 fi
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -77,6 +77,9 @@ fi
 
 VERSION_ROOT="v0.12.2"
 
+DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${VERSION_K8S}/build/dependencies.yaml"
+VERSION_GOLANG="go"$(curl -sL "${DEPENDENCIES_URL}" | yq e '.dependencies[] | select(.name == "golang: upstream version").version' -)
+
 if [[ -n "$GIT_TAG" ]]; then
     if [[ ! "$GIT_TAG" =~ ^"$VERSION_K8S"[+-] ]]; then
         echo "Tagged version '$GIT_TAG' does not match expected version '$VERSION_K8S[+-]*'" >&2


### PR DESCRIPTION
#### Proposed Changes ####

Add runtime checking of golang version.

Forces other groups packaging k3s to intentionally choose to build k3s with an unvalidated golang version, if they wish to do so.

As seen in https://github.com/k3s-io/k3s/issues/8293, there are other teams packaging and distributing K3s using incorrect golang versions. This change will force them to perform validations similar to what we enforce in our build pipeline, and if they fail to do so, make it clear that it is an intentional choice on their part.

#### Types of Changes ####

enhancement

#### Verification ####

Build k3s with wrong golang version, skipping CI validation. Confirm that it exits with an error message.

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/8293

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
