### PR TITLE
Fix etcd snapshot reconcile for agentless servers

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -167,6 +167,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.DisableAPIServer = cfg.DisableAPIServer
 	serverConfig.ControlConfig.DisableScheduler = cfg.DisableScheduler
 	serverConfig.ControlConfig.DisableControllerManager = cfg.DisableControllerManager
+	serverConfig.ControlConfig.DisableAgent = cfg.DisableAgent
 	serverConfig.ControlConfig.EmbeddedRegistry = cfg.EmbeddedRegistry
 	serverConfig.ControlConfig.ClusterInit = cfg.ClusterInit
 	serverConfig.ControlConfig.EncryptSecrets = cfg.EncryptSecrets

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -181,6 +181,7 @@ type Control struct {
 	DataDir                  string
 	Datastore                endpoint.Config `json:"-"`
 	Disables                 map[string]bool
+	DisableAgent             bool
 	DisableAPIServer         bool
 	DisableControllerManager bool
 	DisableETCD              bool

--- a/pkg/etcd/snapshot.go
+++ b/pkg/etcd/snapshot.go
@@ -850,6 +850,12 @@ func (e *ETCD) ReconcileSnapshotData(ctx context.Context) error {
 		}
 	}
 
+	// Agentless servers do not have a node. If we are running agentless, return early to avoid pruning
+	// snapshots for nonexistent nodes and trying to patch the reconcile annotations on our node.
+	if e.config.DisableAgent {
+		return nil
+	}
+
 	// List all snapshots in Kubernetes not stored on S3 or a current etcd node.
 	// These snapshots are local to a node that no longer runs etcd and cannot be restored.
 	// If the node rejoins later and has local snapshots, it will reconcile them itself.


### PR DESCRIPTION
#### Proposed Changes ####

Fix etcd snapshot reconcile for agentless servers

Disable cleanup of orphaned snapshots and patching of node annotations if running agentless

Fixes regression in agentless etcd behavior introduced by #8064

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9774

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
