### PR TITLE
Don't use server value from config file for etcd-snapshot commands

### DIFF
--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -21,11 +21,14 @@ var EtcdSnapshotFlags = []cli.Flag{
 		Destination: &AgentConfig.NodeName,
 	},
 	DataDirFlag,
-	ServerToken,
 	&cli.StringFlag{
-		Name:        "server, s",
-		Usage:       "(cluster) Server to connect to",
-		EnvVar:      version.ProgramUpper + "_URL",
+		Name:        "etcd-token,t",
+		Usage:       "(cluster) Shared secret used to authenticate to etcd server",
+		Destination: &ServerConfig.Token,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-server, s",
+		Usage:       "(cluster) Server with etcd role to connect to for snapshot management operations",
 		Value:       "https://127.0.0.1:6443",
 		Destination: &ServerConfig.ServerURL,
 	},

--- a/pkg/configfilearg/defaultparser_test.go
+++ b/pkg/configfilearg/defaultparser_test.go
@@ -48,7 +48,7 @@ func Test_UnitMustParse(t *testing.T) {
 			name:   "Etcd-snapshot with config with known and unknown flags",
 			args:   []string{"k3s", "etcd-snapshot", "save"},
 			config: "./testdata/defaultdata.yaml",
-			want:   []string{"k3s", "etcd-snapshot", "save", "--token=12345", "--etcd-s3=true", "--etcd-s3-bucket=my-backup"},
+			want:   []string{"k3s", "etcd-snapshot", "save", "--etcd-s3=true", "--etcd-s3-bucket=my-backup"},
 		},
 		{
 			name: "Agent with known flags",


### PR DESCRIPTION
#### Proposed Changes ####

Don't use server and token values from config file for etcd-snapshot commands

Fixes an issue where running etcd-snapshot commands on a node that has a server address set in the config will manage snapshots on that server, instead of on the local node as intended.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10513

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The `--server` and `--token` flags for the `k3s etcd-snapshot` command have been renamed to `--etcd-server` and `--etcd-token`, to avoid unintentionally running snapshot management commands against a remote node when the cluster join address or token are present in a config file.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
