### PR TITLE
Fix wildcard entry upstream fallback

### DIFF
--- a/pkg/agent/containerd/config.go
+++ b/pkg/agent/containerd/config.go
@@ -92,8 +92,10 @@ func getHostConfigs(registry *registries.Registry, noDefaultEndpoint bool, mirro
 				logrus.Errorf("Failed to generate config for registry %s: %v", host, err)
 				continue
 			} else {
-				if host == "*" || noDefaultEndpoint {
+				if noDefaultEndpoint {
 					c.Default = nil
+				} else if host == "*" {
+					c.Default = &templates.RegistryEndpoint{URL: &url.URL{}}
 				}
 				config = *c
 			}


### PR DESCRIPTION
#### Proposed Changes ####

The generated config for the wildcard/default entry was missing a top-level `server` entry, so containerd was not falling back to the default upstream endpoint.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9728

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
