### PR TITLE
[release-1.26] Use `ipFamilyPolicy: RequireDualStack` for dual-stack kube-dns

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -275,9 +275,9 @@ func stageFiles(ctx context.Context, sc *Context, controlConfig *config.Control)
 	}
 	dataDir = filepath.Join(controlConfig.DataDir, "manifests")
 
-	dnsIPFamilyPolicy := "PreferDualStack"
-	if len(controlConfig.ClusterDNSs) == 1 {
-		dnsIPFamilyPolicy = "SingleStack"
+	dnsIPFamilyPolicy := "SingleStack"
+	if len(controlConfig.ClusterDNSs) > 1 {
+		dnsIPFamilyPolicy = "RequireDualStack"
 	}
 
 	templateVars := map[string]string{


### PR DESCRIPTION
#### Proposed Changes ####

*Backport of https://github.com/k3s-io/k3s/pull/8984*

Considering that kube-dns will only be accessed via bare IP addresses, k3s should manually control the `ClusterIPs`, which means its `ipFamilyPolicy` should be set to either `SingleStack` or `RequireDualStack`. I don't think setting `ipFamilyPolicy` to `PreferDualStack` makes much sense for kube-dns, as discussed in https://github.com/k3s-io/k3s/pull/8394#discussion_r1336934121, where the implications of this choice are elaborated.

(Sorry for not mentioning this in #8394 earlier, I was on vacation and it slipped my mind.)

#### Types of Changes ####

Bug fix

#### Verification ####

Deploy k3s in dual-stack mode and verify that the kube-dns service's `ipFamilyPolicy` is set to `RequireDualStack`.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* #9268

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
