### PR TITLE
fix: agent volume in example docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 # to run define K3S_TOKEN, K3S_VERSION is optional, eg:
 #   K3S_TOKEN=${RANDOM}${RANDOM}${RANDOM} docker-compose up
 
-version: '3'
 services:
 
   server:
@@ -45,6 +44,9 @@ services:
     environment:
     - K3S_URL=https://server:6443
     - K3S_TOKEN=${K3S_TOKEN:?err}
+    volumes:
+    - k3s-agent:/var/lib/rancher/k3s
 
 volumes:
   k3s-server: {}
+  k3s-agent: {}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

In the current docker-compose.yml example, a volume has only been created for the server and not for the agent. This will result in the agent container becoming a new agent with each recreation, causing the old agent to be permanently lost.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Running:

```sh
docker compose up -d
docker compose down
docker compose up -d
kubectl get nodes
```

Currently, only two nodes, server and agent, will appear. In previous versions, it would generate one server and two agents, which was incorrect.

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

