### PR TITLE
Bump kine to v0.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/json-iterator/go v1.1.12
 	github.com/k3s-io/helm-controller v0.16.4
-	github.com/k3s-io/kine v0.12.0
+	github.com/k3s-io/kine v0.13.0
 	github.com/klauspost/compress v1.17.9
 	github.com/lib/pq v1.10.2
 	github.com/libp2p/go-libp2p v0.33.2

--- a/go.sum
+++ b/go.sum
@@ -957,8 +957,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.13-k3s1 h1:Pqcxkg7V60c26ZpHoekP9QoUdLuduxF
 github.com/k3s-io/etcd/server/v3 v3.5.13-k3s1/go.mod h1:K/8nbsGupHqmr5MkgaZpLlH1QdX1pcNQLAkODy44XcQ=
 github.com/k3s-io/helm-controller v0.16.4 h1:l1noZJacLT2C9JUgfwO9SV8XtfAv1J9avVXyzv8tYHo=
 github.com/k3s-io/helm-controller v0.16.4/go.mod h1:AcSxEhOIUgeVvBTnJOAwcezBZXtYew/RhKwO5xp3RlM=
-github.com/k3s-io/kine v0.12.0 h1:OWUdEAjwbZivVCwOWaPbTNnnQTrEmSW32+13UWQjYz4=
-github.com/k3s-io/kine v0.12.0/go.mod h1:L4x3qotFebVh1ZVzYwFVL5PPfqw2sRJTjDTIeViO70Y=
+github.com/k3s-io/kine v0.13.0 h1:DVh9VDZYVlyJWKoPoIgGc1LAsoSwkZyazhWzQW15L2k=
+github.com/k3s-io/kine v0.13.0/go.mod h1:L4x3qotFebVh1ZVzYwFVL5PPfqw2sRJTjDTIeViO70Y=
 github.com/k3s-io/klog/v2 v2.120.1-k3s1 h1:7twAHPFpZA21KdMnMNnj68STQMPldAxF2Zsaol57dxw=
 github.com/k3s-io/klog/v2 v2.120.1-k3s1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 github.com/k3s-io/kube-router/v2 v2.2.1 h1:LrU6l4khFt67+QCIvgok9B/C9JY/U2/TaF9TCVUw0vw=


### PR DESCRIPTION
#### Proposed Changes ####

Bump kine to v0.13.0

#### Types of Changes ####

version bump

#### Verification ####

check version

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10936
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kine has been bumped to v0.13.0. This release includes changes that should enhance performance when using postgres as an external DB. The updated schema will be automatically used for new databases; to migrate to the new schema on existing databases, K3s can be started with the `KINE_SCHEMA_MIGRATION=2` environment variable set.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
