### PR TITLE
Fix wildcard with embbeded registry test

### DIFF
--- a/pkg/agent/containerd/config_test.go
+++ b/pkg/agent/containerd/config_test.go
@@ -1148,8 +1148,16 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				"_default": templates.HostConfig{
 					Program: "k3s",
 					Endpoints: []templates.RegistryEndpoint{
-						// note that the embedded registry mirror is NOT listed as an endpoint.
-						// individual registries must be enabled for mirroring by name.
+						{
+							URL: u("https://127.0.0.1:6443/v2"),
+							Config: registries.RegistryConfig{
+								TLS: &registries.TLSConfig{
+									CAFile:   "server-ca",
+									KeyFile:  "client-key",
+									CertFile: "client-cert",
+								},
+							},
+						},
 						{
 							URL: u("https://registry.example.com/v2"),
 						},


### PR DESCRIPTION
#### Proposed Changes ####
Thanks @vitorsavian 

Fix test broken by combined changes from https://github.com/k3s-io/k3s/pull/9599 and https://github.com/k3s-io/k3s/pull/9556

One PR added tests, another PR changed the logic; the combination of the two was not tested until both were merged to master.

#### Types of Changes ####

test

#### Verification ####

check CI

#### Testing ####

yes

#### Linked Issues ####

*
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
