### PR TITLE
Rootless mode also bind service nodePort to host for LoadBalancer type

### DIFF
--- a/pkg/rootlessports/controller.go
+++ b/pkg/rootlessports/controller.go
@@ -143,11 +143,14 @@ func (h *handler) toBindPorts() (map[int]int, error) {
 					continue
 				}
 
-				if port.Port != 0 {
-					if port.Port <= 1024 {
-						toBindPorts[10000+int(port.Port)] = int(port.Port)
+				for _, toBindPort := range []int32{port.Port, port.NodePort} {
+					if toBindPort == 0 {
+						continue
+					}
+					if toBindPort <= 1024 {
+						toBindPorts[10000+int(toBindPort)] = int(toBindPort)
 					} else {
-						toBindPorts[int(port.Port)] = int(port.Port)
+						toBindPorts[int(toBindPort)] = int(toBindPort)
 					}
 				}
 			}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

When creating a service, typically the service port is for pod-to-pod access whereas nodePort is used for external access. In non-rootless mode, I was able to access a service of type LoadBalancer via localhost on both its service port and nodePort.

However, in rootless mode, I was only able to access it via localhost on its service port but not its nodePort.

#### Types of Changes ####

Rootless mode should also bind service nodePort to host for LoadBalancer type, matching UX of rootful mode.

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

1. `kubectl apply` a simple pod & `LoadBalancer` service with `nodePort`
2. Pod is accessible via service `port` and `nodePort`

#### Linked Issues ####

* #9511

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Rootless mode should also bind service nodePort to host for LoadBalancer type, matching UX of rootful mode.
```
