### PR TITLE
[Backport 1.28]Add test for `isValidResolvConf` (#10302)

### DIFF
--- a/pkg/agent/config/config_internal_test.go
+++ b/pkg/agent/config/config_internal_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_isValidResolvConf(t *testing.T) {
+	tests := []struct {
+		name           string
+		fileContent    string
+		expectedResult bool
+	}{
+		{name: "Valid ResolvConf", fileContent: "nameserver 8.8.8.8\nnameserver 2001:4860:4860::8888\n", expectedResult: true},
+		{name: "Invalid ResolvConf", fileContent: "nameserver 999.999.999.999\nnameserver not.an.ip\n", expectedResult: false},
+		{name: "Wrong Nameserver", fileContent: "search example.com\n", expectedResult: false},
+		{name: "One valid nameserver", fileContent: "test test.com\nnameserver 8.8.8.8", expectedResult: true},
+		{name: "Non GlobalUnicast", fileContent: "nameserver ::1\nnameserver 169.254.0.1\nnameserver fe80::1\n", expectedResult: false},
+		{name: "Empty File", fileContent: "", expectedResult: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpfile, err := os.CreateTemp("", "resolv.conf")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(tmpfile.Name())
+
+			if _, err := tmpfile.WriteString(tt.fileContent); err != nil {
+				t.Errorf("error writing to file: %v with content: %v", tmpfile.Name(), tt.fileContent)
+			}
+
+			res := isValidResolvConf(tmpfile.Name())
+			if res != tt.expectedResult {
+				t.Errorf("isValidResolvConf(%s) = %v; want %v", tt.name, res, tt.expectedResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
(cherry picked from commit 043b1eac5d50861d2f4044d7c543c095f3b19838)

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
