### PR TITLE
[Release 1.29] Add the nvidia runtime cdi

### DIFF
--- a/pkg/agent/containerd/runtimes.go
+++ b/pkg/agent/containerd/runtimes.go
@@ -71,6 +71,10 @@ func findNvidiaContainerRuntimes(foundRuntimes runtimeConfigs) {
 			RuntimeType: "io.containerd.runc.v2",
 			BinaryName:  "nvidia-container-runtime-experimental",
 		},
+                "nvidia-cdi": {
+                        RuntimeType: "io.containerd.runc.v2",
+                        BinaryName:  "nvidia-container-runtime.cdi",
+                },
 	}
 
 	searchForRuntimes(potentialRuntimes, foundRuntimes)


### PR DESCRIPTION
Backport: https://github.com/k3s-io/k3s/pull/11065
Issue: https://github.com/k3s-io/k3s/issues/11090