### PR TITLE
Add supervisor cert/key to rotate list

### DIFF
--- a/pkg/cli/cmds/certs.go
+++ b/pkg/cli/cmds/certs.go
@@ -23,7 +23,7 @@ var (
 		DataDirFlag,
 		&cli.StringSliceFlag{
 			Name:  "service,s",
-			Usage: "List of services to manage certificates for. Options include (admin, api-server, controller-manager, scheduler, " + version.Program + "-controller, " + version.Program + "-server, cloud-controller, etcd, auth-proxy, kubelet, kube-proxy)",
+			Usage: "List of services to manage certificates for. Options include (admin, api-server, controller-manager, scheduler, supervisor, " + version.Program + "-controller, " + version.Program + "-server, cloud-controller, etcd, auth-proxy, kubelet, kube-proxy)",
 			Value: &ServicesList,
 		},
 	}

--- a/pkg/util/services/services.go
+++ b/pkg/util/services/services.go
@@ -12,6 +12,7 @@ const (
 	APIServer            = "api-server"
 	Admin                = "admin"
 	AuthProxy            = "auth-proxy"
+	CertificateAuthority = "certificate-authority"
 	CloudController      = "cloud-controller"
 	ControllerManager    = "controller-manager"
 	ETCD                 = "etcd"
@@ -20,7 +21,7 @@ const (
 	ProgramController    = "-controller"
 	ProgramServer        = "-server"
 	Scheduler            = "scheduler"
-	CertificateAuthority = "certificate-authority"
+	Supervisor           = "supervisor"
 )
 
 var Agent = []string{
@@ -30,13 +31,14 @@ var Agent = []string{
 }
 
 var Server = []string{
-	Admin,
 	APIServer,
+	Admin,
 	AuthProxy,
 	CloudController,
 	ControllerManager,
 	ETCD,
 	Scheduler,
+	Supervisor,
 	version.Program + ProgramServer,
 }
 
@@ -95,6 +97,11 @@ func FilesForServices(controlConfig config.Control, services []string) (map[stri
 				controlConfig.Runtime.ClientK3sControllerKey,
 				filepath.Join(agentDataDir, "client-"+version.Program+"-controller.crt"),
 				filepath.Join(agentDataDir, "client-"+version.Program+"-controller.key"),
+			}
+		case Supervisor:
+			fileMap[service] = []string{
+				controlConfig.Runtime.ClientSupervisorCert,
+				controlConfig.Runtime.ClientSupervisorKey,
 			}
 		case AuthProxy:
 			fileMap[service] = []string{

--- a/pkg/util/services/services_test.go
+++ b/pkg/util/services/services_test.go
@@ -88,6 +88,10 @@ func Test_UnitFilesForServices(t *testing.T) {
 					"/var/lib/rancher/k3s/server/tls/client-scheduler.crt",
 					"/var/lib/rancher/k3s/server/tls/client-scheduler.key",
 				},
+				"supervisor": []string{
+					"/var/lib/rancher/k3s/server/tls/client-supervisor.crt",
+					"/var/lib/rancher/k3s/server/tls/client-supervisor.key",
+				},
 			},
 		},
 		{
@@ -137,6 +141,10 @@ func Test_UnitFilesForServices(t *testing.T) {
 				"scheduler": []string{
 					"/var/lib/rancher/k3s/server/tls/client-scheduler.crt",
 					"/var/lib/rancher/k3s/server/tls/client-scheduler.key",
+				},
+				"supervisor": []string{
+					"/var/lib/rancher/k3s/server/tls/client-supervisor.crt",
+					"/var/lib/rancher/k3s/server/tls/client-supervisor.key",
 				},
 			},
 		},

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -345,7 +345,6 @@ var _ = Describe("Verify Create", Ordered, func() {
 			// Everything else should be changed.
 			var expectResult = []string{
 				"client-ca.crt", "client-ca.key", "client-ca.nochain.crt",
-				"client-supervisor.crt", "client-supervisor.key",
 				"peer-ca.crt", "peer-ca.key",
 				"server-ca.crt", "server-ca.key",
 				"request-header-ca.crt", "request-header-ca.key",


### PR DESCRIPTION
#### Proposed Changes ####

* We added a new cert a while back in https://github.com/k3s-io/k3s/pull/7616, but didn't add it to the rotate list.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

Yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9831

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
