### PR TITLE
[release-1.27] Fix netpol startup when flannel is disabled

### DIFF
--- a/pkg/agent/netpol/netpol.go
+++ b/pkg/agent/netpol/netpol.go
@@ -75,7 +75,7 @@ func Run(ctx context.Context, nodeConfig *config.Node) error {
 		node, err := client.CoreV1().Nodes().Get(ctx, nodeConfig.AgentConfig.NodeName, metav1.GetOptions{})
 		if err != nil {
 			logrus.Errorf("Error getting the node object: %v", err)
-			return false, err
+			return false, nil
 		}
 		// Check for the uninitialized taint that should be removed by cloud-provider
 		// If there is no cloud-provider, the taint will not be there


### PR DESCRIPTION
#### Proposed Changes ####

Fix netpol startup when flannel is disabled.

Don't break out of the poll loop if we can't get the node, RBAC might not be ready yet.

#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Testing ####

tbd
/cc @manuelbuil 

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9576

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
