### PR TITLE
Fix rotateca validation failures when not touching default self-signed CAs

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -33,13 +33,13 @@ func ReadFromDisk(w io.Writer, bootstrap *config.ControlRuntimeBootstrap) error 
 		if path == "" {
 			continue
 		}
-		data, err := os.ReadFile(path)
+		info, err := os.Stat(path)
 		if err != nil {
-			logrus.Warnf("failed to read %s", path)
+			logrus.Warnf("failed to stat %s: %v", pathKey, err)
 			continue
 		}
 
-		info, err := os.Stat(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -30,7 +30,7 @@ import (
 
 // Bootstrap attempts to load a managed database driver, if one has been initialized or should be created/joined.
 // It then checks to see if the cluster needs to load bootstrap data, and if so, loads data into the
-// ControlRuntimeBoostrap struct, either via HTTP or from the datastore.
+// ControlRuntimeBootstrap struct, either via HTTP or from the datastore.
 func (c *Cluster) Bootstrap(ctx context.Context, clusterReset bool) error {
 	if err := c.assignManagedDriver(ctx); err != nil {
 		return err

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -288,18 +288,18 @@ func (c *Control) Loopback(urlSafe bool) string {
 }
 
 type ControlRuntimeBootstrap struct {
-	ETCDServerCA       string
-	ETCDServerCAKey    string
-	ETCDPeerCA         string
-	ETCDPeerCAKey      string
-	ServerCA           string
-	ServerCAKey        string
-	ClientCA           string
-	ClientCAKey        string
-	ServiceKey         string
+	ETCDServerCA       string `rotate:"true"`
+	ETCDServerCAKey    string `rotate:"true"`
+	ETCDPeerCA         string `rotate:"true"`
+	ETCDPeerCAKey      string `rotate:"true"`
+	ServerCA           string `rotate:"true"`
+	ServerCAKey        string `rotate:"true"`
+	ClientCA           string `rotate:"true"`
+	ClientCAKey        string `rotate:"true"`
+	ServiceKey         string `rotate:"true"`
 	PasswdFile         string
-	RequestHeaderCA    string
-	RequestHeaderCAKey string
+	RequestHeaderCA    string `rotate:"true"`
+	RequestHeaderCAKey string `rotate:"true"`
 	IPSECKey           string
 	EncryptionConfig   string
 	EncryptionHash     string


### PR DESCRIPTION
#### Proposed Changes ####

Fix rotateca validation failures when not touching default self-signed CAs

Also silences warnings about bootstrap fields that are not intended to be handled by CA rotation

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10689
* 
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
