### PR TITLE
Add more paths to crun runtime detection

### DIFF
--- a/pkg/agent/containerd/runtimes.go
+++ b/pkg/agent/containerd/runtimes.go
@@ -65,9 +65,9 @@ func findContainerRuntimes(root fs.FS) runtimeConfigs {
 func findCRunContainerRuntime(root fs.FS, foundRuntimes runtimeConfigs) {
 	// Check these locations in order.
 	locationsToCheck := []string{
-		"usr/sbin", // Path when installing via package manager
-		"usr/bin",  // Path when installing via package manager
-		"usr/local/bin", // Path when installing manually
+		"usr/sbin",       // Path when installing via package manager
+		"usr/bin",        // Path when installing via package manager
+		"usr/local/bin",  // Path when installing manually
 		"usr/local/sbin", // Path when installing manually
 	}
 

--- a/pkg/agent/containerd/runtimes.go
+++ b/pkg/agent/containerd/runtimes.go
@@ -67,6 +67,8 @@ func findCRunContainerRuntime(root fs.FS, foundRuntimes runtimeConfigs) {
 	locationsToCheck := []string{
 		"usr/sbin", // Path when installing via package manager
 		"usr/bin",  // Path when installing via package manager
+		"usr/local/bin", // Path when installing manually
+		"usr/local/sbin", // Path when installing manually
 	}
 
 	// Fill in the binary location with just the name of the binary,


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Add /usr/local/bin and /usr/local/sbin to crun detection. Crun can also be installed manually, without packages, and /usr/local is preferred path when dealing with non-packaged software.

#### Types of Changes ####

New feature

#### Verification ####

Drop crun binary to /usr/local/bin or /usr/local/sbin, k3s should detect it and add to containerd config

#### Testing ####

This is just new path to detection, so i hasn't touched tests

#### Linked Issues ####

#9112 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
