### PR TITLE
[Release-1.28] Bump E2E opensuse leap to 15.6, fix btrfs test

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -648,7 +648,7 @@ steps:
     if [ "$DRONE_BUILD_EVENT" = "pull_request" ]; then
       cd ../upgradecluster
       vagrant destroy -f
-      E2E_RELEASE_CHANNEL="latest" go test -v -timeout=45m ./upgradecluster_test.go  -ci -local
+      go test -v -timeout=45m ./upgradecluster_test.go  -ci -local
       cp ./coverage.out /tmp/artifacts/upgrade-coverage.out
     fi
   - docker stop registry && docker rm registry

--- a/tests/e2e/btrfs/Vagrantfile
+++ b/tests/e2e/btrfs/Vagrantfile
@@ -4,7 +4,7 @@ ENV['VAGRANT_LOG']="error"
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
   ["server-0"])
 NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
-  ['opensuse/Leap-15.5.x86_64'])
+  ['opensuse/Leap-15.6.x86_64'])
 GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i

--- a/tests/e2e/btrfs/btrfs_test.go
+++ b/tests/e2e/btrfs/btrfs_test.go
@@ -38,9 +38,9 @@ var _ = Describe("Verify that btrfs based servers work", Ordered, func() {
 			var err error
 			// OS and server are hardcoded because only openSUSE Leap 15.5 natively supports Btrfs
 			if *local {
-				serverNodeNames, _, err = e2e.CreateLocalCluster("opensuse/Leap-15.5.x86_64", 1, 0)
+				serverNodeNames, _, err = e2e.CreateLocalCluster("opensuse/Leap-15.6.x86_64", 1, 0)
 			} else {
-				serverNodeNames, _, err = e2e.CreateCluster("opensuse/Leap-15.5.x86_64", 1, 0)
+				serverNodeNames, _, err = e2e.CreateCluster("opensuse/Leap-15.6.x86_64", 1, 0)
 			}
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")

--- a/tests/e2e/token/token_test.go
+++ b/tests/e2e/token/token_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Valid nodeOS:
-// generic/ubuntu2310, generic/centos7, generic/rocky8, opensuse/Leap-15.5.x86_64
+// generic/ubuntu2310, generic/centos7, generic/rocky8, opensuse/Leap-15.6.x86_64
 
 var nodeOS = flag.String("nodeOS", "generic/ubuntu2310", "VM operating system")
 var serverCount = flag.Int("serverCount", 3, "number of server nodes")

--- a/tests/e2e/upgradecluster/Vagrantfile
+++ b/tests/e2e/upgradecluster/Vagrantfile
@@ -3,7 +3,7 @@ NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
   ["server-0", "server-1", "server-2", "agent-0", "agent-1"])
 NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
   ['generic/ubuntu2310', 'generic/ubuntu2310', 'generic/ubuntu2310', 'generic/ubuntu2310', 'generic/ubuntu2310'])
-RELEASE_CHANNEL = (ENV['E2E_RELEASE_CHANNEL'] || "latest")
+RELEASE_CHANNEL = (ENV['E2E_RELEASE_CHANNEL'] || "v1.28")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 EXTERNAL_DB = (ENV['E2E_EXTERNAL_DB'] || "etcd")
 REGISTRY = (ENV['E2E_REGISTRY'] || "")

--- a/tests/install/opensuse-leap/Vagrantfile
+++ b/tests/install/opensuse-leap/Vagrantfile
@@ -6,7 +6,7 @@ ENV['TEST_INSTALL_SH'] ||= '../../../install.sh'
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = ["vagrant-k3s"]
-  config.vm.box = 'opensuse/Leap-15.5.x86_64'
+  config.vm.box = 'opensuse/Leap-15.6.x86_64'
   config.vm.boot_timeout = ENV['TEST_VM_BOOT_TIMEOUT'] || 600 # seconds
   config.vm.synced_folder '.', '/vagrant', disabled: true
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

Backport https://github.com/k3s-io/k3s/pull/10057

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
