### PR TITLE
Add support for svclb pod PriorityClassName

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -28,11 +28,12 @@ import (
 // Config describes externally-configurable cloud provider configuration.
 // This is normally unmarshalled from a JSON config file.
 type Config struct {
-	LBEnabled   bool   `json:"lbEnabled"`
-	LBImage     string `json:"lbImage"`
-	LBNamespace string `json:"lbNamespace"`
-	NodeEnabled bool   `json:"nodeEnabled"`
-	Rootless    bool   `json:"rootless"`
+	LBDefaultPriorityClassName string `json:"lbDefaultPriorityClassName"`
+	LBEnabled                  bool   `json:"lbEnabled"`
+	LBImage                    string `json:"lbImage"`
+	LBNamespace                string `json:"lbNamespace"`
+	NodeEnabled                bool   `json:"nodeEnabled"`
+	Rootless                   bool   `json:"rootless"`
 }
 
 type k3s struct {
@@ -56,10 +57,11 @@ func init() {
 		var err error
 		k := k3s{
 			Config: Config{
-				LBEnabled:   true,
-				LBImage:     DefaultLBImage,
-				LBNamespace: DefaultLBNS,
-				NodeEnabled: true,
+				LBDefaultPriorityClassName: DefaultLBPriorityClassName,
+				LBEnabled:                  true,
+				LBImage:                    DefaultLBImage,
+				LBNamespace:                DefaultLBNS,
+				NodeEnabled:                true,
 			},
 		}
 

--- a/pkg/cloudprovider/servicelb.go
+++ b/pkg/cloudprovider/servicelb.go
@@ -40,12 +40,14 @@ var (
 	daemonsetNodeLabel     = "svccontroller." + version.Program + ".cattle.io/enablelb"
 	daemonsetNodePoolLabel = "svccontroller." + version.Program + ".cattle.io/lbpool"
 	nodeSelectorLabel      = "svccontroller." + version.Program + ".cattle.io/nodeselector"
+	priorityAnnotation     = "svccontroller." + version.Program + ".cattle.io/priorityclassname"
 	controllerName         = ccmapp.DefaultInitFuncConstructors["service"].InitContext.ClientName
 )
 
 const (
-	Ready       = condition.Cond("Ready")
-	DefaultLBNS = meta.NamespaceSystem
+	Ready                      = condition.Cond("Ready")
+	DefaultLBNS                = meta.NamespaceSystem
+	DefaultLBPriorityClassName = "system-node-critical"
 )
 
 var (
@@ -436,6 +438,7 @@ func (k *k3s) deleteDaemonSet(ctx context.Context, svc *core.Service) error {
 func (k *k3s) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 	name := generateName(svc)
 	oneInt := intstr.FromInt(1)
+	priorityClassName := k.getPriorityClassName(svc)
 	localTraffic := servicehelper.RequestsOnlyLocalTraffic(svc)
 	sourceRangesSet, err := servicehelper.GetLoadBalancerSourceRanges(svc)
 	if err != nil {
@@ -487,6 +490,7 @@ func (k *k3s) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 					},
 				},
 				Spec: core.PodSpec{
+					PriorityClassName:            priorityClassName,
 					ServiceAccountName:           "svclb",
 					AutomountServiceAccountToken: utilsptr.To(false),
 					SecurityContext: &core.PodSecurityContext{
@@ -692,6 +696,17 @@ func (k *k3s) removeFinalizer(ctx context.Context, svc *core.Service) (*core.Ser
 		return k.client.CoreV1().Services(svc.Namespace).Update(ctx, svc, meta.UpdateOptions{})
 	}
 	return svc, nil
+}
+
+// getPriorityClassName returns the value of the priority class name annotation on the service,
+// or the system default priority class name.
+func (k *k3s) getPriorityClassName(svc *core.Service) string {
+	if svc != nil {
+		if v, ok := svc.Annotations[priorityAnnotation]; ok {
+			return v
+		}
+	}
+	return k.LBDefaultPriorityClassName
 }
 
 // generateName generates a distinct name for the DaemonSet based on the service name and UID

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -829,11 +829,12 @@ func genEgressSelectorConfig(controlConfig *config.Control) error {
 
 func genCloudConfig(controlConfig *config.Control) error {
 	cloudConfig := cloudprovider.Config{
-		LBEnabled:   !controlConfig.DisableServiceLB,
-		LBNamespace: controlConfig.ServiceLBNamespace,
-		LBImage:     cloudprovider.DefaultLBImage,
-		Rootless:    controlConfig.Rootless,
-		NodeEnabled: !controlConfig.DisableCCM,
+		LBDefaultPriorityClassName: cloudprovider.DefaultLBPriorityClassName,
+		LBEnabled:                  !controlConfig.DisableServiceLB,
+		LBNamespace:                controlConfig.ServiceLBNamespace,
+		LBImage:                    cloudprovider.DefaultLBImage,
+		Rootless:                   controlConfig.Rootless,
+		NodeEnabled:                !controlConfig.DisableCCM,
 	}
 	if controlConfig.SystemDefaultRegistry != "" {
 		cloudConfig.LBImage = controlConfig.SystemDefaultRegistry + "/" + cloudConfig.LBImage


### PR DESCRIPTION
#### Proposed Changes ####

Add support for svclb pod PriorityClassName

At this point I would prefer not to add another CLI flag to control the default priorityClassName, but you can override it on a per-service basis via an annotation. The annotation can be set to an empty value if svclb pods for that service should not have a priorityClassName set.

#### Types of Changes ####

enhancement

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10033
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ServiceLB now sets the priorityClassName on svclb pods to `system-node-critical` by default. This can be overridden on a per-service basis via the `svccontroller.k3s.cattle.io/priorityclassname` annotation.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
