### PR TITLE
Bump runc to v1.1.12 and helm-controller to v0.15.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ replace (
 	github.com/juju/errors => github.com/k3s-io/nocode v0.0.0-20200630202308-cb097102c09f
 	github.com/kubernetes-sigs/cri-tools => github.com/k3s-io/cri-tools v1.29.0-k3s1
 	github.com/open-policy-agent/opa => github.com/open-policy-agent/opa v0.59.0 // github.com/Microsoft/hcsshim using bad version v0.42.2
-	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.10
+	github.com/opencontainers/runc => github.com/k3s-io/runc v1.1.12-k3s1
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.10.1
 	github.com/quic-go/qtls-go1-20 => github.com/quic-go/qtls-go1-20 v0.3.3
@@ -120,7 +120,7 @@ require (
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/json-iterator/go v1.1.12
-	github.com/k3s-io/helm-controller v0.15.4
+	github.com/k3s-io/helm-controller v0.15.7
 	github.com/k3s-io/kine v0.11.0
 	github.com/klauspost/compress v1.17.2
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000
@@ -132,7 +132,7 @@ require (
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.13.2
 	github.com/onsi/gomega v1.30.0
-	github.com/opencontainers/runc v1.1.10
+	github.com/opencontainers/runc v1.1.12
 	github.com/opencontainers/selinux v1.11.0
 	github.com/otiai10/copy v1.7.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -967,8 +967,8 @@ github.com/k3s-io/etcd/raft/v3 v3.5.9-k3s1 h1:nlix2+EM1UDofoHgp/X2VHzMvJW7oYbZbE
 github.com/k3s-io/etcd/raft/v3 v3.5.9-k3s1/go.mod h1:WnFkqzFdZua4LVlVXQEGhmooLeyS7mqzS4Pf4BCVqXg=
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZe8rfaBPfbXo=
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
-github.com/k3s-io/helm-controller v0.15.4 h1:l4DWmUWpphbtwmuXGtpr5Rql/2NaCLSv4ZD8HlND9uY=
-github.com/k3s-io/helm-controller v0.15.4/go.mod h1:BgCPBQblj/Ect4Q7/Umf86WvyDjdG/34D+n8wfXtoeM=
+github.com/k3s-io/helm-controller v0.15.7 h1:LSmT0vb8f+X6IH9IydPjU9dPvJOwILlk4L5S+oeHr5o=
+github.com/k3s-io/helm-controller v0.15.7/go.mod h1:AYitg40howLjKloL/zdjDDOPL1jg/K5R4af0tQcyPR8=
 github.com/k3s-io/kine v0.11.0 h1:7tS0H9yBDxXiy1BgEEkBWLswwG/q4sARPTHdxOMz1qw=
 github.com/k3s-io/kine v0.11.0/go.mod h1:tjSsWrCetgaGMTfnJW6vzqdT/qOPhF/+nUEaE+eixBA=
 github.com/k3s-io/klog/v2 v2.100.1-k3s1 h1:xb/Ta8dpQuIZueQEw2YTZUYrKoILdBmPiITVkNmYPa0=
@@ -1031,6 +1031,8 @@ github.com/k3s-io/kubernetes/staging/src/k8s.io/mount-utils v1.29.1-k3s1 h1:maIQ
 github.com/k3s-io/kubernetes/staging/src/k8s.io/mount-utils v1.29.1-k3s1/go.mod h1:6PUWfpRhx/A8aRuFIntAVJjxcnLWyqircvt5UQpbbWg=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/pod-security-admission v1.29.1-k3s1 h1:BGWkmjGvOpUXnEpHmOYvnZJbRbPle2p4hrInkuRO3GY=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/pod-security-admission v1.29.1-k3s1/go.mod h1:+i0KHF7uvjXRUVsTwepg6652j9mzsnS7YHrbldQ5pZ0=
+github.com/k3s-io/runc v1.1.12-k3s1 h1:p2x48K2BbRdF8crLEB4xoJ1pdjSprlvNNGpYBBULHL4=
+github.com/k3s-io/runc v1.1.12-k3s1/go.mod h1:S+lQwSfncpBha7XTy/5lBwWgm5+y5Ma/O44Ekby9FK8=
 github.com/k3s-io/spegel v0.0.17-0.20240109004735-9466a5529330 h1:Tn9qxllPEzcyJqhqbYywUz0y0bFnZG3eMDLCb9UXeVM=
 github.com/k3s-io/spegel v0.0.17-0.20240109004735-9466a5529330/go.mod h1:VwX+8hz21pU7YjrvMmLCv7G4ww2Ds3HPEw3oDalMkGM=
 github.com/karrick/godirwalk v1.17.0 h1:b4kY7nqDdioR/6qnbHQyDvmA17u5G1cZ6J+CZXwSWoI=
@@ -1358,8 +1360,6 @@ github.com/opencontainers/image-spec v1.1.0-rc2/go.mod h1:3OVijpioIKYWTqjiG0zfF6
 github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
 github.com/opencontainers/image-spec v1.1.0-rc5 h1:Ygwkfw9bpDvs+c9E34SdgGOj41dX/cbdlwvlWt0pnFI=
 github.com/opencontainers/image-spec v1.1.0-rc5/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
-github.com/opencontainers/runc v1.1.10 h1:EaL5WeO9lv9wmS6SASjszOeQdSctvpbu0DdBQBizE40=
-github.com/opencontainers/runc v1.1.10/go.mod h1:+/R6+KmDlh+hOO8NkjmgkG9Qzvypzk0yXxAPYYR65+M=
 github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78 h1:R5M2qXZiK/mWPMT4VldCOiSL9HIAMuxQZWdG0CSM5+4=
 github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=

--- a/pkg/agent/containerd/config_test.go
+++ b/pkg/agent/containerd/config_test.go
@@ -53,7 +53,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://127.0.0.1:6443/v2",
 							Config: registries.RegistryConfig{
 								TLS: &registries.TLSConfig{
@@ -68,7 +68,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"127.0.0.1:6443": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://127.0.0.1:6443/v2",
 							Config: registries.RegistryConfig{
 								TLS: &registries.TLSConfig{
@@ -99,7 +99,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"docker.io": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry-1.docker.io/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -127,7 +127,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"docker.io": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry-1.docker.io/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -167,7 +167,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"registry.example.com": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -195,7 +195,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"registry.example.com": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -223,7 +223,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							OverridePath: true,
 							URI:          "https://registry.example.com/prefix/v2",
 						},
@@ -246,7 +246,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							OverridePath: true,
 							URI:          "https://registry.example.com/prefix/v2",
 						},
@@ -269,7 +269,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 						},
 					},
@@ -291,7 +291,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 						},
 					},
@@ -313,7 +313,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 						},
 					},
