### PR TITLE
Several E2E Matrix improvments

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -60,6 +60,10 @@ jobs:
         with: 
           go-version-file: 'go.mod'
           cache: false
+      - name: Install Kubectl
+        run: |
+           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       - name: "Download k3s binary"
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         # TODO fix embeddedmirror and add it to the matrix
-        etest: [startup, s3, btrfs, externalip, privateregistry]
+        etest: [startup, s3, btrfs, externalip, privateregistry, wasm]
       max-parallel: 3
     steps:
       - name: "Checkout"

--- a/tests/e2e/embeddedmirror/Vagrantfile
+++ b/tests/e2e/embeddedmirror/Vagrantfile
@@ -38,7 +38,6 @@ def provision(vm, role, role_num, node_num)
 
   if role.include?("server") && role_num == 0
     vm.provision "private-registry", type: "shell", inline: writePrivateRegistry
-    dockerInstall(vm)
 
     vm.provision 'k3s-primary-server', type: 'k3s', run: 'once' do |k3s|
       k3s.args = "server "

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -2,20 +2,16 @@ def defaultOSConfigure(vm)
   box = vm.box.to_s
   if box.include?("generic/ubuntu")
     vm.provision "Set DNS", type: "shell", inline: "netplan set ethernets.eth0.nameservers.addresses=[8.8.8.8,1.1.1.1]; netplan apply", run: 'once'
-    vm.provision "Install jq", type: "shell", inline: "apt install -y jq"
   elsif box.include?("Leap") || box.include?("Tumbleweed")
-    vm.provision "Install jq", type: "shell", inline: "zypper install -y jq"
     vm.provision "Install apparmor-parser", type: "shell", inline: "zypper install -y apparmor-parser"
   elsif box.include?("rocky8") || box.include?("rocky9")
-    vm.provision "Install jq", type: "shell", inline: "dnf install -y jq"
     vm.provision "Disable firewall", type: "shell", inline: "systemctl stop firewalld"
   elsif box.include?("centos7")
-    vm.provision "Install jq", type: "shell", inline: "yum install -y jq"
     vm.provision "Disable firewall", type: "shell", inline: "systemctl stop firewalld"
   elsif box.include?("alpine")
-    vm.provision "Install tools", type: "shell", inline: "apk add jq coreutils"
+    vm.provision "Install tools", type: "shell", inline: "apk add coreutils"
   elsif box.include?("microos")
-    vm.provision "Install jq", type: "shell", inline: "transactional-update pkg install -y jq"
+    # Add stuff here, but we always need to reload at the end
     vm.provision 'reload', run: 'once'
   end 
 end
@@ -26,6 +22,7 @@ def getInstallType(vm, release_version, branch)
   elsif !release_version.empty?
     return "INSTALL_K3S_VERSION=#{release_version}"
   else
+    jqInstall(vm)
     scripts_location = Dir.exists?("./scripts") ? "./scripts" : "../scripts" 
     # Grabs the last 5 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
     # MicroOS requires it not be in a /tmp/ or other root system folder
@@ -80,6 +77,24 @@ def getHardenedArg(vm, hardened, scripts_location)
     exit 1
   end
   return hardened_arg
+end
+
+def jqInstall(vm)
+  box = vm.box.to_s
+  if box.include?("generic/ubuntu")
+    vm.provision "Install jq", type: "shell", inline: "apt install -y jq"
+  elsif box.include?("Leap") || box.include?("Tumbleweed")
+    vm.provision "Install jq", type: "shell", inline: "zypper install -y jq"
+  elsif box.include?("rocky8") || box.include?("rocky9")
+    vm.provision "Install jq", type: "shell", inline: "dnf install -y jq"
+  elsif box.include?("centos7")
+    vm.provision "Install jq", type: "shell", inline: "yum install -y jq"
+  elsif box.include?("alpine")
+    vm.provision "Install jq", type: "shell", inline: "apk add coreutils"
+  elsif box.include?("microos")
+    vm.provision "Install jq", type: "shell", inline: "transactional-update pkg install -y jq"
+    vm.provision 'reload', run: 'once'
+  end 
 end
 
 def dockerInstall(vm)

--- a/tests/e2e/wasm/Vagrantfile
+++ b/tests/e2e/wasm/Vagrantfile
@@ -41,12 +41,10 @@ def provision(vm, role, role_num, node_num)
   addCoverageDir(vm, role, GOCOVER)
   install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
 
-  vm.provision "shell", inline: "ping -c 2 k3s.io"
   vm.provision "Install run-wasi containerd shims", type: "shell", inline: INSTALL_WASM_SHIMS
 
   if role.include?("server") && role_num == 0
 
-    dockerInstall(vm)
     vm.provision 'k3s-primary-server', type: 'k3s', run: 'once' do |k3s|
       k3s.args = "server "
       k3s.config = <<~YAML


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com><!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Add WASM E2E test to GitHub Actions matrix
- Optimize `vagrant provision` steps, don't install JQ unless we need it. (We don't use it in the PR/local build case, which should slightly improve CI time)
- Fix golang for Embedded Registry test. This PR just addresses issue around the E2E test itself. It does not add the test to the GH matrix yet because an issue was discovered around agents being up before servers that is causing this test to fail, but that is a separate issue that will be fixed in another PR.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Testing/CI
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- CI Green
- You can locally run the emedded registry test, but you have to manually bump the sleep times between provisioning of servers and agents to actually get it to pass. 
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
Testing all the way down
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/9656
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
