### PR TITLE
Fix loadbalancer reentrant rlock

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -370,10 +370,9 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to retrieve configuration from server")
 	}
-
 	// If the supervisor and externally-facing apiserver are not on the same port, tell the proxy where to find the apiserver.
 	if controlConfig.SupervisorPort != controlConfig.HTTPSPort {
-		isIPv6 := utilsnet.IsIPv6(net.ParseIP([]string{envInfo.NodeIP.String()}[0]))
+		isIPv6 := utilsnet.IsIPv6(net.ParseIP(util.GetFirstValidIPString(envInfo.NodeIP)))
 		if err := proxy.SetAPIServerPort(controlConfig.HTTPSPort, isIPv6); err != nil {
 			return nil, errors.Wrapf(err, "failed to set apiserver port to %d", controlConfig.HTTPSPort)
 		}

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -103,7 +103,7 @@ func APIServers(ctx context.Context, node *config.Node, proxy proxy.Proxy) []str
 			return false, err
 		}
 		if len(addresses) == 0 {
-			logrus.Infof("Waiting for apiserver addresses")
+			logrus.Infof("Waiting for supervisor to provide apiserver addresses")
 			return false, nil
 		}
 		return true, nil

--- a/pkg/agent/loadbalancer/servers.go
+++ b/pkg/agent/loadbalancer/servers.go
@@ -111,10 +111,12 @@ func (lb *LoadBalancer) setServers(serverAddresses []string) bool {
 	return true
 }
 
