### PR TITLE
Force creation of CNI Symlink

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -292,9 +292,9 @@ func extract(dataDir string) (string, error) {
 	if err := os.MkdirAll(cniPath, 0755); err != nil {
 		return "", err
 	}
-	if err := os.Symlink(cniBin, filepath.Join(cniPath, "cni")); err != nil {
-		return "", err
-	}
+	cniSymlink := filepath.Join(cniPath, "cni")
+	os.RemoveAll(cniSymlink)
+	os.Symlink(cniBin, cniSymlink)
 
 	// Find symlinks that point to the cni multicall binary, and clone them in the stable CNI bin dir.
 	ents, err := os.ReadDir(filepath.Join(dir, "bin"))
@@ -304,9 +304,9 @@ func extract(dataDir string) (string, error) {
 	for _, ent := range ents {
 		if info, err := ent.Info(); err == nil && info.Mode()&fs.ModeSymlink != 0 {
 			if target, err := os.Readlink(filepath.Join(dir, "bin", ent.Name())); err == nil && target == "cni" {
-				if err := os.Symlink(cniBin, filepath.Join(cniPath, ent.Name())); err != nil {
-					return "", err
-				}
+				entSymlink := filepath.Join(cniPath, ent.Name())
+				os.RemoveAll(entSymlink)
+				os.Symlink(cniBin, entSymlink)
 			}
 		}
 	}


### PR DESCRIPTION
The path is generated according to the data packet hash
The symbolic link is abnormal when it is started after the build (new hash).
```txt
INFO[0000] Acquiring lock file /var/lib/rancher/k3s/data/.lock 
INFO[0000] Preparing data dir /var/lib/rancher/k3s/data/1267d53c640fd1e129004e75aead56683efc73b6a8f1b3dcff655119e1341690 
FATA[0002] extracting data: symlink /var/lib/rancher/k3s/data/1267d53c640fd1e129004e75aead56683efc73b6a8f1b3dcff655119e1341690/bin/cni /var/lib/rancher/k3s/data/cni/bandwidth: file exists 
```