### PR TITLE
[release-1.28] Fix agent supervisor port using apiserver port instead

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -546,6 +546,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		FlannelExternalIP:        controlConfig.FlannelExternalIP,
 		EgressSelectorMode:       controlConfig.EgressSelectorMode,
 		ServerHTTPSPort:          controlConfig.HTTPSPort,
+		SupervisorPort:           controlConfig.SupervisorPort,
 		SupervisorMetrics:        controlConfig.SupervisorMetrics,
 		Token:                    info.String(),
 	}

--- a/pkg/agent/https/https.go
+++ b/pkg/agent/https/https.go
@@ -36,7 +36,7 @@ func Start(ctx context.Context, nodeConfig *config.Node, runtime *config.Control
 
 		if runtime == nil {
 			// If we do not have an existing handler, set up a new listener
-			tcp, lerr := util.ListenWithLoopback(ctx, nodeConfig.AgentConfig.ListenAddress, strconv.Itoa(nodeConfig.ServerHTTPSPort))
+			tcp, lerr := util.ListenWithLoopback(ctx, nodeConfig.AgentConfig.ListenAddress, strconv.Itoa(nodeConfig.SupervisorPort))
 			if lerr != nil {
 				err = lerr
 				return

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -59,6 +59,7 @@ type Node struct {
 	Token                    string
 	Certificate              *tls.Certificate
 	ServerHTTPSPort          int
+	SupervisorPort           int
 	DefaultRuntime           string
 }
 


### PR DESCRIPTION
#### Proposed Changes ####

Fix agent supervisor port using apiserver port instead

The agent's supervisor listener on RKE2 is using the wrong port. Didn't notice it here because they're the same in k3s.

#### Types of Changes ####

bugfix

#### Verification ####

Can only be tested in RKE2

#### Testing ####


#### Linked Issues ####

* https://github.com/rancher/rke2/issues/6091#issuecomment-2166778220

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
