### PR TITLE
Expand GHA golang caching to includ newest release branch

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -6,10 +6,10 @@ runs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'  # Just use whatever version is in the go.mod file
-        cache: ${{ github.ref == 'refs/heads/master' }}
+        cache: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release-1.29' }}
 
     - name: Prepare for go cache
-      if: ${{ github.ref != 'refs/heads/master' }}
+      if: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/release-1.29' }}
       shell: bash
       run: |
         echo "GO_CACHE=$(go env GOCACHE)" | tee -a "$GITHUB_ENV"
@@ -17,7 +17,7 @@ runs:
         echo "GO_VERSION=$(go env GOVERSION | tr -d 'go')" | tee -a "$GITHUB_ENV"
 
     - name: Setup read-only cache
-      if: ${{ github.ref != 'refs/heads/master' }}
+      if: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/release-1.29' }}
       uses: actions/cache/restore@v4
       with:
         path: |


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- After several weeks of running with https://github.com/k3s-io/k3s/pull/9495, our GHA cache looks way better.
![image](https://github.com/k3s-io/k3s/assets/11727736/b440c70b-98da-4abc-b0a5-095c861169e5)

There is now enough space in the cache to support an additional golang cache. I have chosen the newest release-1.29. Unit test on backports to this branch will now be faster (uncached its about 7min, cached its 2.5min)


<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CI Improvements
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Pull requests on backports to release-1.29 and commits to release-1.29 should now see a usable go cache.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/9494
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
