### PR TITLE
Dockerfile.dapper: set $HOME properly

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -56,9 +56,10 @@ ENV DAPPER_RUN_ARGS="--privileged -v k3s-cache:/go/src/github.com/k3s-io/k3s/.ca
     DAPPER_SOURCE="/go/src/github.com/k3s-io/k3s/" \
     DAPPER_OUTPUT="./bin ./dist ./build/out ./build/static ./pkg/static ./pkg/deploy" \
     DAPPER_DOCKER_SOCKET=true \
-    HOME=${DAPPER_SOURCE} \
     CROSS=true \
     STATIC_BUILD=true
+# Set $HOME separately because it refers to $DAPPER_SOURCE, set above
+ENV HOME=${DAPPER_SOURCE}
 
 WORKDIR ${DAPPER_SOURCE}
 


### PR DESCRIPTION
`$HOME` refers to `$DAPPER_SOURCE`, which is set in the same expression and is thus not visible at the time of substitution.

This problem is not immediately visible with Docker, Inc.'s docker merely because it resets an unset `$HOME` to `/root` (but still breaking the Go cache). Under podman, this problem is immediately visible because an unset `$HOME` remains unset and subsequently breaks the `go generate` invocation.

#### Types of Changes ####

Bug fix — build system

#### Verification ####

Run `make generate` under podman

#### Testing ####

N/A — build system

#### Linked Issues ####

* #9089

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```