### PR TITLE
fix: Use actual warningPeriod in certmonitor

### DIFF
--- a/pkg/certmonitor/certmonitor.go
+++ b/pkg/certmonitor/certmonitor.go
@@ -126,7 +126,7 @@ func checkCerts(fileMap map[string][]string, warningPeriod time.Duration) error 
 				} else if now.After(cert.NotAfter) {
 					errs = append(errs, fmt.Errorf("%s/%s: certificate %s expired at %s", service, basename, cert.Subject, cert.NotAfter.Format(time.RFC3339)))
 				} else if warn.After(cert.NotAfter) {
-					errs = append(errs, fmt.Errorf("%s/%s: certificate %s will expire within %d days at %s", service, basename, cert.Subject, daemonconfig.CertificateRenewDays, cert.NotAfter.Format(time.RFC3339)))
+					errs = append(errs, fmt.Errorf("%s/%s: certificate %s will expire within %d days at %s", service, basename, cert.Subject, int(warningPeriod.Hours()/24), cert.NotAfter.Format(time.RFC3339)))
 				}
 			}
 		}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Correct the warning message that is generated by the K3s certificate monitor for CA certificates

#### Types of Changes ####

Bugfix

#### Verification ####

See issue #10270 for reproducibility

#### Testing ####

N/A

#### Linked Issues ####
#10270

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
