### PR TITLE
Respect cloud-provider fields set by kubelet

### DIFF
--- a/pkg/cloudprovider/instances_test.go
+++ b/pkg/cloudprovider/instances_test.go
@@ -1,0 +1,132 @@
+package cloudprovider
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cloudprovider "k8s.io/cloud-provider"
+)
+
+func Test_UnitK3sInstanceMetadata(t *testing.T) {
+	nodeName := "test-node"
+	nodeInternalIP := "10.0.0.1"
+	nodeExternalIP := "1.2.3.4"
+
+	tests := []struct {
+		name    string
+		node    *corev1.Node
+		want    *cloudprovider.InstanceMetadata
+		wantErr bool
+	}{
+		{
+			name:    "No Annotations",
+			node:    &corev1.Node{},
+			wantErr: true,
+		},
+		{
+			name: "Internal IP",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						InternalIPKey: nodeInternalIP,
+					},
+				},
+			},
+			want: &cloudprovider.InstanceMetadata{
+				InstanceType: version.Program,
+				ProviderID:   version.Program + "://" + nodeName,
+				NodeAddresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: nodeInternalIP},
+				},
+			},
+		},
+		{
+			name: "Internal IP, External IP",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						InternalIPKey: nodeInternalIP,
+						ExternalIPKey: nodeExternalIP,
+					},
+				},
+			},
+			want: &cloudprovider.InstanceMetadata{
+				InstanceType: version.Program,
+				ProviderID:   version.Program + "://" + nodeName,
+				NodeAddresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: nodeInternalIP},
+					{Type: corev1.NodeExternalIP, Address: nodeExternalIP},
+				},
+			},
+		},
+		{
+			name: "Internal IP, External IP, Hostname",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						InternalIPKey: nodeInternalIP,
+						ExternalIPKey: nodeExternalIP,
+						HostnameKey:   nodeName + ".example.com",
+					},
+				},
+			},
+			want: &cloudprovider.InstanceMetadata{
+				InstanceType: version.Program,
+				ProviderID:   version.Program + "://" + nodeName,
+				NodeAddresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: nodeInternalIP},
+					{Type: corev1.NodeExternalIP, Address: nodeExternalIP},
+					{Type: corev1.NodeHostName, Address: nodeName + ".example.com"},
+				},
+			},
+		},
+		{
+			name: "Custom Metadata",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						InternalIPKey: nodeInternalIP,
+					},
+					Labels: map[string]string{
+						corev1.LabelInstanceTypeStable: "test.t1",
+						corev1.LabelTopologyRegion:     "region",
+						corev1.LabelTopologyZone:       "zone",
+					},
+				},
+				Spec: corev1.NodeSpec{
+					ProviderID: "test://i-abc",
+				},
+			},
+			want: &cloudprovider.InstanceMetadata{
+				InstanceType: "test.t1",
+				ProviderID:   "test://i-abc",
+				NodeAddresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: nodeInternalIP},
+				},
+				Region: "region",
+				Zone:   "zone",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &k3s{}
+			got, err := k.InstanceMetadata(context.Background(), tt.node)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("k3s.InstanceMetadata() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("k3s.InstanceMetadata() = %+v\nWant = %+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Proposed Changes ####

Don't clobber the providerID field and instance-type/region/zone labels if provided by the kubelet. This allows the user to set these to the correct values when using the embedded CCM in a real cloud environment.

#### Types of Changes ####

enhancement

#### Verification ####

Start k3s server or agent with provider-id, instance-type, region, and zone set:
`k3s server --kubelet-arg=provider-id=aws://i-xxx --node-label=node.kubernetes.io/instance-type=c4.large --node-label=topology.kubernetes.io/region=us-west-2 --node-label=topology.kubernetes.io/zone=us-west-2a`

Check the output of `kubectl get node -o yaml`: k3s should leave these set as requested, and not clobber them with k3s or empty values.

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9280

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The k3s stub cloud provider now respects the kubelet's requested provider-id, instance type, and topology labels
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
