### PR TITLE
Add health-check support to loadbalancer

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -362,7 +362,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	// If the supervisor and externally-facing apiserver are not on the same port, tell the proxy where to find the apiserver.
 	if controlConfig.SupervisorPort != controlConfig.HTTPSPort {
 		isIPv6 := utilsnet.IsIPv6(net.ParseIP([]string{envInfo.NodeIP.String()}[0]))
-		if err := proxy.SetAPIServerPort(ctx, controlConfig.HTTPSPort, isIPv6); err != nil {
+		if err := proxy.SetAPIServerPort(controlConfig.HTTPSPort, isIPv6); err != nil {
 			return nil, errors.Wrapf(err, "failed to setup access to API Server port %d on at %s", controlConfig.HTTPSPort, proxy.SupervisorURL())
 		}
 	}

--- a/pkg/agent/loadbalancer/loadbalancer.go
+++ b/pkg/agent/loadbalancer/loadbalancer.go
@@ -16,7 +16,10 @@ import (
 
 // server tracks the connections to a server, so that they can be closed when the server is removed.
 type server struct {
+	// This mutex protects access to the connections map. All direct access to the map should be protected by it.
 	mutex       sync.Mutex
+	address     string
+	healthCheck func() bool
 	connections map[net.Conn]struct{}
 }
 
@@ -31,7 +34,9 @@ type serverConn struct {
 // actually balance connections, but instead fails over to a new server only
 // when a connection attempt to the currently selected server fails.
 type LoadBalancer struct {
-	mutex sync.Mutex
+	// This mutex protects access to servers map and randomServers list.
+	// All direct access to the servers map/list should be protected by it.
+	mutex sync.RWMutex
 	proxy *tcpproxy.Proxy
 
 	serviceName          string
@@ -123,26 +128,9 @@ func New(ctx context.Context, dataDir, serviceName, serverURL string, lbServerPo
 	}
 	logrus.Infof("Running load balancer %s %s -> %v [default: %s]", serviceName, lb.localAddress, lb.ServerAddresses, lb.defaultServerAddress)
 
+	go lb.runHealthChecks(ctx)
+
 	return lb, nil
-}
-
-func (lb *LoadBalancer) SetDefault(serverAddress string) {
-	lb.mutex.Lock()
-	defer lb.mutex.Unlock()
-
-	_, hasOriginalServer := sortServers(lb.ServerAddresses, lb.defaultServerAddress)
-	// if the old default server is not currently in use, remove it from the server map
-	if server := lb.servers[lb.defaultServerAddress]; server != nil && !hasOriginalServer {
-		defer server.closeAll()
-		delete(lb.servers, lb.defaultServerAddress)
-	}
-	// if the new default server doesn't have an entry in the map, add one
-	if _, ok := lb.servers[serverAddress]; !ok {
-		lb.servers[serverAddress] = &server{connections: make(map[net.Conn]struct{})}
-	}
-
-	lb.defaultServerAddress = serverAddress
-	logrus.Infof("Updated load balancer %s default server address -> %s", lb.serviceName, serverAddress)
 }
 
 func (lb *LoadBalancer) Update(serverAddresses []string) {
@@ -166,7 +154,10 @@ func (lb *LoadBalancer) LoadBalancerServerURL() string {
 	return lb.localServerURL
 }
 
-func (lb *LoadBalancer) dialContext(ctx context.Context, network, address string) (net.Conn, error) {
+func (lb *LoadBalancer) dialContext(ctx context.Context, network, _ string) (net.Conn, error) {
+	lb.mutex.RLock()
+	defer lb.mutex.RUnlock()
+
 	startIndex := lb.nextServerIndex
 	for {
 		targetServer := lb.currentServerAddress
@@ -174,7 +165,7 @@ func (lb *LoadBalancer) dialContext(ctx context.Context, network, address string
 		server := lb.servers[targetServer]
 		if server == nil || targetServer == "" {
 			logrus.Debugf("Nil server for load balancer %s: %s", lb.serviceName, targetServer)
-		} else {
+		} else if server.healthCheck() {
 			conn, err := server.dialContext(ctx, network, targetServer)
 			if err == nil {
 				return conn, nil

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -56,7 +56,7 @@ func (c *Cluster) Start(ctx context.Context) (<-chan struct{}, error) {
 			clientURL.Host = clientURL.Hostname() + ":2379"
 			clientURLs = append(clientURLs, clientURL.String())
 		}
-		etcdProxy, err := etcd.NewETCDProxy(ctx, true, c.config.DataDir, clientURLs[0], utilsnet.IsIPv6CIDR(c.config.ServiceIPRanges[0]))
+		etcdProxy, err := etcd.NewETCDProxy(ctx, c.config.SupervisorPort, c.config.DataDir, clientURLs[0], utilsnet.IsIPv6CIDR(c.config.ServiceIPRanges[0]))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -126,7 +126,7 @@ func (c *Cluster) assignManagedDriver(ctx context.Context) error {
 	return nil
 }
 
-// setupEtcdProxy periodically updates the etcd proxy with the current list of
+// setupEtcdProxy starts a goroutine to periodically update the etcd proxy with the current list of
 // cluster client URLs, as retrieved from etcd.
 func (c *Cluster) setupEtcdProxy(ctx context.Context, etcdProxy etcd.Proxy) {
 	if c.managedDB == nil {
@@ -138,7 +138,7 @@ func (c *Cluster) setupEtcdProxy(ctx context.Context, etcdProxy etcd.Proxy) {
 		for range t.C {
 			newAddresses, err := c.managedDB.GetMembersClientURLs(ctx)
 			if err != nil {
-				logrus.Warnf("failed to get etcd client URLs: %v", err)
+				logrus.Warnf("Failed to get etcd client URLs: %v", err)
 				continue
 			}
 			// client URLs are a full URI, but the proxy only wants host:port
@@ -146,7 +146,7 @@ func (c *Cluster) setupEtcdProxy(ctx context.Context, etcdProxy etcd.Proxy) {
 			for _, address := range newAddresses {
 				u, err := url.Parse(address)
 				if err != nil {
-					logrus.Warnf("failed to parse etcd client URL: %v", err)
+					logrus.Warnf("Failed to parse etcd client URL: %v", err)
 					continue
 				}
 				hosts = append(hosts, u.Host)
@@ -162,7 +162,7 @@ func (c *Cluster) deleteNodePasswdSecret(ctx context.Context) {
 	secretsClient := c.config.Runtime.Core.Core().V1().Secret()
 	if err := nodepassword.Delete(secretsClient, nodeName); err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Debugf("node password secret is not found for node %s", nodeName)
+			logrus.Debugf("Node password secret is not found for node %s", nodeName)
 			return
 		}
 		logrus.Warnf("failed to delete old node password secret: %v", err)

--- a/pkg/etcd/etcdproxy.go
+++ b/pkg/etcd/etcdproxy.go
@@ -2,10 +2,18 @@ package etcd
 
 import (
 	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
 	"net/url"
+	"strconv"
+	"time"
 
 	"github.com/k3s-io/k3s/pkg/agent/loadbalancer"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type Proxy interface {
@@ -15,9 +23,17 @@ type Proxy interface {
 	ETCDServerURL() string
 }
 
+var httpClient = &http.Client{
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	},
+}
+
 // NewETCDProxy initializes a new proxy structure that contain a load balancer
 // which listens on port 2379 and proxy between etcd cluster members
-func NewETCDProxy(ctx context.Context, enabled bool, dataDir, etcdURL string, isIPv6 bool) (Proxy, error) {
+func NewETCDProxy(ctx context.Context, supervisorPort int, dataDir, etcdURL string, isIPv6 bool) (Proxy, error) {
 	u, err := url.Parse(etcdURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse etcd client URL")
@@ -27,16 +43,16 @@ func NewETCDProxy(ctx context.Context, enabled bool, dataDir, etcdURL string, is
 		dataDir:        dataDir,
 		initialETCDURL: etcdURL,
 		etcdURL:        etcdURL,
+		supervisorPort: supervisorPort,
+		disconnect:     map[string]context.CancelFunc{},
 	}
 
-	if enabled {
-		lb, err := loadbalancer.New(ctx, dataDir, loadbalancer.ETCDServerServiceName, etcdURL, 2379, isIPv6)
-		if err != nil {
-			return nil, err
-		}
-		e.etcdLB = lb
-		e.etcdLBURL = lb.LoadBalancerServerURL()
+	lb, err := loadbalancer.New(ctx, dataDir, loadbalancer.ETCDServerServiceName, etcdURL, 2379, isIPv6)
+	if err != nil {
+		return nil, err
 	}
+	e.etcdLB = lb
+	e.etcdLBURL = lb.LoadBalancerServerURL()
 
 	e.fallbackETCDAddress = u.Host
 	e.etcdPort = u.Port()
@@ -48,17 +64,34 @@ type etcdproxy struct {
 	dataDir   string
 	etcdLBURL string
 
+	supervisorPort      int
 	initialETCDURL      string
 	etcdURL             string
 	etcdPort            string
 	fallbackETCDAddress string
 	etcdAddresses       []string
 	etcdLB              *loadbalancer.LoadBalancer
+	disconnect          map[string]context.CancelFunc
 }
 
 func (e *etcdproxy) Update(addresses []string) {
-	if e.etcdLB != nil {
-		e.etcdLB.Update(addresses)
+	e.etcdLB.Update(addresses)
+
+	validEndpoint := map[string]bool{}
+	for _, address := range e.etcdLB.ServerAddresses {
+		validEndpoint[address] = true
+		if _, ok := e.disconnect[address]; !ok {
+			ctx, cancel := context.WithCancel(context.Background())
+			e.disconnect[address] = cancel
+			e.etcdLB.SetHealthCheck(address, e.createHealthCheck(ctx, address))
+		}
+	}
+
+	for address, cancel := range e.disconnect {
+		if !validEndpoint[address] {
+			cancel()
+			delete(e.disconnect, address)
+		}
 	}
 }
 
@@ -75,4 +108,36 @@ func (e *etcdproxy) ETCDAddresses() []string {
 
 func (e *etcdproxy) ETCDServerURL() string {
 	return e.etcdURL
+}
+
+// start a polling routine that makes periodic requests to the etcd node's supervisor port.
+// If the request fails, the node is marked unhealthy.
+func (e etcdproxy) createHealthCheck(ctx context.Context, address string) func() bool {
+	// Assume that the connection to the server will succeed, to avoid failing health checks while attempting to connect.
+	// If we cannot connect, connected will be set to false when the initial connection attempt fails.
+	connected := true
+
+	host, _, _ := net.SplitHostPort(address)
+	url := fmt.Sprintf("https://%s/ping", net.JoinHostPort(host, strconv.Itoa(e.supervisorPort)))
+
+	go wait.JitterUntilWithContext(ctx, func(ctx context.Context) {
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		resp, err := httpClient.Do(req)
+		var statusCode int
+		if resp != nil {
+			statusCode = resp.StatusCode
+		}
+		if err != nil || statusCode != http.StatusOK {
+			logrus.Debugf("Health check %s failed: %v (StatusCode: %d)", url, err, statusCode)
+			connected = false
+		} else {
+			connected = true
+		}
+	}, 5*time.Second, 1.0, true)
+
+	return func() bool {
+		return connected
+	}
 }


### PR DESCRIPTION
#### Proposed Changes ####
Add health-check support to loadbalancer

* Adds support for health-checking loadbalancer servers. Servers are now health-checked periodically and before dialing; if the health-check fails, all existing connections to the  server will be closed.
* Wires up a remotedialer tunnel connectivity check as the health check for supervisor/apiserver connections.
* Wires up a simple http request to the supervisor as the health check for etcd connections.

This ensures that any load-balanced connections to a node will be closed when the remotedialer tunnel to that node disconnects. This isn't much of an issue on K3s as the apiserver always exits when the supervisor shuts down, but on RKE2 the apiserver may continue running even when the supervisor stops, but without its load-balanced connection to etcd. This change will ensure that agents and etcd-only nodes disconnect from an apiserver when its supervisor goes down. Similarly, apiservers will fail over to a different etcd server when an etcd node's supervisor goes down.

#### Types of Changes ####

enhancement / bugfix

#### Verification ####

See linked RKE2 issue

There is no effective change to K3s, as the apiserver and etcd always exit when the supervisor exits, which forces clients to disconnect. The change is only apparent on RKE2, where the pods can continue running in a degraded state after the supervisor exits.

#### Testing ####

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/5614


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
