### PR TITLE
Warn and suppress duplicate registry mirror endpoints

### DIFF
--- a/pkg/agent/containerd/config.go
+++ b/pkg/agent/containerd/config.go
@@ -99,6 +99,9 @@ func getHostConfigs(registry *registries.Registry, noDefaultEndpoint bool, mirro
 			}
 		}
 
+		// track which endpoints we've already seen to avoid creating duplicates
+		seenEndpoint := map[string]bool{}
+
 		// TODO: rewrites are currently copied from the mirror settings into each endpoint.
 		// In the future, we should allow for per-endpoint rewrites, instead of expecting
 		// all mirrors to have the same structure. This will require changes to the registries.yaml
@@ -107,7 +110,10 @@ func getHostConfigs(registry *registries.Registry, noDefaultEndpoint bool, mirro
 			registryName, url, override, err := normalizeEndpointAddress(endpoint, mirrorAddr)
 			if err != nil {
 				logrus.Warnf("Ignoring invalid endpoint URL %d=%s for %s: %v", i, endpoint, host, err)
+			} else if _, ok := seenEndpoint[url.String()]; ok {
+				logrus.Warnf("Skipping duplicate endpoint URL %d=%s for %s", i, endpoint, host)
 			} else {
+				seenEndpoint[url.String()] = true
 				var rewrites map[string]string
 				// Do not apply rewrites to the embedded registry endpoint
 				if url.Host != mirrorAddr {

--- a/pkg/agent/containerd/config_test.go
+++ b/pkg/agent/containerd/config_test.go
@@ -476,6 +476,86 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 			},
 		},
 		{
+			name: "registry with mirror endpoint - duplicate endpoints",
+			args: args{
+				registryContent: `
+				  mirrors:
+						docker.io:
+							endpoint:
+								- registry.example.com
+								- registry.example.com
+				`,
+			},
+			want: HostConfigs{
+				"docker.io": templates.HostConfig{
+					Program: "k3s",
+					Default: &templates.RegistryEndpoint{
+						URL: u("https://registry-1.docker.io/v2"),
+					},
+					Endpoints: []templates.RegistryEndpoint{
+						{
+							URL: u("https://registry.example.com/v2"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "registry with mirror endpoint - duplicate endpoints in different formats",
+			args: args{
+				registryContent: `
+				  mirrors:
+						docker.io:
+							endpoint:
+								- registry.example.com
+								- https://registry.example.com
+								- https://registry.example.com/v2
+				`,
+			},
+			want: HostConfigs{
+				"docker.io": templates.HostConfig{
+					Program: "k3s",
+					Default: &templates.RegistryEndpoint{
+						URL: u("https://registry-1.docker.io/v2"),
+					},
+					Endpoints: []templates.RegistryEndpoint{
+						{
+							URL: u("https://registry.example.com/v2"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "registry with mirror endpoint - duplicate endpoints in different positions",
+			args: args{
+				registryContent: `
+				  mirrors:
+						docker.io:
+							endpoint:
+								- https://registry.example.com
+								- https://registry.example.org
+								- https://registry.example.com
+				`,
+			},
+			want: HostConfigs{
+				"docker.io": templates.HostConfig{
+					Program: "k3s",
+					Default: &templates.RegistryEndpoint{
+						URL: u("https://registry-1.docker.io/v2"),
+					},
+					Endpoints: []templates.RegistryEndpoint{
+						{
+							URL: u("https://registry.example.com/v2"),
+						},
+						{
+							URL: u("https://registry.example.org/v2"),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "registry with mirror endpoint - localhost and port only",
 			args: args{
 				registryContent: `


### PR DESCRIPTION

#### Proposed Changes ####

Warn and suppress duplicate registry mirror endpoints

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue and test
#### Testing ####

yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9693

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
K3s will now warn and suppress duplicate entries in the mirror endpoint list for a registry. Containerd does not support listing the same endpoint multiple times as a mirror for a single upstream registry.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
