### PR TITLE
Switch stargz over to cri registry config_path

### DIFF
--- a/pkg/agent/containerd/config_test.go
+++ b/pkg/agent/containerd/config_test.go
@@ -1471,6 +1471,17 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				t.Fatalf("failed to parse %s: %v\n", registriesFile, err)
 			}
 
+			nodeConfig := &config.Node{
+				Containerd: config.Containerd{
+					Registry: tempDir + "/hosts.d",
+				},
+				AgentConfig: config.Agent{
+					ImageServiceSocket: "containerd-stargz-grpc.sock",
+					Registry:           registry.Registry,
+					Snapshotter:        "stargz",
+				},
+			}
+
 			// set up embedded registry, if enabled for the test
 			if tt.args.mirrorAddr != "" {
 				conf := spegel.DefaultRegistry
@@ -1478,7 +1489,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 				conf.ClientKeyFile = "client-key"
 				conf.ClientCertFile = "client-cert"
 				conf.InternalAddress, conf.RegistryPort, _ = net.SplitHostPort(tt.args.mirrorAddr)
-				conf.InjectMirror(&config.Node{AgentConfig: config.Agent{Registry: registry.Registry}})
+				conf.InjectMirror(nodeConfig)
 			}
 
 			// Generate config template struct for all hosts
@@ -1494,11 +1505,7 @@ func Test_UnitGetHostConfigs(t *testing.T) {
 
 			// Confirm that the main containerd config.toml renders properly
 			containerdConfig := templates.ContainerdConfig{
-				NodeConfig: &config.Node{
-					Containerd: config.Containerd{
-						Registry: tempDir + "/hosts.d",
-					},
-				},
+				NodeConfig:            nodeConfig,
 				PrivateRegistryConfig: registry.Registry,
 				Program:               "k3s",
 			}

--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -44,19 +44,11 @@ cri_keychain_image_service_path = "{{ .NodeConfig.AgentConfig.ImageServiceSocket
 [plugins."io.containerd.snapshotter.v1.stargz".cri_keychain]
 enable_keychain = true
 {{end}}
+
+[plugins."io.containerd.snapshotter.v1.stargz".registry]
+  config_path = "{{ .NodeConfig.Containerd.Registry }}"
+
 {{ if .PrivateRegistryConfig }}
-{{ if .PrivateRegistryConfig.Mirrors }}
-[plugins."io.containerd.snapshotter.v1.stargz".registry.mirrors]{{end}}
-{{range $k, $v := .PrivateRegistryConfig.Mirrors }}
-[plugins."io.containerd.snapshotter.v1.stargz".registry.mirrors."{{$k}}"]
-  endpoint = [{{range $i, $j := $v.Endpoints}}{{if $i}}, {{end}}{{printf "%q" .}}{{end}}]
-{{if $v.Rewrites}}
-  [plugins."io.containerd.snapshotter.v1.stargz".registry.mirrors."{{$k}}".rewrite]
-{{range $pattern, $replace := $v.Rewrites}}
-    "{{$pattern}}" = "{{$replace}}"
-{{end}}
-{{end}}
-{{end}}
 {{range $k, $v := .PrivateRegistryConfig.Configs }}
 {{ if $v.Auth }}
 [plugins."io.containerd.snapshotter.v1.stargz".registry.configs."{{$k}}".auth]
@@ -64,13 +56,6 @@ enable_keychain = true
   {{ if $v.Auth.Password }}password = {{ printf "%q" $v.Auth.Password }}{{end}}
   {{ if $v.Auth.Auth }}auth = {{ printf "%q" $v.Auth.Auth }}{{end}}
   {{ if $v.Auth.IdentityToken }}identitytoken = {{ printf "%q" $v.Auth.IdentityToken }}{{end}}
-{{end}}
-{{ if $v.TLS }}
-[plugins."io.containerd.snapshotter.v1.stargz".registry.configs."{{$k}}".tls]
-  {{ if $v.TLS.CAFile }}ca_file = "{{ $v.TLS.CAFile }}"{{end}}
-  {{ if $v.TLS.CertFile }}cert_file = "{{ $v.TLS.CertFile }}"{{end}}
-  {{ if $v.TLS.KeyFile }}key_file = "{{ $v.TLS.KeyFile }}"{{end}}
-  {{ if $v.TLS.InsecureSkipVerify }}insecure_skip_verify = true{{end}}
 {{end}}
 {{end}}
 {{end}}


### PR DESCRIPTION
#### Proposed Changes ####

Migrate the stargz CRI registry config over to `config_path`, same as the core containerd CRI config.

This should have been done as part of https://github.com/k3s-io/k3s/pull/8973 but I didn't realize stargz already supported it, ref: https://github.com/containerd/stargz-snapshotter/pull/331

#### Types of Changes ####

tech debt

#### Verification ####

Note use of `config_path` under `[plugins."io.containerd.snapshotter.v1.stargz".registry]` in config.toml, when stargz snapshotter is enabled.

#### Testing ####

yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9976

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
