### PR TITLE
Restore original order of agent startup functions

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -143,12 +143,12 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 			return err
 		}
 	}
-	// the agent runtime is ready to host workloads when containerd is up and the airgap
+	// the container runtime is ready to host workloads when containerd is up and the airgap
 	// images have finished loading, as that portion of startup may block for an arbitrary
 	// amount of time depending on how long it takes to import whatever the user has placed
 	// in the images directory.
-	if cfg.AgentReady != nil {
-		close(cfg.AgentReady)
+	if cfg.ContainerRuntimeReady != nil {
+		close(cfg.ContainerRuntimeReady)
 	}
 
 	notifySocket := os.Getenv("NOTIFY_SOCKET")
@@ -258,8 +258,8 @@ func RunStandalone(ctx context.Context, cfg cmds.Agent) error {
 		return err
 	}
 
-	if cfg.AgentReady != nil {
-		close(cfg.AgentReady)
+	if cfg.ContainerRuntimeReady != nil {
+		close(cfg.ContainerRuntimeReady)
 	}
 
 	if err := tunnelSetup(ctx, nodeConfig, cfg, proxy); err != nil {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -13,6 +13,7 @@ import (
 
 	systemd "github.com/coreos/go-systemd/daemon"
 	"github.com/k3s-io/k3s/pkg/agent/config"
+	"github.com/k3s-io/k3s/pkg/agent/containerd"
 	"github.com/k3s-io/k3s/pkg/agent/flannel"
 	"github.com/k3s-io/k3s/pkg/agent/netpol"
 	"github.com/k3s-io/k3s/pkg/agent/proxy"
@@ -130,19 +131,31 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 		}
 	}
 
-	notifySocket := os.Getenv("NOTIFY_SOCKET")
-	os.Unsetenv("NOTIFY_SOCKET")
-
-	if err := setupTunnelAndRunAgent(ctx, nodeConfig, cfg, proxy); err != nil {
-		return err
+	if nodeConfig.Docker {
+		if err := executor.Docker(ctx, nodeConfig); err != nil {
+			return err
+		}
+	} else if nodeConfig.ContainerRuntimeEndpoint == "" {
+		if err := containerd.SetupContainerdConfig(nodeConfig); err != nil {
+			return err
+		}
+		if err := executor.Containerd(ctx, nodeConfig); err != nil {
+			return err
+		}
 	}
-
 	// the agent runtime is ready to host workloads when containerd is up and the airgap
 	// images have finished loading, as that portion of startup may block for an arbitrary
 	// amount of time depending on how long it takes to import whatever the user has placed
 	// in the images directory.
 	if cfg.AgentReady != nil {
 		close(cfg.AgentReady)
+	}
+
+	notifySocket := os.Getenv("NOTIFY_SOCKET")
+	os.Unsetenv("NOTIFY_SOCKET")
+
+	if err := setupTunnelAndRunAgent(ctx, nodeConfig, cfg, proxy); err != nil {
+		return err
 	}
 
 	if err := util.WaitForAPIServerReady(ctx, nodeConfig.AgentConfig.KubeConfigKubelet, util.DefaultAPIServerReadyTimeout); err != nil {

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -51,7 +51,7 @@ type Agent struct {
 	Taints                   cli.StringSlice
 	ImageCredProvBinDir      string
 	ImageCredProvConfig      string
-	AgentReady               chan<- struct{}
+	ContainerRuntimeReady    chan<- struct{}
 	AgentShared
 }
 

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -110,11 +110,11 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		}
 	}
 
-	agentReady := make(chan struct{})
+	containerRuntimeReady := make(chan struct{})
 
 	serverConfig := server.Config{}
 	serverConfig.DisableAgent = cfg.DisableAgent
-	serverConfig.ControlConfig.Runtime = config.NewRuntime(agentReady)
+	serverConfig.ControlConfig.Runtime = config.NewRuntime(containerRuntimeReady)
 	serverConfig.ControlConfig.Token = cfg.Token
 	serverConfig.ControlConfig.AgentToken = cfg.AgentToken
 	serverConfig.ControlConfig.JoinURL = cfg.ServerURL
@@ -513,7 +513,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	}
 
 	agentConfig := cmds.AgentConfig
-	agentConfig.AgentReady = agentReady
+	agentConfig.ContainerRuntimeReady = containerRuntimeReady
 	agentConfig.Debug = app.GlobalBool("debug")
 	agentConfig.DataDir = filepath.Dir(serverConfig.ControlConfig.DataDir)
 	agentConfig.ServerURL = url

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/k3s-io/k3s/pkg/agent/config"
-	"github.com/k3s-io/k3s/pkg/agent/containerd"
 	"github.com/k3s-io/k3s/pkg/agent/proxy"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
@@ -23,16 +22,6 @@ func Agent(ctx context.Context, nodeConfig *daemonconfig.Node, proxy proxy.Proxy
 	logsapi.ReapplyHandling = logsapi.ReapplyHandlingIgnoreUnchanged
 	logs.InitLogs()
 	defer logs.FlushLogs()
-
-	if nodeConfig.Docker {
-		if err := startDocker(ctx, nodeConfig); err != nil {
-			return err
-		}
-	} else if nodeConfig.ContainerRuntimeEndpoint == "" {
-		if err := startContainerd(ctx, nodeConfig); err != nil {
-			return err
-		}
-	}
 
 	if err := startKubelet(ctx, &nodeConfig.AgentConfig); err != nil {
 		return err
@@ -63,17 +52,6 @@ func startKubelet(ctx context.Context, cfg *daemonconfig.Agent) error {
 	logrus.Infof("Running kubelet %s", daemonconfig.ArgString(args))
 
 	return executor.Kubelet(ctx, args)
-}
-
-func startContainerd(ctx context.Context, cfg *daemonconfig.Node) error {
-	if err := containerd.SetupContainerdConfig(cfg); err != nil {
-		return err
-	}
-	return executor.Containerd(ctx, cfg)
-}
-
-func startDocker(ctx context.Context, cfg *daemonconfig.Node) error {
-	return executor.Docker(ctx, cfg)
 }
 
 // ImageCredProvAvailable checks to see if the kubelet image credential provider bin dir and config

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -295,7 +295,7 @@ type ControlRuntime struct {
 
 	HTTPBootstrap                        bool
 	APIServerReady                       <-chan struct{}
-	AgentReady                           <-chan struct{}
+	ContainerRuntimeReady                <-chan struct{}
 	ETCDReady                            <-chan struct{}
 	StartupHooksWg                       *sync.WaitGroup
 	ClusterControllerStarts              map[string]leader.Callback
@@ -361,9 +361,9 @@ type ControlRuntime struct {
 	EtcdConfig endpoint.ETCDConfig
 }
 
-func NewRuntime(agentReady <-chan struct{}) *ControlRuntime {
+func NewRuntime(containerRuntimeReady <-chan struct{}) *ControlRuntime {
 	return &ControlRuntime{
-		AgentReady:                           agentReady,
+		ContainerRuntimeReady:                containerRuntimeReady,
 		ClusterControllerStarts:              map[string]leader.Callback{},
 		LeaderElectedClusterControllerStarts: map[string]leader.Callback{},
 	}

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -308,7 +308,7 @@ func (e *ETCD) IsInitialized() (bool, error) {
 func (e *ETCD) Reset(ctx context.Context, rebootstrap func() error) error {
 	// Wait for etcd to come up as a new single-node cluster, then exit
 	go func() {
-		<-e.config.Runtime.AgentReady
+		<-e.config.Runtime.ContainerRuntimeReady
 		t := time.NewTicker(5 * time.Second)
 		defer t.Stop()
 		for range t.C {
@@ -450,8 +450,8 @@ func (e *ETCD) Start(ctx context.Context, clientAccessInfo *clientaccess.Info) e
 		for {
 			select {
 			case <-time.After(30 * time.Second):
-				logrus.Infof("Waiting for agent to become ready before joining etcd cluster")
-			case <-e.config.Runtime.AgentReady:
+				logrus.Infof("Waiting for container runtime to become ready before joining etcd cluster")
+			case <-e.config.Runtime.ContainerRuntimeReady:
 				if err := wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (bool, error) {
 					if err := e.join(ctx, clientAccessInfo); err != nil {
 						// Retry the join if waiting for another member to be promoted, or waiting for peers to connect after promotion
@@ -1040,7 +1040,7 @@ func (e *ETCD) RemovePeer(ctx context.Context, name, address string, allowSelfRe
 // being promoted to full voting member. The checks only run on the cluster member that is
 // the etcd leader.
 func (e *ETCD) manageLearners(ctx context.Context) {
-	<-e.config.Runtime.AgentReady
+	<-e.config.Runtime.ContainerRuntimeReady
 	t := time.NewTicker(manageTickerTime)
 	defer t.Stop()
 

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -27,8 +27,8 @@ func mustGetAddress() string {
 }
 
 func generateTestConfig() *config.Control {
-	agentReady := make(chan struct{})
-	close(agentReady)
+	containerRuntimeReady := make(chan struct{})
+	close(containerRuntimeReady)
 	criticalControlArgs := config.CriticalControlArgs{
 		ClusterDomain:  "cluster.local",
 		ClusterDNS:     net.ParseIP("10.43.0.10"),
@@ -37,7 +37,7 @@ func generateTestConfig() *config.Control {
 		ServiceIPRange: testutil.ServiceIPNet(),
 	}
 	return &config.Control{
-		Runtime:               config.NewRuntime(agentReady),
+		Runtime:               config.NewRuntime(containerRuntimeReady),
 		HTTPSPort:             6443,
 		SupervisorPort:        6443,
 		AdvertisePort:         6443,

--- a/scripts/test-run-etcd
+++ b/scripts/test-run-etcd
@@ -38,7 +38,7 @@ LABEL="ETCD-JOIN-BASIC" SERVER_ARGS="" run-test
 # --- create a basic cluster to test joining a managed etcd cluster with --agent-token set
 LABEL="ETCD-JOIN-AGENTTOKEN" SERVER_ARGS="--agent-token ${RANDOM}${RANDOM}${RANDOM}" run-test
 
-# --- create a cluster with one etcd-only server, one control-plane-only server, and one agent
+# --- create a cluster with three etcd-only server, two control-plane-only server, and one agent
 server-post-hook() {
   if [ $1 -eq 1 ]; then
     local url=$(cat $TEST_DIR/servers/1/metadata/url)
@@ -46,7 +46,13 @@ server-post-hook() {
   fi
 }
 export -f server-post-hook
-LABEL="ETCD-SPLIT-ROLE" NUM_AGENTS=1 KUBECONFIG_SERVER=2 SERVER_1_ARGS="--cluster-init --disable-apiserver --disable-controller-manager --disable-scheduler" SERVER_2_ARGS="--disable-etcd" run-test
+LABEL="ETCD-SPLIT-ROLE" NUM_AGENTS=1 KUBECONFIG_SERVER=4 NUM_SERVERS=5 \
+SERVER_1_ARGS="--disable-apiserver --disable-controller-manager --disable-scheduler --cluster-init" \
+SERVER_2_ARGS="--disable-apiserver --disable-controller-manager --disable-scheduler" \
+SERVER_3_ARGS="--disable-apiserver --disable-controller-manager --disable-scheduler" \
+SERVER_4_ARGS="--disable-etcd" \
+SERVER_5_ARGS="--disable-etcd" \
+run-test
 
 
 # The following tests deploy clusters of mixed versions. The traefik helm chart may not deploy

--- a/tests/e2e/splitserver/Vagrantfile
+++ b/tests/e2e/splitserver/Vagrantfile
@@ -1,6 +1,6 @@
 ENV['VAGRANT_NO_PARALLEL'] = 'no'
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
-  ["server-etcd-0", "server-cp-0", "server-cp-1", "agent-0"])
+  ["server-etcd-0", "server-etcd-1", "server-etcd-2", "server-cp-0", "server-cp-1", "agent-0"])
 NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
   ['generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004', 'generic/ubuntu2004'])
 GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -15,7 +15,7 @@ import (
 
 // Valid nodeOS: generic/ubuntu2004, opensuse/Leap-15.3.x86_64
 var nodeOS = flag.String("nodeOS", "generic/ubuntu2004", "VM operating system")
-var etcdCount = flag.Int("etcdCount", 1, "number of server nodes only deploying etcd")
+var etcdCount = flag.Int("etcdCount", 3, "number of server nodes only deploying etcd")
 var controlPlaneCount = flag.Int("controlPlaneCount", 1, "number of server nodes acting as control plane")
 var agentCount = flag.Int("agentCount", 1, "number of agent nodes")
 var ci = flag.Bool("ci", false, "running on CI")


### PR DESCRIPTION
#### Proposed Changes ####
- Partial revert of #9184, restoring the orginal order of setting up container runtimes, closing the channel, then running the kubelet.
- Renamed `AgentReady` to `ContainerRuntimeReady` to better reflect what the channel is actually tracking.
- Closed E2E coverage gap around this issue by increasing number of etcd nodes in the split role test.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Manually running split servers (3 etcd, 2 cp, 1 agent), the cluster now initialized all etcd nodes correctly. 
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
Change is now covered by E2E test, and the docker/drone `test` stage now covers this case.
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/9540
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####
I will not be squashing this, as we want the revert commit to stand alone from the other 2 "new" changes.
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
