### PR TITLE
Updating the script binary_size_check to complete the command name by…

### DIFF
--- a/scripts/binary_size_check.sh
+++ b/scripts/binary_size_check.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+. ./scripts/version.sh
+
 GO=${GO-go}
 ARCH=${ARCH:-$("${GO}" env GOARCH)}
 
@@ -22,7 +24,7 @@ elif [ ${ARCH} = s390x ]; then
     BIN_SUFFIX="-s390x"
 fi
 
-CMD_NAME="dist/artifacts/k3s${BIN_SUFFIX}"
+CMD_NAME="dist/artifacts/k3s${BIN_SUFFIX}${BINARY_POSTFIX}"
 SIZE=$(stat -c '%s' ${CMD_NAME})
 
 if [ -n "${DEBUG}" ]; then


### PR DESCRIPTION
… adding .exe extension to the k3s binary name to make it available to run stat command

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

This is the Modification in K3s agent for Windows port. This pull request is focused on:

1. Updating the script binary_size_check.sh to complete the command name by adding .exe extension to the k3s binary name to make it available to run stat command

#### Types of Changes ####

BugFix

#### Verification ####

Run GOOS=windows CXX=x86_64-w64-mingw32-g++ CC=x86_64-w64-mingw32-gcc SKIP_VALIDATE=true ./scripts/ci on Ubuntu machine to proof build Windows port.

NOTE: You may need to install the following packages to build:

sudo apt-get install mingw-w64
sudo apt-get install zstd

#### Testing ####

We Can follow same testing steps as mentioned in the PR - https://github.com/k3s-io/k3s/pull/7259

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/k3s-io/k3s/issues/9991

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
None
```release-note

```

#### Further Comments ####
None
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
