### PR TITLE
Fix bug that caused agents to bypass local loadbalancer

### DIFF
--- a/pkg/agent/tunnel/tunnel.go
+++ b/pkg/agent/tunnel/tunnel.go
@@ -451,7 +451,7 @@ func (a *agentTunnel) connect(rootCtx context.Context, waitGroup *sync.WaitGroup
 			err := remotedialer.ConnectToProxy(ctx, wsURL, nil, auth, ws, onConnect)
 			connected = false
 			if err != nil && !errors.Is(err, context.Canceled) {
-				logrus.WithField("url", wsURL).WithError(err).Error("Remotedialer proxy error; reconecting...")
+				logrus.WithField("url", wsURL).WithError(err).Error("Remotedialer proxy error; reconnecting...")
 				// wait between reconnection attempts to avoid hammering the server
 				time.Sleep(endpointDebounceDelay)
 			}


### PR DESCRIPTION
#### Proposed Changes ####
Fix bug that caused agents to bypass local loadbalancer

If proxy.SetAPIServerPort was called multiple times, all calls after the first one would cause the apiserver address to be set to the default server address, bypassing the local load-balancer. This was most likely to occur on RKE2, where the supervisor may be up for a longer period of time before it is ready to manage node password secrets, causing the agent to retry. Also, K3s does not ever take the affected code path due to the apiserver and supervisor always using the same port.

I also added some comments to the code as I was stepping through it trying to figure out what's going on.

#### Types of Changes ####

bugfix

#### Verification ####

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10279
* https://github.com/rancher/rke2/issues/5949

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
