### PR TITLE
[release-1.28] Backports for 2024-02 release cycle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,12 +121,12 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/json-iterator/go v1.1.12
 	github.com/k3s-io/helm-controller v0.15.8
-	github.com/k3s-io/kine v0.11.0
+	github.com/k3s-io/kine v0.11.4
 	github.com/klauspost/compress v1.17.2
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.10.2
 	github.com/libp2p/go-libp2p v0.30.0
-	github.com/mattn/go-sqlite3 v1.14.17
+	github.com/mattn/go-sqlite3 v1.14.19
 	github.com/minio/minio-go/v7 v7.0.33
 	github.com/mwitkow/go-http-dialer v0.0.0-20161116154839-378f744fb2b8
 	github.com/natefinch/lumberjack v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -967,8 +967,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1 h1:B3039IkTPnwQEt4tIMjC6yd6b1Q3Z9ZZ
 github.com/k3s-io/etcd/server/v3 v3.5.9-k3s1/go.mod h1:GgI1fQClQCFIzuVjlvdbMxNbnISt90gdfYyqiAIt65g=
 github.com/k3s-io/helm-controller v0.15.8 h1:CAMEPmiqf4ugUCpZdICGINthCn+hkG/l1fadn8aVjfQ=
 github.com/k3s-io/helm-controller v0.15.8/go.mod h1:AYitg40howLjKloL/zdjDDOPL1jg/K5R4af0tQcyPR8=
-github.com/k3s-io/kine v0.11.0 h1:7tS0H9yBDxXiy1BgEEkBWLswwG/q4sARPTHdxOMz1qw=
-github.com/k3s-io/kine v0.11.0/go.mod h1:tjSsWrCetgaGMTfnJW6vzqdT/qOPhF/+nUEaE+eixBA=
+github.com/k3s-io/kine v0.11.4 h1:ZIXQT4vPPKNL9DwLF4dQ11tWtpJ1C/7OKNIpFmTkImo=
+github.com/k3s-io/kine v0.11.4/go.mod h1:NmwOWsWgB3aScq5+LEYytAaceqkG7lmCLLjjrWug8v4=
 github.com/k3s-io/klog/v2 v2.100.1-k3s1 h1:xb/Ta8dpQuIZueQEw2YTZUYrKoILdBmPiITVkNmYPa0=
 github.com/k3s-io/klog/v2 v2.100.1-k3s1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 github.com/k3s-io/kube-router/v2 v2.0.1 h1:UCsdkQjSfOkVakixilRDDkG9yq775GBSKxBfsyUj8ng=
@@ -1145,8 +1145,8 @@ github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
-github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/mattn/go-sqlite3 v1.14.19 h1:fhGleo2h1p8tVChob4I9HpmVFIAkKGpiukdrgQbWfGI=
+github.com/mattn/go-sqlite3 v1.14.19/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -149,6 +149,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.ExtraEtcdArgs = cfg.ExtraEtcdArgs
 	serverConfig.ControlConfig.ExtraSchedulerAPIArgs = cfg.ExtraSchedulerArgs
 	serverConfig.ControlConfig.ClusterDomain = cfg.ClusterDomain
+	serverConfig.ControlConfig.Datastore.NotifyInterval = 5 * time.Second
 	serverConfig.ControlConfig.Datastore.Endpoint = cfg.DatastoreEndpoint
 	serverConfig.ControlConfig.Datastore.BackendTLSConfig.CAFile = cfg.DatastoreCAFile
 	serverConfig.ControlConfig.Datastore.BackendTLSConfig.CertFile = cfg.DatastoreCertFile

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -442,6 +442,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		serverConfig.ControlConfig.DisableControllerManager = true
 		serverConfig.ControlConfig.DisableScheduler = true
 		serverConfig.ControlConfig.DisableCCM = true
+		serverConfig.ControlConfig.DisableServiceLB = true
 
 		// If the supervisor and apiserver are on the same port, everything is running embedded
 		// and we don't need the kubelet or containerd up to perform a cluster reset.

