### PR TITLE
Auto import images for containerd image store

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        etest: [startup, s3, btrfs, externalip, privateregistry, embeddedmirror, wasm]
+        etest: [autoimport, startup, s3, btrfs, externalip, privateregistry, embeddedmirror, wasm]
       max-parallel: 3
     steps:
       - name: "Checkout"

--- a/docs/adrs/add-auto-import-containerd.md
+++ b/docs/adrs/add-auto-import-containerd.md
@@ -42,7 +42,7 @@ When the controller receive a event saying that a file was renamed, or removed, 
 
 ## Decision
 
-- Not decided yet
+- Decided
 
 ## Consequences
 

--- a/docs/adrs/add-auto-import-embedded-registry.md
+++ b/docs/adrs/add-auto-import-embedded-registry.md
@@ -1,0 +1,54 @@
+# Easy way for auto adding images to k3s
+
+Date: 2024-10-2
+
+## Status
+
+Proposed
+
+## Context
+
+Since the feature for embedded registry, the users appeared with a question about having to manually import images, specially in edge environments.
+
+As a result, there is a need for a folder who can handle this action, where every image there will be watched by a controller for changes or new images, this new images or new changes will be added to the containerd image store.
+
+The controller will watch the agent/images folder that is the default folder for the images, as the first iteration about the controller he will mainly work with the default image folder, but in the future we can set to watch more folders.
+
+The main idea for the controller is to create a map for the file infos maintaining the state for the files, with that we can see if a file was modified and if the size changed.
+
+### Map to handle the state from the files
+
+This map will have the entire filepath of the file in the `key` value, since we can get the value from the key with only the `event.Name`
+
+```go
+    map[string]fs.FileInfo
+```
+
+### Why use fsnotify
+
+With this library we can easily use for any linux distros without the need to port for a specify distro and can also run in windows.
+
+The main idea for the watch will be taking care of the last time that was modified the image file.
+
+fsnotify has a great toolset for handling changes in files, since the code will have a channel to receive events such as CREATE, RENAME, REMOVE and WRITE.
+
+### How the controller will work with the events
+
+When the controller receive a event saying that a file was created, he will add to the map and import the images if the event that he has received is not a directory and then import the image.
+
+When the controller receive a event saying that a file was writen, he will verify if the file has the size changed and if the file has the time modified based on the time and size from the state.
+
+When the controller receive a event saying that a file was renamed, or removed, he will delete this file from the state. when a file is renamed, it is created a new file with the same infos but with a the new name, so the watcher will sent for the controller a event saying that a file was created.
+
+## Decision
+
+- Not decided yet
+
+## Consequences
+
+Good:
+- Better use of embedded containerd image store.
+- Fsnotify it's a indirect dependency that upstream uses
+
+Bad:
+- The need for another dependency

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/docker/docker v27.1.1+incompatible
 	github.com/erikdubbelboer/gspt v0.0.0-20190125194910-e68493906b83
 	github.com/flannel-io/flannel v0.25.7
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/stdr v1.2.3-0.20220714215716-96bad1d688c5
@@ -252,7 +253,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -273,7 +273,6 @@ require (
 	github.com/google/cel-go v0.20.1 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -166,6 +166,7 @@ require (
 	k8s.io/utils v0.0.0-20240902221715-702e33fdd3c3
 	sigs.k8s.io/cri-tools v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/yaml v1.4.0
+	github.com/google/go-containerregistry v0.20.2
 )
 
 require (
@@ -272,7 +273,7 @@ require (
 	github.com/google/cel-go v0.20.1 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/go-containerregistry v0.20.2 // indirect
+
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 // indirect

--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -293,13 +293,15 @@ func labelImages(ctx context.Context, client *containerd.Client, images []images
 	imageService := client.ImageService()
 	for i, image := range images {
 		if image.Labels[k3sPinnedImageLabelKey] == k3sPinnedImageLabelValue &&
-			image.Labels[labels.PinnedImageLabelKey] == labels.PinnedImageLabelValue {
+			image.Labels[labels.PinnedImageLabelKey] == labels.PinnedImageLabelValue &&
+			image.Labels[k3sAutoImportImageLabelKey] == fileName {
 			continue
 		}
 
 		if image.Labels == nil {
 			image.Labels = map[string]string{}
 		}
+
 		image.Labels[k3sAutoImportImageLabelKey] = fileName
 		image.Labels[k3sPinnedImageLabelKey] = k3sPinnedImageLabelValue
 		image.Labels[labels.PinnedImageLabelKey] = labels.PinnedImageLabelValue

--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -361,9 +361,13 @@ func prePullImages(ctx context.Context, client *containerd.Client, imageClient r
 	for scanner.Scan() {
 		name := strings.TrimSpace(scanner.Text())
 
+		if name == "" {
+			continue
+		}
+
 		// the options in the reference.ParseReference are for filtering only strings that cannot be seen as a possible image
 		if _, err := reference.ParseReference(name, reference.WeakValidation, reference.Insecure); err != nil {
-			logrus.Errorf("Unable to pull image %s: %v", name, err)
+			logrus.Errorf("Failed to parse image reference %q: %v", name, err)
 			continue
 		}
 

--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -277,6 +277,7 @@ func clearLabels(ctx context.Context, client *containerd.Client) error {
 		return err
 	}
 	for _, image := range images {
+		delete(image.Labels, k3sAutoImportImageLabelKey)
 		delete(image.Labels, k3sPinnedImageLabelKey)
 		delete(image.Labels, labels.PinnedImageLabelKey)
 		if _, err := imageService.Update(ctx, image, "labels"); err != nil {

--- a/pkg/agent/containerd/watcher.go
+++ b/pkg/agent/containerd/watcher.go
@@ -1,0 +1,356 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/containerd/containerd"
+	"github.com/fsnotify/fsnotify"
+	"github.com/k3s-io/k3s/pkg/agent/cri"
+	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/pkg/errors"
+	"github.com/rancher/wrangler/v3/pkg/merr"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/util/workqueue"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+type Watcher struct {
+	watcher   *fsnotify.Watcher
+	filesMap  map[string]fs.FileInfo
+	workqueue workqueue.TypedRateLimitingInterface[fsnotify.Event]
+}
+
+func CreateWatcher() (*Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Watcher{
+		watcher:   watcher,
+		filesMap:  make(map[string]fs.FileInfo),
+		workqueue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[fsnotify.Event]()),
+	}, nil
+}
+
+func isFileSupported(path string) bool {
+	supportedExtensions := map[string]bool{
+		".tar":     true,
+		".tar.lz4": true,
+		".tar.bz2": true,
+		".tbz":     true,
+		".tar.gz":  true,
+		".tgz":     true,
+		".tar.zst": true,
+		".tzst":    true,
+		".txt":     true,
+	}
+
+	suffix := filepath.Ext(path)
+	return supportedExtensions[suffix]
+}
+
+func (w *Watcher) HandleWatch(path string) error {
+	if err := w.watcher.Add(path); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to watch from %s directory: %v", path, err))
+	}
+
+	return nil
+}
+
+// Populate the state of the files in the directory
+// for the watcher to have infos about the file changing
+// this function need to break
+func (w *Watcher) Populate(path string) error {
+	var errs []error
+
+	fileInfos, err := os.ReadDir(path)
+	if err != nil {
+		logrus.Errorf("Unable to read files in %s: %v", path, err)
+		return err
+	}
+
+	for _, dirEntry := range fileInfos {
+		if dirEntry.IsDir() {
+			continue
+		}
+
+		// get the file info to add to the state map
+		fileInfo, err := dirEntry.Info()
+		if err != nil {
+			logrus.Errorf("Failed while getting the info from file: %v", err)
+			errs = append(errs, err)
+			continue
+		}
+
+		if isFileSupported(dirEntry.Name()) {
+			// insert the file into the state map that will have the state from the file
+			w.filesMap[filepath.Join(path, dirEntry.Name())] = fileInfo
+		}
+	}
+
+	return merr.NewErrors(errs...)
+}
+
+func (w *Watcher) ClearMap() {
+	w.filesMap = make(map[string]fs.FileInfo)
+}
+
+func (w *Watcher) runWorkerForImages(ctx context.Context, cfg *config.Node) {
+	// create the connections to not create every time when processing a event
+	client, err := Client(cfg.Containerd.Address)
+	if err != nil {
+		logrus.Errorf("Failed to create containerd client: %v", err)
+		w.watcher.Close()
+		return
+	}
+
+	defer client.Close()
+
+	criConn, err := cri.Connection(ctx, cfg.Containerd.Address)
+	if err != nil {
+		logrus.Errorf("Failed to create CRI connection: %v", err)
+		w.watcher.Close()
+		return
+	}
+
+	defer criConn.Close()
+
+	imageClient := runtimeapi.NewImageServiceClient(criConn)
+
+	for w.processNextEventForImages(ctx, cfg, client, imageClient) {
+	}
+}
+
+func (w *Watcher) processNextEventForImages(ctx context.Context, cfg *config.Node, client *containerd.Client, imageClient runtimeapi.ImageServiceClient) bool {
+	event, shutdown := w.workqueue.Get()
+
+	if shutdown {
+		return false
+	}
+
+	if err := w.processImageEvent(ctx, event, cfg, client, imageClient); err != nil {
+		logrus.Errorf("Failed to process image event: %v", err)
+	}
+
+	return true
+}
+
+func (w *Watcher) processImageEvent(ctx context.Context, event fsnotify.Event, cfg *config.Node, client *containerd.Client, imageClient runtimeapi.ImageServiceClient) error {
+	defer w.workqueue.Done(event)
+
+	switch event.Op {
+	case fsnotify.Write:
+		newStateFile, err := os.Stat(event.Name)
+		if err != nil {
+			logrus.Errorf("Failed to get file %s info for image event write: %s", event.Name, err.Error())
+			break
+		}
+
+		// we do not want to handle directorys, only files
+		if newStateFile.IsDir() {
+			w.workqueue.Done(event)
+			break
+		}
+
+		if !isFileSupported(event.Name) {
+			w.workqueue.Done(event)
+			break
+		}
+
+		lastStateFile := w.filesMap[event.Name]
+		w.filesMap[event.Name] = newStateFile
+
+		if (newStateFile.Size() != lastStateFile.Size()) && newStateFile.ModTime().After(lastStateFile.ModTime()) {
+			logrus.Debugf("File met the requirements for import to containerd image store: %s", event.Name)
+			start := time.Now()
+			if err := preloadFile(ctx, cfg, client, imageClient, event.Name); err != nil {
+				logrus.Errorf("Failed to import %s: %v", event.Name, err)
+				break
+			}
+			logrus.Infof("Imported images from %s in %s", event.Name, time.Since(start))
+		}
+	case fsnotify.Create:
+		info, err := os.Stat(event.Name)
+		if err != nil {
+			logrus.Errorf("Failed to get file %s info for image event Create: %v", event.Name, err)
+			break
+		}
+
+		if info.IsDir() {
+			// only add the image watcher, populate and search for images when it is the images folder
+			if event.Name == cfg.Images {
+				if err := w.HandleWatch(cfg.Images); err != nil {
+					logrus.Errorf("Failed to watch %s: %v", cfg.Images, err)
+					break
+				}
+
+				if err := w.Populate(cfg.Images); err != nil {
+					logrus.Errorf("Failed to populate %s files: %v", cfg.Images, err)
+					break
+				}
+
+				// Read the directory to see if the created folder has files inside
+				fileInfos, err := os.ReadDir(cfg.Images)
+				if err != nil {
+					logrus.Errorf("Unable to read images in %s: %v", cfg.Images, err)
+					break
+				}
+
+				for _, fileInfo := range fileInfos {
+					if fileInfo.IsDir() {
+						continue
+					}
+
+					start := time.Now()
+					filePath := filepath.Join(cfg.Images, fileInfo.Name())
+
+					if err := preloadFile(ctx, cfg, client, imageClient, filePath); err != nil {
+						logrus.Errorf("Error encountered while importing %s: %v", filePath, err)
+						continue
+					}
+					logrus.Infof("Imported images from %s in %s", filePath, time.Since(start))
+				}
+			}
+
+			w.workqueue.Done(event)
+			break
+		}
+
+		if !isFileSupported(event.Name) {
+			w.workqueue.Done(event)
+			break
+		}
+
+		w.filesMap[event.Name] = info
+		logrus.Debugf("File added to watcher controller: %s", event.Name)
+
+		start := time.Now()
+		if err := preloadFile(ctx, cfg, client, imageClient, event.Name); err != nil {
+			logrus.Errorf("Error encountered while importing %s: %v", event.Name, err)
+			break
+		}
+		logrus.Infof("Imported images from %s in %s", event.Name, time.Since(start))
+	case fsnotify.Rename:
+		// Clear the map when cfg.Images directory is renamed, it does not need to remove the watcher
+		// because the fsnotify already removes
+		if event.Name == cfg.Images {
+			w.ClearMap()
+			break
+		}
+
+		if !isFileSupported(event.Name) {
+			w.workqueue.Done(event)
+			break
+		}
+
+		// clear label because when a new file will be created because of the rename
+		// the create event will label the images with the name of the new file
+		err := clearLabelFromAutoImport(ctx, client, event.Name)
+		if err != nil {
+			logrus.Errorf("Failed to clear auto import label for %s: %v", event.Name, err)
+		}
+		delete(w.filesMap, event.Name)
+		logrus.Debugf("Removed file from the image watcher controller: %s", event.Name)
+	case fsnotify.Remove:
+		// Clear the map when cfg.Images directory is removed, it does not need to remove the watcher
+		// because the fsnotify already removes
+		if event.Name == cfg.Images {
+			w.ClearMap()
+			break
+		}
+
+		if !isFileSupported(event.Name) {
+			w.workqueue.Done(event)
+			break
+		}
+
+		// Remove the auto import label from the image
+		err := clearLabelFromAutoImport(ctx, client, event.Name)
+		if err != nil {
+			logrus.Errorf("Failed to clear auto import label for %s: %v", event.Name, err)
+		}
+		delete(w.filesMap, event.Name)
+		logrus.Debugf("Removed file from the image watcher controller: %s", event.Name)
+	}
+
+	return nil
+}
+
+func watchImages(ctx context.Context, cfg *config.Node) {
+	w, err := CreateWatcher()
+	if err != nil {
+		logrus.Errorf("Failed to create image watcher: %v", err)
+		return
+	}
+
+	logrus.Debugf("Image Watcher created")
+	defer w.watcher.Close()
+
+	if err := w.HandleWatch(filepath.Dir(cfg.Images)); err != nil {
+		logrus.Errorf("Failed to watch %s: %v", cfg.Images, err)
+		return
+	}
+
+	_, err = os.Stat(cfg.Images)
+	if err == nil {
+		if err := w.HandleWatch(cfg.Images); err != nil {
+			logrus.Errorf("Failed to watch %s: %v", cfg.Images, err)
+			return
+		}
+
+		if err := w.Populate(cfg.Images); err != nil {
+			logrus.Errorf("Failed to populate %s files: %v", cfg.Images, err)
+			return
+		}
+	} else if os.IsNotExist(err) {
+		logrus.Debugf("Image folder not created %s", cfg.Images)
+	} else {
+		logrus.Debugf("Unable to get info from %s: %v", cfg.Images, err)
+	}
+
+	go w.runWorkerForImages(ctx, cfg)
+
+	for {
+		select {
+		case event, ok := <-w.watcher.Events:
+			if !ok {
+				logrus.Info("Image watcher channel closed, shutting down workqueue and retrying in 5 seconds")
+				w.workqueue.ShutDown()
+				select {
+				case <-time.After(time.Second * 5):
+					go watchImages(ctx, cfg)
+					return
+				case <-ctx.Done():
+					return
+				}
+
+			}
+
+			// this part is to specify to only get events that were from /agent/images
+			if strings.Contains(event.Name, "/agent/images") {
+				w.workqueue.Add(event)
+			}
+
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				logrus.Info("Image watcher channel closed, shutting down workqueue and retrying in 5 seconds")
+				w.workqueue.ShutDown()
+				select {
+				case <-time.After(time.Second * 5):
+					go watchImages(ctx, cfg)
+					return
+				case <-ctx.Done():
+					return
+				}
+			}
+			logrus.Errorf("Image watcher received an error: %v", err)
+		}
+	}
+}

--- a/pkg/agent/containerd/watcher.go
+++ b/pkg/agent/containerd/watcher.go
@@ -324,7 +324,7 @@ func watchImages(ctx context.Context, cfg *config.Node) {
 
 			// this part is to specify to only get events that were from /agent/images
 			if strings.Contains(event.Name, "/agent/images") {
-				w.workqueue.AddAfter(event, 1*time.Second)
+				w.workqueue.AddAfter(event, 2*time.Second)
 			}
 
 		case err, ok := <-w.watcher.Errors:

--- a/pkg/agent/containerd/watcher.go
+++ b/pkg/agent/containerd/watcher.go
@@ -41,12 +41,8 @@ func CreateWatcher() (*Watcher, error) {
 }
 
 func isFileSupported(path string) bool {
-	if filepath.Ext(path) == ".txt" {
-		return true
-	}
-
-	for _, value := range tarfile.SupportedExtensions {
-		if filepath.Ext(path) == value {
+	for _, ext := range append(tarfile.SupportedExtensions, ".txt") {
+		if strings.HasSuffix(path, ext) {
 			return true
 		}
 	}

--- a/pkg/agent/containerd/watcher.go
+++ b/pkg/agent/containerd/watcher.go
@@ -155,12 +155,10 @@ func (w *Watcher) processImageEvent(ctx context.Context, key string, cfg *config
 
 		// we do not want to handle directorys, only files
 		if newStateFile.IsDir() {
-			w.workqueue.Done(key)
 			return nil
 		}
 
 		if !isFileSupported(event.Name) {
-			w.workqueue.Done(key)
 			return nil
 		}
 
@@ -175,8 +173,6 @@ func (w *Watcher) processImageEvent(ctx context.Context, key string, cfg *config
 			}
 			logrus.Infof("Imported images from %s in %s", event.Name, time.Since(start))
 		}
-
-		w.workqueue.Done(key)
 	}
 
 	if event.Has(fsnotify.Create) {
@@ -222,12 +218,10 @@ func (w *Watcher) processImageEvent(ctx context.Context, key string, cfg *config
 				}
 			}
 
-			w.workqueue.Done(key)
 			return nil
 		}
 
 		if !isFileSupported(event.Name) {
-			w.workqueue.Done(key)
 			return nil
 		}
 
@@ -239,7 +233,6 @@ func (w *Watcher) processImageEvent(ctx context.Context, key string, cfg *config
 			return err
 		}
 		logrus.Infof("Imported images from %s in %s", event.Name, time.Since(start))
-		w.workqueue.Done(key)
 	}
 
 	if event.Has(fsnotify.Remove) {
@@ -251,7 +244,6 @@ func (w *Watcher) processImageEvent(ctx context.Context, key string, cfg *config
 		}
 
 		if !isFileSupported(event.Name) {
-			w.workqueue.Done(key)
 			return nil
 		}
 
@@ -269,7 +261,6 @@ func (w *Watcher) processImageEvent(ctx context.Context, key string, cfg *config
 		}
 
 		if !isFileSupported(event.Name) {
-			w.workqueue.Done(key)
 			return nil
 		}
 

--- a/pkg/agent/containerd/watcher.go
+++ b/pkg/agent/containerd/watcher.go
@@ -247,11 +247,7 @@ func (w *Watcher) processImageEvent(ctx context.Context, event fsnotify.Event, c
 			return nil
 		}
 
-		// Remove the auto import label from the image
-		err := clearLabelFromAutoImport(ctx, client, event.Name)
-		if err != nil {
-			logrus.Errorf("Failed to clear auto import label for %s: %v", event.Name, err)
-		}
+		// delete the file from the file map
 		delete(w.filesMap, event.Name)
 		logrus.Debugf("Removed file from the image watcher controller: %s", event.Name)
 	}
@@ -269,12 +265,7 @@ func (w *Watcher) processImageEvent(ctx context.Context, event fsnotify.Event, c
 			return nil
 		}
 
-		// clear label because when a new file will be created because of the rename
-		// the create event will label the images with the name of the new file
-		err := clearLabelFromAutoImport(ctx, client, event.Name)
-		if err != nil {
-			logrus.Errorf("Failed to clear auto import label for %s: %v", event.Name, err)
-		}
+		// delete the file from the file map
 		delete(w.filesMap, event.Name)
 		logrus.Debugf("Removed file from the image watcher controller: %s", event.Name)
 	}

--- a/tests/e2e/autoimport/Vagrantfile
+++ b/tests/e2e/autoimport/Vagrantfile
@@ -1,8 +1,8 @@
 ENV['VAGRANT_NO_PARALLEL'] = 'no'
 NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
-  ["server-0", "agent-0"])
+  ["server-0"])
 NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
-  ['bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04'])
+  ['bento/ubuntu-24.04'])
 GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
 RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
 GOCOVER = (ENV['E2E_GOCOVER'] || "")

--- a/tests/e2e/autoimport/Vagrantfile
+++ b/tests/e2e/autoimport/Vagrantfile
@@ -1,0 +1,104 @@
+ENV['VAGRANT_NO_PARALLEL'] = 'no'
+NODE_ROLES = (ENV['E2E_NODE_ROLES'] ||
+  ["server-0", "agent-0"])
+NODE_BOXES = (ENV['E2E_NODE_BOXES'] ||
+  ['bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04', 'bento/ubuntu-24.04'])
+GITHUB_BRANCH = (ENV['E2E_GITHUB_BRANCH'] || "master")
+RELEASE_VERSION = (ENV['E2E_RELEASE_VERSION'] || "")
+GOCOVER = (ENV['E2E_GOCOVER'] || "")
+NODE_CPUS = (ENV['E2E_NODE_CPUS'] || 2).to_i
+NODE_MEMORY = (ENV['E2E_NODE_MEMORY'] || 2048).to_i
+# Virtualbox >= 6.1.28 require `/etc/vbox/network.conf` for expanded private networks 
+NETWORK_PREFIX = "10.10.10"
+install_type = ""
+
+def provision(vm, role, role_num, node_num)
+  vm.box = NODE_BOXES[node_num]
+  vm.hostname = role
+  # An expanded netmask is required to allow VM<-->VM communication, virtualbox defaults to /32
+  node_ip = "#{NETWORK_PREFIX}.#{100+node_num}"
+  vm.network "private_network", ip: node_ip, netmask: "255.255.255.0"
+
+  scripts_location = Dir.exist?("./scripts") ? "./scripts" : "../scripts"
+  vagrant_defaults = File.exist?("./vagrantdefaults.rb") ? "./vagrantdefaults.rb" : "../vagrantdefaults.rb"
+  load vagrant_defaults
+
+  defaultOSConfigure(vm)
+  addCoverageDir(vm, role, GOCOVER)
+  install_type = getInstallType(vm, RELEASE_VERSION, GITHUB_BRANCH)
+
+  if role.include?("server") && role_num == 0
+    dockerInstall(vm)
+
+    vm.provision 'k3s-primary-server', type: 'k3s', run: 'once' do |k3s|
+      k3s.args = "server "
+      k3s.config = <<~YAML
+        token: vagrant
+        node-external-ip: #{NETWORK_PREFIX}.100
+        flannel-iface: eth1
+        cluster-init: true
+      YAML
+      k3s.env = %W[K3S_KUBECONFIG_MODE=0644 #{install_type}]
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+  
+  elsif role.include?("server") && role_num != 0
+    vm.provision 'k3s-secondary-server', type: 'k3s', run: 'once' do |k3s|
+      k3s.args = "server"
+      k3s.config = <<~YAML
+        server: "https://#{NETWORK_PREFIX}.100:6443"
+        token: vagrant
+        node-external-ip: #{node_ip}
+        flannel-iface: eth1
+      YAML
+      k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+  end
+  
+  if role.include?("agent")
+    vm.provision 'k3s-agent', type: 'k3s', run: 'once' do |k3s|
+      k3s.args = "agent"
+      k3s.config = <<~YAML
+        server: "https://#{NETWORK_PREFIX}.100:6443"
+        token: vagrant
+        node-external-ip: #{node_ip}
+        flannel-iface: eth1
+      YAML
+      k3s.env = %W[K3S_KUBECONFIG_MODE=0644 #{install_type}]
+      k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+    end
+  end
+  if vm.box.to_s.include?("microos")
+    vm.provision 'k3s-reload', type: 'reload', run: 'once'
+  end
+end
+
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = ["vagrant-k3s", "vagrant-reload"]
+  # Default provider is libvirt, virtualbox is only provided as a backup
+  config.vm.provider "libvirt" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+    # We replicate the default prefix, but add a timestamp to enable parallel runs and cleanup of old VMs
+    v.default_prefix = File.basename(Dir.getwd) + "_" + Time.now.to_i.to_s + "_"
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.cpus = NODE_CPUS
+    v.memory = NODE_MEMORY
+  end
+  
+  if NODE_ROLES.kind_of?(String)
+    NODE_ROLES = NODE_ROLES.split(" ", -1)
+  end
+  if NODE_BOXES.kind_of?(String)
+    NODE_BOXES = NODE_BOXES.split(" ", -1)
+  end
+
+  NODE_ROLES.each_with_index do |role, i|
+    role_num = role.split("-", -1).pop.to_i
+    config.vm.define role do |node|
+      provision(node.vm, role, role_num, i)
+    end
+  end
+end

--- a/tests/e2e/autoimport/autoimport_test.go
+++ b/tests/e2e/autoimport/autoimport_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
 
 			Eventually(func(g Gomega) {
-				cmd := `k3s ctr images list | grep 'k3s'`
+				cmd := `k3s ctr images list | grep library/busybox`
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=bb.txt"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
@@ -165,8 +165,40 @@ var _ = Describe("Verify Create", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
 
 			Eventually(func(g Gomega) {
-				cmd := `k3s ctr images list | grep 'library/mysql'`
+				cmd := `k3s ctr images list | grep library/mysql`
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=mysql.txt"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
+			}, "620s", "5s").Should(Succeed())
+		})
+
+		It("Restarts normally", func() {
+			errRestart := e2e.RestartCluster(append(serverNodeNames, agentNodeNames...))
+			Expect(errRestart).NotTo(HaveOccurred(), "Restart Nodes not happened correctly")
+
+			Eventually(func(g Gomega) {
+				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, node := range nodes {
+					g.Expect(node.Status).Should(Equal("Ready"))
+				}
+				pods, _ := e2e.ParsePods(kubeConfigFile, false)
+				count := e2e.CountOfStringInSlice("test-daemonset", pods)
+				g.Expect(len(nodes)).Should((Equal(count)), "Daemonset pod count does not match node count")
+				podsRunningAr := 0
+				for _, pod := range pods {
+					if strings.Contains(pod.Name, "test-daemonset") && pod.Status == "Running" && pod.Ready == "1/1" {
+						podsRunningAr++
+					}
+				}
+				g.Expect(len(nodes)).Should((Equal(podsRunningAr)), "Daemonset pods are not running after the restart")
+			}, "620s", "5s").Should(Succeed())
+		})
+
+		It("Verify pinned images", func() {
+			Eventually(func(g Gomega) {
+				cmd := `k3s ctr images list | grep library/busybox`
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=bb.txt"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())

--- a/tests/e2e/autoimport/autoimport_test.go
+++ b/tests/e2e/autoimport/autoimport_test.go
@@ -91,12 +91,10 @@ var _ = Describe("Verify Create", Ordered, func() {
 		})
 
 		It("Create file for auto import and search in the image store", func() {
-			fmt.Printf("\nCreate the file with hello world image\n")
 			cmd := `echo 'docker.io/library/hello-world:latest' | sudo tee /var/lib/rancher/k3s/agent/images/testautoimport.txt`
 			_, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
 			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
 
-			fmt.Printf("\nSearch for image in image store\n")
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep 'library/hello-world'`
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("library/hello-world"))
@@ -108,6 +106,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			cmd := `mv /var/lib/rancher/k3s/agent/images/testautoimport.txt /var/lib/rancher/k3s/agent/images/testautoimportrename.txt`
 			_, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
 			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
+
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep 'library/hello-world'`
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).ShouldNot(ContainSubstring("io.cattle.k3s.import=testautoimport.txt"))

--- a/tests/e2e/autoimport/autoimport_test.go
+++ b/tests/e2e/autoimport/autoimport_test.go
@@ -97,20 +97,18 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep library/redis`
-				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=testautoimport.txt"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
 		})
 
-		It("Change name for the file and see if the label is removed", func() {
+		It("Change name for the file and see if the label is still pinned", func() {
 			cmd := `mv /var/lib/rancher/k3s/agent/images/testautoimport.txt /var/lib/rancher/k3s/agent/images/testautoimportrename.txt`
 			_, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
 			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
 
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep library/redis`
-				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=testautoimportrename.txt"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
@@ -123,7 +121,6 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep library/busybox`
-				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=bb.txt"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
@@ -134,7 +131,6 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep library/busybox`
-				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).ShouldNot(ContainSubstring("io.cattle.k3s.import=bb.txt"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
@@ -145,13 +141,12 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep library/busybox`
-				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=bb.txt"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
 		})
 
-		It("Move the folder, add another image and then see if the image was added", func() {
+		It("Move the folder, add a image and then see if the image is going to be pinned", func() {
 			cmd := `mv /var/lib/rancher/k3s/agent/images /var/lib/rancher/k3s/agent/test`
 			_, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
 			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
@@ -166,7 +161,6 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep library/mysql`
-				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=mysql.txt"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
@@ -188,7 +182,6 @@ var _ = Describe("Verify Create", Ordered, func() {
 		It("Verify bb.txt image and see if are pinned", func() {
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep library/busybox`
-				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=bb.txt"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
@@ -201,7 +194,6 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep library/busybox`
-				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).ShouldNot(ContainSubstring("io.cattle.k3s.import=bb.txt"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
@@ -223,7 +215,6 @@ var _ = Describe("Verify Create", Ordered, func() {
 		It("Verify if bb.txt image is unpinned", func() {
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep library/busybox`
-				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).ShouldNot(ContainSubstring("io.cattle.k3s.import=bb.txt"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).ShouldNot(ContainSubstring("io.cattle.k3s.pinned=pinned"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).ShouldNot(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())

--- a/tests/e2e/autoimport/autoimport_test.go
+++ b/tests/e2e/autoimport/autoimport_test.go
@@ -1,0 +1,153 @@
+package autoimport
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/k3s-io/k3s/tests/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Valid nodeOS:
+// bento/ubuntu-24.04, opensuse/Leap-15.6.x86_64
+// eurolinux-vagrant/rocky-8, eurolinux-vagrant/rocky-9,
+var nodeOS = flag.String("nodeOS", "bento/ubuntu-24.04", "VM operating system")
+var serverCount = flag.Int("serverCount", 1, "number of server nodes")
+var agentCount = flag.Int("agentCount", 0, "number of agent nodes")
+var ci = flag.Bool("ci", false, "running on CI")
+var local = flag.Bool("local", false, "deploy a locally built K3s binary")
+
+// Environment Variables Info:
+// E2E_RELEASE_VERSION=v1.23.1+k3s2 (default: latest commit from master)
+// E2E_REGISTRY: true/false (default: false)
+
+func Test_E2EAutoImport(t *testing.T) {
+	RegisterFailHandler(Fail)
+	flag.Parse()
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+	RunSpecs(t, "Create Cluster Test Suite", suiteConfig, reporterConfig)
+}
+
+var (
+	kubeConfigFile  string
+	serverNodeNames []string
+	agentNodeNames  []string
+)
+
+var _ = ReportAfterEach(e2e.GenReport)
+
+var _ = Describe("Verify Create", Ordered, func() {
+	Context("Cluster :", func() {
+		It("Starts up with no issues", func() {
+			var err error
+			if *local {
+				serverNodeNames, agentNodeNames, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
+			} else {
+				serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
+			}
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
+			fmt.Println("CLUSTER CONFIG")
+			fmt.Println("OS:", *nodeOS)
+			fmt.Println("Server Nodes:", serverNodeNames)
+			fmt.Println("Agent Nodes:", agentNodeNames)
+			kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Checks Node and Pod Status", func() {
+			fmt.Printf("\nFetching node status\n")
+			Eventually(func(g Gomega) {
+				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, node := range nodes {
+					g.Expect(node.Status).Should(Equal("Ready"))
+				}
+			}, "620s", "5s").Should(Succeed())
+			_, _ = e2e.ParseNodes(kubeConfigFile, true)
+
+			fmt.Printf("\nFetching Pods status\n")
+			Eventually(func(g Gomega) {
+				pods, err := e2e.ParsePods(kubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, pod := range pods {
+					if strings.Contains(pod.Name, "helm-install") {
+						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
+					} else {
+						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
+					}
+				}
+			}, "620s", "5s").Should(Succeed())
+			_, _ = e2e.ParsePods(kubeConfigFile, true)
+		})
+
+		It("Create a folder in agent/images", func() {
+			cmd := `mkdir /var/lib/rancher/k3s/agent/images`
+			_, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
+		})
+
+		It("Create file for auto import and search in the image store", func() {
+			fmt.Printf("\nCreate the file with hello world image\n")
+			cmd := `echo 'docker.io/library/hello-world:latest' | sudo tee /var/lib/rancher/k3s/agent/images/testautoimport.txt`
+			_, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
+
+			fmt.Printf("\nSearch for image in image store\n")
+			Eventually(func(g Gomega) {
+				cmd := `k3s ctr images list | grep 'library/hello-world'`
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("library/hello-world"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=testautoimport.txt"))
+			}, "620s", "5s").Should(Succeed())
+		})
+
+		It("Change name for the file and see if the label is removed", func() {
+			cmd := `mv /var/lib/rancher/k3s/agent/images/testautoimport.txt /var/lib/rancher/k3s/agent/images/testautoimportrename.txt`
+			_, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
+			Eventually(func(g Gomega) {
+				cmd := `k3s ctr images list | grep 'library/hello-world'`
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).ShouldNot(ContainSubstring("io.cattle.k3s.import=testautoimport.txt"))
+			}, "620s", "5s").Should(Succeed())
+		})
+
+		It("Move the folder, add another image and then see if the image was added", func() {
+			cmd := `mv /var/lib/rancher/k3s/agent/images /var/lib/rancher/k3s/agent/test`
+			_, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
+
+			cmd = `echo 'docker.io/library/mysql:latest' | sudo tee /var/lib/rancher/k3s/agent/test/mysql.txt`
+			_, err = e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
+
+			cmd = `mv /var/lib/rancher/k3s/agent/test /var/lib/rancher/k3s/agent/images`
+			_, err = e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
+
+			Eventually(func(g Gomega) {
+				cmd := `k3s ctr images list | grep 'library/mysql'`
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=mysql.txt"))
+			}, "620s", "5s").Should(Succeed())
+		})
+
+	})
+})
+
+var failed bool
+var _ = AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
+var _ = AfterSuite(func() {
+
+	if !failed {
+		Expect(e2e.GetCoverageReport(append(serverNodeNames, agentNodeNames...))).To(Succeed())
+	}
+	if !failed || *ci {
+		Expect(e2e.DestroyCluster()).To(Succeed())
+		Expect(os.Remove(kubeConfigFile)).To(Succeed())
+	}
+})

--- a/tests/e2e/autoimport/autoimport_test.go
+++ b/tests/e2e/autoimport/autoimport_test.go
@@ -195,12 +195,50 @@ var _ = Describe("Verify Create", Ordered, func() {
 			}, "620s", "5s").Should(Succeed())
 		})
 
-		It("Verify pinned images", func() {
+		It("Verify bb.txt image and see if are pinned", func() {
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep library/busybox`
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=bb.txt"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
+			}, "620s", "5s").Should(Succeed())
+		})
+
+		It("Removes bb.txt file", func() {
+			cmd := `rm /var/lib/rancher/k3s/agent/images/bb.txt`
+			_, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
+		})
+
+		It("Restarts normally", func() {
+			errRestart := e2e.RestartCluster(append(serverNodeNames, agentNodeNames...))
+			Expect(errRestart).NotTo(HaveOccurred(), "Restart Nodes not happened correctly")
+
+			Eventually(func(g Gomega) {
+				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, node := range nodes {
+					g.Expect(node.Status).Should(Equal("Ready"))
+				}
+				pods, _ := e2e.ParsePods(kubeConfigFile, false)
+				count := e2e.CountOfStringInSlice("test-daemonset", pods)
+				g.Expect(len(nodes)).Should((Equal(count)), "Daemonset pod count does not match node count")
+				podsRunningAr := 0
+				for _, pod := range pods {
+					if strings.Contains(pod.Name, "test-daemonset") && pod.Status == "Running" && pod.Ready == "1/1" {
+						podsRunningAr++
+					}
+				}
+				g.Expect(len(nodes)).Should((Equal(podsRunningAr)), "Daemonset pods are not running after the restart")
+			}, "620s", "5s").Should(Succeed())
+		})
+
+		It("Verify if bb.txt image is unpinned", func() {
+			Eventually(func(g Gomega) {
+				cmd := `k3s ctr images list | grep library/busybox`
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).ShouldNot(ContainSubstring("io.cattle.k3s.import=bb.txt"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).ShouldNot(ContainSubstring("io.cattle.k3s.pinned=pinned"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).ShouldNot(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
 		})
 

--- a/tests/e2e/autoimport/autoimport_test.go
+++ b/tests/e2e/autoimport/autoimport_test.go
@@ -97,8 +97,9 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep 'library/hello-world'`
-				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("library/hello-world"))
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=testautoimport.txt"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
 		})
 
@@ -110,6 +111,8 @@ var _ = Describe("Verify Create", Ordered, func() {
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep 'library/hello-world'`
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=testautoimportrename.txt"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
 		})
 
@@ -121,6 +124,8 @@ var _ = Describe("Verify Create", Ordered, func() {
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep 'k3s'`
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=bb.txt"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
 
 			cmd = `rm /var/lib/rancher/k3s/agent/images/bb.txt`
@@ -130,6 +135,8 @@ var _ = Describe("Verify Create", Ordered, func() {
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep 'k3s'`
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).ShouldNot(ContainSubstring("io.cattle.k3s.import=bb.txt"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
 
 			cmd = `echo docker.io/library/busybox:latest | sudo tee /var/lib/rancher/k3s/agent/images/bb.txt`
@@ -138,7 +145,9 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep 'k3s'`
-				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).ShouldNot(ContainSubstring("io.cattle.k3s.import=bb.txt"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=bb.txt"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
 		})
 
@@ -158,6 +167,8 @@ var _ = Describe("Verify Create", Ordered, func() {
 			Eventually(func(g Gomega) {
 				cmd := `k3s ctr images list | grep 'library/mysql'`
 				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.import=mysql.txt"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cattle.k3s.pinned=pinned"))
+				g.Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Should(ContainSubstring("io.cri-containerd.pinned=pinned"))
 			}, "620s", "5s").Should(Succeed())
 		})
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- ADR
- Auto import images form .txt files and tar files

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

- New Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- run a k3s server
```shell
k3s server
```
- create the images folder
```shell
mkdir /var/lib/rancher/k3s/agent/images
```

- create a .txt file and add a docker.io image path to the .txt file
```shell
docker.io/library/mysql:latest
```

- move the file to /var/lib/rancher/k3s/agent/images
```shell
cp example.txt /var/lib/rancher/k3s/agent/images
```

- then see if the file was imported in the containerd image store
```shell
k3s ctr images list | grep "mysql"
```

- you can also change the file inside var/lib/rancher/k3s/agent/images
```shell
nano /var/lib/rancher/k3s/agent/images/example.txt
```

- then you can add 
```shell
docker.io/library/redis:latest
```

- the controller will see the change and then import the redis image
```shell
k3s ctr images list | grep "redis"
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- https://github.com/k3s-io/k3s/issues/9759
- https://github.com/k3s-io/k3s/issues/8084
#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users can now auto import images to containerd by just throwing the image in the agent/images folder while k3s is running
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