+// nextServer attempts to get the next server in the loadbalancer server list.
+// If another goroutine has already updated the current server address to point at
+// a different address than just failed, nothing is changed. Otherwise, a new server address
+// is stored to the currentServerAddress field, and returned for use.
+// This function must always be called by a goroutine that holds a read lock on the loadbalancer mutex.
 func (lb *LoadBalancer) nextServer(failedServer string) (string, error) {
-	lb.mutex.RLock()
-	defer lb.mutex.RUnlock()
-
 	// note: these fields are not protected by the mutex, so we clamp the index value and update
 	// the index/current address using local variables, to avoid time-of-check vs time-of-use
 	// race conditions caused by goroutine A incrementing it in between the time goroutine B

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -322,7 +322,7 @@ func createProxyAndValidateToken(ctx context.Context, cfg *cmds.Agent) (proxy.Pr
 	if err := os.MkdirAll(agentDir, 0700); err != nil {
 		return nil, err
 	}
-	isIPv6 := utilsnet.IsIPv6(net.ParseIP([]string{cfg.NodeIP.String()}[0]))
+	isIPv6 := utilsnet.IsIPv6(net.ParseIP(util.GetFirstValidIPString(cfg.NodeIP)))
 
 	proxy, err := proxy.NewSupervisorProxy(ctx, !cfg.DisableLoadBalancer, agentDir, cfg.ServerURL, cfg.LBServerPort, isIPv6)
 	if err != nil {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -530,19 +530,30 @@ func setupTunnelAndRunAgent(ctx context.Context, nodeConfig *daemonconfig.Node, 
 }
 
 func waitForAPIServerAddresses(ctx context.Context, nodeConfig *daemonconfig.Node, cfg cmds.Agent, proxy proxy.Proxy) error {
+	var localSupervisorDefault bool
+	if addresses := proxy.SupervisorAddresses(); len(addresses) > 0 {
+		host, _, _ := net.SplitHostPort(addresses[0])
+		if host == "127.0.0.1" || host == "::1" {
+			localSupervisorDefault = true
+		}
+	}
+
 	for {
 		select {
 		case <-time.After(5 * time.Second):
-			logrus.Info("Waiting for apiserver addresses")
+			logrus.Info("Waiting for control-plane node to register apiserver addresses in etcd")
 		case addresses := <-cfg.APIAddressCh:
 			for i, a := range addresses {
 				host, _, err := net.SplitHostPort(a)
 				if err == nil {
 					addresses[i] = net.JoinHostPort(host, strconv.Itoa(nodeConfig.ServerHTTPSPort))
-					if i == 0 {
-						proxy.SetSupervisorDefault(addresses[i])
-					}
 				}
+			}
+			// If this is an etcd-only node that started up using its local supervisor,
+			// switch to using a control-plane node as the supervisor. Otherwise, leave the
+			// configured server address as the default.
+			if localSupervisorDefault && len(addresses) > 0 {
+				proxy.SetSupervisorDefault(addresses[0])
 			}
 			proxy.Update(addresses)
 			return nil

--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -34,8 +34,7 @@ func createRootlessConfig(argsMap map[string]string, controllers map[string]bool
 
 func kubeProxyArgs(cfg *config.Agent) map[string]string {
 	bindAddress := "127.0.0.1"
-	isIPv6 := utilsnet.IsIPv6(net.ParseIP([]string{cfg.NodeIP}[0]))
-	if isIPv6 {
+	if utilsnet.IsIPv6(net.ParseIP(cfg.NodeIP)) {
 		bindAddress = "::1"
 	}
 	argsMap := map[string]string{
@@ -67,8 +66,7 @@ func kubeProxyArgs(cfg *config.Agent) map[string]string {
 
 func kubeletArgs(cfg *config.Agent) map[string]string {
 	bindAddress := "127.0.0.1"
-	isIPv6 := utilsnet.IsIPv6(net.ParseIP([]string{cfg.NodeIP}[0]))
-	if isIPv6 {
+	if utilsnet.IsIPv6(net.ParseIP(cfg.NodeIP)) {
 		bindAddress = "::1"
 	}
 	argsMap := map[string]string{


### PR DESCRIPTION
#### Proposed Changes ####

* Fix reentrant rlock in loadbalancer.dialContext
  When I added health-checks in https://github.com/k3s-io/k3s/pull/9757 and promoted the loadbalancer mutex to a rwmutex, I also added a readlock call to dialContext since it is accessing the servers list. As dialContext calls nextServer, which also takes a readlock, this can now deadlock if another goroutine attempts to acquire a writelock while dialContext is in its loop. dialContext will hold a readlock, but the goroutine attempting to acquire a writelock will cause nextServer's readlock to block, which prevents the outer readlock from ever being released.
  nextServer is only ever called from dialContext, so it doesn't need to take another lock. I should have removed the lock from nextServer when I added it to dialContext.
* Fix agents removing configured supervisor address
  The configured fixed registration address was being replaced with the first control-plane node address, which prevented the fixed registration address from being used if all discovered control-plane addresses are unavailable.
* Fix IPv6 primary node-ip handling
  The loadbalancer does not properly bind to the ipv6 loopback when the node has an ipv6 primary node ip, as the comma-separated flag value containing both IPs cannot be parsed as a valid ipv6 address. Found when attempting to reproduce this issue on a node with an ipv6 primary node ip (ie `--node-ip=fd7c:53a5:aef5::242:ac11:8,172.17.0.8`)
* Add dial duration to debug error message
  This should give us more detail on how long dials take before failing, so that we can perhaps better tune the loadbalancer fail over loop in the future.

#### Types of Changes ####

bugfix

#### Verification ####

Since this is a locking issue, it requires specific timing to reproduce. The best way I have found to reproduce it requires taking the server an agent is connected to off the network, so that attempts to connect to it time out. Since a lock is held while connecting, this makes the issue more likely to trigger

This is easier to reproduce on rke2, but both distros should be affected

1. Create a cluster with 3 servers and 1 agent
2. Identify the server that the agent is connected to : `netstat -na | grep 6443`
3. Disconnect the network on that server: `ip link set dev eth0 down` (or whatever interface that node is using)
4. Note that the agent's connection to that server times out, and the agent switches over to a new server - but the failed server is never removed from the server list:
    ```
    Jul 12 07:51:31 systemd-node-4 rke2[2189]: time="2024-07-12T07:51:31Z" level=error msg="Remotedialer proxy error; reconnecting..." error="read tcp 172.17.0.11:51850->172.17.0.8:9345: i/o timeout" url="wss://172.17.0.8:9345/v1-rke2/connect"
    Jul 12 07:51:32 systemd-node-4 rke2[2189]: time="2024-07-12T07:51:32Z" level=info msg="Connecting to proxy" url="wss://172.17.0.8:9345/v1-rke2/connect"
    Jul 12 07:51:32 systemd-node-4 rke2[2189]: time="2024-07-12T07:51:32Z" level=debug msg="Failed over to new server for load balancer rke2-api-server-agent-load-balancer: 172.17.0.8:6443 -> 172.17.0.9:6443"
    ```
    If the issue is NOT reproduced, you will see the failed server removed from the load balancer:
    ```
    Jul 12 07:45:42 systemd-node-4 rke2[2189]: time="2024-07-12T07:45:42Z" level=info msg="Removing server from load balancer rke2-api-server-agent-load-balancer: 172.17.0.8:6443"
    Jul 12 07:45:42 systemd-node-4 rke2[2189]: time="2024-07-12T07:45:42Z" level=info msg="Updated load balancer rke2-api-server-agent-load-balancer server addresses -> [172.17.0.10:6443 172.17.0.9:6443] [default: 172.17.0.100:6443]"
    ```
5. Note that attempts to use the agent loadbalancer to reach the apiserver time out:
    ```console
    root@systemd-node-4:/# export KUBECONFIG=/var/lib/rancher/rke2/agent/kubelet.kubeconfig
    root@systemd-node-4:/# kubectl get node -o wide
    E0712 07:58:06.786096   12756 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:6443/api?timeout=32s": net/http: TLS handshake timeout
    E0712 07:58:16.787510   12756 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:6443/api?timeout=32s": net/http: TLS handshake timeout
    E0712 07:58:26.788272   12756 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:6443/api?timeout=32s": net/http: TLS handshake timeout
    E0712 07:58:36.789182   12756 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:6443/api?timeout=32s": net/http: TLS handshake timeout
    E0712 07:58:46.790039   12756 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:6443/api?timeout=32s": net/http: TLS handshake timeout
    Unable to connect to the server: net/http: TLS handshake timeout
    ```

#### Testing ####

I will add some tests to the loadbalancer in the August release cycle to prevent things like this from happening again.
* https://github.com/k3s-io/k3s/issues/10505

#### Linked Issues ####


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an issue that could cause the agent loadbalancer to deadlock when the currently in-use server goes down.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
