### PR TITLE
ci: add gomod to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,3 +63,14 @@ updates:
       - "k3s-io/k3s-dev"
     schedule:
       interval: "weekly"
+
+  # Maintain dependencies for Go
+  - package-ecosystem: "gomod"
+    open-pull-requests-limit: 15
+    directory: "/"
+    labels:
+      - "kind/dependabot"
+    reviewers:
+      - "k3s-io/k3s-dev"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Purpose

This change allows Dependabot to automatically check for updates to Go dependencies and create pull requests for those updates.