--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -36,23 +36,25 @@ type Executor interface {
 }
 
 type ETCDConfig struct {
-	InitialOptions                  `json:",inline"`
-	Name                            string      `json:"name,omitempty"`
-	ListenClientURLs                string      `json:"listen-client-urls,omitempty"`
-	ListenClientHTTPURLs            string      `json:"listen-client-http-urls,omitempty"`
-	ListenMetricsURLs               string      `json:"listen-metrics-urls,omitempty"`
-	ListenPeerURLs                  string      `json:"listen-peer-urls,omitempty"`
-	AdvertiseClientURLs             string      `json:"advertise-client-urls,omitempty"`
-	DataDir                         string      `json:"data-dir,omitempty"`
-	SnapshotCount                   int         `json:"snapshot-count,omitempty"`
-	ServerTrust                     ServerTrust `json:"client-transport-security"`
-	PeerTrust                       PeerTrust   `json:"peer-transport-security"`
-	ForceNewCluster                 bool        `json:"force-new-cluster,omitempty"`
-	HeartbeatInterval               int         `json:"heartbeat-interval"`
-	ElectionTimeout                 int         `json:"election-timeout"`
-	Logger                          string      `json:"logger"`
-	LogOutputs                      []string    `json:"log-outputs"`
-	ExperimentalInitialCorruptCheck bool        `json:"experimental-initial-corrupt-check"`
+	InitialOptions       `json:",inline"`
+	Name                 string      `json:"name,omitempty"`
+	ListenClientURLs     string      `json:"listen-client-urls,omitempty"`
+	ListenClientHTTPURLs string      `json:"listen-client-http-urls,omitempty"`
+	ListenMetricsURLs    string      `json:"listen-metrics-urls,omitempty"`
+	ListenPeerURLs       string      `json:"listen-peer-urls,omitempty"`
+	AdvertiseClientURLs  string      `json:"advertise-client-urls,omitempty"`
+	DataDir              string      `json:"data-dir,omitempty"`
+	SnapshotCount        int         `json:"snapshot-count,omitempty"`
+	ServerTrust          ServerTrust `json:"client-transport-security"`
+	PeerTrust            PeerTrust   `json:"peer-transport-security"`
+	ForceNewCluster      bool        `json:"force-new-cluster,omitempty"`
+	HeartbeatInterval    int         `json:"heartbeat-interval"`
+	ElectionTimeout      int         `json:"election-timeout"`
+	Logger               string      `json:"logger"`
+	LogOutputs           []string    `json:"log-outputs"`
+
+	ExperimentalInitialCorruptCheck         bool          `json:"experimental-initial-corrupt-check"`
+	ExperimentalWatchProgressNotifyInterval time.Duration `json:"experimental-watch-progress-notify-interval"`
 }
 
 type ServerTrust struct {

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -908,13 +908,15 @@ func (e *ETCD) cluster(ctx context.Context, reset bool, options executor.Initial
 			ClientCertAuth: true,
 			TrustedCAFile:  e.config.Runtime.ETCDPeerCA,
 		},
-		SnapshotCount:                   10000,
-		ElectionTimeout:                 5000,
-		HeartbeatInterval:               500,
-		Logger:                          "zap",
-		LogOutputs:                      []string{"stderr"},
-		ExperimentalInitialCorruptCheck: true,
-		ListenClientHTTPURLs:            e.listenClientHTTPURLs(),
+		SnapshotCount:        10000,
+		ElectionTimeout:      5000,
+		HeartbeatInterval:    500,
+		Logger:               "zap",
+		LogOutputs:           []string{"stderr"},
+		ListenClientHTTPURLs: e.listenClientHTTPURLs(),
+
+		ExperimentalInitialCorruptCheck:         true,
+		ExperimentalWatchProgressNotifyInterval: e.config.Datastore.NotifyInterval,
 	}, e.config.ExtraEtcdArgs)
 }
 
