### PR TITLE
Fix #10012 - empty string as a parameter in etcd extra args

### DIFF
--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -103,7 +103,7 @@ func (e ETCDConfig) ToConfigFile(extraArgs []string) (string, error) {
 				} else if time, err := time.ParseDuration(extraArg[1]); err == nil && (strings.Contains(lowerKey, "time") || strings.Contains(lowerKey, "duration") || strings.Contains(lowerKey, "interval") || strings.Contains(lowerKey, "retention")) {
 					// auto-compaction-retention is either a time.Duration or int, depending on version. If it is an int, it will be caught above.
 					s[key] = time
-				} else if err := yaml.Unmarshal([]byte(extraArg[1]), &stringArr); err == nil {
+				} else if err := yaml.Unmarshal([]byte(extraArg[1]), &stringArr); err == nil && (len(extraArg[1]) > 0) {
 					s[key] = stringArr
 				} else {
 					switch strings.ToLower(extraArg[1]) {


### PR DESCRIPTION
#### Proposed Changes ####

This modification checks if a parameter passed in ` --etcd-arg` is an empty string, preventing it from being wrongly converted to an empty array by the function `ToConfigFile`.

#### Types of Changes ####

BugFix

#### Verification ####

1. Build `k3s` following the tutorial in https://github.com/k3s-io/k3s/blob/master/BUILDING.md
2. Run `./dist/artifacts/k3s server --cluster-init --etcd-arg=listen-metrics-urls=`

Instead of throwing the error: `error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go struct field configYAML.listen-metrics-urls of type string`, k3s will continue the startup process.

#### Testing ####

See linked issue

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/10012

#### User-Facing Change ####

NONE