### PR TITLE
Update stale.yml to be more aggressive

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 180
+daysUntilStale: 45
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
@@ -28,12 +28,16 @@ exemptLabels:
   - priority/critical-urgent
   - priority/important-longterm
   - priority/important-soon
+  - priority/low
+  - priority/medium
+  - priority/high
+  - priority/urgent
 
 # Set to true to ignore issues in a project (defaults to false)
-exemptProjects: true
+exemptProjects: false
 
 # Set to true to ignore issues in a milestone (defaults to false)
-exemptMilestones: false
+exemptMilestones: true
 
 # Set to true to ignore issues with an assignee (defaults to false)
 exemptAssignees: true
@@ -44,7 +48,7 @@ staleLabel: status/stale
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
   This repository uses a bot to automatically label issues which have not had any activity (commit/comment/label) 
-  for 180 days. This helps us manage the community issues better. If the issue is still relevant, please add a comment to the 
+  for 45 days. This helps us manage the community issues better. If the issue is still relevant, please add a comment to the 
   issue so the bot can remove the label and we know it is still valid. If it is no longer relevant (or possibly fixed in the 
   latest release), the bot will automatically close the issue in 14 days. Thank you for your contributions.
 


### PR DESCRIPTION
Changing the stalebot to tag issue as stale after 45 days of inactivity. In addition, it will now not ignore issues in Projects, but will ignore issues in milestones.

