### PR TITLE
Add WithSkipMissing to not fail import on missing blobs

### DIFF
--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -208,7 +208,7 @@ func preloadFile(ctx context.Context, cfg *config.Node, client *containerd.Clien
 		defer imageReader.Close()
 
 		logrus.Infof("Importing images from %s", filePath)
-		images, err = client.Import(ctx, imageReader, containerd.WithAllPlatforms(true))
+		images, err = client.Import(ctx, imageReader, containerd.WithAllPlatforms(true), containerd.WithSkipMissing())
 		if err != nil {
 			return errors.Wrap(err, "failed to import images from "+filePath)
 		}


### PR DESCRIPTION

#### Proposed Changes ####

Add WithSkipMissing to not fail import on missing blobs.

Fix an issue where archives produced by `ctr image export` cannot be imported, unless the images are pulled and exported with the `--all-platforms` flag.

#### Types of Changes ####

enhancement

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10132

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
