### PR TITLE
[release-1.28] Bump containerd to v1.7.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.11.7
 	github.com/Mirantis/cri-dockerd => github.com/k3s-io/cri-dockerd v0.3.12-k3s1.28 // k3s/release-1.28
 	github.com/cloudnativelabs/kube-router/v2 => github.com/k3s-io/kube-router/v2 v2.2.1
-	github.com/containerd/containerd => github.com/k3s-io/containerd v1.7.21-k3s2.28
+	github.com/containerd/containerd => github.com/k3s-io/containerd v1.7.22-k3s1.28
 	github.com/containerd/imgcrypt => github.com/containerd/imgcrypt v1.1.11
 	github.com/distribution/reference => github.com/distribution/reference v0.5.0
 	github.com/docker/distribution => github.com/docker/distribution v2.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -980,8 +980,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k3s-io/containerd v1.7.21-k3s2.28 h1:8/n+LEaVm2ui1YbogAnv/c8l9T95wO49qpF0qKej0wQ=
-github.com/k3s-io/containerd v1.7.21-k3s2.28/go.mod h1:T9perze1nIMl5JzddImIgsCEDaM0i8nAfnm+U48DmJw=
+github.com/k3s-io/containerd v1.7.22-k3s1.28 h1:xmjGz0RakOL/C7z3FM53ke3mHkXLCl8rInGpP9EfNyI=
+github.com/k3s-io/containerd v1.7.22-k3s1.28/go.mod h1:T9perze1nIMl5JzddImIgsCEDaM0i8nAfnm+U48DmJw=
 github.com/k3s-io/cri-dockerd v0.3.12-k3s1.28 h1:6M8Gpo/CC3AQKZ58Hodz9qZZhvyC2wHv0s45ja9HB9o=
 github.com/k3s-io/cri-dockerd v0.3.12-k3s1.28/go.mod h1:YWXI6VrFgqt6VTgvSPvTKYFE+mL37s7jUFufY18JcaE=
 github.com/k3s-io/cri-tools v1.26.0-rc.0-k3s1 h1:yWVy9pS0T1BWBMZBPRy2Q29gaLmaGknQHSnx+HStrVM=


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to v1.7.22

#### Types of Changes ####

version bump

#### Verification ####

check version

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/11071
#### User-Facing Change ####
```release-note
```

#### Further Comments ####