### PR TITLE
Fix issue with etcd node name missing hostname

### DIFF
--- a/pkg/cli/etcdsnapshot/etcd_snapshot.go
+++ b/pkg/cli/etcdsnapshot/etcd_snapshot.go
@@ -80,10 +80,11 @@ func commandSetup(app *cli.Context, cfg *cmds.Server, config *server.Config) (*e
 	// command uses the same endpoint selection logic as it does when starting up the full server. Specifically,
 	// we need to set an IPv6 service CIDR on IPv6-only or IPv6-first nodes, as the etcd default endpoints check
 	// the service CIDR primary addresss family to determine what loopback address to use.
-	_, nodeIPs, err := util.GetHostnameAndIPs(cmds.AgentConfig.NodeName, cmds.AgentConfig.NodeIP)
+	nodeName, nodeIPs, err := util.GetHostnameAndIPs(cmds.AgentConfig.NodeName, cmds.AgentConfig.NodeIP)
 	if err != nil {
 		return nil, err
 	}
+	config.ControlConfig.ServerNodeName = nodeName
 
 	// configure ClusterIPRanges. Use default 10.42.0.0/16 or fd00:42::/56 if user did not set it
 	_, defaultClusterCIDR, defaultServiceCIDR, _ := util.GetDefaultAddresses(nodeIPs[0])

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -623,6 +623,9 @@ func (e *ETCD) setName(force bool) error {
 	fileName := nameFile(e.config)
 	data, err := os.ReadFile(fileName)
 	if os.IsNotExist(err) || force {
+		if e.config.ServerNodeName == "" {
+			return errors.New("server node name not set")
+		}
 		e.name = e.config.ServerNodeName + "-" + uuid.New().String()[:8]
 		if err := os.MkdirAll(filepath.Dir(fileName), 0700); err != nil {
 			return err
@@ -1106,7 +1109,7 @@ func (e *ETCD) manageLearners(ctx context.Context) {
 
 			var node *v1.Node
 			for _, n := range nodes {
-				if strings.HasPrefix(member.Name, n.Name+"-") {
+				if member.Name == n.Annotations[NodeNameAnnotation] {
 					node = n
 					nodeIsMember[n.Name] = true
 					break

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -27,6 +27,7 @@ func mustGetAddress() string {
 }
 
 func generateTestConfig() *config.Control {
+	hostname, _ := os.Hostname()
 	containerRuntimeReady := make(chan struct{})
 	close(containerRuntimeReady)
 	criticalControlArgs := config.CriticalControlArgs{
@@ -37,6 +38,7 @@ func generateTestConfig() *config.Control {
 		ServiceIPRange: testutil.ServiceIPNet(),
 	}
 	return &config.Control{
+		ServerNodeName:        hostname,
 		Runtime:               config.NewRuntime(containerRuntimeReady),
 		HTTPSPort:             6443,
 		SupervisorPort:        6443,


### PR DESCRIPTION
#### Proposed Changes ####

* Set ServerNodeName in snapshot CLI setup
* Raise error if ServerNodeName ends up empty some other way
* Fix status controller to use etcd node name annotation instead of prefix checking

#### Types of Changes ####

bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9521
* https://github.com/rancher/rke2/issues/5482

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
