### PR TITLE
Specify port in 'Test_isValidResolvConf'

### DIFF
--- a/pkg/agent/config/config_internal_test.go
+++ b/pkg/agent/config/config_internal_test.go
@@ -11,7 +11,7 @@ func Test_isValidResolvConf(t *testing.T) {
 		fileContent    string
 		expectedResult bool
 	}{
-		{name: "Valid ResolvConf", fileContent: "nameserver 8.8.8.8\nnameserver 2001:4860:4860::8888\n", expectedResult: true},
+		{name: "Valid ResolvConf", fileContent: "nameserver 8.8.8.8\nnameserver 8.8.8.8:53\nnameserver 2001:4860:4860::8888\n", expectedResult: true},
 		{name: "Invalid ResolvConf", fileContent: "nameserver 999.999.999.999\nnameserver not.an.ip\n", expectedResult: false},
 		{name: "Wrong Nameserver", fileContent: "search example.com\n", expectedResult: false},
 		{name: "One valid nameserver", fileContent: "test test.com\nnameserver 8.8.8.8", expectedResult: true},


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

This PR expands testing of the 'Valid ResolvConf' scenario (`pkg/agent/config/config_internal_test.go`).

#### Types of Changes ####

New Feature

*I was not able to run tests locally, so I'm opening a pull request for the explicit purpose of running tests in CI.  I'd like to know whether or not port numbers are supported, when installing with the `--resolv-conf` flag.

In other words, where an end-user might run a DNS server on an alternate port, and provide that number in a configuration file (e.g.`/etc/rancher/k3s/resolv.conf` ) when installing like the following:

`curl -sfL https://get.k3s.io | sh -s - --write-kubeconfig-mode 644 --resolv-conf /etc/rancher/k3s/resolv.conf`

#### Verification ####

If CI passes, I expect that to be enough verification.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

Yes.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

N/A

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
