### PR TITLE
Adapt logs to windows in tunnel.go

### DIFF
--- a/pkg/agent/tunnel/tunnel.go
+++ b/pkg/agent/tunnel/tunnel.go
@@ -437,7 +437,7 @@ func (a *agentTunnel) connect(rootCtx context.Context, waitGroup *sync.WaitGroup
 
 	onConnect := func(_ context.Context, _ *remotedialer.Session) error {
 		connected = true
-		logrus.WithField("url", wsURL).Info("Remotedialer connected to proxy")
+		logrus.Infof("Remotedialer connected to proxy: %s", wsURL)
 		if waitGroup != nil {
 			once.Do(waitGroup.Done)
 		}
@@ -451,7 +451,7 @@ func (a *agentTunnel) connect(rootCtx context.Context, waitGroup *sync.WaitGroup
 			err := remotedialer.ConnectToProxy(ctx, wsURL, nil, auth, ws, onConnect)
 			connected = false
 			if err != nil && !errors.Is(err, context.Canceled) {
-				logrus.WithField("url", wsURL).WithError(err).Error("Remotedialer proxy error; reconecting...")
+				logrus.Errorf("Remotedialer proxy error; reconecting to %s... %v", wsURL, err)
 				// wait between reconnection attempts to avoid hammering the server
 				time.Sleep(endpointDebounceDelay)
 			}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Use a logrus notation that works on both Linux and Windows. Unfortunately, the `WithField` function is ignored by windows, so we get:
```
6/4/2024 3:51:44 PM Remotedialer connected to proxy
```
whereas for linux, we get:
```
Jun 04 15:20:46 terraform-mbuil-vm0 rke2[2138]: time="2024-06-04T15:20:46Z" level=info msg="Remotedialer connected to proxy" url="wss://10.1.1.14:9345/v1-rke2/connect"
```

This PR adapts those log lines so that both platforms get the same log information

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Once this version of k3s makes it into rke2, deploy mixedos and check that in the Win-Event (windows node) and the journalctl logs (linux node) you see:
```
"Remotedialer connected to proxy: wss://$IP:9345/v1-rke2/connect"
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/10284
https://github.com/rancher/rke2/issues/6099

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enhance tunnel.go logs in windows
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
