### PR TITLE
Use higher QPS for secrets reencryption

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -68,8 +68,7 @@ func Server(ctx context.Context, cfg *config.Control) error {
 				if err := secretsencrypt.Register(ctx,
 					controllerName,
 					cfg,
-					cfg.Runtime.Core.Core().V1().Node(),
-					cfg.Runtime.Core.Core().V1().Secret()); err != nil {
+					cfg.Runtime.Core.Core().V1().Node()); err != nil {
 					logrus.Errorf("Failed to register %s controller: %v", controllerName, err)
 				}
 			}

--- a/pkg/secretsencrypt/controller.go
+++ b/pkg/secretsencrypt/controller.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	typev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/pager"
 	"k8s.io/client-go/tools/record"
@@ -38,7 +39,7 @@ type handler struct {
 	ctx           context.Context
 	controlConfig *config.Control
 	nodes         coreclient.NodeController
-	secrets       coreclient.SecretController
+	cclient       typev1.CoreV1Interface
 	recorder      record.EventRecorder
 }
 
@@ -47,12 +48,14 @@ func Register(
 	controllerName string,
 	controlConfig *config.Control,
 	nodes coreclient.NodeController,
-	secrets coreclient.SecretController,
 ) error {
 	restConfig, err := clientcmd.BuildConfigFromFlags("", controlConfig.Runtime.KubeConfigSupervisor)
 	if err != nil {
 		return err
 	}
+	// For secrets we need a much higher QPS than what wrangler provides, so we create a new clientset
+	restConfig.QPS = 200
+	restConfig.Burst = 200
 	k8s, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return err
@@ -62,7 +65,7 @@ func Register(
 		ctx:           ctx,
 		controlConfig: controlConfig,
 		nodes:         nodes,
-		secrets:       secrets,
+		cclient:       k8s.CoreV1(),
 		recorder:      util.BuildControllerEventRecorder(k8s, controllerAgentName, metav1.NamespaceDefault),
 	}
 
@@ -217,7 +220,7 @@ func (h *handler) validateReencryptStage(node *corev1.Node, annotation string) (
 
 func (h *handler) updateSecrets(nodeRef *corev1.ObjectReference) error {
 	secretPager := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
-		return h.secrets.List(metav1.NamespaceAll, opts)
+		return h.cclient.Secrets(metav1.NamespaceAll).List(h.ctx, metav1.ListOptions{})
 	}))
 	secretPager.PageSize = secretListPageSize
 
@@ -227,10 +230,10 @@ func (h *handler) updateSecrets(nodeRef *corev1.ObjectReference) error {
 		if !ok {
 			return errors.New("failed to convert object to Secret")
 		}
-		if _, err := h.secrets.Update(secret); err != nil && !apierrors.IsConflict(err) {
+		if _, err := h.cclient.Secrets(secret.Namespace).Update(h.ctx, secret, metav1.UpdateOptions{}); err != nil && !apierrors.IsConflict(err) {
 			return fmt.Errorf("failed to update secret: %v", err)
 		}
-		if i != 0 && i%10 == 0 {
+		if i != 0 && i%50 == 0 {
 			h.recorder.Eventf(nodeRef, corev1.EventTypeNormal, secretsProgressEvent, "reencrypted %d secrets", i)
 		}
 		i++


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Use a separate client go for updating secrets, the default wrangler values strangle the throughput of the secrets encryption controller.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Feature Enhancement
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Time to reencrypt 1000 "basic" secrets (secrets are simple strings)
```
echo "this is a file" > file.txt && for i in {1..1000}; do echo test$i >> file.txt; kubectl create secret generic test$i --from-file=file.txt; done
```
| Master | PR | 
| - | - | 
| 207s | 4s |
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Time to reencrypt 200 "large" secrets (1000K size, aka the maximum secret size)
```
head -c 1000K </dev/urandom  > file.txt && for i in {1..200}; do echo test$i >> file.txt; kubectl create secret generic test$i --from-file=file.txt; done
```
| Master | PR | 
| - | - | 
| 42s | 17s |

#### Testing ####
Already Covered
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/10581
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####
This dramatically cuts the time for secrets encryption. It is possible we no longer even need a controller for this task, as even with 10K+ secrets, the timeline is now seconds not tens of minutes.
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
