### PR TITLE
Enhance E2E Hardened option

### DIFF
--- a/tests/docker/test-run-hardened
+++ b/tests/docker/test-run-hardened
@@ -23,8 +23,6 @@ export SERVER_ARGS="--selinux=true \
 --kube-apiserver-arg=audit-log-maxage=30 \
 --kube-apiserver-arg=audit-log-maxbackup=10 \
 --kube-apiserver-arg=audit-log-maxsize=100 \
---kube-apiserver-arg=request-timeout=300s \
---kube-apiserver-arg=service-account-lookup=true \
 --kube-apiserver-arg=enable-admission-plugins=NodeRestriction,NamespaceLifecycle,ServiceAccount \
 --kube-apiserver-arg=admission-control-config-file=/opt/rancher/k3s/cluster-level-pss.yaml \
 --kube-controller-manager-arg=terminated-pod-gc-threshold=10 \

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -55,11 +55,11 @@ def getHardenedArg(vm, hardened, scripts_location)
     secrets-encryption: true
     kube-controller-manager-arg:
       - 'terminated-pod-gc-threshold=10'
-      - 'use-service-account-credentials=true'
     kubelet-arg:
       - 'streaming-connection-idle-timeout=5m'
       - 'make-iptables-util-chains=true'
       - 'event-qps=0'
+      - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
     kube-apiserver-arg:
       - 'audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log'
       - 'audit-policy-file=/var/lib/rancher/k3s/server/audit.yaml'
@@ -67,15 +67,23 @@ def getHardenedArg(vm, hardened, scripts_location)
       - 'audit-log-maxbackup=10'
       - 'audit-log-maxsize=100'
   HARD
-  if hardened == "psp"
-    vm.provision "Set kernel parameters", type: "shell", path: scripts_location + "/harden.sh"
-    hardened_arg += "  - 'enable-admission-plugins=NodeRestriction,NamespaceLifecycle,ServiceAccount,PodSecurityPolicy'"
-  elsif hardened == "psa"
+ 
+  if hardened == "psa" || hardened == "true"
     vm.provision "Set kernel parameters", type: "shell", path: scripts_location + "/harden.sh", args: [ "psa" ]
     hardened_arg += "  - 'admission-control-config-file=/var/lib/rancher/k3s/server/psa.yaml'"
+  elsif hardened == "psp"
+      vm.provision "Set kernel parameters", type: "shell", path: scripts_location + "/harden.sh"
+      hardened_arg += "  - 'enable-admission-plugins=NodeRestriction,NamespaceLifecycle,ServiceAccount,PodSecurityPolicy'"
   else 
     puts "Invalid E2E_HARDENED option"
     exit 1
+  end
+  if vm.box.to_s.include?("generic/ubuntu")
+    vm.provision "Install kube-bench", type: "shell", inline: <<-SHELL
+    export KBV=0.8.0
+    curl -L "https://github.com/aquasecurity/kube-bench/releases/download/v${KBV}/kube-bench_${KBV}_linux_amd64.deb" -o "kube-bench_${KBV}_linux_amd64.deb"
+    dpkg -i "./kube-bench_${KBV}_linux_amd64.deb"
+    SHELL
   end
   return hardened_arg
 end

--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -66,7 +66,6 @@ def getHardenedArg(vm, hardened, scripts_location)
       - 'audit-log-maxage=30'
       - 'audit-log-maxbackup=10'
       - 'audit-log-maxsize=100'
-      - 'service-account-lookup=true'
   HARD
   if hardened == "psp"
     vm.provision "Set kernel parameters", type: "shell", path: scripts_location + "/harden.sh"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Remove unnecessary config.yaml options
- Add required `tls-cipher-suites` argument to config.yaml
- Rework default of E2E_HARDENED to accept `true` (psa)
- Auto install kube-bench for easier CIS validation
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Testing Enhancements
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Manually run multiple times when overhauling the K3s CIS profiles
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
N/A this is just for manual QA
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
