### PR TITLE
Encode invalid toml table keys

### DIFF
--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -121,6 +121,7 @@ enable_keychain = true
 
 // Linux config templates do not need fixups
 var templateFuncs = template.FuncMap{
+	"keyencode": keyEncode,
 	"deschemify": func(s string) string {
 		return s
 	},

--- a/pkg/agent/templates/templates_windows.go
+++ b/pkg/agent/templates/templates_windows.go
@@ -145,6 +145,7 @@ oom_score = 0
 
 // Windows config templates need named pipe addresses fixed up
 var templateFuncs = template.FuncMap{
+	"keyencode": keyEncode,
 	"deschemify": func(s string) string {
 		if strings.HasPrefix(s, "npipe:") {
 			u, err := url.Parse(s)


### PR DESCRIPTION
#### Proposed Changes ####

Escape invalid characters in containerd mirror host table keys

Requires supporting fix on the containerd side to work properly:
* https://github.com/containerd/containerd/pull/10072

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9897

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####