### PR TITLE
Allow executors to define `containerd` and `cridockerd` behavior

### DIFF
--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -4,7 +4,6 @@
 package containerd
 
 import (
-	"context"
 	"os"
 
 	"github.com/containerd/containerd"
@@ -36,9 +35,9 @@ func getContainerdArgs(cfg *config.Node) []string {
 	return args
 }
 
-// setupContainerdConfig generates the containerd.toml, using a template combined with various
+// SetupContainerdConfig generates the containerd.toml, using a template combined with various
 // runtime configurations and registry mirror settings provided by the administrator.
-func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
+func SetupContainerdConfig(cfg *config.Node) error {
 	isRunningInUserNS := userns.RunningInUserNS()
 	_, _, controllers := cgroups.CheckCgroups()
 	// "/sys/fs/cgroup" is namespaced

--- a/pkg/agent/containerd/config_windows.go
+++ b/pkg/agent/containerd/config_windows.go
@@ -4,8 +4,6 @@
 package containerd
 
 import (
-	"context"
-
 	"github.com/containerd/containerd"
 	"github.com/k3s-io/k3s/pkg/agent/templates"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
@@ -23,9 +21,9 @@ func getContainerdArgs(cfg *config.Node) []string {
 	return args
 }
 
-// setupContainerdConfig generates the containerd.toml, using a template combined with various
+// SetupContainerdConfig generates the containerd.toml, using a template combined with various
 // runtime configurations and registry mirror settings provided by the administrator.
-func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
+func SetupContainerdConfig(cfg *config.Node) error {
 	if cfg.SELinux {
 		logrus.Warn("SELinux isn't supported on windows")
 	}

--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -41,10 +41,6 @@ var (
 // Run configures and starts containerd as a child process. Once it is up, images are preloaded
 // or pulled from files found in the agent images directory.
 func Run(ctx context.Context, cfg *config.Node) error {
-	if err := setupContainerdConfig(ctx, cfg); err != nil {
-		return err
-	}
-
 	args := getContainerdArgs(cfg)
 	stdOut := io.Writer(os.Stdout)
 	stdErr := io.Writer(os.Stderr)
@@ -109,14 +105,14 @@ func Run(ctx context.Context, cfg *config.Node) error {
 		return err
 	}
 
-	return preloadImages(ctx, cfg)
+	return PreloadImages(ctx, cfg)
 }
 
-// preloadImages reads the contents of the agent images directory, and attempts to
+// PreloadImages reads the contents of the agent images directory, and attempts to
 // import into containerd any files found there. Supported compressed types are decompressed, and
 // any .txt files are processed as a list of images that should be pre-pulled from remote registries.
 // If configured, imported images are retagged as being pulled from additional registries.
-func preloadImages(ctx context.Context, cfg *config.Node) error {
+func PreloadImages(ctx context.Context, cfg *config.Node) error {
 	fileInfo, err := os.Stat(cfg.Images)
 	if os.IsNotExist(err) {
 		return nil

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/k3s-io/k3s/pkg/agent/config"
+	"github.com/k3s-io/k3s/pkg/agent/containerd"
 	"github.com/k3s-io/k3s/pkg/agent/proxy"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
@@ -22,6 +23,17 @@ func Agent(ctx context.Context, nodeConfig *daemonconfig.Node, proxy proxy.Proxy
 	logsapi.ReapplyHandling = logsapi.ReapplyHandlingIgnoreUnchanged
 	logs.InitLogs()
 	defer logs.FlushLogs()
+
+	if nodeConfig.Docker {
+		if err := startDocker(ctx, nodeConfig); err != nil {
+			return err
+		}
+	} else if nodeConfig.ContainerRuntimeEndpoint == "" {
+		if err := startContainerd(ctx, nodeConfig); err != nil {
+			return err
+		}
+	}
+
 	if err := startKubelet(ctx, &nodeConfig.AgentConfig); err != nil {
 		return err
 	}
@@ -51,6 +63,17 @@ func startKubelet(ctx context.Context, cfg *daemonconfig.Agent) error {
 	logrus.Infof("Running kubelet %s", daemonconfig.ArgString(args))
 
 	return executor.Kubelet(ctx, args)
+}
+
+func startContainerd(ctx context.Context, cfg *daemonconfig.Node) error {
+	if err := containerd.SetupContainerdConfig(cfg); err != nil {
+		return err
+	}
+	return executor.Containerd(ctx, cfg)
+}
+
+func startDocker(ctx context.Context, cfg *daemonconfig.Node) error {
+	return executor.Docker(ctx, cfg)
 }
 
 // ImageCredProvAvailable checks to see if the kubelet image credential provider bin dir and config

--- a/pkg/daemons/executor/embed.go
+++ b/pkg/daemons/executor/embed.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/k3s-io/k3s/pkg/agent/containerd"
+	"github.com/k3s-io/k3s/pkg/agent/cridockerd"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/util"
@@ -223,6 +225,14 @@ func (*Embedded) CloudControllerManager(ctx context.Context, ccmRBACReady <-chan
 
 func (e *Embedded) CurrentETCDOptions() (InitialOptions, error) {
 	return InitialOptions{}, nil
+}
+
+func (e *Embedded) Containerd(ctx context.Context, cfg *daemonconfig.Node) error {
+	return containerd.Run(ctx, cfg)
+}
+
+func (e *Embedded) Docker(ctx context.Context, cfg *daemonconfig.Node) error {
+	return cridockerd.Run(ctx, cfg)
 }
 
 // waitForUntaintedNode watches nodes, waiting to find one not tainted as

--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -31,6 +31,8 @@ type Executor interface {
 	CurrentETCDOptions() (InitialOptions, error)
 	ETCD(ctx context.Context, args ETCDConfig, extraArgs []string) error
 	CloudControllerManager(ctx context.Context, ccmRBACReady <-chan struct{}, args []string) error
+	Containerd(ctx context.Context, node *daemonconfig.Node) error
+	Docker(ctx context.Context, node *daemonconfig.Node) error
 }
 
 type ETCDConfig struct {
@@ -168,4 +170,12 @@ func ETCD(ctx context.Context, args ETCDConfig, extraArgs []string) error {
 
 func CloudControllerManager(ctx context.Context, ccmRBACReady <-chan struct{}, args []string) error {
 	return executor.CloudControllerManager(ctx, ccmRBACReady, args)
+}
+
+func Containerd(ctx context.Context, config *daemonconfig.Node) error {
+	return executor.Containerd(ctx, config)
+}
+
+func Docker(ctx context.Context, config *daemonconfig.Node) error {
+	return executor.Docker(ctx, config)
 }


### PR DESCRIPTION
#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

In order to properly address https://github.com/rancher/rke2/issues/2204, the rke2 windows agent needs to be able to define how it reacts to `containerd` exiting. Currently, rke2 uses k3s' implementation for `containerd`, which will call [`os.Exit`](https://github.com/k3s-io/k3s/blob/ac8fe8de2b7f2c7d70e9277eca4e3d7a2d6f3a46/pkg/agent/containerd/containerd.go#L98) if the process stops running. On Windows nodes, this sudden exit prevents the top level context from fully canceling, resulting in supporting processes created with `CommandContext` (`kubelet`, `kube-proxy`, etc.) continuing to run. In the event that the rke2 service is restarted, but those processes are not cleaned up, the service will enter a crash loop which must be manually resolved. 

k3s should provide a way for the rke2 windows agent (or any custom executor) to define how containerd is executed, in a similar manner to other components such as the `kubelet` or `kube-proxy`.

+ Enhance the [`Executor` interface](https://github.com/k3s-io/k3s/blob/ac8fe8de2b7f2c7d70e9277eca4e3d7a2d6f3a46/pkg/daemons/executor/executor.go#L23-L34) so that custom executors (i.e. rke2's [`pebinaryexecutor`](https://github.com/rancher/rke2/blob/9674104a5ffd9f4f438fb2f171ff322487e3eda4/pkg/pebinaryexecutor/pebinary.go)) can define how `containerd` and `cridockerd` are executed.
+ Export the utility functions `containerd.PreloadImages` and `containerd.SetupContainerdConfig` so that code duplication between k3s and rke2 is reduced as much as possible
+ Start `containerd`/`cridockerd` when `agent.Agent` is called, as opposed to doing so in the [`run`](https://github.com/k3s-io/k3s/blob/ac8fe8de2b7f2c7d70e9277eca4e3d7a2d6f3a46/pkg/agent/run.go#L54) function
+ Update the embedded executor to satisfy the updated interface, continue to use the existing logic for running containerd and cridockerd

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

Enhancement, custom executors now have control over the behavior of `containerd` and `cridockerd`. 

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

The k3s embedded executor should be tested to ensure that it properly starts the desired container runtime on startup, otherwise there are no functional changes which would need more significant verification. 

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

Manual testing: 

After building a custom k3s binary, I was able to confirm that a 2 node cluster (1 cp+etcd server, 1 agent) will properly start the desired container runtime (both `containerd` and `cridockerd` were tested), and that workloads can be deployed onto that cluster without issue using `kubectl`. 


Automated testing: 

The existing integration and e2e tests cover basic startup and functionality of the k3s agent and server, so no new tests have been added. Since this PR focuses on extending the executor interface, I could not think of a way to add meaningful unit tests to cover these changes


#### Linked Issues ####
https://github.com/rancher/rke2/issues/2204

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####
In order to start the runtime using an executor I had to move the call from `agent.run` to `agent.Agent`. This results in the agent being started before the following code is called
``` 
if cfg.AgentReady != nil {
	close(cfg.AgentReady)
} 
```
Previously this call was made once the runtime was started, but before the agent was created. Looking at the code I don't think this has a negative impact on the server, however I wanted to call this out in case there is a subtlety that I'm missing in how that channel is expected to be closed