### PR TITLE
add node-internal-dns/node-external-dns address pass-through support

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -453,9 +453,6 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 			if len(envInfo.NodeExternalIP) != 0 {
 				logrus.Warn("VPN provider overrides node-external-ip parameter")
 			}
-			if len(envInfo.NodeExternalDNS) != 0 {
-				logrus.Warn("VPN provider overrides node-external-dns parameter")
-			}
 			nodeIPs = vpnIPs
 			flannelIface, err = net.InterfaceByName(vpnInfo.VPNInterface)
 			if err != nil {

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -639,6 +639,15 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		nodeConfig.AgentConfig.NodeExternalDNS = nodeConfig.AgentConfig.NodeExternalDNSs[0]
 	}
 
+	var nodeInternalDNSs []string
+	for _, dnsString := range envInfo.NodeInternalDNS.Value() {
+		nodeInternalDNSs = append(nodeInternalDNSs, strings.Split(dnsString, ",")...)
+	}
+	nodeConfig.AgentConfig.NodeInternalDNSs = nodeInternalDNSs
+	if len(nodeConfig.AgentConfig.NodeInternalDNSs) > 0 {
+		nodeConfig.AgentConfig.NodeInternalDNS = nodeConfig.AgentConfig.NodeInternalDNSs[0]
+	}
+
 	nodeConfig.NoFlannel = nodeConfig.FlannelBackend == config.FlannelBackendNone
 	if !nodeConfig.NoFlannel {
 		hostLocal, err := exec.LookPath("host-local")

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -635,18 +635,12 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		nodeExternalDNSs = append(nodeExternalDNSs, strings.Split(dnsString, ",")...)
 	}
 	nodeConfig.AgentConfig.NodeExternalDNSs = nodeExternalDNSs
-	if len(nodeConfig.AgentConfig.NodeExternalDNSs) > 0 {
-		nodeConfig.AgentConfig.NodeExternalDNS = nodeConfig.AgentConfig.NodeExternalDNSs[0]
-	}
 
 	var nodeInternalDNSs []string
 	for _, dnsString := range envInfo.NodeInternalDNS.Value() {
 		nodeInternalDNSs = append(nodeInternalDNSs, strings.Split(dnsString, ",")...)
 	}
 	nodeConfig.AgentConfig.NodeInternalDNSs = nodeInternalDNSs
