### PR TITLE
Fix /trivy action running against target branch instead of PR branch

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout PR code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.issue.pull_request.head.ref }}
+        ref: refs/pull/${{ github.event.issue.number }}/head
     
     - name: Comment Status on PR
       run: |


### PR DESCRIPTION
#### Proposed Changes ####

Fix /trivy action running against target branch instead of PR branch

Ref: https://github.com/actions/checkout/issues/331#issuecomment-1438220926

#### Types of Changes ####

ci fix

#### Verification ####

Trigger the action

#### Testing ####


#### Linked Issues ####

#### User-Facing Change ####

```release-note

```

#### Further Comments ####
