### PR TITLE
Add /etc/passwd and /etc/group to k3s docker image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -3,6 +3,8 @@ RUN apk add -U ca-certificates tar zstd tzdata
 COPY build/out/data.tar.zst /
 RUN mkdir -p /image/etc/ssl/certs /image/run /image/var/run /image/tmp /image/lib/modules /image/lib/firmware && \
     tar -xa -C /image -f /data.tar.zst && \
+    echo "root:x:0:0:root:/:/bin/sh" > /image/etc/passwd && \
+    echo "root:x:0:" > /image/etc/group && \
     cp /etc/ssl/certs/ca-certificates.crt /image/etc/ssl/certs/ca-certificates.crt
 
 FROM scratch as collect


### PR DESCRIPTION
#### Proposed Changes ####

Add /etc/passwd and /etc/group to k3s docker image

Fixes `cannot find name for user ID 0: No such file or directory` errors when checking user info in docker image

```console
~ # PS1='\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '

@k3s-server-1:/# id
uid=0 gid=0 groups=0

@k3s-server-1:/# groups
groups: cannot find name for group ID 0
0

@k3s-server-1:/# whoami
whoami: cannot find name for user ID 0: No such file or directory

root@k3s-server-1:/# cat /etc/passwd
cat: /etc/passwd: No such file or directory
```

#### Types of Changes ####

bugfix/enhancement

#### Verification ####

run the rancher/k3s image in docker, then exec into the running container:


```console
~ # PS1='\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '

root@k3s-server-1:~# id
uid=0(root) gid=0(root) groups=0(root)

root@k3s-server-1:~# groups
root

root@k3s-server-1:~# whoami
root

root@k3s-server-1:~# cat /etc/passwd /etc/group
root:x:0:0:root:/:/bin/sh
root:x:0:
```

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9789

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
