### PR TITLE
Add workaround for containerd hosts.toml bug when passing config for default registry endpoint

### DIFF
--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -60,7 +60,7 @@ skip_verify = true
 {{- end }}
 {{ end }}
 {{ end }}
-
+[host]
 {{ range $e := .Endpoints -}}
 [host."{{ $e.URL }}"]
   capabilities = ["pull", "resolve"]


### PR DESCRIPTION
#### Proposed Changes ####

Add base `[host]` tree to containerd hosts.toml to work around containerd bug

#### Types of Changes ####
bugfix

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9839
* https://github.com/containerd/containerd/issues/10027
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