-	if len(nodeConfig.AgentConfig.NodeInternalDNSs) > 0 {
-		nodeConfig.AgentConfig.NodeInternalDNS = nodeConfig.AgentConfig.NodeInternalDNSs[0]
-	}
 
 	nodeConfig.NoFlannel = nodeConfig.FlannelBackend == config.FlannelBackendNone
 	if !nodeConfig.NoFlannel {

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -453,6 +453,9 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 			if len(envInfo.NodeExternalIP) != 0 {
 				logrus.Warn("VPN provider overrides node-external-ip parameter")
 			}
+			if len(envInfo.NodeExternalDNS) != 0 {
+				logrus.Warn("VPN provider overrides node-external-dns parameter")
+			}
 			nodeIPs = vpnIPs
 			flannelIface, err = net.InterfaceByName(vpnInfo.VPNInterface)
 			if err != nil {
@@ -628,6 +631,15 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	// unless only IPv6 address given
 	if len(nodeConfig.AgentConfig.NodeExternalIPs) > 0 {
 		nodeConfig.AgentConfig.NodeExternalIP = nodeConfig.AgentConfig.NodeExternalIPs[0].String()
+	}
+
+	var nodeExternalDNSs []string
+	for _, dnsString := range envInfo.NodeExternalDNS.Value() {
+		nodeExternalDNSs = append(nodeExternalDNSs, strings.Split(dnsString, ",")...)
+	}
+	nodeConfig.AgentConfig.NodeExternalDNSs = nodeExternalDNSs
+	if len(nodeConfig.AgentConfig.NodeExternalDNSs) > 0 {
+		nodeConfig.AgentConfig.NodeExternalDNS = nodeConfig.AgentConfig.NodeExternalDNSs[0]
 	}
 
 	nodeConfig.NoFlannel = nodeConfig.FlannelBackend == config.FlannelBackendNone

--- a/pkg/agent/flannel/flannel.go
+++ b/pkg/agent/flannel/flannel.go
@@ -48,7 +48,6 @@ var (
 	FlannelBaseAnnotation         = "flannel.alpha.coreos.com"
 	FlannelExternalIPv4Annotation = FlannelBaseAnnotation + "/public-ip-overwrite"
 	FlannelExternalIPv6Annotation = FlannelBaseAnnotation + "/public-ipv6-overwrite"
-	FlannelExternalDNSAnnotation = FlannelBaseAnnotation + "/public-dns-overwrite"
 )
 
 func flannel(ctx context.Context, flannelIface *net.Interface, flannelConf, kubeConfigFile string, flannelIPv6Masq bool, netMode int) error {

--- a/pkg/agent/flannel/flannel.go
+++ b/pkg/agent/flannel/flannel.go
@@ -48,6 +48,7 @@ var (
 	FlannelBaseAnnotation         = "flannel.alpha.coreos.com"
 	FlannelExternalIPv4Annotation = FlannelBaseAnnotation + "/public-ip-overwrite"
 	FlannelExternalIPv6Annotation = FlannelBaseAnnotation + "/public-ipv6-overwrite"
+	FlannelExternalDNSAnnotation = FlannelBaseAnnotation + "/public-dns-overwrite"
 )
 
 func flannel(ctx context.Context, flannelIface *net.Interface, flannelConf, kubeConfigFile string, flannelIPv6Masq bool, netMode int) error {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -491,6 +491,15 @@ func updateAddressAnnotations(nodeConfig *daemonconfig.Node, nodeAnnotations map
 		}
 	}
 
+	if agentConfig.NodeExternalDNS != "" {
+		result[cp.ExternalDNSKey] = strings.Join(agentConfig.NodeExternalDNSs, ",")
+		if nodeConfig.FlannelExternalIP {
+			for _, dns := range agentConfig.NodeExternalDNSs {
+				result[flannel.FlannelExternalDNSAnnotation] = dns
+			}
+		}
+	}
+
 	result = labels.Merge(nodeAnnotations, result)
 	return result, !equality.Semantic.DeepEqual(nodeAnnotations, result)
 }

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -491,15 +491,6 @@ func updateAddressAnnotations(nodeConfig *daemonconfig.Node, nodeAnnotations map
 		}
 	}
 
-	if agentConfig.NodeExternalDNS != "" {
-		result[cp.ExternalDNSKey] = strings.Join(agentConfig.NodeExternalDNSs, ",")
-		if nodeConfig.FlannelExternalIP {
-			for _, dns := range agentConfig.NodeExternalDNSs {
-				result[flannel.FlannelExternalDNSAnnotation] = dns
-			}
-		}
-	}
-
 	result = labels.Merge(nodeAnnotations, result)
 	return result, !equality.Semantic.DeepEqual(nodeAnnotations, result)
 }

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -491,11 +491,15 @@ func updateAddressAnnotations(nodeConfig *daemonconfig.Node, nodeAnnotations map
 		}
 	}
 
