### PR TITLE
[release-1.29] Add tolerations support for DaemonSet pods

### DIFF
--- a/pkg/cloudprovider/servicelb.go
+++ b/pkg/cloudprovider/servicelb.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"encoding/json"
+	"sigs.k8s.io/yaml"
 
 	"github.com/k3s-io/k3s/pkg/util"
 	"github.com/k3s-io/k3s/pkg/version"
@@ -42,6 +44,7 @@ var (
 	daemonsetNodePoolLabel = "svccontroller." + version.Program + ".cattle.io/lbpool"
 	nodeSelectorLabel      = "svccontroller." + version.Program + ".cattle.io/nodeselector"
 	priorityAnnotation     = "svccontroller." + version.Program + ".cattle.io/priorityclassname"
+	tolerationsAnnotation  = "svccontroller." + version.Program + ".cattle.io/tolerations"
 	controllerName         = names.ServiceLBController
 )
 
@@ -597,6 +600,14 @@ func (k *k3s) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 		ds.Labels[nodeSelectorLabel] = "true"
 	}
 
+	// Fetch tolerations from the "svccontroller.k3s.cattle.io/tolerations" annotation on the service
+	// and append them to the DaemonSet's pod tolerations.
+	tolerations, err := k.getTolerations(svc)
+	if err != nil {
+		return nil, err
+	}
+	ds.Spec.Template.Spec.Tolerations = append(ds.Spec.Template.Spec.Tolerations, tolerations...)
+
 	return ds, nil
 }
 
@@ -697,6 +708,47 @@ func (k *k3s) getPriorityClassName(svc *core.Service) string {
 		}
 	}
 	return k.LBDefaultPriorityClassName
+}
+
+// getTolerations retrieves the tolerations from a service's annotations. 
+// It parses the tolerations from a JSON or YAML string stored in the annotations. 
+func (k *k3s) getTolerations(svc *core.Service) ([]core.Toleration, error) {
+	tolerationsStr, ok := svc.Annotations[tolerationsAnnotation]
+	if !ok {
+		return []core.Toleration{}, nil
+	}
+
+	var tolerations []core.Toleration
+	if err := json.Unmarshal([]byte(tolerationsStr), &tolerations); err != nil {
+		if err := yaml.Unmarshal([]byte(tolerationsStr), &tolerations); err != nil {
+			return nil, fmt.Errorf("failed to parse tolerations from annotation %s: %v", tolerationsAnnotation, err)
+		}
+	}
+
+	for i := range tolerations {
+		if err := validateToleration(&tolerations[i]); err != nil {
+			return nil, fmt.Errorf("validation failed for toleration %d: %v", i, err)
+		}
+	}
+
+	return tolerations, nil
+}
+
+// validateToleration ensures a toleration has valid fields according to its operator.
+func validateToleration(toleration *core.Toleration) error {
+	if toleration.Operator == "" {
+		toleration.Operator = core.TolerationOpEqual
+	}
+
+	if toleration.Key == "" && toleration.Operator != core.TolerationOpExists {
+		return fmt.Errorf("toleration with empty key must have operator 'Exists'")
+	}
+
+	if toleration.Operator == core.TolerationOpExists && toleration.Value != "" {
+		return fmt.Errorf("toleration with operator 'Exists' must have an empty value")
+	}
+
+	return nil
 }
 
 // generateName generates a distinct name for the DaemonSet based on the service name and UID


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

This pull request introduces a new feature that allows ServiceLB to handle Kubernetes tolerations defined in a service's annotations. The changes include:

- Implementation of the `getTolerations` method, which retrieves and validates tolerations from a service's annotations in JSON or YAML string format.
- Updates to the `newDaemonSet` method to append the retrieved tolerations to the DaemonSet's pod tolerations.

These changes enable users to customize tolerations directly through service annotations, providing greater flexibility in pod scheduling.

#### Types of Changes ####

- New Feature

#### Verification ####

To verify the changes:

1. Create a Kubernetes Service with the `LoadBalancer` type and `svccontroller.k3s.cattle.io/tolerations` annotation containing valid JSON or YAML formatted tolerations list.
2. Deploy the service and ensure that the corresponding ServiceLB DaemonSet's pods include the specified tolerations.
3. Verify that the system handles invalid or malformed tolerations gracefully, emitting appropriate error messages.

yaml example:
```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    svccontroller.k3s.cattle.io/tolerations: |
      - effect: NoSchedule
        key: public
        operator: Exists
      - effect: NoExecute
        key: disk
        operator: Equal
        value: ssd

  name: ingress-nginx-controller
  namespace: ingress-nginx
spec:
  type: LoadBalancer
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: http
  selector:
    app.kubernetes.io/name: ingress-nginx
```

json example:
```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    svccontroller.k3s.cattle.io/tolerations: |
      [
        {
          "effect": "NoSchedule",
          "key": "public",
          "operator": "Exists"
        },
        {
          "effect": "NoExecute",
          "key": "disk",
          "operator": "Equal",
          "value": "ssd"
        }
      ]

  name: ingress-nginx-controller
  namespace: ingress-nginx
spec:
  type: LoadBalancer
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: http
  selector:
    app.kubernetes.io/name: ingress-nginx
```

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10699

#### User-Facing Change ####

```release-note
- **New Feature**: Users can now define Kubernetes tolerations for ServiceLB DaemonSet directly in the `svccontroller.k3s.cattle.io/tolerations` annotation on services. 
```

#### Further Comments ####

