### PR TITLE
Bump helm-controller to v0.16.3 to drop Helm v2 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/joho/godotenv v1.5.1
 	github.com/json-iterator/go v1.1.12
-	github.com/k3s-io/helm-controller v0.16.1
+	github.com/k3s-io/helm-controller v0.16.3
 	github.com/k3s-io/kine v0.11.11
 	github.com/klauspost/compress v1.17.7
 	github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -927,8 +927,8 @@ github.com/k3s-io/etcd/raft/v3 v3.5.13-k3s1 h1:yexUwAPPdmYfIMWOj6sSyJ2nEe8QOrFzN
 github.com/k3s-io/etcd/raft/v3 v3.5.13-k3s1/go.mod h1:uUFibGLn2Ksm2URMxN1fICGhk8Wu96EfDQyuLhAcAmw=
 github.com/k3s-io/etcd/server/v3 v3.5.13-k3s1 h1:Pqcxkg7V60c26ZpHoekP9QoUdLuduxFn827A/5CIwm4=
 github.com/k3s-io/etcd/server/v3 v3.5.13-k3s1/go.mod h1:K/8nbsGupHqmr5MkgaZpLlH1QdX1pcNQLAkODy44XcQ=
-github.com/k3s-io/helm-controller v0.16.1 h1:4sdJSYdAeTvMjjq3Pt1ZcyenRTJIAvKojTWRg/i8Ne4=
-github.com/k3s-io/helm-controller v0.16.1/go.mod h1:AcSxEhOIUgeVvBTnJOAwcezBZXtYew/RhKwO5xp3RlM=
+github.com/k3s-io/helm-controller v0.16.3 h1:zjC0PsQF2Pf/LM1Cbfz/2dV6ee6XtCAWyG1PO96m7ow=
+github.com/k3s-io/helm-controller v0.16.3/go.mod h1:AcSxEhOIUgeVvBTnJOAwcezBZXtYew/RhKwO5xp3RlM=
 github.com/k3s-io/kine v0.11.11 h1:f1DhpGNjCDVd1HFWPbeA824YP7MtsrKgstoJ5M0SRgs=
 github.com/k3s-io/kine v0.11.11/go.mod h1:L4x3qotFebVh1ZVzYwFVL5PPfqw2sRJTjDTIeViO70Y=
 github.com/k3s-io/klog/v2 v2.120.1-k3s1 h1:7twAHPFpZA21KdMnMNnj68STQMPldAxF2Zsaol57dxw=

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,4 +1,4 @@
-docker.io/rancher/klipper-helm:v0.8.4-build20240523
+docker.io/rancher/klipper-helm:v0.9.1-build20240731
 docker.io/rancher/klipper-lb:v0.4.9
 docker.io/rancher/local-path-provisioner:v0.0.28
 docker.io/rancher/mirrored-coredns-coredns:1.10.1


### PR DESCRIPTION
#### Proposed Changes ####

Bump helm-controller to v0.16.3 to drop Helm v2 support

#### Types of Changes ####

CVE reduction
Breaking change

#### Verification ####

When creating a HelmChart with `spec.helmVersion` set to anything other than v3, notice the warning event and failed condition:
```console
brandond@dev01:~$ kubectl describe helmchart -n kube-system apache
Name:         apache
Namespace:    kube-system
Labels:       <none>
Annotations:  helmcharts.cattle.io/managed-by: helm-controller
API Version:  helm.cattle.io/v1
Kind:         HelmChart
Metadata:
  Creation Timestamp:  2024-08-01T17:17:56Z
  Finalizers:
    wrangler.cattle.io/on-helm-chart-remove
  Generation:        3
  Resource Version:  731
  UID:               ad0fc12c-d820-43c8-bf87-bfe84a851cdb
Spec:
  Chart:             apache
  Helm Version:      v2
  Repo:              https://charts.bitnami.com/bitnami
  Target Namespace:  web
  Values Content:    service:
  type: ClusterIP
ingress:
  enabled: true
  hostname: www.example.com
metrics:
  enabled: true
Status:
  Conditions:
    Status:   False
    Type:     JobCreated
    Message:  Only Helm v3 charts are supported
    Reason:   Unsupported version
    Status:   True
    Type:     Failed
Events:
  Type     Reason              Age                  From             Message
  ----     ------              ----                 ----             -------
  Warning  UnsupportedVersion  112s (x3 over 112s)  helm-controller  Unsupported Helm version v2: only v3 charts are supported
```

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10627

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

