### PR TITLE
Fix coredns NodeHosts on dual-stack clusters

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -426,7 +426,7 @@ func updateLegacyAddressLabels(agentConfig *daemonconfig.Agent, nodeLabels map[s
 	if ls.Has(cp.InternalIPKey) || ls.Has(cp.HostnameKey) {
 		result := map[string]string{
 			cp.InternalIPKey: agentConfig.NodeIP,
-			cp.HostnameKey:   agentConfig.NodeName,
+			cp.HostnameKey:   getHostname(agentConfig),
 		}
 
 		if agentConfig.NodeExternalIP != "" {
@@ -444,7 +444,7 @@ func updateAddressAnnotations(nodeConfig *daemonconfig.Node, nodeAnnotations map
 	agentConfig := &nodeConfig.AgentConfig
 	result := map[string]string{
 		cp.InternalIPKey: util.JoinIPs(agentConfig.NodeIPs),
-		cp.HostnameKey:   agentConfig.NodeName,
+		cp.HostnameKey:   getHostname(agentConfig),
 	}
 
 	if agentConfig.NodeExternalIP != "" {
@@ -538,4 +538,14 @@ func tunnelSetup(ctx context.Context, nodeConfig *daemonconfig.Node, cfg cmds.Ag
 		return nil
 	}
 	return tunnel.Setup(ctx, nodeConfig, proxy)
+}
+
+// getHostname returns the actual system hostname.
+// If the hostname cannot be determined, or is invalid, the node name is used.
+func getHostname(agentConfig *daemonconfig.Agent) string {
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" || strings.Contains(hostname, "localhost") {
+		return agentConfig.NodeName
+	}
+	return hostname
 }


### PR DESCRIPTION

#### Proposed Changes ####

* Add both dual-stack addresses to the node hosts file
* Add hostname to hosts file as alias for node name to ensure consistent resolution

#### Types of Changes ####

bugfix

#### Verification ####

* See linked issue
* On a dual-stack cluster, ensure that both addresses are present in the hosts file:
  `kubectl get configmap -n kube-system coredns -o template --template '{{.data.NodeHosts}}'`

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9551

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
