### PR TITLE
Fix multiple issues with servicelb

### DIFF
--- a/pkg/cloudprovider/servicelb.go
+++ b/pkg/cloudprovider/servicelb.go
@@ -699,7 +699,17 @@ func (k *k3s) getPriorityClassName(svc *core.Service) string {
 
 // generateName generates a distinct name for the DaemonSet based on the service name and UID
 func generateName(svc *core.Service) string {
-	return fmt.Sprintf("svclb-%s-%s", svc.Name, svc.UID[:8])
+	name := svc.Name
+	// ensure that the service name plus prefix and uuid aren't overly long, but
+	// don't cut the service name at a trailing hyphen.
+	if len(name) > 48 {
+		trimlen := 48
+		for name[trimlen-1] == '-' {
+			trimlen--
+		}
+		name = name[0:trimlen]
+	}
+	return fmt.Sprintf("svclb-%s-%s", name, svc.UID[:8])
 }
 
 // ingressToString converts a list of LoadBalancerIngress entries to strings

--- a/pkg/cloudprovider/servicelb.go
+++ b/pkg/cloudprovider/servicelb.go
@@ -52,7 +52,7 @@ const (
 )
 
 var (
-	DefaultLBImage = "rancher/klipper-lb:v0.4.7"
+	DefaultLBImage = "rancher/klipper-lb:v0.4.9"
 )
 
 func (k *k3s) Register(ctx context.Context,
@@ -437,12 +437,19 @@ func (k *k3s) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 		return nil, err
 	}
 	sourceRanges := strings.Join(sourceRangesSet.StringSlice(), ",")
+	securityContext := &core.PodSecurityContext{}
 
 	for _, ipFamily := range svc.Spec.IPFamilies {
-		if ipFamily == core.IPv6Protocol && sourceRanges == "0.0.0.0/0" {
-			// The upstream default load-balancer source range only includes IPv4, even if the service is IPv6-only or dual-stack.
-			// If using the default range, and IPv6 is enabled, also allow IPv6.
-			sourceRanges += ",::/0"
+		switch ipFamily {
+		case core.IPv4Protocol:
+			securityContext.Sysctls = append(securityContext.Sysctls, core.Sysctl{Name: "net.ipv4.ip_forward", Value: "1"})
+		case core.IPv6Protocol:
+			securityContext.Sysctls = append(securityContext.Sysctls, core.Sysctl{Name: "net.ipv6.conf.all.forwarding", Value: "1"})
+			if sourceRanges == "0.0.0.0/0" {
+				// The upstream default load-balancer source range only includes IPv4, even if the service is IPv6-only or dual-stack.
+				// If using the default range, and IPv6 is enabled, also allow IPv6.
+				sourceRanges += ",::/0"
+			}
 		}
 	}
 
@@ -478,12 +485,7 @@ func (k *k3s) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 					PriorityClassName:            priorityClassName,
 					ServiceAccountName:           "svclb",
 					AutomountServiceAccountToken: utilsptr.To(false),
-					SecurityContext: &core.PodSecurityContext{
-						Sysctls: []core.Sysctl{
-							{Name: "net.ipv4.ip_forward", Value: "1"},
-							{Name: "net.ipv6.conf.all.forwarding", Value: "1"},
-						},
-					},
+					SecurityContext:              securityContext,
 					Tolerations: []core.Toleration{
 						{
 							Key:      util.MasterRoleLabelKey,

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,5 +1,5 @@
 docker.io/rancher/klipper-helm:v0.8.4-build20240523
-docker.io/rancher/klipper-lb:v0.4.7
+docker.io/rancher/klipper-lb:v0.4.9
 docker.io/rancher/local-path-provisioner:v0.0.28
 docker.io/rancher/mirrored-coredns-coredns:1.10.1
 docker.io/rancher/mirrored-library-busybox:1.36.1


### PR DESCRIPTION
#### Proposed Changes ####

* Fix handling of long service names
* Fix ipv6 sysctl required by non-ipv6 LoadBalancer service
  This is a partial revert of https://github.com/k3s-io/k3s/pull/9963, with the workaround for https://github.com/k3s-io/k3s/issues/9949 moved into klipper-lb.

Waiting on: 
* [x] https://github.com/k3s-io/klipper-lb/pull/71

#### Types of Changes ####

bugfix

#### Verification ####

See linked issues

#### Testing ####

yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10537
* https://github.com/k3s-io/k3s/issues/10455

#### User-Facing Change ####
```release-note
Fixed issue that caused ServiceLB to fail to create a daemonset for services with long names
Fixed issue that caused ServiceLB pods to crashloop on nodes with ipv6 disabled at the kernel level
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