@@ -967,20 +969,22 @@ func (e *ETCD) StartEmbeddedTemporary(ctx context.Context) error {
 	embedded := executor.Embedded{}
 	ctx, e.cancel = context.WithCancel(ctx)
 	return embedded.ETCD(ctx, executor.ETCDConfig{
-		InitialOptions:                  executor.InitialOptions{AdvertisePeerURL: peerURL},
-		DataDir:                         tmpDataDir,
-		ForceNewCluster:                 true,
-		AdvertiseClientURLs:             clientURL,
-		ListenClientURLs:                clientURL,
-		ListenClientHTTPURLs:            clientHTTPURL,
-		ListenPeerURLs:                  peerURL,
-		Logger:                          "zap",
-		HeartbeatInterval:               500,
-		ElectionTimeout:                 5000,
-		SnapshotCount:                   10000,
-		Name:                            e.name,
-		LogOutputs:                      []string{"stderr"},
-		ExperimentalInitialCorruptCheck: true,
+		InitialOptions:       executor.InitialOptions{AdvertisePeerURL: peerURL},
+		DataDir:              tmpDataDir,
+		ForceNewCluster:      true,
+		AdvertiseClientURLs:  clientURL,
+		ListenClientURLs:     clientURL,
+		ListenClientHTTPURLs: clientHTTPURL,
+		ListenPeerURLs:       peerURL,
+		Logger:               "zap",
+		HeartbeatInterval:    500,
+		ElectionTimeout:      5000,
+		SnapshotCount:        10000,
+		Name:                 e.name,
+		LogOutputs:           []string{"stderr"},
+
+		ExperimentalInitialCorruptCheck:         true,
+		ExperimentalWatchProgressNotifyInterval: e.config.Datastore.NotifyInterval,
 	}, append(e.config.ExtraEtcdArgs, "--max-snapshots=0", "--max-wals=0"))
 }
 

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -400,6 +400,7 @@ func (e *ETCD) Reset(ctx context.Context, rebootstrap func() error) error {
 	if err := os.WriteFile(e.ResetFile(), []byte{}, 0600); err != nil {
 		return err
 	}
+
 	return e.newCluster(ctx, true)
 }
 
