### PR TITLE
Readd `k3s secrets-encrypt rotate-keys` with correct support for KMSv2 GA

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -651,6 +651,10 @@ steps:
   - vagrant destroy -f
   - go test -v -timeout=45m ./validatecluster_test.go -ci -local
   - cp ./coverage.out /tmp/artifacts/validate-coverage.out
+  - cd ../secretsencryption
+  - vagrant destroy -f
+  - go test -v -timeout=30m ./secretsencryption_test.go -ci -local
+  - cp ./coverage.out /tmp/artifacts/se-coverage.out
   - cd ../startup
   - vagrant destroy -f
   - go test -v -timeout=30m ./startup_test.go -ci -local

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -46,9 +46,9 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
     ./scripts/download
 
 COPY ./cmd ./cmd
-COPY ./pkg ./pkg
 COPY ./tests ./tests
 COPY ./.git ./.git
+COPY ./pkg ./pkg
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
     --mount=type=cache,id=gobuild,target=/root/.cache/go-build \
     ./scripts/build

--- a/go.mod
+++ b/go.mod
@@ -136,6 +136,7 @@ require (
 	github.com/opencontainers/selinux v1.11.0
 	github.com/otiai10/copy v1.7.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/common v0.45.0
 	github.com/rancher/dynamiclistener v0.3.6
 	github.com/rancher/lasso v0.0.0-20230830164424-d684fdeb6f29
 	github.com/rancher/remotedialer v0.3.0
@@ -420,7 +421,6 @@ require (
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
-	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/qtls-go1-20 v0.3.3 // indirect

--- a/pkg/cli/cmds/secrets_encrypt.go
+++ b/pkg/cli/cmds/secrets_encrypt.go
@@ -84,6 +84,13 @@ func NewSecretsEncryptCommands(status, enable, disable, prepare, rotate, reencry
 						Destination: &ServerConfig.EncryptSkip,
 					}),
 			},
+			{
+				Name:           "rotate-keys",
+				Usage:          "(experimental) Dynamically rotates secrets encryption keys and re-encrypt secrets",
+				SkipArgReorder: true,
+				Action:         rotateKeys,
+				Flags:          EncryptFlags,
+			},
 		},
 	}
 }