@@ -335,7 +335,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 						},
 					},
@@ -357,7 +357,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com:443/v2",
 						},
 					},
@@ -379,7 +379,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://1.2.3.4/v2",
 						},
 					},
@@ -401,7 +401,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://1.2.3.4:443/v2",
 						},
 					},
@@ -423,7 +423,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "http://localhost:5000/v2",
 						},
 					},
@@ -445,7 +445,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://localhost:5000/v2",
 						},
 					},
@@ -467,7 +467,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "http://127.0.0.1:5000/v2",
 						},
 					},
@@ -489,7 +489,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://127.0.0.1:5000/v2",
 						},
 					},
@@ -516,7 +516,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -530,7 +530,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"registry.example.com": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -566,7 +566,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							OverridePath: true,
 							URI:          "https://registry.example.com/prefix/v2",
 							Config: registries.RegistryConfig{
@@ -582,7 +582,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry.example.com/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							OverridePath: true,
 							URI:          "https://registry.example.com/prefix/v2",
 							Config: registries.RegistryConfig{
@@ -619,7 +619,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							OverridePath: true,
 							URI:          "https://registry.example.com/project/registry",
 							Config: registries.RegistryConfig{
@@ -635,7 +635,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry.example.com/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							OverridePath: true,
 							URI:          "https://registry.example.com/project/registry",
 							Config: registries.RegistryConfig{
@@ -669,7 +669,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"docker.io": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -683,7 +683,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"registry.example.com": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -717,7 +717,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://127.0.0.1:6443/v2",
 							Config: registries.RegistryConfig{
 								TLS: &registries.TLSConfig{
@@ -727,7 +727,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 								},
 							},
 						},
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -741,7 +741,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"registry.example.com": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -755,7 +755,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"127.0.0.1:6443": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://127.0.0.1:6443/v2",
 							Config: registries.RegistryConfig{
 								TLS: &registries.TLSConfig{
@@ -792,7 +792,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "https://registry-1.docker.io/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://127.0.0.1:6443/v2",
 							Config: registries.RegistryConfig{
 								TLS: &registries.TLSConfig{
@@ -802,7 +802,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 								},
 							},
 						},
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -819,7 +819,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"registry.example.com": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -833,7 +833,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"127.0.0.1:6443": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://127.0.0.1:6443/v2",
 							Config: registries.RegistryConfig{
 								TLS: &registries.TLSConfig{
@@ -868,7 +868,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"docker.io": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://127.0.0.1:6443/v2",
 							Config: registries.RegistryConfig{
 								TLS: &registries.TLSConfig{
@@ -878,7 +878,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 								},
 							},
 						},
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -892,7 +892,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"registry.example.com": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 							Config: registries.RegistryConfig{
 								Auth: &registries.AuthConfig{
@@ -906,7 +906,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"127.0.0.1:6443": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://127.0.0.1:6443/v2",
 							Config: registries.RegistryConfig{
 								TLS: &registries.TLSConfig{
@@ -934,7 +934,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"_default": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 						},
 					},
@@ -958,7 +958,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					Endpoints: []templates.RegistryEndpoint{
 						// note that the embedded registry mirror is NOT listed as an endpoint.
 						// individual registries must be enabled for mirroring by name.
-						templates.RegistryEndpoint{
+						{
 							URI: "https://registry.example.com/v2",
 						},
 					},
@@ -966,7 +966,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"127.0.0.1:6443": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://127.0.0.1:6443/v2",
 							Config: registries.RegistryConfig{
 								TLS: &registries.TLSConfig{
@@ -1034,7 +1034,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"127.0.0.1:6443": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://127.0.0.1:6443/v2",
 							Config: registries.RegistryConfig{
 								TLS: &registries.TLSConfig{
@@ -1067,7 +1067,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 					DefaultEndpoint: "http://localhost:5000/v2",
 					Program:         "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						templates.RegistryEndpoint{
+						{
 							URI: "https://localhost:5000/v2",
 							Config: registries.RegistryConfig{
 								TLS: &registries.TLSConfig{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -228,6 +228,7 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 		helmchart.Register(ctx,
 			metav1.NamespaceAll,
 			helmcommon.Name,
+			"cluster-admin",
 			strconv.Itoa(config.ControlConfig.APIServerPort),
 			k8s,
 			apply,

--- a/scripts/download
+++ b/scripts/download
@@ -24,7 +24,7 @@ mkdir -p ${DATA_DIR}
 
 case ${OS} in
   linux)
-    git clone --single-branch --branch=${VERSION_RUNC} --depth=1 https://github.com/opencontainers/runc ${RUNC_DIR}
+    git clone --single-branch --branch=${VERSION_RUNC} --depth=1 https://github.com/k3s-io/runc ${RUNC_DIR}
     curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${VERSION_ROOT}/k3s-root-${ARCH}.tar | tar xf -
     cp scripts/wg-add.sh bin/aux
     ;;


### PR DESCRIPTION
#### Proposed Changes ####

Bump runc and helm-controller versions

Also applies `gofmt -s` changes to test file added in https://github.com/k3s-io/k3s/pull/9323. Master has gofmt checks disabled but other branches do not and are failing CI.

#### Types of Changes ####

version bump

#### Verification ####

check versions

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9324
* https://github.com/k3s-io/k3s/issues/9325

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

NOTE: This switches to a fork of runc due to https://github.com/opencontainers/runc/commit/0c8e2cc602bab3c8c1127b50aa26fa6f6954e58b breaking Windows platform cross-builds of things that pull in runc/libcontainer. The fix is in https://github.com/k3s-io/runc/commit/7d07dac287da807a624adba7ea7ccc1b3f28c614