-	if agentConfig.NodeInternalDNS != "" {
+	if len(agentConfig.NodeInternalDNSs) > 0 {
 		result[cp.InternalDNSKey] = strings.Join(agentConfig.NodeInternalDNSs, ",")
+	} else {
+		delete(result, cp.InternalDNSKey)
 	}
-	if agentConfig.NodeExternalDNS != "" {
+	if len(agentConfig.NodeExternalDNSs) > 0 {
 		result[cp.ExternalDNSKey] = strings.Join(agentConfig.NodeExternalDNSs, ",")
+	} else {
+		delete(result, cp.ExternalDNSKey)
 	}
 
 	result = labels.Merge(nodeAnnotations, result)

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -491,6 +491,13 @@ func updateAddressAnnotations(nodeConfig *daemonconfig.Node, nodeAnnotations map
 		}
 	}
 
+	if agentConfig.NodeInternalDNS != "" {
+		result[cp.InternalDNSKey] = strings.Join(agentConfig.NodeInternalDNSs, ",")
+	}
+	if agentConfig.NodeExternalDNS != "" {
+		result[cp.ExternalDNSKey] = strings.Join(agentConfig.NodeExternalDNSs, ",")
+	}
+
 	result = labels.Merge(nodeAnnotations, result)
 	return result, !equality.Semantic.DeepEqual(nodeAnnotations, result)
 }

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -23,6 +23,7 @@ type Agent struct {
 	BindAddress              string
 	NodeIP                   cli.StringSlice
 	NodeExternalIP           cli.StringSlice
+	NodeExternalDNS          cli.StringSlice
 	NodeName                 string
 	PauseImage               string
 	Snapshotter              string
@@ -79,6 +80,11 @@ var (
 		Name:  "node-external-ip",
 		Usage: "(agent/networking) IPv4/IPv6 external IP addresses to advertise for node",
 		Value: &AgentConfig.NodeExternalIP,
+	}
+	NodeExternalDNSFlag = &cli.StringSliceFlag{
+		Name:  "node-external-dns",
+		Usage: "(agent/networking) external DNS addresses to advertise for node",
+		Value: &AgentConfig.NodeExternalDNS,
 	}
 	NodeNameFlag = &cli.StringFlag{
 		Name:        "node-name",
@@ -295,6 +301,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			NodeIPFlag,
 			BindAddressFlag,
 			NodeExternalIPFlag,
+			NodeExternalDNSFlag,
 			ResolvConfFlag,
 			FlannelIfaceFlag,
 			FlannelConfFlag,

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -23,6 +23,7 @@ type Agent struct {
 	BindAddress              string
 	NodeIP                   cli.StringSlice
 	NodeExternalIP           cli.StringSlice
+	NodeInternalDNS          cli.StringSlice
 	NodeExternalDNS          cli.StringSlice
 	NodeName                 string
 	PauseImage               string
@@ -80,6 +81,11 @@ var (
 		Name:  "node-external-ip",
 		Usage: "(agent/networking) IPv4/IPv6 external IP addresses to advertise for node",
 		Value: &AgentConfig.NodeExternalIP,
+	}
+	NodeInternalDNSFlag = &cli.StringSliceFlag{
+		Name:  "node-internal-dns",
+		Usage: "(agent/networking) internal DNS addresses to advertise for node",
+		Value: &AgentConfig.NodeInternalDNS,
 	}
 	NodeExternalDNSFlag = &cli.StringSliceFlag{
 		Name:  "node-external-dns",
@@ -301,6 +307,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			NodeIPFlag,
 			BindAddressFlag,
 			NodeExternalIPFlag,
+			NodeInternalDNSFlag,
 			NodeExternalDNSFlag,
 			ResolvConfFlag,
 			FlannelIfaceFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -539,6 +539,7 @@ var ServerFlags = []cli.Flag{
 	AirgapExtraRegistryFlag,
 	NodeIPFlag,
 	NodeExternalIPFlag,
+	NodeInternalDNSFlag,
 	NodeExternalDNSFlag,
 	ResolvConfFlag,
 	FlannelIfaceFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -539,6 +539,7 @@ var ServerFlags = []cli.Flag{
 	AirgapExtraRegistryFlag,
 	NodeIPFlag,
 	NodeExternalIPFlag,
+	NodeExternalDNSFlag,
 	ResolvConfFlag,
 	FlannelIfaceFlag,
 	FlannelConfFlag,

--- a/pkg/cloudprovider/instances.go
+++ b/pkg/cloudprovider/instances.go
@@ -80,6 +80,15 @@ func (k *k3s) InstanceMetadata(ctx context.Context, node *corev1.Node) (*cloudpr
 		metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: address})
 	}
 
+	// check internal dns
+	if address := node.Annotations[InternalDNSKey]; address != "" {
+		for _, v := range strings.Split(address, ",") {
+			metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeInternalDNS, Address: v})
+		}
+	} else if address = node.Labels[InternalDNSKey]; address != "" {
+		metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeInternalDNS, Address: address})
+	}
+
 	// check external dns
 	if address := node.Annotations[ExternalDNSKey]; address != "" {
 		for _, v := range strings.Split(address, ",") {

--- a/pkg/cloudprovider/instances.go
+++ b/pkg/cloudprovider/instances.go
@@ -86,8 +86,6 @@ func (k *k3s) InstanceMetadata(ctx context.Context, node *corev1.Node) (*cloudpr
 		for _, v := range strings.Split(address, ",") {
 			metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeInternalDNS, Address: v})
 		}
-	} else if address = node.Labels[InternalDNSKey]; address != "" {
-		metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeInternalDNS, Address: address})
 	}
 
 	// check external dns

