### PR TITLE
Send error response if member list cannot be retrieved

### DIFF
--- a/pkg/util/apierrors.go
+++ b/pkg/util/apierrors.go
@@ -1,0 +1,71 @@
+package util
+
+import (
+	"net/http"
+
+	"github.com/k3s-io/k3s/pkg/generated/clientset/versioned/scheme"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+)
+
+var ErrNotReady = errors.New("apiserver not ready")
+
+// SendError sends a properly formatted error response
+func SendError(err error, resp http.ResponseWriter, req *http.Request, status ...int) {
+	var code int
+	if len(status) == 1 {
+		code = status[0]
+	}
+	if code == 0 || code == http.StatusOK {
+		code = http.StatusInternalServerError
+	}
+
+	// Don't log "apiserver not ready" errors, they are frequent during startup
+	if !errors.Is(err, ErrNotReady) {
+		logrus.Errorf("Sending HTTP %d response to %s: %v", code, req.RemoteAddr, err)
+	}
+
+	var serr *apierrors.StatusError
+	switch code {
+	case http.StatusBadRequest:
+		serr = apierrors.NewBadRequest(err.Error())
+	case http.StatusUnauthorized:
+		serr = apierrors.NewUnauthorized(err.Error())
+	case http.StatusForbidden:
+		serr = newForbidden(err)
+	case http.StatusInternalServerError:
+		serr = apierrors.NewInternalError(err)
+	case http.StatusBadGateway:
+		serr = newBadGateway(err)
+	case http.StatusServiceUnavailable:
+		serr = apierrors.NewServiceUnavailable(err.Error())
+	default:
+		serr = apierrors.NewGenericServerResponse(code, req.Method, schema.GroupResource{}, req.URL.Path, err.Error(), 0, true)
+	}
+
+	responsewriters.ErrorNegotiated(serr, scheme.Codecs.WithoutConversion(), schema.GroupVersion{}, resp, req)
+}
+
+func newForbidden(err error) *apierrors.StatusError {
+	return &apierrors.StatusError{
+		ErrStatus: metav1.Status{
+			Status:  metav1.StatusFailure,
+			Code:    http.StatusForbidden,
+			Reason:  metav1.StatusReasonForbidden,
+			Message: err.Error(),
+		}}
+}
+
+func newBadGateway(err error) *apierrors.StatusError {
+	return &apierrors.StatusError{
+		ErrStatus: metav1.Status{
+			Status:  metav1.StatusFailure,
+			Code:    http.StatusBadGateway,
+			Reason:  metav1.StatusReasonInternalError,
+			Message: err.Error(),
+		}}
+}


### PR DESCRIPTION
#### Proposed Changes ####

* Move error response generation code into util
* Send error response if member list cannot be retrieved
  Prevents joining nodes from being stuck with bad initial member list if there is a transient failure, or if they try to join themselves
  
I am assuming there was some reason we generated a dummy list instead of sending an error, but it's done this since the initial embedded etcd code was bulk-added by Darren in https://github.com/k3s-io/k3s/pull/1770 so I don't know why this was supposed to be a good idea.
  
#### Types of Changes ####

bugfix

#### Verification ####

* See linked issue
* Try joining a node that is behind an external load-balancer that includes the new node in its target poor. For example, using the following haproxy config, where `SERVER1` is the existing node, and `SERVER2` is the node attempting to join the cluster:

```
    global
        maxconn 256
        max-spread-checks 0

    defaults
        mode tcp
        timeout connect 10ms
        timeout client  60s
        timeout server  60s

    frontend listener
        bind *:6443
        default_backend servers

    backend servers
        retries 10
        retry-on conn-failure
        server server1 SERVER1:6443 check downinter 5ms inter 1s weight 1
        server server2 SERVER2:6443 check downinter 5ms inter 1s weight 100
```

This haproxy config will cause it to send traffic to the new server as soon as it is up, but before it is actually ready - which will result in it trying to join itself.

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9661

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
