### PR TITLE
Fix on-demand snapshots timing out; not honoring folder

### DIFF
--- a/pkg/etcd/snapshot_handler.go
+++ b/pkg/etcd/snapshot_handler.go
@@ -170,14 +170,15 @@ func (e *ETCD) withRequest(sr *SnapshotRequest) *ETCD {
 	}
 	if sr.S3 != nil {
 		re.config.EtcdS3 = true
-		re.config.EtcdS3BucketName = sr.S3.Bucket
 		re.config.EtcdS3AccessKey = sr.S3.AccessKey
-		re.config.EtcdS3SecretKey = sr.S3.SecretKey
+		re.config.EtcdS3BucketName = sr.S3.Bucket
 		re.config.EtcdS3Endpoint = sr.S3.Endpoint
 		re.config.EtcdS3EndpointCA = sr.S3.EndpointCA
-		re.config.EtcdS3SkipSSLVerify = sr.S3.SkipSSLVerify
+		re.config.EtcdS3Folder = sr.S3.Folder
 		re.config.EtcdS3Insecure = sr.S3.Insecure
 		re.config.EtcdS3Region = sr.S3.Region
+		re.config.EtcdS3SecretKey = sr.S3.SecretKey
+		re.config.EtcdS3SkipSSLVerify = sr.S3.SkipSSLVerify
 		re.config.EtcdS3Timeout = sr.S3.Timeout.Duration
 	}
 	return re

--- a/tests/e2e/s3/Vagrantfile
+++ b/tests/e2e/s3/Vagrantfile
@@ -29,7 +29,7 @@ def provision(vm, role, role_num, node_num)
 
 
   runS3mock = <<~'SCRIPT'
-    docker run -p 9090:9090 -p 9191:9191 -d -e initialBuckets=test -e debug=true -t adobe/s3mock
+    docker run -p 9090:9090 -p 9191:9191 -d -e initialBuckets=test-bucket -e debug=true -t adobe/s3mock
   SCRIPT
 
 
@@ -45,7 +45,8 @@ def provision(vm, role, role_num, node_num)
         flannel-iface: eth1
         cluster-init: true
         etcd-s3-insecure: true
-        etcd-s3-bucket: test
+        etcd-s3-bucket: test-bucket
+        etcd-s3-folder: test-folder
         etcd-s3: true
         etcd-s3-endpoint: localhost:9090
         etcd-s3-skip-ssl-verify: true

--- a/tests/e2e/s3/s3_test.go
+++ b/tests/e2e/s3/s3_test.go
@@ -95,6 +95,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			res, err := e2e.RunCmdOnNode("k3s etcd-snapshot list", serverNodeNames[0])
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(ContainSubstring("file:///var/lib/rancher/k3s/server/db/snapshots/on-demand-server-0"))
+			Expect(res).To(ContainSubstring("s3://test-bucket/test-folder/on-demand-server-0"))
 		})
 		It("save 3 more s3 snapshots", func() {
 			for _, i := range []string{"1", "2", "3"} {
@@ -106,10 +107,10 @@ var _ = Describe("Verify Create", Ordered, func() {
 		It("lists saved s3 snapshot", func() {
 			res, err := e2e.RunCmdOnNode("k3s etcd-snapshot list", serverNodeNames[0])
 			Expect(err).NotTo(HaveOccurred())
-			Expect(res).To(ContainSubstring("on-demand-server-0"))
-			Expect(res).To(ContainSubstring("special-1-server-0"))
-			Expect(res).To(ContainSubstring("special-2-server-0"))
-			Expect(res).To(ContainSubstring("special-3-server-0"))
+			Expect(res).To(ContainSubstring("s3://test-bucket/test-folder/on-demand-server-0"))
+			Expect(res).To(ContainSubstring("s3://test-bucket/test-folder/special-1-server-0"))
+			Expect(res).To(ContainSubstring("s3://test-bucket/test-folder/special-2-server-0"))
+			Expect(res).To(ContainSubstring("s3://test-bucket/test-folder/special-3-server-0"))
 		})
 		It("delete first on-demand s3 snapshot", func() {
 			_, err := e2e.RunCmdOnNode("sudo k3s etcd-snapshot ls >> ./snapshotname.txt", serverNodeNames[0])


### PR DESCRIPTION
#### Proposed Changes ####

* Fix on-demand snapshots not honoring folder
  Also fix etcd s3 tests to actually check that the files are saved to s3 🙃
* Fix 10 second etcd-snapshot request timeout
  The default clientaccess request timeout is too short. Wait longer by default, and add the s3 timeout if s3 is enabled.


#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/9982
* https://github.com/k3s-io/k3s/issues/9985

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
