### PR TITLE
Fix: issue #8293. Remove useless log init code

### DIFF
--- a/pkg/cli/cmds/log.go
+++ b/pkg/cli/cmds/log.go
@@ -1,9 +1,7 @@
 package cmds
 
 import (
-	"flag"
 	"fmt"
-	"strconv"
 	"sync"
 	"time"
 
@@ -73,10 +71,6 @@ func checkUnixTimestamp() error {
 }
 
 func setupLogging() {
-	flag.Set("v", strconv.Itoa(LogConfig.VLevel))
-	flag.Set("vmodule", LogConfig.VModule)
-	flag.Set("alsologtostderr", strconv.FormatBool(Debug))
-	flag.Set("logtostderr", strconv.FormatBool(!Debug))
 	if Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This should only be accepted after the upstream upgrade to golang 1.21.  

Set an undefined flag will lead to panic in golang 1.21.
These code actually returns error (https://github.com/golang/go/blob/8cb86b5f85ce695cba8cb54fd9780d39d9de924d/src/flag/flag.go#L486), did nothing. it's harmless in 1.20 but not work in 1.21.


#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
There is no more panic at k3s/pkg/cli/cmds/log.go

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/8293

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
