### PR TITLE
[Release-1.28] Only publish to code_cov on merged E2E builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -685,7 +685,7 @@ steps:
       - e2etests
   when:
     event:
-    - pull_request
+    - push
 
   volumes:
   - name: cache


### PR DESCRIPTION
Backport https://github.com/k3s-io/k3s/pull/9051 to release-1.28