### PR TITLE
Allow configuration of Rootlesskit's CopyUpDirs through an environment variable

### DIFF
--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -32,6 +32,7 @@ var (
 	enableIPv6Env      = "K3S_ROOTLESS_ENABLE_IPV6"
 	portDriverEnv      = "K3S_ROOTLESS_PORT_DRIVER"
 	disableLoopbackEnv = "K3S_ROOTLESS_DISABLE_HOST_LOOPBACK"
+	copyUpDirsEnv      = "K3S_ROOTLESS_COPYUPDIRS"
 )
 
 func Rootless(stateDir string, enableIPv6 bool) error {
@@ -218,6 +219,9 @@ func createChildOpt(driver portDriver) (*child.Opt, error) {
 	opt.NetworkDriver = slirp4netns.NewChildDriver()
 	opt.PortDriver = driver.NewChildDriver()
 	opt.CopyUpDirs = []string{"/etc", "/var/run", "/run", "/var/lib"}
+	if copyUpDirs := os.Getenv(copyUpDirsEnv); copyUpDirs != "" {
+		opt.CopyUpDirs = append(opt.CopyUpDirs, strings.Split(copyUpDirs, ",")...)
+	}
 	opt.CopyUpDriver = tmpfssymlink.NewChildDriver()
 	opt.MountProcfs = true
 	opt.Reaper = true


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

In our use-case we are running an K3S Agent in a Rootless environment at the end-user's own workstation. This works well (enough), but we also want to provide access to the local folders (through e.g. HostPath volume mounts). But the Agent runs inside the rootless namespace, disallowing read/write access to the actual file-system.

This PR allows the Agent to setup extra "CopyUpDirs" entries, through an environment variable called "K3S_ROOTLESS_COPYUPDIRS". This environment variable can receive a comma-separated list absolute paths, which will be added to the existing list.

#### Types of Changes ####

This change is non-breaking, fully backwards compatible. It only adds a new feature and a new environment variable. The setup will not start (with a fatal error) if any of the added folders doesn't exist in the host system. Which is the normal behavior of the pre-existing code.

#### Verification ####
- Create a folder as your normal user:   mkdir /home/<your_username>/containerShare
- Set an environment variable: export K3S_ROOTLESS_COPYUPDIRS=/home/<your_username>/containerShare
- Start a K3S agent (and/or server) with the --rootless parameter.
- Create a container with a hostPath volume mount like:

```
  volumeMounts:
    - mountPath:   /my_share/
      name: containerShare
```

```
   volumes: 
      - hostPath:
           path: /home/<your_username>/containerShare
           type: ""
        name: containerShare
```
- Try to write a file into the volume mount inside the container:  touch /my_share/helloWorld
- From the host system, check if the file is there:  ls  /home/<your_username>/containerShare/   

#### Testing ####

No, I currently have no unit test for this change. 

#### Linked Issues ####

See #10385 for a further description.

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add new environment variable "K3S_ROOTLESS_COPYUPDIRS" to add folders to the Rootlesskit configuration.
```

#### Further Comments ####
