### PR TITLE
Expose rootless state dir under ~/.rancher/k3s/rootless

### DIFF
--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -132,11 +132,6 @@ func createParentOpt(driver portDriver, stateDir string, enableIPv6 bool) (*pare
 		return nil, errors.Wrapf(err, "failed to mkdir %s", stateDir)
 	}
 
-	stateDir, err := os.MkdirTemp("", "rootless")
-	if err != nil {
-		return nil, err
-	}
-
 	driver.SetStateDir(stateDir)
 
 	opt := &parent.Opt{


### PR DESCRIPTION
#### Proposed Changes ####

Currently, the `~/.rancher/k3s/rootless` directory is created but is unused. The directory is passed to the `createParentOpts` but the variable is then overrided by a call to `os.MkdirTemp`. This makes it harder to `nsenter` via rootlesskit's `child_pid` or hit the rootlesskit's API socket.

#### Types of Changes ####

- When running k3s in rootless mode, expose rootlesskit's state directory as `~/.rancher/k3s/rootless`

#### Verification ####

- Run k3s in rootless mode
- List files in `~/.rancher/k3s/rootless`

#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/9449

#### User-Facing Change ####
```release-note
When running k3s in rootless mode, expose rootlesskit's state directory as `~/.rancher/k3s/rootless`
```
