### PR TITLE
Fix issues loading data-dir value from env vars or dropin config files

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -86,11 +86,14 @@ func main() {
 	}
 }
 
-// findDataDir reads data-dir settings from the CLI args and config file.
+// findDataDir reads data-dir settings from the environment, CLI args, and config file.
 // If not found, the default will be used, which varies depending on whether
 // k3s is being run as root or not.
 func findDataDir(args []string) string {
-	var dataDir string
+	dataDir := os.Getenv(version.ProgramUpper + "_DATA_DIR")
+	if dataDir != "" {
+		return dataDir
+	}
 	fs := pflag.NewFlagSet("data-dir-set", pflag.ContinueOnError)
 	fs.ParseErrorsWhitelist.UnknownFlags = true
 	fs.SetOutput(io.Discard)

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -193,9 +193,6 @@ func stageAndRun(dataDir, cmd string, args []string, calledAsInternal bool) erro
 	if err := os.Setenv("PATH", pathEnv); err != nil {
 		return err
 	}
-	if err := os.Setenv(version.ProgramUpper+"_DATA_DIR", dir); err != nil {
-		return err
-	}
 
 	cmd, err = exec.LookPath(cmd)
 	if err != nil {

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -266,11 +266,14 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 				EnvVar:      version.ProgramUpper + "_URL",
 				Destination: &AgentConfig.ServerURL,
 			},
+			// Note that this is different from DataDirFlag used elswhere in the CLI,
+			// as this is bound to AgentConfig instead of ServerConfig.
 			&cli.StringFlag{
 				Name:        "data-dir,d",
 				Usage:       "(agent/data) Folder to hold state",
 				Destination: &AgentConfig.DataDir,
 				Value:       "/var/lib/rancher/" + version.Program + "",
+				EnvVar:      version.ProgramUpper + "_DATA_DIR",
 			},
 			NodeNameFlag,
 			WithNodeIDFlag,

--- a/pkg/cli/cmds/certs.go
+++ b/pkg/cli/cmds/certs.go
@@ -28,17 +28,13 @@ var (
 		},
 	}
 	CertRotateCACommandFlags = []cli.Flag{
+		DataDirFlag,
 		cli.StringFlag{
 			Name:        "server,s",
 			Usage:       "(cluster) Server to connect to",
 			EnvVar:      version.ProgramUpper + "_URL",
 			Value:       "https://127.0.0.1:6443",
 			Destination: &ServerConfig.ServerURL,
-		},
-		cli.StringFlag{
-			Name:        "data-dir,d",
-			Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
-			Destination: &ServerConfig.DataDir,
 		},
 		cli.StringFlag{
 			Name:        "path",

--- a/pkg/cli/cmds/root.go
+++ b/pkg/cli/cmds/root.go
@@ -41,10 +41,7 @@ func NewApp() *cli.App {
 	}
 	app.Flags = []cli.Flag{
 		DebugFlag,
-		&cli.StringFlag{
-			Name:  "data-dir,d",
-			Usage: "(data) Folder to hold state (default: /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root)",
-		},
+		DataDirFlag,
 	}
 
 	return app

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -117,6 +117,7 @@ var (
 		Name:        "data-dir,d",
 		Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
 		Destination: &ServerConfig.DataDir,
+		EnvVar:      version.ProgramUpper + "_DATA_DIR",
 	}
 	ServerToken = &cli.StringFlag{
 		Name:        "token,t",

--- a/pkg/configfilearg/testdata/dropin-only.yaml.d/01-data.yml
+++ b/pkg/configfilearg/testdata/dropin-only.yaml.d/01-data.yml
@@ -1,0 +1,15 @@
+foo-bar: get-overriden
+a-slice:
+- 1
+- "1.5"
+- "2"
+- ""
+- three
+b-string: one
+c-slice:
+- one
+- two
+d-slice:
+- one
+- two
+f-string: beta

--- a/pkg/configfilearg/testdata/dropin-only.yaml.d/02-data-ignore-this.txt
+++ b/pkg/configfilearg/testdata/dropin-only.yaml.d/02-data-ignore-this.txt
@@ -1,0 +1,1 @@
+foo-bar: ignored

--- a/pkg/configfilearg/testdata/dropin-only.yaml.d/02-data.yaml
+++ b/pkg/configfilearg/testdata/dropin-only.yaml.d/02-data.yaml
@@ -1,0 +1,10 @@
+foo-bar: bar-foo
+b-string+: two
+c-slice+:
+- three
+d-slice:
+- three
+- four
+e-slice+:
+- one
+- two

--- a/pkg/configfilearg/testdata/invalid-dropin.yaml.d/01-data.yml
+++ b/pkg/configfilearg/testdata/invalid-dropin.yaml.d/01-data.yml
@@ -1,0 +1,1 @@
+!invalid

--- a/pkg/configfilearg/testdata/invalid.yaml
+++ b/pkg/configfilearg/testdata/invalid.yaml
@@ -1,0 +1,1 @@
+!invalid


### PR DESCRIPTION
#### Proposed Changes ####

* Don't set K3S_DATA_DIR env var in self-extracting multicall wrapper
  This was only used to pass the bundled strongswan path through to the flannel ipsec backend, and is no longer needed. Ref: #719
* Add K3S_DATA_DIR as env var for --data-dir flag
* Fix inconsistent loading of config dropins when config file does not exist
  `configfilearg.FindString` would silently skip parsing dropins if the main config file didn't exist. If a custom config file path was passed it would raise an error, but if we were parsing the default config file and it didn't exist it would just silently fail to load the dropins.

#### Types of Changes ####

bugfix

#### Verification ####

Includes tests

#### Testing ####

See linked issue

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10589

#### User-Facing Change ####
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
