### PR TITLE
Fix embedded mirror blocked by SAR RBAC and re-enable test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,8 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO fix embeddedmirror and add it to the matrix
-        etest: [startup, s3, btrfs, externalip, privateregistry, wasm]
+        etest: [startup, s3, btrfs, externalip, privateregistry, embeddedmirror, wasm]
       max-parallel: 3
     steps:
       - name: "Checkout"

--- a/pkg/agent/https/https.go
+++ b/pkg/agent/https/https.go
@@ -75,7 +75,11 @@ func Start(ctx context.Context, nodeConfig *config.Node, runtime *config.Control
 		}
 
 		authz := options.NewDelegatingAuthorizationOptions()
-		authz.AlwaysAllowPaths = []string{"/v2", "/debug/pprof", "/v1-" + version.Program + "/p2p"}
+		authz.AlwaysAllowPaths = []string{ // skip authz for paths that should not use SubjectAccessReview; basically everything that will use this router other than metrics
+			"/v1-" + version.Program + "/p2p", // spegel libp2p peer discovery
+			"/v2/*",                           // spegel registry mirror
+			"/debug/pprof/*",                  // profiling
+		}
 		authz.RemoteKubeConfigFile = nodeConfig.AgentConfig.KubeConfigKubelet
 		if applyErr := authz.ApplyTo(&config.Authorization); applyErr != nil {
 			err = applyErr

--- a/tests/e2e/embeddedmirror/Vagrantfile
+++ b/tests/e2e/embeddedmirror/Vagrantfile
@@ -38,6 +38,9 @@ def provision(vm, role, role_num, node_num)
 
   if role.include?("server") && role_num == 0
     vm.provision "private-registry", type: "shell", inline: writePrivateRegistry
+    vm.provision "create-images-dir", type: "shell", inline: "mkdir -p -m 777 /tmp/images /var/lib/rancher/k3s/agent/images"
+    vm.provision "copy-images-file", type: "file", source: "../../../scripts/airgap/image-list.txt", destination: "/tmp/images/image-list.txt"
+    vm.provision "move-images-file", type: "shell", inline: "mv /tmp/images/image-list.txt /var/lib/rancher/k3s/agent/images/image-list.txt"
 
     vm.provision 'k3s-primary-server', type: 'k3s', run: 'once' do |k3s|
       k3s.args = "server "
@@ -54,6 +57,9 @@ def provision(vm, role, role_num, node_num)
   
   elsif role.include?("server") && role_num != 0
     vm.provision "shell", inline: writePrivateRegistry
+    vm.provision "create-images-dir", type: "shell", inline: "mkdir -p -m 777 /tmp/images /var/lib/rancher/k3s/agent/images"
+    vm.provision "copy-images-file", type: "file", source: "../../../scripts/airgap/image-list.txt", destination: "/tmp/images/image-list.txt"
+    vm.provision "move-images-file", type: "shell", inline: "mv /tmp/images/image-list.txt /var/lib/rancher/k3s/agent/images/image-list.txt"
 
     vm.provision 'k3s-secondary-server', type: 'k3s', run: 'once' do |k3s|
       k3s.args = "server"


### PR DESCRIPTION
#### Proposed Changes ####

Fix embedded mirror blocked by SAR RBAC and re-enable test.

The embedded registry mirror was broken by https://github.com/k3s-io/k3s/pull/10019 - requests to the registry API are being run rejected by authz subject access reviews when they should not be. This is due to the AlwaysAllowPaths being incorrectly configured to match specific paths instead of prefixes.

#### Types of Changes ####

bugfix

#### Verification ####

see linked issue

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10256

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
