### PR TITLE
[Release-1.28] Runtimes refactor using exec.LookPath

### DIFF
--- a/pkg/agent/containerd/runtimes.go
+++ b/pkg/agent/containerd/runtimes.go
@@ -6,7 +6,7 @@ package containerd
 import (
 	"errors"
 	"io/fs"
-	"path/filepath"
+	"os/exec"
 
 	"github.com/k3s-io/k3s/pkg/agent/templates"
 	"github.com/sirupsen/logrus"
@@ -17,63 +17,40 @@ import (
 type runtimeConfigs map[string]templates.ContainerdRuntimeConfig
 
 // searchForRuntimes searches for runtimes and add into foundRuntimes
-// It checks install locations provided via potentitalRuntimes variable.
-// The binaries are searched at the locations specivied by locationsToCheck.
-// The given fs.FS should represent the filesystem root directory to search in.
-func searchForRuntimes(root fs.FS, potentialRuntimes runtimeConfigs, locationsToCheck []string, foundRuntimes runtimeConfigs) {
-	// Check these locations in order. The GPU operator's installation should
-	// take precedence over the package manager's installation.
-
+// It checks the PATH for the executables
+func searchForRuntimes(potentialRuntimes runtimeConfigs, foundRuntimes runtimeConfigs) {
 	// Fill in the binary location with just the name of the binary,
 	// and check against each of the possible locations. If a match is found,
 	// set the location to the full path.
 	for runtimeName, runtimeConfig := range potentialRuntimes {
-		for _, location := range locationsToCheck {
-			binaryPath := filepath.Join(location, runtimeConfig.BinaryName)
-			logrus.Debugf("Searching for %s container runtime at /%s", runtimeName, binaryPath)
-			if info, err := fs.Stat(root, binaryPath); err == nil {
-				if info.IsDir() {
-					logrus.Debugf("Found %s container runtime at /%s, but it is a directory. Skipping.", runtimeName, binaryPath)
-					continue
-				}
-				runtimeConfig.BinaryName = filepath.Join("/", binaryPath)
-				logrus.Infof("Found %s container runtime at %s", runtimeName, runtimeConfig.BinaryName)
-				foundRuntimes[runtimeName] = runtimeConfig
-				break
+		logrus.Debugf("Searching for %s container runtime", runtimeName)
+		path, err := exec.LookPath(runtimeConfig.BinaryName)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				logrus.Debugf("%s container runtime not found in $PATH: %v", runtimeName, err)
 			} else {
-				if errors.Is(err, fs.ErrNotExist) {
-					logrus.Debugf("%s container runtime not found at /%s", runtimeName, binaryPath)
-				} else {
-					logrus.Errorf("Error searching for %s container runtime at /%s: %v", runtimeName, binaryPath, err)
-				}
+				logrus.Debugf("Error searching for %s in $PATH: %v", runtimeName, err)
 			}
+			continue
 		}
+
+		logrus.Infof("Found %s container runtime at %s", runtimeName, path)
+		runtimeConfig.BinaryName = path
+		foundRuntimes[runtimeName] = runtimeConfig
 	}
 }
 
 // findContainerRuntimes is a function that searches for all the runtimes and
 // return a list with all the runtimes that have been found
-func findContainerRuntimes(root fs.FS) runtimeConfigs {
+func findContainerRuntimes() runtimeConfigs {
 	foundRuntimes := runtimeConfigs{}
-	findCRunContainerRuntime(root, foundRuntimes)
-	findNvidiaContainerRuntimes(root, foundRuntimes)
-	findWasiRuntimes(root, foundRuntimes)
+	findCRunContainerRuntime(foundRuntimes)
+	findNvidiaContainerRuntimes(foundRuntimes)
+	findWasiRuntimes(foundRuntimes)
 	return foundRuntimes
 }
 
-// findCRunContainerRuntime finds if crun is available in the system and adds to foundRuntimes
-func findCRunContainerRuntime(root fs.FS, foundRuntimes runtimeConfigs) {
-	// Check these locations in order.
-	locationsToCheck := []string{
-		"usr/sbin",       // Path when installing via package manager
-		"usr/bin",        // Path when installing via package manager
-		"usr/local/bin",  // Path when installing manually
-		"usr/local/sbin", // Path when installing manually
-	}
-
-	// Fill in the binary location with just the name of the binary,
-	// and check against each of the possible locations. If a match is found,
-	// set the location to the full path.
+func findCRunContainerRuntime(foundRuntimes runtimeConfigs) {
 	potentialRuntimes := runtimeConfigs{
 		"crun": {
 			RuntimeType: "io.containerd.runc.v2",
@@ -81,25 +58,10 @@ func findCRunContainerRuntime(root fs.FS, foundRuntimes runtimeConfigs) {
 		},
 	}
 
-	searchForRuntimes(root, potentialRuntimes, locationsToCheck, foundRuntimes)
+	searchForRuntimes(potentialRuntimes, foundRuntimes)
 }
 
-// findNvidiaContainerRuntimes finds the nvidia runtimes that are are available on the system
-// and adds to foundRuntimes. It checks install locations used by the nvidia
-// gpu operator and by system package managers. The gpu operator installation
-// takes precedence over the system package manager installation.
-// The given fs.FS should represent the filesystem root directory to search in.
-func findNvidiaContainerRuntimes(root fs.FS, foundRuntimes runtimeConfigs) {
-	// Check these locations in order. The GPU operator's installation should
-	// take precedence over the package manager's installation.
-	locationsToCheck := []string{
-		"usr/local/nvidia/toolkit", // Path when installing via GPU Operator
-		"usr/bin",                  // Path when installing via package manager
-	}
-
-	// Fill in the binary location with just the name of the binary,
-	// and check against each of the possible locations. If a match is found,
-	// set the location to the full path.
+func findNvidiaContainerRuntimes(foundRuntimes runtimeConfigs) {
 	potentialRuntimes := runtimeConfigs{
 		"nvidia": {
 			RuntimeType: "io.containerd.runc.v2",
@@ -110,25 +72,11 @@ func findNvidiaContainerRuntimes(root fs.FS, foundRuntimes runtimeConfigs) {
 			BinaryName:  "nvidia-container-runtime-experimental",
 		},
 	}
-	searchForRuntimes(root, potentialRuntimes, locationsToCheck, foundRuntimes)
+
+	searchForRuntimes(potentialRuntimes, foundRuntimes)
 }
 
-// findWasiRuntimes finds the WebAssembly (WASI) container runtimes that
-// are available on the system and adds to foundRuntimes. It checks install locations used by the kwasm
-// operator and by system package managers. The kwasm operator installation
-// takes precedence over the system package manager installation.
-// The given fs.FS should represent the filesystem root directory to search in.
-func findWasiRuntimes(root fs.FS, foundRuntimes runtimeConfigs) {
-	// Check these locations in order.
-	locationsToCheck := []string{
-		"opt/kwasm/bin", // Path when installing via kwasm Operator
-		"usr/bin",       // Path when installing via package manager
-		"usr/sbin",      // Path when installing via package manager
-	}
-
-	// Fill in the binary location with just the name of the binary,
-	// and check against each of the possible locations. If a match is found,
-	// set the location to the full path.
+func findWasiRuntimes(foundRuntimes runtimeConfigs) {
 	potentialRuntimes := runtimeConfigs{
 		"lunatic": {
 			RuntimeType: "io.containerd.lunatic.v2",
@@ -159,5 +107,6 @@ func findWasiRuntimes(root fs.FS, foundRuntimes runtimeConfigs) {
 			BinaryName:  "containerd-shim-wasmtime-v1",
 		},
 	}
-	searchForRuntimes(root, potentialRuntimes, locationsToCheck, foundRuntimes)
+
+	searchForRuntimes(potentialRuntimes, foundRuntimes)
 }

--- a/pkg/agent/containerd/runtimes_test.go
+++ b/pkg/agent/containerd/runtimes_test.go
@@ -4,17 +4,15 @@
 package containerd
 
 import (
-	"io/fs"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
-	"testing/fstest"
 )
 
 func Test_UnitFindContainerRuntimes(t *testing.T) {
-	executable := &fstest.MapFile{Mode: 0755}
-
 	type args struct {
-		root fs.FS
+		exec []string
 	}
 
 	tests := []struct {
@@ -24,39 +22,102 @@ func Test_UnitFindContainerRuntimes(t *testing.T) {
 	}{
 		{
 			name: "No runtimes",
-			args: args{
-				root: fstest.MapFS{},
-			},
+			args: args{},
 			want: runtimeConfigs{},
 		},
 		{
 			name: "Found crun, nvidia and wasm",
 			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime":         executable,
-					"usr/bin/crun":                             executable,
-					"opt/kwasm/bin/containerd-shim-lunatic-v1": executable,
+				exec: []string{
+					"nvidia-container-runtime",
+					"crun",
+					"containerd-shim-lunatic-v1",
 				},
 			},
 			want: runtimeConfigs{
 				"nvidia": {
 					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime",
+					BinaryName:  "/tmp/testExecutables/nvidia-container-runtime",
 				},
 				"crun": {
 					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/crun",
+					BinaryName:  "/tmp/testExecutables/crun",
 				},
 				"lunatic": {
 					RuntimeType: "io.containerd.lunatic.v2",
-					BinaryName:  "/opt/kwasm/bin/containerd-shim-lunatic-v1",
+					BinaryName:  "/tmp/testExecutables/containerd-shim-lunatic-v1",
+				},
+			},
+		},
+		{
+			name: "Found only wasm",
+			args: args{
+				exec: []string{
+					"containerd-shim-lunatic-v1",
+					"containerd-shim-wasmtime-v1",
+					"containerd-shim-lunatic-v1",
+					"containerd-shim-slight-v1",
+					"containerd-shim-spin-v1",
+					"containerd-shim-wws-v1",
+					"containerd-shim-wasmedge-v1",
+					"containerd-shim-wasmer-v1",
+				},
+			},
+			want: runtimeConfigs{
+				"wasmtime": {
+					RuntimeType: "io.containerd.wasmtime.v2",
+					BinaryName:  "/tmp/testExecutables/containerd-shim-wasmtime-v1",
+				},
+				"lunatic": {
+					RuntimeType: "io.containerd.lunatic.v2",
+					BinaryName:  "/tmp/testExecutables/containerd-shim-lunatic-v1",
+				},
+				"slight": {
+					RuntimeType: "io.containerd.slight.v2",
+					BinaryName:  "/tmp/testExecutables/containerd-shim-slight-v1",
+				},
+				"spin": {
+					RuntimeType: "io.containerd.spin.v2",
+					BinaryName:  "/tmp/testExecutables/containerd-shim-spin-v1",
+				},
+				"wws": {
+					RuntimeType: "io.containerd.wws.v2",
+					BinaryName:  "/tmp/testExecutables/containerd-shim-wws-v1",
+				},
+				"wasmedge": {
+					RuntimeType: "io.containerd.wasmedge.v2",
+					BinaryName:  "/tmp/testExecutables/containerd-shim-wasmedge-v1",
+				},
+				"wasmer": {
+					RuntimeType: "io.containerd.wasmer.v2",
+					BinaryName:  "/tmp/testExecutables/containerd-shim-wasmer-v1",
 				},
 			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			foundRuntimes := findContainerRuntimes(tt.args.root)
+			tempDirPath := filepath.Join(os.TempDir(), "testExecutables")
+			err := os.Mkdir(tempDirPath, 0755)
+			if err != nil {
+				t.Errorf("Error creating directory: %v", err)
+			}
+
+			defer os.RemoveAll(tempDirPath)
+
+			for _, execName := range tt.args.exec {
+				execPath := filepath.Join(tempDirPath, execName)
+				if err := createExec(execPath); err != nil {
+					t.Errorf("Failed to create executable %s: %v", execPath, err)
+				}
+			}
+
+			originalPath := os.Getenv("PATH")
+			os.Setenv("PATH", tempDirPath)
+			defer os.Setenv("PATH", originalPath)
+
+			foundRuntimes := findContainerRuntimes()
 			if !reflect.DeepEqual(foundRuntimes, tt.want) {
 				t.Errorf("findContainerRuntimes = %+v\nWant = %+v", foundRuntimes, tt.want)
 			}
@@ -64,733 +125,14 @@ func Test_UnitFindContainerRuntimes(t *testing.T) {
 	}
 }
 
-func Test_UnitSearchContainerRuntimes(t *testing.T) {
-	executable := &fstest.MapFile{Mode: 0755}
-	locationsToCheck := []string{
-		"usr/local/nvidia/toolkit", // Path for nvidia shim when installing via GPU Operator
-		"opt/kwasm/bin",            // Path for wasm shim when installing via the kwasm operator
-		"usr/bin",                  // Path when installing via package manager
-		"usr/sbin",                 // Path when installing via package manager
+func createExec(path string) error {
+	if err := os.WriteFile(path, []byte{}, 0755); err != nil {
+		return err
 	}
 
-	potentialRuntimes := runtimeConfigs{
-		"nvidia": {
-			RuntimeType: "io.containerd.runc.v2",
-			BinaryName:  "nvidia-container-runtime",
-		},
-		"spin": {
-			RuntimeType: "io.containerd.spin.v2",
-			BinaryName:  "containerd-shim-spin-v1",
-		},
+	if err := os.Chmod(path, 0755); err != nil {
+		return err
 	}
 
-	type args struct {
-		root              fs.FS
-		potentialRuntimes runtimeConfigs
-		locationsToCheck  []string
-	}
-	tests := []struct {
-		name string
-		args args
-		want runtimeConfigs
-	}{
-		{
-			name: "No runtimes",
-			args: args{
-				root:              fstest.MapFS{},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{},
-		},
-		{
-			name: "Nvidia runtime in /usr/bin",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime": executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime",
-				},
-			},
-		},
-		{
-			name: "Two runtimes in separate directories",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime":      executable,
-					"opt/kwasm/bin/containerd-shim-spin-v1": executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime",
-				},
-				"spin": {
-					RuntimeType: "io.containerd.spin.v2",
-					BinaryName:  "/opt/kwasm/bin/containerd-shim-spin-v1",
-				},
-			},
-		},
-		{
-			name: "Same runtime in two directories",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/containerd-shim-spin-v1":       executable,
-					"opt/kwasm/bin/containerd-shim-spin-v1": executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"spin": {
-					RuntimeType: "io.containerd.spin.v2",
-					BinaryName:  "/opt/kwasm/bin/containerd-shim-spin-v1",
-				},
-			},
-		},
-		{
-			name: "Both runtimes in /usr/bin",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/containerd-shim-spin-v1":  executable,
-					"usr/bin/nvidia-container-runtime": executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime",
-				},
-				"spin": {
-					RuntimeType: "io.containerd.spin.v2",
-					BinaryName:  "/usr/bin/containerd-shim-spin-v1",
-				},
-			},
-		},
-		{
-			name: "Both runtimes in both directories",
-			args: args{
-				root: fstest.MapFS{
-					"usr/local/nvidia/toolkit/nvidia-container-runtime": executable,
-					"usr/bin/nvidia-container-runtime":                  executable,
-					"usr/bin/containerd-shim-spin-v1":                   executable,
-					"opt/kwasm/bin/containerd-shim-spin-v1":             executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
-				},
-				"spin": {
-					RuntimeType: "io.containerd.spin.v2",
-					BinaryName:  "/opt/kwasm/bin/containerd-shim-spin-v1",
-				},
-			},
-		},
-		{
-			name: "Both runtimes in /usr/bin and one duplicate in /usr/local/nvidia/toolkit",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime":                  executable,
-					"usr/bin/containerd-shim-spin-v1":                   executable,
-					"usr/local/nvidia/toolkit/nvidia-container-runtime": executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"spin": {
-					RuntimeType: "io.containerd.spin.v2",
-					BinaryName:  "/usr/bin/containerd-shim-spin-v1",
-				},
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
-				},
-			},
-		},
-		{
-			name: "Runtime is a directory",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime": &fstest.MapFile{
-						Mode: fs.ModeDir,
-					},
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{},
-		},
-		{
-			name: "Runtime in both directories, but one is a directory",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime": executable,
-					"usr/local/nvidia/toolkit/nvidia-container-runtime": &fstest.MapFile{
-						Mode: fs.ModeDir,
-					},
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			foundRuntimes := runtimeConfigs{}
-			searchForRuntimes(tt.args.root, tt.args.potentialRuntimes, tt.args.locationsToCheck, foundRuntimes)
-			if !reflect.DeepEqual(foundRuntimes, tt.want) {
-				t.Errorf("findContainerRuntimes() = %+v\nWant = %+v", foundRuntimes, tt.want)
-			}
-		})
-	}
-}
-
-func Test_UnitSearchWasiRuntimes(t *testing.T) {
-	executable := &fstest.MapFile{Mode: 0755}
-
-	locationsToCheck := []string{
-		"usr/local/nvidia/toolkit", // Path for nvidia shim when installing via GPU Operator
-		"opt/kwasm/bin",            // Path for wasm shim when installing via the kwasm operator
-		"usr/bin",                  // Path when installing via package manager
-		"usr/sbin",                 // Path when installing via package manager
-	}
-
-	potentialRuntimes := runtimeConfigs{
-		"wasmtime": {
-			RuntimeType: "io.containerd.wasmtime.v2",
-			BinaryName:  "containerd-shim-wasmtime-v1",
-		},
-		"lunatic": {
-			RuntimeType: "io.containerd.lunatic.v2",
-			BinaryName:  "containerd-shim-lunatic-v1",
-		},
-		"slight": {
-			RuntimeType: "io.containerd.slight.v2",
-			BinaryName:  "containerd-shim-slight-v1",
-		},
-		"spin": {
-			RuntimeType: "io.containerd.spin.v2",
-			BinaryName:  "containerd-shim-spin-v1",
-		},
-		"wws": {
-			RuntimeType: "io.containerd.wws.v2",
-			BinaryName:  "containerd-shim-wws-v1",
-		},
-		"wasmedge": {
-			RuntimeType: "io.containerd.wasmedge.v2",
-			BinaryName:  "containerd-shim-wasmedge-v1",
-		},
-		"wasmer": {
-			RuntimeType: "io.containerd.wasmer.v2",
-			BinaryName:  "containerd-shim-wasmer-v1",
-		},
-		"nvidia": {
-			RuntimeType: "io.containerd.runc.v2",
-			BinaryName:  "nvidia-container-runtime",
-		},
-	}
-
-	type args struct {
-		root              fs.FS
-		potentialRuntimes runtimeConfigs
-		locationsToCheck  []string
-	}
-
-	tests := []struct {
-		name string
-		args args
-		want runtimeConfigs
-	}{
-		{
-			name: "No runtimes",
-			args: args{
-				root:              fstest.MapFS{},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{},
-		},
-		{
-			name: "wasmtime runtime in /usr/sbin",
-			args: args{
-				root: fstest.MapFS{
-					"usr/sbin/containerd-shim-wasmtime-v1": executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"wasmtime": {
-					RuntimeType: "io.containerd.wasmtime.v2",
-					BinaryName:  "/usr/sbin/containerd-shim-wasmtime-v1",
-				},
-			},
-		},
-		{
-			name: "lunatic runtime in /opt/kwasm/bin/",
-			args: args{
-				root: fstest.MapFS{
-					"opt/kwasm/bin/containerd-shim-lunatic-v1": executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"lunatic": {
-					RuntimeType: "io.containerd.lunatic.v2",
-					BinaryName:  "/opt/kwasm/bin/containerd-shim-lunatic-v1",
-				},
-			},
-		},
-		{
-			name: "Two runtimes in separate directories",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/containerd-shim-wasmer-v1":       executable,
-					"opt/kwasm/bin/containerd-shim-slight-v1": executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"slight": {
-					RuntimeType: "io.containerd.slight.v2",
-					BinaryName:  "/opt/kwasm/bin/containerd-shim-slight-v1",
-				},
-				"wasmer": {
-					RuntimeType: "io.containerd.wasmer.v2",
-					BinaryName:  "/usr/bin/containerd-shim-wasmer-v1",
-				},
-			},
-		},
-		{
-			name: "Same runtime in two directories",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/containerd-shim-wasmedge-v1":       executable,
-					"opt/kwasm/bin/containerd-shim-wasmedge-v1": executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"wasmedge": {
-					RuntimeType: "io.containerd.wasmedge.v2",
-					BinaryName:  "/opt/kwasm/bin/containerd-shim-wasmedge-v1",
-				},
-			},
-		},
-		{
-			name: "All runtimes in /usr/bin",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/containerd-shim-lunatic-v1":  executable,
-					"usr/bin/containerd-shim-slight-v1":   executable,
-					"usr/bin/containerd-shim-spin-v1":     executable,
-					"usr/bin/containerd-shim-wws-v1":      executable,
-					"usr/bin/containerd-shim-wasmedge-v1": executable,
-					"usr/bin/containerd-shim-wasmer-v1":   executable,
-					"usr/bin/containerd-shim-wasmtime-v1": executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"lunatic": {
-					RuntimeType: "io.containerd.lunatic.v2",
-					BinaryName:  "/usr/bin/containerd-shim-lunatic-v1",
-				},
-				"slight": {
-					RuntimeType: "io.containerd.slight.v2",
-					BinaryName:  "/usr/bin/containerd-shim-slight-v1",
-				},
-				"spin": {
-					RuntimeType: "io.containerd.spin.v2",
-					BinaryName:  "/usr/bin/containerd-shim-spin-v1",
-				},
-				"wws": {
-					RuntimeType: "io.containerd.wws.v2",
-					BinaryName:  "/usr/bin/containerd-shim-wws-v1",
-				},
-				"wasmedge": {
-					RuntimeType: "io.containerd.wasmedge.v2",
-					BinaryName:  "/usr/bin/containerd-shim-wasmedge-v1",
-				},
-				"wasmer": {
-					RuntimeType: "io.containerd.wasmer.v2",
-					BinaryName:  "/usr/bin/containerd-shim-wasmer-v1",
-				},
-				"wasmtime": {
-					RuntimeType: "io.containerd.wasmtime.v2",
-					BinaryName:  "/usr/bin/containerd-shim-wasmtime-v1",
-				},
-			},
-		},
-		{
-			name: "Both runtimes in both directories",
-			args: args{
-				root: fstest.MapFS{
-					"opt/kwasm/bin/containerd-shim-slight-v1":   executable,
-					"opt/kwasm/bin/containerd-shim-wasmtime-v1": executable,
-					"usr/bin/containerd-shim-slight-v1":         executable,
-					"usr/bin/containerd-shim-wasmtime-v1":       executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"slight": {
-					RuntimeType: "io.containerd.slight.v2",
-					BinaryName:  "/opt/kwasm/bin/containerd-shim-slight-v1",
-				},
-				"wasmtime": {
-					RuntimeType: "io.containerd.wasmtime.v2",
-					BinaryName:  "/opt/kwasm/bin/containerd-shim-wasmtime-v1",
-				},
-			},
-		},
-		{
-			name: "Preserve already found runtimes",
-			args: args{
-				root: fstest.MapFS{
-					"opt/kwasm/bin/containerd-shim-wasmtime-v1": executable,
-					"usr/bin/nvidia-container-runtime":          executable,
-				},
-				locationsToCheck:  locationsToCheck,
-				potentialRuntimes: potentialRuntimes,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime",
-				},
-				"wasmtime": {
-					RuntimeType: "io.containerd.wasmtime.v2",
-					BinaryName:  "/opt/kwasm/bin/containerd-shim-wasmtime-v1",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			foundRuntimes := runtimeConfigs{}
-			searchForRuntimes(tt.args.root, tt.args.potentialRuntimes, tt.args.locationsToCheck, foundRuntimes)
-			if !reflect.DeepEqual(foundRuntimes, tt.want) {
-				t.Errorf("searchForRuntimes = %+v\nWant = %+v", foundRuntimes, tt.want)
-			}
-		})
-	}
-}
-
-func Test_UnitSearchNvidiaContainerRuntimes(t *testing.T) {
-	executable := &fstest.MapFile{Mode: 0755}
-
-	locationsToCheck := []string{
-		"usr/local/nvidia/toolkit", // Path for nvidia shim when installing via GPU Operator
-		"opt/kwasm/bin",            // Path for wasm shim when installing via the kwasm operator
-		"usr/bin",                  // Path when installing via package manager
-		"usr/sbin",                 // Path when installing via package manager
-	}
-
-	potentialRuntimes := runtimeConfigs{
-		"nvidia": {
-			RuntimeType: "io.containerd.runc.v2",
-			BinaryName:  "nvidia-container-runtime",
-		},
-		"nvidia-experimental": {
-			RuntimeType: "io.containerd.runc.v2",
-			BinaryName:  "nvidia-container-runtime-experimental",
-		},
-		"slight": {
-			RuntimeType: "io.containerd.slight.v2",
-			BinaryName:  "containerd-shim-slight-v1",
-		},
-		"wasmtime": {
-			RuntimeType: "io.containerd.wasmtime.v2",
-			BinaryName:  "containerd-shim-wasmtime-v1",
-		},
-	}
-
-	type args struct {
-		root              fs.FS
-		potentialRuntimes runtimeConfigs
-		locationsToCheck  []string
-	}
-
-	tests := []struct {
-		name string
-		args args
-		want runtimeConfigs
-	}{
-		{
-			name: "No runtimes",
-			args: args{
-				root:              fstest.MapFS{},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{},
-		},
-		{
-			name: "Nvidia runtime in /usr/bin",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime": executable,
-				},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime",
-				},
-			},
-		},
-		{
-			name: "Experimental runtime in /usr/local/nvidia/toolkit",
-			args: args{
-				root: fstest.MapFS{
-					"usr/local/nvidia/toolkit/nvidia-container-runtime": executable,
-				},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
-				},
-			},
-		},
-		{
-			name: "Two runtimes in separate directories",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime":                  executable,
-					"usr/local/nvidia/toolkit/nvidia-container-runtime": executable,
-				},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
-				},
-			},
-		},
-		{
-			name: "Experimental runtime in /usr/bin",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime-experimental": executable,
-				},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{
-				"nvidia-experimental": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime-experimental",
-				},
-			},
-		},
-		{
-			name: "Same runtime in two directories",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime-experimental":                  executable,
-					"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
-				},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{
-				"nvidia-experimental": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime-experimental",
-				},
-			},
-		},
-		{
-			name: "Both runtimes in /usr/bin",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime-experimental": executable,
-					"usr/bin/nvidia-container-runtime":              executable,
-				},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime",
-				},
-				"nvidia-experimental": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime-experimental",
-				},
-			},
-		},
-		{
-			name: "Both runtimes in both directories",
-			args: args{
-				root: fstest.MapFS{
-					"usr/local/nvidia/toolkit/nvidia-container-runtime":              executable,
-					"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
-					"usr/bin/nvidia-container-runtime":                               executable,
-					"usr/bin/nvidia-container-runtime-experimental":                  executable,
-				},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
-				},
-				"nvidia-experimental": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime-experimental",
-				},
-			},
-		},
-		{
-			name: "Both runtimes in /usr/local/nvidia/toolkit",
-			args: args{
-				root: fstest.MapFS{
-					"usr/local/nvidia/toolkit/nvidia-container-runtime":              executable,
-					"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
-				},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
-				},
-				"nvidia-experimental": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime-experimental",
-				},
-			},
-		},
-		{
-			name: "Both runtimes in /usr/bin and one duplicate in /usr/local/nvidia/toolkit",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime":                               executable,
-					"usr/bin/nvidia-container-runtime-experimental":                  executable,
-					"usr/local/nvidia/toolkit/nvidia-container-runtime-experimental": executable,
-				},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime",
-				},
-				"nvidia-experimental": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime-experimental",
-				},
-			},
-		},
-		{
-			name: "Runtime is a directory",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime": &fstest.MapFile{
-						Mode: fs.ModeDir,
-					},
-				},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{},
-		},
-		{
-			name: "Runtime in both directories, but one is a directory",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime": executable,
-					"usr/local/nvidia/toolkit/nvidia-container-runtime": &fstest.MapFile{
-						Mode: fs.ModeDir,
-					},
-				},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime",
-				},
-			},
-		},
-		{
-			name: "Preserve already found runtimes",
-			args: args{
-				root: fstest.MapFS{
-					"usr/bin/nvidia-container-runtime":          executable,
-					"opt/kwasm/bin/containerd-shim-wasmtime-v1": executable,
-					"opt/kwasm/bin/containerd-shim-slight-v1":   executable,
-					"usr/local/nvidia/toolkit/nvidia-container-runtime": &fstest.MapFile{
-						Mode: fs.ModeDir,
-					},
-				},
-				potentialRuntimes: potentialRuntimes,
-				locationsToCheck:  locationsToCheck,
-			},
-			want: runtimeConfigs{
-				"slight": {
-					RuntimeType: "io.containerd.slight.v2",
-					BinaryName:  "/opt/kwasm/bin/containerd-shim-slight-v1",
-				},
-				"wasmtime": {
-					RuntimeType: "io.containerd.wasmtime.v2",
-					BinaryName:  "/opt/kwasm/bin/containerd-shim-wasmtime-v1",
-				},
-				"nvidia": {
-					RuntimeType: "io.containerd.runc.v2",
-					BinaryName:  "/usr/bin/nvidia-container-runtime",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			foundRuntimes := runtimeConfigs{}
-			searchForRuntimes(tt.args.root, tt.args.potentialRuntimes, tt.args.locationsToCheck, foundRuntimes)
-			if !reflect.DeepEqual(foundRuntimes, tt.want) {
-				t.Errorf("searchForRuntimes() = %+v\nWant = %+v", foundRuntimes, tt.want)
-			}
-		})
-	}
+	return nil
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- Backport from https://github.com/k3s-io/k3s/pull/9311
- Since we have hard coded paths for runtimes, this refactor uses the `exec.LookPath` to find the runtimes using the `PATH` variable 

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

- Refactor

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- See the test

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- https://github.com/k3s-io/k3s/issues/9412

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Directories containing runtimes need to be included in the $PATH environment variable for effective runtime detection.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- Since this refactor will change the entire search for runtimes, I deleted all the old tests to write a new one
