### PR TITLE
Unit Testing Matrix and Actions bump

### DIFF
--- a/.github/workflows/unitcoverage.yaml
+++ b/.github/workflows/unitcoverage.yaml
@@ -28,10 +28,7 @@ permissions:
 jobs:
   test:
     name: Unit Tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
     - name: Checkout
@@ -41,23 +38,21 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with: 
-        go-version: '1.21.7'
+        go-version-file: go.mod # Just use whatever version is in the go.mod file
         check-latest: true
-        cache: true
-        cache-dependency-path: |
-          **/go.sum
-          **/go.mod
     - name: Run Unit Tests
       run: | 
         go test -coverpkg=./... -coverprofile=coverage.out ./pkg/... -run Unit
         go tool cover -func coverage.out
     - name: On Failure, Launch Debug Session
       if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 5
+      uses: lhotari/action-upterm@v1
+      with:
+        wait-timeout-minutes: 5
     - name: Upload Results To Codecov
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.out
         flags: unittests # optional
         verbose: true # optional (default = false)


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Remove the matrix for unit testing, if it passes on ubuntu=latest, its fine, we don't need to waste time testing it on another ubuntu version
- Move to a different debug action: the new action allows a "timeout for non connection", so if you do use the debugging session, the timeout becomes null and void. No longer will a  user have to race against a clock for debugging purposes. 
- Install the version of go given in the go.mod, reduces having to maintain multiple versions of go in infra.
- setup-go@v4 and above enables caching by default, no need to configure it. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/9478
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
