### PR TITLE
Reduce the number of GH api request for E2E nightly

### DIFF
--- a/tests/e2e/scripts/latest_commit.sh
+++ b/tests/e2e/scripts/latest_commit.sh
@@ -4,8 +4,6 @@ branch=$1
 output_file=$2
 # Grabs the last 10 commit SHA's from the given branch, then purges any commits that do not have a passing CI build
 iterations=0
-commits_str=$(curl -s -H 'Accept: application/vnd.github.v3+json' "https://api.github.com/repos/k3s-io/k3s/commits?per_page=10&sha=$branch" | jq -j -r '.[] | .sha, " "')
-read -a commits <<< "$commits_str"
 
 # The VMs take time on startup to hit aws, wait loop until we can
 while ! curl -s --fail https://k3s-ci-builds.s3.amazonaws.com > /dev/null; do
@@ -16,6 +14,28 @@ while ! curl -s --fail https://k3s-ci-builds.s3.amazonaws.com > /dev/null; do
     fi
     sleep 1
 done
+
+if [ -n "$GH_TOKEN" ]; then
+    response=$(curl -s -H "Authorization: token $GH_TOKEN" -H 'Accept: application/vnd.github.v3+json' "https://api.github.com/repos/k3s-io/k3s/commits?per_page=10&sha=$branch")
+else
+    response=$(curl -s -H 'Accept: application/vnd.github.v3+json' "https://api.github.com/repos/k3s-io/k3s/commits?per_page=10&sha=$branch")
+fi
+type=$(echo "$response" | jq -r type)
+
+# Verify if the response is an array with the k3s commits
+if [[ $type == "object" ]]; then
+    message=$(echo "$response" | jq -r .message)
+    if [[ $message == "API rate limit exceeded for "* ]]; then
+        echo "Github API rate limit exceeded"
+	exit 1
+    fi
+    echo "Github API returned a non-expected response ${message}"
+    exit 1
+elif [[ $type == "array" ]]; then
+    commits_str=$(echo "$response" | jq -j -r '.[] | .sha, " "')
+fi
+
+read -a commits <<< "$commits_str"
 
 for commit in "${commits[@]}"; do
     if curl -s --fail https://k3s-ci-builds.s3.amazonaws.com/k3s-$commit.sha256sum > /dev/null; then

--- a/tests/e2e/scripts/run_tests.sh
+++ b/tests/e2e/scripts/run_tests.sh
@@ -6,6 +6,26 @@ agentcount=${3:-1}
 db=${4:-"etcd"}
 hardened=${5:-""}
 
+cleanup() {
+  for net in $(virsh net-list --all | tail -n +2 | tr -s ' ' | cut -d ' ' -f2 | grep -v default); do
+    virsh net-destroy "$net"
+    virsh net-undefine "$net"
+  done
+
+  for domain in $(virsh list --all | tail -n +2 | tr -s ' ' | cut -d ' ' -f3); do
+     virsh destroy "$domain"
+    virsh undefine "$domain" --remove-all-storage
+  done
+
+  for vm in $(vagrant global-status  |tr -s ' '|tail +3 |grep "/" |cut -d ' '  -f5); do
+    cd $vm
+    vagrant destroy -f
+    cd ..
+  done
+  # Prune Vagrant global status
+  vagrant global-status --prune
+}
+
 E2E_EXTERNAL_DB=$db && export E2E_EXTERNAL_DB
 E2E_REGISTRY=true && export E2E_REGISTRY
 
@@ -18,7 +38,10 @@ OS=$(echo "$nodeOS"|cut -d'/' -f2)
 echo "$OS"
 
 vagrant global-status | awk '/running/'|cut -c1-7| xargs -r -d '\n' -n 1 -- vagrant destroy -f
-E2E_RELEASE_CHANNEL="commit" && export E2E_RELEASE_CHANNEL
+
+# To reduce GH API requsts, we grab the latest commit on the host and pass it to the tests
+./scripts/latest_commit.sh master latest_commit.txt
+E2E_RELEASE_VERSION=$(cat latest_commit.txt) && export E2E_RELEASE_VERSION
 
 echo 'RUNNING DUALSTACK TEST'
 E2E_HARDENED="$hardened" /usr/local/go/bin/go test -v dualstack/dualstack_test.go -nodeOS="$nodeOS" -serverCount=1 -agentCount=1  -timeout=30m -json -ci |tee  k3s_"$OS".log
@@ -44,6 +67,8 @@ echo 'RUNNING SNAPSHOT AND RESTORE TEST'
 echo 'RUNNING ROTATE CUSTOM CA TEST'
 /usr/local/go/bin/go test -v rotateca/rotateca_test.go -nodeOS="$nodeOS" -serverCount=1 -agentCount=1 -timeout=30m -json -ci | tee -a k3s_"$OS".log
 
+# For upgrade test we use the release channel install as the starting point
+unset E2E_RELEASE_VERSION
 E2E_RELEASE_CHANNEL="latest" && export E2E_RELEASE_CHANNEL
 echo 'RUNNING CLUSTER UPGRADE TEST'
 E2E_REGISTRY=true /usr/local/go/bin/go test -v upgradecluster/upgradecluster_test.go -nodeOS="$nodeOS" -serverCount=$((servercount)) -agentCount=$((agentcount)) -timeout=1h -json -ci | tee -a k3s_"$OS".log


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Nightly E2E suite is seeing failures due to limits on GH api calls for the "latest commit". This PR attempts to address this in several ways:
- Allow E2E_RELEASE_VERSION=<commit_SHA> to install a specific commit SHA
- For the nightly test suite. run the `latest_commit.sh` script before all the tests, then pass that commit into each test (reduces API calls from I nodes x J tests to a single API call)
- Allow for an optional authenticated commits request via GH_TOKEN
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
E2E, CI
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Running on the nightly nodes by hand. 
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
