### PR TITLE
[Release 1.28] Improve tailscale e2e test

### DIFF
--- a/tests/e2e/tailscale/README.md
+++ b/tests/e2e/tailscale/README.md
@@ -16,3 +16,14 @@ Tailscale requires three steps before running the test:
 ```
 
 3 - In `Settings` > `Keys`, generate an auth key which is Reusable and Ephemeral. That key should be the value of a new env variable `E2E_TAILSCALE_KEY`
+
+# Typical problems
+
+### The cluster does not start correctly
+
+Please verify that the tailscale key was correctly passed to the config. To verify this, check the config in the server/agent in the file /etc/rancher/k3s/config.yaml
+
+
+### The verification on the routing fails
+
+Please verify that you filled the autoApprovers section and that the config applies to your key. If you access the tailscale UI and see that the machine has "Subnets" that require manual approval, the test will not work

--- a/tests/e2e/tailscale/Vagrantfile
+++ b/tests/e2e/tailscale/Vagrantfile
@@ -38,6 +38,7 @@ def provision(vm, roles, role_num, node_num)
       k3s.config = <<~YAML
         cluster-init: true
         token: vagrant
+        tls-san: #{node_ip4}
         vpn-auth: "name=tailscale,joinKey=#{TAILSCALE_KEY}"
       YAML
       k3s.env = ["K3S_KUBECONFIG_MODE=0644", install_type]

--- a/tests/e2e/tailscale/tailscale_test.go
+++ b/tests/e2e/tailscale/tailscale_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Verify Tailscale Configuration", Ordered, func() {
 			for _, node := range nodes {
 				g.Expect(node.Status).Should(Equal("Ready"))
 			}
-		}, "620s", "5s").Should(Succeed())
+		}, "300s", "5s").Should(Succeed())
 		_, err := e2e.ParseNodes(kubeConfigFile, true)
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -85,7 +85,7 @@ var _ = Describe("Verify Tailscale Configuration", Ordered, func() {
 			for _, node := range nodes {
 				g.Expect(node.Status).Should(Equal("Ready"))
 			}
-		}, "620s", "5s").Should(Succeed())
+		}, "300s", "5s").Should(Succeed())
 		_, err := e2e.ParseNodes(kubeConfigFile, true)
 		Expect(err).NotTo(HaveOccurred())
 	})


### PR DESCRIPTION
Backport: https://github.com/k3s-io/k3s/pull/9586