@@ -757,7 +758,7 @@ func getAdvertiseAddress(advertiseIP string) (string, error) {
 
 // newCluster returns options to set up etcd for a new cluster
 func (e *ETCD) newCluster(ctx context.Context, reset bool) error {
-	logrus.Infof("Starting etcd for new cluster")
+	logrus.Infof("Starting etcd for new cluster, cluster-reset=%v", reset)
 	err := e.cluster(ctx, reset, executor.InitialOptions{
 		AdvertisePeerURL: e.peerURL(),
 		Cluster:          fmt.Sprintf("%s=%s", e.name, e.peerURL()),
@@ -766,8 +767,10 @@ func (e *ETCD) newCluster(ctx context.Context, reset bool) error {
 	if err != nil {
 		return err
 	}
-	if err := e.migrateFromSQLite(ctx); err != nil {
-		return fmt.Errorf("failed to migrate content from sqlite to etcd: %w", err)
+	if !reset {
+		if err := e.migrateFromSQLite(ctx); err != nil {
+			return fmt.Errorf("failed to migrate content from sqlite to etcd: %w", err)
+		}
 	}
 	return nil
 }
@@ -848,7 +851,7 @@ func (e *ETCD) clientURL() string {
 // on other nodes connect mid-process.
 func (e *ETCD) advertiseClientURLs(reset bool) string {
 	if reset {
-		return fmt.Sprintf("https://%s", net.JoinHostPort(e.config.Loopback(true), "2379"))
+		return fmt.Sprintf("https://%s:2379", e.config.Loopback(true))
 	}
 	return e.clientURL()
 }

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -47,7 +47,7 @@ func generateTestConfig() *config.Control {
 		EtcdSnapshotRetention: 5,
 		EtcdS3Endpoint:        "s3.amazonaws.com",
 		EtcdS3Region:          "us-east-1",
-		SANs:                  []string{"127.0.0.1"},
+		SANs:                  []string{"127.0.0.1", mustGetAddress()},
 		CriticalControlArgs:   criticalControlArgs,
 	}
 }

--- a/pkg/etcd/snapshot.go
+++ b/pkg/etcd/snapshot.go
@@ -245,7 +245,13 @@ func (e *ETCD) Snapshot(ctx context.Context) error {
 
 	snapshotDir, err := snapshotDir(e.config, true)
 	if err != nil {
-		return errors.Wrap(err, "failed to get the snapshot dir")
+		return errors.Wrap(err, "failed to get etcd-snapshot-dir")
+	}
+
+	if info, err := os.Stat(snapshotDir); err != nil {
+		return errors.Wrapf(err, "failed to stat etcd-snapshot-dir %s", snapshotDir)
+	} else if !info.IsDir() {
+		return fmt.Errorf("etcd-snapshot-dir %s is not a directory", snapshotDir)
 	}
 
 	cfg, err := getClientConfig(ctx, e.config)
@@ -436,7 +442,7 @@ func (e *ETCD) listLocalSnapshots() (map[string]snapshotFile, error) {
 	}
 
 	if err := filepath.Walk(snapshotDir, func(path string, file os.FileInfo, err error) error {
-		if file.IsDir() || err != nil {
+		if err != nil || file.IsDir() {
 			return err
 		}
 

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -132,11 +132,6 @@ func createParentOpt(driver portDriver, stateDir string, enableIPv6 bool) (*pare
 		return nil, errors.Wrapf(err, "failed to mkdir %s", stateDir)
 	}
 
-	stateDir, err := os.MkdirTemp("", "rootless")
-	if err != nil {
-		return nil, err
-	}
-
 	driver.SetStateDir(stateDir)
 
 	opt := &parent.Opt{

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -488,6 +488,11 @@ func passwordBootstrap(ctx context.Context, config *Config) nodePassBootstrapper
 }
 
 func verifyLocalPassword(ctx context.Context, config *Config, mu *sync.Mutex, deferredNodes map[string]bool, node *nodeInfo) (string, int, error) {
+	// do not attempt to verify the node password if the local host is not running an agent and does not have a node resource.
+	if config.DisableAgent {
+		return node.Name, http.StatusOK, nil
+	}
+
 	// use same password file location that the agent creates
 	nodePasswordRoot := "/"
 	if config.ControlConfig.Rootless {

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -68,7 +68,7 @@ if [ -z "$VERSION_CRI_DOCKERD" ]; then
   VERSION_CRI_DOCKERD="v0.0.0"
 fi
 
-VERSION_CNIPLUGINS="v1.3.0-k3s1"
+VERSION_CNIPLUGINS="v1.4.0-k3s2"
 
 VERSION_KUBE_ROUTER=$(get-module-version github.com/cloudnativelabs/kube-router/v2)
 if [ -z "$VERSION_KUBE_ROUTER" ]; then


### PR DESCRIPTION
#### Proposed Changes ####

Backports:
* https://github.com/k3s-io/k3s/pull/9247
* https://github.com/k3s-io/k3s/pull/9318
* https://github.com/k3s-io/k3s/pull/9249
* https://github.com/k3s-io/k3s/pull/9354
* https://github.com/k3s-io/k3s/pull/9317
* https://github.com/k3s-io/k3s/pull/9312
* https://github.com/k3s-io/k3s/pull/9349
* https://github.com/k3s-io/k3s/pull/9308
* https://github.com/k3s-io/k3s/pull/9309

#### Types of Changes ####

backports

#### Verification ####

See linked issues

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9368
* https://github.com/k3s-io/k3s/issues/9371
* https://github.com/k3s-io/k3s/issues/9377
* https://github.com/k3s-io/k3s/issues/9380
* https://github.com/k3s-io/k3s/issues/9389
* https://github.com/k3s-io/k3s/issues/9450
* https://github.com/k3s-io/k3s/issues/9453
* https://github.com/k3s-io/k3s/issues/9456
* https://github.com/k3s-io/k3s/issues/9459

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
