### PR TITLE
Add user path to runtimes search

### DIFF
--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	socketPrefix = "unix://"
-	runtimesPath = "/usr/local/nvidia/toolkit:/opt/kwasm/bin:/usr/sbin:/usr/local/sbin:/usr/bin:/usr/local/bin"
+	runtimesPath = "/usr/local/nvidia/toolkit:/opt/kwasm/bin"
 )
 
 func getContainerdArgs(cfg *config.Node) []string {
@@ -55,10 +55,10 @@ func SetupContainerdConfig(cfg *config.Node) error {
 		cfg.AgentConfig.Systemd = !isRunningInUserNS && controllers["cpuset"] && os.Getenv("INVOCATION_ID") != ""
 	}
 
-	// set the path to include the runtimes and then remove the aditional path entries
+	// set the path to include the default runtimes and remove the aditional path entries
 	// that we added after finding the runtimes
 	originalPath := os.Getenv("PATH")
-	os.Setenv("PATH", runtimesPath)
+	os.Setenv("PATH", runtimesPath+string(os.PathListSeparator)+originalPath)
 	extraRuntimes := findContainerRuntimes()
 	os.Setenv("PATH", originalPath)
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- Use the runtimes default paths and the user path when searching for the runtimes

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

- Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- https://github.com/k3s-io/k3s/issues/10761

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Runtimes detection will now use $PATH
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- I think this will be a good idea, since we will also detect runtimes in the entire user path
