### PR TITLE
Bump kine and set NotifyInterval to what the apiserver expects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,12 +121,12 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/json-iterator/go v1.1.12
 	github.com/k3s-io/helm-controller v0.15.8
-	github.com/k3s-io/kine v0.11.0
+	github.com/k3s-io/kine v0.11.4
 	github.com/klauspost/compress v1.17.2
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.10.2
 	github.com/libp2p/go-libp2p v0.30.0
-	github.com/mattn/go-sqlite3 v1.14.17
+	github.com/mattn/go-sqlite3 v1.14.19
 	github.com/minio/minio-go/v7 v7.0.33
 	github.com/mwitkow/go-http-dialer v0.0.0-20161116154839-378f744fb2b8
 	github.com/natefinch/lumberjack v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -969,8 +969,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZ
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
 github.com/k3s-io/helm-controller v0.15.8 h1:CAMEPmiqf4ugUCpZdICGINthCn+hkG/l1fadn8aVjfQ=
 github.com/k3s-io/helm-controller v0.15.8/go.mod h1:AYitg40howLjKloL/zdjDDOPL1jg/K5R4af0tQcyPR8=
-github.com/k3s-io/kine v0.11.0 h1:7tS0H9yBDxXiy1BgEEkBWLswwG/q4sARPTHdxOMz1qw=
-github.com/k3s-io/kine v0.11.0/go.mod h1:tjSsWrCetgaGMTfnJW6vzqdT/qOPhF/+nUEaE+eixBA=
+github.com/k3s-io/kine v0.11.4 h1:ZIXQT4vPPKNL9DwLF4dQ11tWtpJ1C/7OKNIpFmTkImo=
+github.com/k3s-io/kine v0.11.4/go.mod h1:NmwOWsWgB3aScq5+LEYytAaceqkG7lmCLLjjrWug8v4=
 github.com/k3s-io/klog/v2 v2.100.1-k3s1 h1:xb/Ta8dpQuIZueQEw2YTZUYrKoILdBmPiITVkNmYPa0=
 github.com/k3s-io/klog/v2 v2.100.1-k3s1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 github.com/k3s-io/kube-router/v2 v2.0.0-20230925161250-364f994b140b h1:qskSYKhQcW2OjKyiJkuCmy35FsdLRTMrzPkuMshgGHk=
@@ -1148,8 +1148,8 @@ github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
-github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/mattn/go-sqlite3 v1.14.19 h1:fhGleo2h1p8tVChob4I9HpmVFIAkKGpiukdrgQbWfGI=
+github.com/mattn/go-sqlite3 v1.14.19/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -149,6 +149,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.ExtraEtcdArgs = cfg.ExtraEtcdArgs
 	serverConfig.ControlConfig.ExtraSchedulerAPIArgs = cfg.ExtraSchedulerArgs
 	serverConfig.ControlConfig.ClusterDomain = cfg.ClusterDomain
+	serverConfig.ControlConfig.Datastore.NotifyInterval = 5 * time.Second
 	serverConfig.ControlConfig.Datastore.Endpoint = cfg.DatastoreEndpoint
 	serverConfig.ControlConfig.Datastore.BackendTLSConfig.CAFile = cfg.DatastoreCAFile
 	serverConfig.ControlConfig.Datastore.BackendTLSConfig.CertFile = cfg.DatastoreCertFile

