### PR TITLE
Include flannel version in flannel cni plugin version

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -41,7 +41,7 @@ VERSIONFLAGS="
 
     -X ${PKG_CNI_PLUGINS}/pkg/utils/buildversion.BuildVersion=${VERSION_CNIPLUGINS}
     -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Program=flannel
-    -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Version=${VERSION_FLANNEL_PLUGIN}
+    -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Version=${VERSION_FLANNEL_PLUGIN}+${VERSION_FLANNEL}
     -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Commit=HEAD
     -X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.buildDate=${buildDate}
 


### PR DESCRIPTION
#### Proposed Changes ####

We actually embed two separate things from the flannel project:
* the flannel controller: https://github.com/flannel-io/flannel/releases/tag/v0.24.2
* the flannel cni plugin: https://github.com/flannel-io/cni-plugin/releases/tag/v1.4.0-flannel1

We were misreporting the flannel controller version as the flannel cni plugin version. That was fixed in https://github.com/k3s-io/k3s/pull/9635, but the QA and release teams were relying on that to look up the flannel controller version embedded in k3s.

Restore the actual flannel controller version as build metadata in the cni plugin version.

#### Types of Changes ####

enhancement

#### Verification ####

check the flannel cni plugin version:

```
/ # flannel --version
CNI Plugin flannel version v1.4.0-flannel1+v0.24.2 (linux/amd64) commit HEAD built on 2024-03-05T19:38:31Z
CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0
```

This denotes flannel cni-plugin `v1.4.0-flannel1` and flannel controller `v0.24.2`

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9636

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The flannel controller version is now reported as build metadata on the flannel cni plugin version.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
