### PR TITLE
Fix caching name for e2e vagrant box

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           path: |
              ~/.vagrant.d/boxes
-          key: vagrant-box-ubuntu-2204
+          key: vagrant-box-ubuntu-2404
       - name: "Vagrant Plugin(s)"
         run: vagrant plugin install vagrant-k3s vagrant-reload vagrant-scp
       

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -71,12 +71,12 @@ ___
 Install tests are a collection of tests defined under the [tests/install](./tests/install). These tests are used to validate the installation and operation of K3s on a variety of operating systems. The test themselves are Vagrantfiles describing single-node installations that are easily spun up with Vagrant for the `libvirt` and `virtualbox` providers:
 
 - [Install Script](install) :arrow_right: scheduled nightly and on an install script change
-  - [CentOS 7](install/centos-7) (stand-in for RHEL 7)
+  - [CentOS 9 Stream](install/centos-stream)
   - [Rocky Linux 8](install/rocky-8) (stand-in for RHEL 8)
   - [Rocky Linux 9](install/rocky-9) (stand-in for RHEL 9)
-  - [Fedora 37](install/fedora)
-  - [Leap 15.5](install/opensuse-leap) (stand-in for SLES)
-  - [Ubuntu 22.04](install/ubuntu-2204)
+  - [Fedora 40](install/fedora)
+  - [Leap 15.6](install/opensuse-leap) (stand-in for SLES)
+  - [Ubuntu 24.04](install/ubuntu-2404)
 
 ## Format
 When adding new installer test(s) please copy the prevalent style for the `Vagrantfile`.


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Addendum to https://github.com/k3s-io/k3s/pull/10681, update the cache key used for e2e boxes in CI
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bug fix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI green
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
