### PR TITLE
Use fixed stream server bind address for cri-dockerd

### DIFF
--- a/pkg/agent/cridockerd/cridockerd.go
+++ b/pkg/agent/cridockerd/cridockerd.go
@@ -53,6 +53,7 @@ func getDockerCRIArgs(cfg *config.Node) []string {
 	argsMap := map[string]string{
 		"container-runtime-endpoint": cfg.CRIDockerd.Address,
 		"cri-dockerd-root-directory": cfg.CRIDockerd.Root,
+		"streaming-bind-addr":        "127.0.0.1:10010",
 	}
 
 	if dualNode, _ := utilsnet.IsDualStackIPs(cfg.AgentConfig.NodeIPs); dualNode {


### PR DESCRIPTION
#### Proposed Changes ####

Use fixed stream server bind address for cri-dockerd

Will now use 127.0.0.1:10010, same as containerd's CRI:
https://github.com/k3s-io/k3s/blob/d973fadbed133cf9c5db64c87ae724b1a80c766f/pkg/agent/templates/templates_linux.go#L16-L18

#### Types of Changes ####

enhancement

#### Verification ####

* See linked issue
* Check for listener on 127.0.0.1:10010 when using cri-dockerd

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9965


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