--- a/pkg/cloudprovider/instances.go
+++ b/pkg/cloudprovider/instances.go
@@ -93,8 +93,6 @@ func (k *k3s) InstanceMetadata(ctx context.Context, node *corev1.Node) (*cloudpr
 		for _, v := range strings.Split(address, ",") {
 			metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeExternalDNS, Address: v})
 		}
-	} else if address = node.Labels[ExternalDNSKey]; address != "" {
-		metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeExternalDNS, Address: address})
 	}
 
 	// check hostname

--- a/pkg/cloudprovider/instances.go
+++ b/pkg/cloudprovider/instances.go
@@ -15,6 +15,7 @@ import (
 var (
 	InternalIPKey = version.Program + ".io/internal-ip"
 	ExternalIPKey = version.Program + ".io/external-ip"
+	ExternalDNSKey = version.Program + ".io/external-dns"
 	HostnameKey   = version.Program + ".io/hostname"
 )
 
@@ -77,6 +78,15 @@ func (k *k3s) InstanceMetadata(ctx context.Context, node *corev1.Node) (*cloudpr
 		}
 	} else if address = node.Labels[ExternalIPKey]; address != "" {
 		metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: address})
+	}
+
+	// check external dns
+	if address := node.Annotations[ExternalDNSKey]; address != "" {
+		for _, v := range strings.Split(address, ",") {
+			metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeExternalDNS, Address: v})
+		}
+	} else if address = node.Labels[ExternalDNSKey]; address != "" {
+		metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeExternalDNS, Address: address})
 	}
 
 	// check hostname

--- a/pkg/cloudprovider/instances.go
+++ b/pkg/cloudprovider/instances.go
@@ -15,6 +15,7 @@ import (
 var (
 	InternalIPKey = version.Program + ".io/internal-ip"
 	ExternalIPKey = version.Program + ".io/external-ip"
+	InternalDNSKey = version.Program + ".io/internal-dns"
 	ExternalDNSKey = version.Program + ".io/external-dns"
 	HostnameKey   = version.Program + ".io/hostname"
 )

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -123,6 +123,8 @@ type Agent struct {
 	NodeIPs                 []net.IP
 	NodeExternalIP          string
 	NodeExternalIPs         []net.IP
+	NodeExternalDNS         string
+	NodeExternalDNSs        []string
 	RuntimeSocket           string
 	ImageServiceSocket      string
 	ListenAddress           string

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -123,9 +123,7 @@ type Agent struct {
 	NodeIPs                 []net.IP
 	NodeExternalIP          string
 	NodeExternalIPs         []net.IP
-	NodeInternalDNS         string
 	NodeInternalDNSs        []string
-	NodeExternalDNS         string
 	NodeExternalDNSs        []string
 	RuntimeSocket           string
 	ImageServiceSocket      string

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -123,6 +123,8 @@ type Agent struct {
 	NodeIPs                 []net.IP
 	NodeExternalIP          string
 	NodeExternalIPs         []net.IP
+	NodeInternalDNS         string
+	NodeInternalDNSs        []string
 	NodeExternalDNS         string
 	NodeExternalDNSs        []string
 	RuntimeSocket           string


### PR DESCRIPTION
#### Proposed Changes ####

Add support for setting NodeInternalDNS and NodeExternalDNS addresses via stub cloud provider

#### Types of Changes ####

enhancement

#### Verification ####

```
k3s server --node-external-dns node.example.com
```

now yields:

![image](https://github.com/user-attachments/assets/73072a3e-99fd-42f3-818a-395b09e05fd0)

As you can see it correctly sets the ExternalDNS address.

#### Testing ####


#### Linked Issues ####

* #10848 

#### User-Facing Change ####

#### Further Comments ####