--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/erikdubbelboer/gspt"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
@@ -226,7 +227,11 @@ func RotateKeys(app *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err = info.Put("/v1-"+version.Program+"/encrypt/config", b); err != nil {
+	timeout := 70 * time.Second
+	if err = info.Put("/v1-"+version.Program+"/encrypt/config",
+		b,
+		clientaccess.WithTimeout(timeout),
+		clientaccess.WithHeaderTimeout(timeout)); err != nil {
 		return wrapServerError(err)
 	}
 	fmt.Println("keys rotated, reencryption started")

--- a/pkg/cli/secretsencrypt/secrets_encrypt.go
+++ b/pkg/cli/secretsencrypt/secrets_encrypt.go
@@ -228,10 +228,7 @@ func RotateKeys(app *cli.Context) error {
 		return err
 	}
 	timeout := 70 * time.Second
-	if err = info.Put("/v1-"+version.Program+"/encrypt/config",
-		b,
-		clientaccess.WithTimeout(timeout),
-		clientaccess.WithHeaderTimeout(timeout)); err != nil {
+	if err = info.Put("/v1-"+version.Program+"/encrypt/config", b, clientaccess.WithTimeout(timeout)); err != nil {
 		return wrapServerError(err)
 	}
 	fmt.Println("keys rotated, reencryption started")

--- a/pkg/clientaccess/token.go
+++ b/pkg/clientaccess/token.go
@@ -289,7 +289,7 @@ func (i *Info) Get(path string, option ...ClientOption) ([]byte, error) {
 	return get(p.String(), GetHTTPClient(i.CACerts, i.CertFile, i.KeyFile, option...), i.Username, i.Password, i.Token())
 }
 
-// Put makes a request to a subpath of info's BaseURL, with a 10 second timeout
+// Put makes a request to a subpath of info's BaseURL
 func (i *Info) Put(path string, body []byte, option ...ClientOption) error {
 
 	u, err := url.Parse(i.BaseURL)
@@ -302,7 +302,6 @@ func (i *Info) Put(path string, body []byte, option ...ClientOption) error {
 	}
 	p.Scheme = u.Scheme
 	p.Host = u.Host
-
 	return put(p.String(), body, GetHTTPClient(i.CACerts, i.CertFile, i.KeyFile, option...), i.Username, i.Password, i.Token())
 }
 

--- a/pkg/clientaccess/token.go
+++ b/pkg/clientaccess/token.go
@@ -41,6 +41,9 @@ var (
 	}
 )
 
+// ClientOption is a callback to mutate the http client prior to use
+type ClientOption func(*http.Client)
+
 // Info contains fields that track parsed parts of a cluster join token
 type Info struct {
 	*kubeadm.BootstrapTokenString
@@ -233,7 +236,7 @@ func parseToken(token string) (*Info, error) {
 // If the CA bundle is not empty but does not contain any valid certs, it validates using
 // an empty CA bundle (which will always fail).
 // If valid cert+key paths can be loaded from the provided paths, they are used for client cert auth.
-func GetHTTPClient(cacerts []byte, certFile, keyFile string) *http.Client {
+func GetHTTPClient(cacerts []byte, certFile, keyFile string, option ...ClientOption) *http.Client {
 	if len(cacerts) == 0 {
 		return defaultClient
 	}
@@ -250,18 +253,34 @@ func GetHTTPClient(cacerts []byte, certFile, keyFile string) *http.Client {
 	if err == nil {
 		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
-
-	return &http.Client{
+	client := &http.Client{
 		Timeout: defaultClientTimeout,
 		Transport: &http.Transport{
 			DisableKeepAlives: true,
 			TLSClientConfig:   tlsConfig,
 		},
 	}
+
+	for _, o := range option {
+		o(client)
+	}
+	return client
+}
+
+func WithTimeout(d time.Duration) ClientOption {
+	return func(c *http.Client) {
+		c.Timeout = d
+	}
+}
+
+func WithHeaderTimeout(d time.Duration) ClientOption {
+	return func(c *http.Client) {
+		c.Transport.(*http.Transport).ResponseHeaderTimeout = d
+	}
 }
 
 // Get makes a request to a subpath of info's BaseURL
-func (i *Info) Get(path string) ([]byte, error) {
+func (i *Info) Get(path string, option ...ClientOption) ([]byte, error) {
 	u, err := url.Parse(i.BaseURL)
 	if err != nil {
 		return nil, err
@@ -272,11 +291,12 @@ func (i *Info) Get(path string) ([]byte, error) {
 	}
 	p.Scheme = u.Scheme
 	p.Host = u.Host
-	return get(p.String(), GetHTTPClient(i.CACerts, i.CertFile, i.KeyFile), i.Username, i.Password, i.Token())
+	return get(p.String(), GetHTTPClient(i.CACerts, i.CertFile, i.KeyFile, option...), i.Username, i.Password, i.Token())
 }
 
-// Put makes a request to a subpath of info's BaseURL
-func (i *Info) Put(path string, body []byte) error {
+// Put makes a request to a subpath of info's BaseURL, with a 10 second timeout
+func (i *Info) Put(path string, body []byte, option ...ClientOption) error {
+
 	u, err := url.Parse(i.BaseURL)
 	if err != nil {
 		return err
@@ -287,7 +307,13 @@ func (i *Info) Put(path string, body []byte) error {
 	}
 	p.Scheme = u.Scheme
 	p.Host = u.Host
-	return put(p.String(), body, GetHTTPClient(i.CACerts, i.CertFile, i.KeyFile), i.Username, i.Password, i.Token())
+
+	client := GetHTTPClient(i.CACerts, i.CertFile, i.KeyFile, option...)
+	for _, o := range option {
+		o(client)
+	}
+
+	return put(p.String(), body, client, i.Username, i.Password, i.Token())
 }
 
 // setServer sets the BaseURL and CACerts fields of the Info by connecting to the server

--- a/pkg/clientaccess/token.go
+++ b/pkg/clientaccess/token.go
@@ -270,11 +270,6 @@ func GetHTTPClient(cacerts []byte, certFile, keyFile string, option ...ClientOpt
 func WithTimeout(d time.Duration) ClientOption {
 	return func(c *http.Client) {
 		c.Timeout = d
-	}
-}
-
-func WithHeaderTimeout(d time.Duration) ClientOption {
-	return func(c *http.Client) {
 		c.Transport.(*http.Transport).ResponseHeaderTimeout = d
 	}
 }
@@ -308,9 +303,7 @@ func (i *Info) Put(path string, body []byte, option ...ClientOption) error {
 	p.Scheme = u.Scheme
 	p.Host = u.Host
 
-	client := GetHTTPClient(i.CACerts, i.CertFile, i.KeyFile, option...)
-
-	return put(p.String(), body, client, i.Username, i.Password, i.Token())
+	return put(p.String(), body, GetHTTPClient(i.CACerts, i.CertFile, i.KeyFile, option...), i.Username, i.Password, i.Token())
 }
 
 // setServer sets the BaseURL and CACerts fields of the Info by connecting to the server

--- a/pkg/clientaccess/token.go
+++ b/pkg/clientaccess/token.go
@@ -309,9 +309,6 @@ func (i *Info) Put(path string, body []byte, option ...ClientOption) error {
 	p.Host = u.Host
 
 	client := GetHTTPClient(i.CACerts, i.CertFile, i.KeyFile, option...)
-	for _, o := range option {
-		o(client)
-	}
 
 	return put(p.String(), body, client, i.Username, i.Password, i.Token())
 }

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -741,7 +741,7 @@ func genEncryptionConfigAndState(controlConfig *config.Control) error {
 		return nil
 	}
 
-	aescbcKey := make([]byte, aescbcKeySize, aescbcKeySize)
+	aescbcKey := make([]byte, aescbcKeySize)
 	_, err := cryptorand.Read(aescbcKey)
 	if err != nil {
 		return err

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -64,7 +64,6 @@ func Server(ctx context.Context, cfg *config.Control) error {
 		if cfg.EncryptSecrets {
 			controllerName := "reencrypt-secrets"
 			cfg.Runtime.ClusterControllerStarts[controllerName] = func(ctx context.Context) {
-				logrus.Warn("HELP Current Node is", os.Getenv("NODE_NAME"))
 				// cfg.Runtime.Core is populated before this callback is triggered
 				if err := secretsencrypt.Register(ctx,
 					controllerName,

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/control/deps"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
+	"github.com/k3s-io/k3s/pkg/secretsencrypt"
 	"github.com/k3s-io/k3s/pkg/util"
 	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/pkg/errors"
@@ -59,6 +60,20 @@ func Server(ctx context.Context, cfg *config.Control) error {
 
 		if err := apiServer(ctx, cfg); err != nil {
 			return err
+		}
+		if cfg.EncryptSecrets {
+			controllerName := "reencrypt-secrets"
+			cfg.Runtime.ClusterControllerStarts[controllerName] = func(ctx context.Context) {
+				logrus.Warn("HELP Current Node is", os.Getenv("NODE_NAME"))
+				// cfg.Runtime.Core is populated before this callback is triggered
+				if err := secretsencrypt.Register(ctx,
+					controllerName,
+					cfg,
+					cfg.Runtime.Core.Core().V1().Node(),
+					cfg.Runtime.Core.Core().V1().Secret()); err != nil {
+					logrus.Errorf("Failed to register %s controller: %v", controllerName, err)
+				}
+			}
 		}
 	}
 

--- a/pkg/secretsencrypt/controller.go
+++ b/pkg/secretsencrypt/controller.go
@@ -47,8 +47,7 @@ func Register(
 	nodes coreclient.NodeController,
 	secrets coreclient.SecretController,
 ) error {
-	cfg := controlConfig.Runtime.KubeConfigAPIServer
-	restConfig, err := clientcmd.BuildConfigFromFlags("", cfg)
+	restConfig, err := clientcmd.BuildConfigFromFlags("", controlConfig.Runtime.KubeConfigSupervisor)
 	if err != nil {
 		return err
 	}

--- a/pkg/secretsencrypt/controller.go
+++ b/pkg/secretsencrypt/controller.go
@@ -137,7 +137,7 @@ func (h *handler) onChangeNode(nodeName string, node *corev1.Node) (*corev1.Node
 	}
 
 	// Remove last key
-	curKeys, err := GetEncryptionKeys(h.controlConfig.Runtime)
+	curKeys, err := GetEncryptionKeys(h.controlConfig.Runtime, false)
 	if err != nil {
 		h.recorder.Event(nodeRef, corev1.EventTypeWarning, secretsUpdateErrorEvent, err.Error())
 		return node, err
@@ -186,7 +186,6 @@ func (h *handler) validateReencryptStage(node *corev1.Node, annotation string) (
 	if reencryptRequestHash, err := GenReencryptHash(h.controlConfig.Runtime, EncryptionReencryptRequest); err != nil {
 		return false, err
 	} else if reencryptRequestHash != hash {
-		logrus.Infof("HELP: %s %s", reencryptRequestHash, hash)
 		err = fmt.Errorf("invalid hash: %s found on node %s", hash, node.ObjectMeta.Name)
 		return false, err
 	}
@@ -208,9 +207,6 @@ func (h *handler) validateReencryptStage(node *corev1.Node, annotation string) (
 			stage := split[0]
 			hash := split[1]
 			if stage == EncryptionReencryptActive && hash == reencryptActiveHash {
-				return false, fmt.Errorf("another reencrypt is already active")
-			}
-			if stage == EncryptionReencryptActive {
 				return false, fmt.Errorf("another reencrypt is already active")
 			}
 		}

--- a/pkg/server/secrets-encrypt.go
+++ b/pkg/server/secrets-encrypt.go
@@ -326,7 +326,7 @@ func encryptionRotateKeys(ctx context.Context, server *config.Control) error {
 		return err
 	}
 
-	reloadSuccesses, reloadTime, err := secretsencrypt.GetEncryptionConfigMetrics(server.Runtime, true)
+	reloadTime, reloadSuccesses, err := secretsencrypt.GetEncryptionConfigMetrics(server.Runtime, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/secrets-encrypt.go
+++ b/pkg/server/secrets-encrypt.go
@@ -128,7 +128,7 @@ func encryptionEnable(ctx context.Context, server *config.Control, enable bool) 
 	if len(providers) > 2 {
 		return fmt.Errorf("more than 2 providers (%d) found in secrets encryption", len(providers))
 	}
-	curKeys, err := secretsencrypt.GetEncryptionKeys(server.Runtime)
+	curKeys, err := secretsencrypt.GetEncryptionKeys(server.Runtime, false)
 	if err != nil {
 		return err
 	}
@@ -174,7 +174,6 @@ func encryptionConfigHandler(ctx context.Context, server *config.Control) http.H
 			resp.Write([]byte(err.Error()))
 			return
 		}
-
 		if encryptReq.Stage != nil {
 			switch *encryptReq.Stage {
 			case secretsencrypt.EncryptionPrepare:
@@ -210,7 +209,7 @@ func encryptionPrepare(ctx context.Context, server *config.Control, force bool) 
 		return err
 	}
 
-	curKeys, err := secretsencrypt.GetEncryptionKeys(server.Runtime)
+	curKeys, err := secretsencrypt.GetEncryptionKeys(server.Runtime, false)
 	if err != nil {
 		return err
 	}
@@ -242,7 +241,7 @@ func encryptionRotate(ctx context.Context, server *config.Control, force bool) e
 		return err
 	}
 
-	curKeys, err := secretsencrypt.GetEncryptionKeys(server.Runtime)
+	curKeys, err := secretsencrypt.GetEncryptionKeys(server.Runtime, false)
 	if err != nil {
 		return err
 	}
@@ -294,7 +293,7 @@ func encryptionReencrypt(ctx context.Context, server *config.Control, force bool
 }
 
 func addAndRotateKeys(server *config.Control) error {
-	curKeys, err := secretsencrypt.GetEncryptionKeys(server.Runtime)
+	curKeys, err := secretsencrypt.GetEncryptionKeys(server.Runtime, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -244,16 +244,6 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 			core.V1().Secret())
 	}
 
-	if config.ControlConfig.EncryptSecrets {
-		if err := secretsencrypt.Register(ctx,
-			sc.K8s,
-			&config.ControlConfig,
-			sc.Core.Core().V1().Node(),
-			sc.Core.Core().V1().Secret()); err != nil {
-			return err
-		}
-	}
-
 	if config.ControlConfig.Rootless {
 		return rootlessports.Register(ctx,
 			sc.Core.Core().V1().Service(),

--- a/tests/e2e/secretsencryption/Vagrantfile
+++ b/tests/e2e/secretsencryption/Vagrantfile
@@ -47,7 +47,7 @@ def provision(vm, role, role_num, node_num)
 end
 
 Vagrant.configure("2") do |config|
-  config.vagrant.plugins = ["vagrant-k3s", "vagrant-reload"]
+  config.vagrant.plugins = ["vagrant-k3s", "vagrant-reload", "vagrant-scp"]
   # Default provider is libvirt, virtualbox is only provided as a backup
   config.vm.provider "libvirt" do |v|
     v.cpus = NODE_CPUS

--- a/tests/e2e/secretsencryption/Vagrantfile
+++ b/tests/e2e/secretsencryption/Vagrantfile
@@ -44,6 +44,7 @@ def provision(vm, role, role_num, node_num)
   if vm.box.to_s.include?("microos")
     vm.provision 'k3s-reload', type: 'reload', run: 'once'
   end
+  vm.provision 'k3s-autocomplete', type: 'shell', inline: "k3s completion -i bash"
 end
 
 Vagrant.configure("2") do |config|

--- a/tests/e2e/secretsencryption/secretsencryption_test.go
+++ b/tests/e2e/secretsencryption/secretsencryption_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 					} else {
 						g.Expect(res).Should(ContainSubstring("Current Rotation Stage: start"))
 					}
-				}, "420s", "2s").Should(Succeed())
+				}, "420s", "10s").Should(Succeed())
 			}
 		})
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Uses the new automatic reload metrics to correctly wait for apiserver reloading
- Resolve bugs around using the `rotate-keys`  and `disable` commands on non etcd-leader nodes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Feature "Fix"
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
`go test ./tests/e2e/secretsencryption/secretsencryption_test.go`

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
Reenabled the E2E test for this feature. 
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/9080
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
