### PR TITLE
Fix OS PRETTY_NAME on tagged releases

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -102,6 +102,8 @@ steps:
     repo: "rancher/k3s"
     username:
       from_secret: docker_username
+    build_args_from_env:
+      - DRONE_TAG
   when:
     instance:
     - drone-publish.k3s.io
@@ -270,6 +272,8 @@ steps:
     repo: "rancher/k3s"
     username:
       from_secret: docker_username
+    build_args_from_env:
+      - DRONE_TAG
   when:
     instance:
     - drone-publish.k3s.io
@@ -379,6 +383,8 @@ steps:
     repo: "rancher/k3s"
     username:
       from_secret: docker_username
+    build_args_from_env:
+      - DRONE_TAG
   when:
     instance:
     - drone-publish.k3s.io
@@ -496,7 +502,6 @@ steps:
     - DOCKER_USERNAME
     - DOCKER_PASSWORD
     - DRONE_TAG
-
 trigger:
   instance:
   - drone-publish.k3s.io

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -5,14 +5,17 @@ RUN mkdir -p /image/etc/ssl/certs /image/run /image/var/run /image/tmp /image/li
     tar -xa -C /image -f /data.tar.zst && \
     cp /etc/ssl/certs/ca-certificates.crt /image/etc/ssl/certs/ca-certificates.crt
 
-FROM scratch
-ARG VERSION="dev"
+FROM scratch as collect
+ARG DRONE_TAG="dev"
 COPY --from=base /image /
 COPY --from=base /usr/share/zoneinfo /usr/share/zoneinfo
 RUN mkdir -p /etc && \
     echo 'hosts: files dns' > /etc/nsswitch.conf && \
-    echo "PRETTY_NAME=\"K3s ${VERSION}\"" > /etc/os-release && \
+    echo "PRETTY_NAME=\"K3s ${DRONE_TAG}\"" > /etc/os-release && \
     chmod 1777 /tmp
+
+FROM scratch
+COPY --from=collect / /
 VOLUME /var/lib/kubelet
 VOLUME /var/lib/rancher/k3s
 VOLUME /var/lib/cni

--- a/scripts/package-image
+++ b/scripts/package-image
@@ -14,6 +14,6 @@ PROXY_OPTS=
 [ -z "$http_proxy" ] || PROXY_OPTS="$PROXY_OPTS --build-arg http_proxy=$http_proxy"
 [ -z "$https_proxy" ] || PROXY_OPTS="$PROXY_OPTS --build-arg https_proxy=$https_proxy"
 [ -z "$no_proxy" ] || PROXY_OPTS="$PROXY_OPTS --build-arg no_proxy=$no_proxy"
-docker build ${PROXY_OPTS} --build-arg VERSION=${VERSION} -t ${IMAGE} -f package/Dockerfile .
+docker build ${PROXY_OPTS} --build-arg DRONE_TAG=${VERSION_TAG} -t ${IMAGE} -f package/Dockerfile .
 ./scripts/image_scan.sh ${IMAGE} ${ARCH}
 echo Built ${IMAGE}


### PR DESCRIPTION
#### Proposed Changes ####

Fix OS PRETTY_NAME on tagged releases.

These were always showing up as dev due to the build arg not being set by the drone step.

#### Types of Changes ####

bugfix

#### Verification ####

check `OS-IMAGE` in `kubectl get node -o wide`

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9063

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
