### PR TITLE
Disable color outputs using `NO_COLOR` env var

### DIFF
--- a/contrib/util/check-config.sh
+++ b/contrib/util/check-config.sh
@@ -21,6 +21,9 @@ binDir=$(dirname "$0")
 configFormat=gz
 isError=0
 
+# RAW_OUTPUT=1 disables colored outputs
+RAW_OUTPUT=${RAW_OUTPUT:-0}
+
 if [ $# -gt 0 ]; then
   CONFIG="$1"
 fi
@@ -81,6 +84,11 @@ color() {
   printf '\033['"$codes"'m'
 }
 wrap_color() {
+  if [ $RAW_OUTPUT -eq 1 ]; then
+    echo -n "$1"
+    return
+  fi
+
   text="$1"
   shift
   color "$@"

--- a/contrib/util/check-config.sh
+++ b/contrib/util/check-config.sh
@@ -21,9 +21,6 @@ binDir=$(dirname "$0")
 configFormat=gz
 isError=0
 
-# RAW_OUTPUT=1 disables colored outputs
-RAW_OUTPUT=${RAW_OUTPUT:-0}
-
 if [ $# -gt 0 ]; then
   CONFIG="$1"
 fi
@@ -58,6 +55,10 @@ is_set_as_module() {
 }
 
 color() {
+  if [[ -n "$NO_COLOR" ]]; then
+    return
+  fi
+
   codes=
   if [ "$1" = 'bold' ]; then
     codes=1
@@ -84,11 +85,6 @@ color() {
   printf '\033['"$codes"'m'
 }
 wrap_color() {
-  if [ $RAW_OUTPUT -eq 1 ]; then
-    echo -n "$1"
-    return
-  fi
-
   text="$1"
   shift
   color "$@"

--- a/contrib/util/check-config.sh
+++ b/contrib/util/check-config.sh
@@ -55,7 +55,7 @@ is_set_as_module() {
 }
 
 color() {
-  if [[ -n "$NO_COLOR" ]]; then
+  if [ -n "$NO_COLOR" ]; then
     return
   fi
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Setting this environment variable will not wrap the text in ANSI color codes, so that we can print a raw output.
This helps us a lot when piping the output to a text file, ANSI color codes make it difficult to read through the output in a text editor.

#### Types of Changes ####

Introduced a new environment variable called `NO_COLOR`.
`NO_COLOR=1` will disable the wrapping of output text in ANSI color codes.
Default functionality will be maintained if the env var is not set at all.

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->
Ran this suit of tests:
- Default usage:   
   ![Screenshot 2024-02-29 at 16 53 31](https://github.com/k3s-io/k3s/assets/42700059/91550c4f-d1aa-4345-ad66-bd7645e93264)
- Usage with `NO_COLOR` env var:
   ![Screenshot 2024-02-29 at 16 53 56](https://github.com/k3s-io/k3s/assets/42700059/d8bd2669-1533-4bde-bbf4-2fb0084b5ed9)
   NO_COLOR can be set to whatever.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
* #9355 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
To enable raw output for the `check-config` subcommand, run:

NO_COLOR=1 k3s check-config
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Let me know if the variable name is not suitable, or any other questions/discussions. Will be happy to refactor my solution if needed.