--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -34,23 +34,25 @@ type Executor interface {
 }
 
 type ETCDConfig struct {
-	InitialOptions                  `json:",inline"`
-	Name                            string      `json:"name,omitempty"`
-	ListenClientURLs                string      `json:"listen-client-urls,omitempty"`
-	ListenClientHTTPURLs            string      `json:"listen-client-http-urls,omitempty"`
-	ListenMetricsURLs               string      `json:"listen-metrics-urls,omitempty"`
-	ListenPeerURLs                  string      `json:"listen-peer-urls,omitempty"`
-	AdvertiseClientURLs             string      `json:"advertise-client-urls,omitempty"`
-	DataDir                         string      `json:"data-dir,omitempty"`
-	SnapshotCount                   int         `json:"snapshot-count,omitempty"`
-	ServerTrust                     ServerTrust `json:"client-transport-security"`
-	PeerTrust                       PeerTrust   `json:"peer-transport-security"`
-	ForceNewCluster                 bool        `json:"force-new-cluster,omitempty"`
-	HeartbeatInterval               int         `json:"heartbeat-interval"`
-	ElectionTimeout                 int         `json:"election-timeout"`
-	Logger                          string      `json:"logger"`
-	LogOutputs                      []string    `json:"log-outputs"`
-	ExperimentalInitialCorruptCheck bool        `json:"experimental-initial-corrupt-check"`
+	InitialOptions       `json:",inline"`
+	Name                 string      `json:"name,omitempty"`
+	ListenClientURLs     string      `json:"listen-client-urls,omitempty"`
+	ListenClientHTTPURLs string      `json:"listen-client-http-urls,omitempty"`
+	ListenMetricsURLs    string      `json:"listen-metrics-urls,omitempty"`
+	ListenPeerURLs       string      `json:"listen-peer-urls,omitempty"`
+	AdvertiseClientURLs  string      `json:"advertise-client-urls,omitempty"`
+	DataDir              string      `json:"data-dir,omitempty"`
+	SnapshotCount        int         `json:"snapshot-count,omitempty"`
+	ServerTrust          ServerTrust `json:"client-transport-security"`
+	PeerTrust            PeerTrust   `json:"peer-transport-security"`
+	ForceNewCluster      bool        `json:"force-new-cluster,omitempty"`
+	HeartbeatInterval    int         `json:"heartbeat-interval"`
+	ElectionTimeout      int         `json:"election-timeout"`
+	Logger               string      `json:"logger"`
+	LogOutputs           []string    `json:"log-outputs"`
+
+	ExperimentalInitialCorruptCheck         bool          `json:"experimental-initial-corrupt-check"`
+	ExperimentalWatchProgressNotifyInterval time.Duration `json:"experimental-watch-progress-notify-interval"`
 }
 
 type ServerTrust struct {

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -904,13 +904,15 @@ func (e *ETCD) cluster(ctx context.Context, reset bool, options executor.Initial
 			ClientCertAuth: true,
 			TrustedCAFile:  e.config.Runtime.ETCDPeerCA,
 		},
-		SnapshotCount:                   10000,
-		ElectionTimeout:                 5000,
-		HeartbeatInterval:               500,
-		Logger:                          "zap",
-		LogOutputs:                      []string{"stderr"},
-		ExperimentalInitialCorruptCheck: true,
-		ListenClientHTTPURLs:            e.listenClientHTTPURLs(),
+		SnapshotCount:        10000,
+		ElectionTimeout:      5000,
+		HeartbeatInterval:    500,
+		Logger:               "zap",
+		LogOutputs:           []string{"stderr"},
+		ListenClientHTTPURLs: e.listenClientHTTPURLs(),
+
+		ExperimentalInitialCorruptCheck:         true,
+		ExperimentalWatchProgressNotifyInterval: e.config.Datastore.NotifyInterval,
 	}, e.config.ExtraEtcdArgs)
 }
 
@@ -963,20 +965,22 @@ func (e *ETCD) StartEmbeddedTemporary(ctx context.Context) error {
 	embedded := executor.Embedded{}
 	ctx, e.cancel = context.WithCancel(ctx)
 	return embedded.ETCD(ctx, executor.ETCDConfig{
-		InitialOptions:                  executor.InitialOptions{AdvertisePeerURL: peerURL},
-		DataDir:                         tmpDataDir,
-		ForceNewCluster:                 true,
-		AdvertiseClientURLs:             clientURL,
-		ListenClientURLs:                clientURL,
-		ListenClientHTTPURLs:            clientHTTPURL,
-		ListenPeerURLs:                  peerURL,
-		Logger:                          "zap",
-		HeartbeatInterval:               500,
-		ElectionTimeout:                 5000,
-		SnapshotCount:                   10000,
-		Name:                            e.name,
-		LogOutputs:                      []string{"stderr"},
-		ExperimentalInitialCorruptCheck: true,
+		InitialOptions:       executor.InitialOptions{AdvertisePeerURL: peerURL},
+		DataDir:              tmpDataDir,
+		ForceNewCluster:      true,
+		AdvertiseClientURLs:  clientURL,
+		ListenClientURLs:     clientURL,
+		ListenClientHTTPURLs: clientHTTPURL,
+		ListenPeerURLs:       peerURL,
+		Logger:               "zap",
+		HeartbeatInterval:    500,
+		ElectionTimeout:      5000,
+		SnapshotCount:        10000,
+		Name:                 e.name,
+		LogOutputs:           []string{"stderr"},
+
+		ExperimentalInitialCorruptCheck:         true,
+		ExperimentalWatchProgressNotifyInterval: e.config.Datastore.NotifyInterval,
 	}, append(e.config.ExtraEtcdArgs, "--max-snapshots=0", "--max-wals=0"))
 }
 


### PR DESCRIPTION
#### Proposed Changes ####

Bump kine for WatchProgressRequest support and set NotifyInterval to what the apiserver expects

Note upstream says they always test with the notification interval set to 5 seconds. The flag is apparently GA in 3.5 despite being named `experimental`.
https://github.com/kubernetes/kubernetes/issues/122805#issuecomment-1898386268

#### Types of Changes ####

version bump
upstream compat

#### Verification ####

Normal release tests

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9385

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
