### PR TITLE
Revert to previous kubelet bind address logic

### DIFF
--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -119,8 +119,9 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 			argsMap["image-service-endpoint"] = socketPrefix + cfg.ImageServiceSocket
 		}
 	}
-	if cfg.ListenAddress != "" {
-		argsMap["address"] = cfg.ListenAddress
+	listenAddress, _, _, _ := util.GetDefaultAddresses(cfg.NodeIPs[0])
+	if listenAddress != "" {
+		argsMap["address"] = listenAddress
 	}
 	if cfg.ClientCA != "" {
 		argsMap["anonymous-auth"] = "false"

--- a/pkg/daemons/agent/agent_windows.go
+++ b/pkg/daemons/agent/agent_windows.go
@@ -81,8 +81,9 @@ func kubeletArgs(cfg *config.Agent) map[string]string {
 			argsMap["container-runtime-endpoint"] = socketPrefix + cfg.RuntimeSocket
 		}
 	}
-	if cfg.ListenAddress != "" {
-		argsMap["address"] = cfg.ListenAddress
+	listenAddress, _, _, _ := util.GetDefaultAddresses(cfg.NodeIPs[0])
+	if listenAddress != "" {
+		argsMap["address"] = listenAddress
 	}
 	if cfg.ClientCA != "" {
 		argsMap["anonymous-auth"] = "false"


### PR DESCRIPTION
This is a backup PR, in case we can't get a change made to dynamiclistener. I would prefer to allow users to bind the kubelet to a specific IP, but that requires:
* [ ] https://github.com/rancher/remotedialer/pull/80

---

#### Proposed Changes ####

Revert to previous kubelet bind address logic

The kubelet bind address should always be a wildcard address selected based on the primary node-ip; don't pass the bind-address value through directly.


#### Types of Changes ####

bugfix

#### Verification ####

1. Set `--bind-address` on a server or agent node
2. Note that `kubectl logs` works properly to retrieve logs from pods on that node

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10444

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an issue where the --bind-address value was incorrectly passed through to the kubelet's --address flag.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
