### PR TITLE
Improve tailscale e2e test

### DIFF
--- a/tests/e2e/tailscale/README.md
+++ b/tests/e2e/tailscale/README.md
@@ -16,3 +16,14 @@ Tailscale requires three steps before running the test:
 ```
 
 3 - In `Settings` > `Keys`, generate an auth key which is Reusable and Ephemeral. That key should be the value of a new env variable `E2E_TAILSCALE_KEY`
+
+# Typical problems
+
+### The cluster does not start correctly
+
+Please verify that the tailscale key was correctly passed to the config. To verify this, check the config in the server/agent in the file /etc/rancher/k3s/config.yaml
+
+
+### The verification on the routing fails
+
+Please verify that you filled the autoApprovers section and that the config applies to your key. If you access the tailscale UI and see that the machine has "Subnets" that require manual approval, the test will not work

--- a/tests/e2e/tailscale/Vagrantfile
+++ b/tests/e2e/tailscale/Vagrantfile
@@ -38,6 +38,7 @@ def provision(vm, roles, role_num, node_num)
       k3s.config = <<~YAML
         cluster-init: true
         token: vagrant
+        tls-san: #{node_ip4}
         vpn-auth: "name=tailscale,joinKey=#{TAILSCALE_KEY}"
       YAML
       k3s.env = ["K3S_KUBECONFIG_MODE=0644", install_type]

--- a/tests/e2e/tailscale/tailscale_test.go
+++ b/tests/e2e/tailscale/tailscale_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Verify Tailscale Configuration", Ordered, func() {
 			for _, node := range nodes {
 				g.Expect(node.Status).Should(Equal("Ready"))
 			}
-		}, "620s", "5s").Should(Succeed())
+		}, "300s", "5s").Should(Succeed())
 		_, err := e2e.ParseNodes(kubeConfigFile, true)
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -85,7 +85,7 @@ var _ = Describe("Verify Tailscale Configuration", Ordered, func() {
 			for _, node := range nodes {
 				g.Expect(node.Status).Should(Equal("Ready"))
 			}
-		}, "620s", "5s").Should(Succeed())
+		}, "300s", "5s").Should(Succeed())
 		_, err := e2e.ParseNodes(kubeConfigFile, true)
 		Expect(err).NotTo(HaveOccurred())
 	})


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This PR applies three improvements to the Tailscale e2e test:
1 - Adds `tls-san: #{node_ip4}` to the server config, otherwise, the test fails because it tries to access kube-api via the node-ip. That can work but we must append the node-ip to the kube-apiserver tls-san
2 - Reduce the time limit to 300s. 620s is too much and makes the wait too long when something does not work
3 - Add a "gotchas" section in the README


#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Test improvement


#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
go test -v -timeout=15m tests/e2e/tailscale/tailscale_test.go


#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
