### PR TITLE
Add channel for v1.31

### DIFF
--- a/channel.yaml
+++ b/channel.yaml
@@ -59,6 +59,9 @@ channels:
 - name: v1.30
   latestRegexp: v1\.30\..*
   excludeRegexp: ^[^+]+-
+- name: v1.31
+  latestRegexp: v1\.31\..*
+  excludeRegexp: ^[^+]+-
 github:
   owner: k3s-io
   repo: k3s


### PR DESCRIPTION
#### Proposed Changes ####

Add channel for v1.31

#### Types of Changes ####

channel server

#### Verification ####


#### Testing ####


#### Linked Issues ####


#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

This is why e2e tests are failing for backports to release-v1.31: https://github.com/k3s-io/k3s/pull/10817
```
  ==> server-0: Invoking: /vagrant/k3s-provisioner.sh
      server-0: [INFO]  Finding release for channel v1.31
      server-0: [INFO]  Using v1.31 as release
      server-0: [INFO]  Downloading hash https://github.com/k3s-io/k3s/releases/download/v1.31/sha256sum-amd64.txt
      server-0: [ERROR]  Download failed
```
