### PR TITLE
Fix deploy latest commit on E2E tests

### DIFF
--- a/tests/e2e/vagrantdefaults.rb
+++ b/tests/e2e/vagrantdefaults.rb
@@ -19,7 +19,7 @@ def getInstallType(vm, release_version, branch, release_channel='')
     install_type = "INSTALL_K3S_SKIP_DOWNLOAD=true"
   elsif !release_version.empty?
     return "INSTALL_K3S_VERSION=#{release_version}"
-  elsif release_channel != "commit"
+  elsif !release_channel.empty? && release_channel != "commit"
     return "INSTALL_K3S_CHANNEL=#{release_channel}"
   else
     jqInstall(vm)


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Our nightly E2E tests have not actually been deploying the latest commit. I found out when manually testing. This has been in place since https://github.com/k3s-io/k3s/commit/14549535f13c63fc239ba055d36d590e68b01503 (3 months ago)
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
using validatecluster test as an example
`vagrant up server-0` will no other arguments now correctly deploys the latest commit build from AWS of K3s.

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
Its all testing
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
