### PR TITLE
Fix bug: allow helm controller set owner reference

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -220,7 +220,7 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 			return err
 		}
 
-		apply := apply.New(k8s, apply.NewClientFactory(restConfig)).WithDynamicLookup()
+		apply := apply.New(k8s, apply.NewClientFactory(restConfig)).WithDynamicLookup().WithSetOwnerReference(false, false)
 		helm := sc.Helm.WithAgent(restConfig.UserAgent)
 		batch := sc.Batch.WithAgent(restConfig.UserAgent)
 		auth := sc.Auth.WithAgent(restConfig.UserAgent)


### PR DESCRIPTION
Allow helm controller set owner reference, when helm controller obj is deleteed , will delete helm-delete-job.
Reference:
https://github.com/k3s-io/helm-controller/blob/d74a09dfcaefdd6e8bea80d5aac66e70ea4e93d3/pkg/controllers/controllers.go#L144