### PR TITLE
Bump latest to v1.29.3+k3s1

### DIFF
--- a/channel.yaml
+++ b/channel.yaml
@@ -1,7 +1,7 @@
 # Example channels config
 channels:
 - name: stable
-  latest: v1.28.8+k3s1
+  latest: v1.29.3+k3s1
 - name: latest
   latestRegexp: .*
   excludeRegexp: (^[^+]+-|v1\.25\.5\+k3s1|v1\.26\.0\+k3s1)


### PR DESCRIPTION
#### Proposed Changes ####

Bump latest to v1.29.3+k3s1

v1.30.0 is coming out next week and we're still serving 1.28 as latest.

#### Types of Changes ####

channel server version bump

#### Verification ####

check latest served by install script

#### Testing ####


#### Linked Issues ####


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
