### PR TITLE
chore: Update Code of Conduct to Redirect to CNCF CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,40 +1,4 @@
-k3s observes the [CNCF Community Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md), reproduced below for emphasis.
+# Community Code of Conduct
+k3s observes the [CNCF Community Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-### Contributor Code of Conduct
-
-As contributors and maintainers of this project, and in the interest of fostering
-an open and welcoming community, we pledge to respect all people who contribute
-through reporting issues, posting feature requests, updating documentation,
-submitting pull requests or patches, and other activities.
-
-We are committed to making participation in this project a harassment-free experience for
-everyone, regardless of level of experience, gender, gender identity and expression,
-sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
-religion, or nationality.
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery
-* Personal attacks
-* Trolling or insulting/derogatory comments
-* Public or private harassment
-* Publishing others' private information, such as physical or electronic addresses,
- without explicit permission
-* Other unethical or unprofessional conduct.
-
-Project maintainers have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are not
-aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers
-commit themselves to fairly and consistently applying these principles to every aspect
-of managing this project. Project maintainers who do not follow or enforce the Code of
-Conduct may be permanently removed from the project team.
-
-This code of conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community.
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a Rancher administrator  on [Slack](https://slack.rancher.io), or <conduct@suse.com>.
-
-This Code of Conduct is adapted from the Contributor Covenant
-(http://contributor-covenant.org), version 1.2.0, available at
-http://contributor-covenant.org/version/1/2/0/
-
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a Rancher administrator on [Slack](https://slack.rancher.io), or <conduct@suse.com>.


### PR DESCRIPTION
This commit updates the Code of Conduct to redirect to the latest version of the CNCF Code of Conduct.
Instead of maintaining a separate CoC text, it now link directly to the CNCF CoC for consistency and alignment with industry best practices.

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
Currently the CoC file has a link to CNCF CoC but also describes the CoC. This becomes an issue in case CNCF CoC is updated and k3s's CoC stays outdated, creating a potetial discrepancy between k3s' CoC and CNCF's CoC. The PR updates the CoC to only redirect to CNCF CoC.

Ref: [Kubernetes CoC](https://github.com/kubernetes/community/blob/master/code-of-conduct.md)
Ref: [Helm CoC](https://github.com/helm/helm/blob/main/code-of-conduct.md)

#### Types of Changes ####

Document changes

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Ref: [Kubernetes CoC](https://github.com/kubernetes/community/blob/master/code-of-conduct.md)
Ref: [Helm CoC](https://github.com/helm/helm/blob/main/code-of-conduct.md)

#### Testing ####

N/A

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/8986

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

N/A