### PR TITLE
Add write-kubeconfig-group flag to server

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -45,6 +45,7 @@ type Server struct {
 	DisableAgent             bool
 	KubeConfigOutput         string
 	KubeConfigMode           string
+	KubeConfigGroup          string
 	HelmJobImage             string
 	TLSSan                   cli.StringSlice
 	TLSSanSecurity           bool
@@ -254,6 +255,12 @@ var ServerFlags = []cli.Flag{
 		Usage:       "(client) Write kubeconfig with this mode",
 		Destination: &ServerConfig.KubeConfigMode,
 		EnvVar:      version.ProgramUpper + "_KUBECONFIG_MODE",
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-group",
+		Usage:       "(client) Write kubeconfig with this group",
+		Destination: &ServerConfig.KubeConfigGroup,
+		EnvVar:      version.ProgramUpper + "_KUBECONFIG_GROUP",
 	},
 	&cli.StringFlag{
 		Name:        "helm-job-image",

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -131,6 +131,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.DataDir = cfg.DataDir
 	serverConfig.ControlConfig.KubeConfigOutput = cfg.KubeConfigOutput
 	serverConfig.ControlConfig.KubeConfigMode = cfg.KubeConfigMode
+	serverConfig.ControlConfig.KubeConfigGroup = cfg.KubeConfigGroup
 	serverConfig.ControlConfig.HelmJobImage = cfg.HelmJobImage
 	serverConfig.ControlConfig.Rootless = cfg.Rootless
 	serverConfig.ControlConfig.ServiceLBNamespace = cfg.ServiceLBNamespace

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -177,6 +177,7 @@ type Control struct {
 	ServiceNodePortRange     *utilnet.PortRange
 	KubeConfigOutput         string
 	KubeConfigMode           string
+	KubeConfigGroup          string
 	HelmJobImage             string
 	DataDir                  string
 	KineTLS                  bool

--- a/pkg/kubectl/main.go
+++ b/pkg/kubectl/main.go
@@ -54,7 +54,8 @@ func checkReadConfigPermissions(configFile string) error {
 	if err != nil {
 		if os.IsPermission(err) {
 			return fmt.Errorf("Unable to read %s, please start server "+
-				"with --write-kubeconfig-mode to modify kube config permissions", configFile)
+				"with --write-kubeconfig-mode or --write-kubeconfig-group "+
+				"to modify kube config permissions", configFile)
 		}
 	}
 	file.Close()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -465,6 +465,13 @@ func writeKubeConfig(certs string, config *Config) error {
 		util.SetFileModeForPath(kubeConfig, os.FileMode(0600))
 	}
 
+	if config.ControlConfig.KubeConfigGroup != "" {
+		err := util.SetFileGroupForPath(kubeConfig, config.ControlConfig.KubeConfigGroup)
+		if err != nil {
+			logrus.Errorf("Failed to set %s to group %s: %v", kubeConfig, config.ControlConfig.KubeConfigGroup, err)
+		}
+	}
+
 	if kubeConfigSymlink != kubeConfig {
 		if err := writeConfigSymlink(kubeConfig, kubeConfigSymlink); err != nil {
 			logrus.Errorf("Failed to write kubeconfig symlink: %v", err)

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -2,7 +2,9 @@ package util
 
 import (
 	"os"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -12,6 +14,27 @@ import (
 
 func SetFileModeForPath(name string, mode os.FileMode) error {
 	return os.Chmod(name, mode)
+}
+
+func SetFileGroupForPath(name string, group string) error {
+	// Try to use as group id
+	gid, err := strconv.Atoi(group)
+	if err == nil {
+		return os.Chown(name, -1, gid)
+	}
+
+	// Otherwise, it must be a group name
+	g, err := user.LookupGroup(group)
+	if err != nil {
+		return err
+	}
+
+	gid, err = strconv.Atoi(g.Gid)
+	if err != nil {
+		return err
+	}
+
+	return os.Chown(name, -1, gid)
 }
 
 func SetFileModeForFile(file *os.File, mode os.FileMode) error {


### PR DESCRIPTION
#### Proposed Changes ####

Add the flag as discussed in issue #9209 in order to enable configuring of group for writing kubeconfig.

#### Types of Changes ####

New Feature

#### Verification ####

Manually run k3s server with the flag `--write-kubeconfig-group` and check if kubeconfig has appropriate groups.

#### Testing ####

It seems there is no relevant test I found for write-kubeconfig-mode (other than it incidentally being used in some tests. If there is a request for tests please point me in the right direction!

#### Linked Issues ####

* #9209 

#### User-Facing Change ####

Yes, it creates a new optional flag.

```release-note
New flag in k3s server: --write-kubeconfig-group
```

#### Further Comments ####

Unfortunately, my laptop doesn't have Linux on it at the moment (due to some suspend issues with new hardware support I'm procrastinating), and under WSL2 I'm having trouble running the final binary to test whether this commit works. Once I have time again I will try this in a VM or on baremetal linux and update here with any changes needed.