### PR TITLE
Don't create NodePasswordValidationFailed event if agent is disabled

### DIFF
--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -488,6 +488,11 @@ func passwordBootstrap(ctx context.Context, config *Config) nodePassBootstrapper
 }
 
 func verifyLocalPassword(ctx context.Context, config *Config, mu *sync.Mutex, deferredNodes map[string]bool, node *nodeInfo) (string, int, error) {
+	// do not attempt to verify the node password if the local host is not running an agent and does not have a node resource.
+	if config.DisableAgent {
+		return node.Name, http.StatusOK, nil
+	}
+
 	// use same password file location that the agent creates
 	nodePasswordRoot := "/"
 	if config.ControlConfig.Rootless {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
When the agent is disabled, e.g. when k3s image is used in a [vcluster](https://github.com/loft-sh/vcluster), a "NodePasswordValidationFailed" Event is created on every restart. This results in users questioning the state of their cluster, even though there is no impact on functionality.
The proposed change would create a debug log instead of a user-facing event.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
enhancment/bug fix?
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9447

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The `NodePasswordValidationFailed` Events will no longer be emitted, if the agent is disabled.
```

#### Further Comments ####
I am open to discussion and suggestion on better implementation. 
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
