### PR TITLE
Use k3s lease only to avoid the informer not starting problem

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -615,7 +615,11 @@ func (e *ETCD) Register(handler http.Handler) (http.Handler, error) {
 	// also needs to run on a non-etcd node as to avoid disruption if running on the node that
 	// is being removed from the cluster.
 	if !e.config.DisableAPIServer {
-		e.config.Runtime.LeaderElectedClusterControllerStarts[version.Program+"-etcd"] = func(ctx context.Context) {
+		cb := e.config.Runtime.LeaderElectedClusterControllerStarts[version.Program]
+		e.config.Runtime.LeaderElectedClusterControllerStarts[version.Program] = func(ctx context.Context) {
+			if cb != nil {
+				cb(ctx)
+			}
 			registerEndpointsHandlers(ctx, e)
 			registerMemberHandlers(ctx, e)
 			registerSnapshotHandlers(ctx, e)


### PR DESCRIPTION
The logic of the k3s controllers and the k3s-etcd controllers is in the same condition which is APIServer enabled. After running all the callbacks of k3s lease then re-start the controllers can avoid the informer not starting problem of etcd snapshot handlers.

Refer to https://github.com/k3s-io/k3s/issues/10046