### PR TITLE
Add nonroot-devices flag to agent CLI

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -603,6 +603,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	nodeConfig.Containerd.Log = filepath.Join(envInfo.DataDir, "agent", "containerd", "containerd.log")
 	nodeConfig.Containerd.Registry = filepath.Join(envInfo.DataDir, "agent", "etc", "containerd", "certs.d")
 	nodeConfig.Containerd.NoDefault = envInfo.ContainerdNoDefault
+	nodeConfig.Containerd.NonrootDevices = envInfo.ContainerdNonrootDevices
 	nodeConfig.Containerd.Debug = envInfo.Debug
 	applyContainerdStateAndAddress(nodeConfig)
 	applyCRIDockerdAddress(nodeConfig)

--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -73,6 +73,7 @@ func SetupContainerdConfig(cfg *config.Node) error {
 		SystemdCgroup:         cfg.AgentConfig.Systemd,
 		IsRunningInUserNS:     isRunningInUserNS,
 		EnableUnprivileged:    kernel.CheckKernelVersion(4, 11, 0),
+		NonrootDevices:        cfg.Containerd.NonrootDevices,
 		PrivateRegistryConfig: cfg.AgentConfig.Registry,
 		ExtraRuntimes:         extraRuntimes,
 		Program:               version.Program,

--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -23,6 +23,7 @@ type ContainerdConfig struct {
 	IsRunningInUserNS     bool
 	EnableUnprivileged    bool
 	NoDefaultEndpoint     bool
+	NonrootDevices        bool
 	PrivateRegistryConfig *registries.Registry
 	ExtraRuntimes         map[string]ContainerdRuntimeConfig
 	Program               string

--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -19,6 +19,7 @@ version = 2
   enable_selinux = {{ .NodeConfig.SELinux }}
   enable_unprivileged_ports = {{ .EnableUnprivileged }}
   enable_unprivileged_icmp = {{ .EnableUnprivileged }}
+  device_ownership_from_security_context = {{ .NonrootDevices }}
 
 {{- if .DisableCgroup}}
   disable_cgroup = true

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -30,6 +30,7 @@ type Agent struct {
 	Snapshotter              string
 	Docker                   bool
 	ContainerdNoDefault      bool
+	ContainerdNonrootDevices bool
 	ContainerRuntimeEndpoint string
 	DefaultRuntime           string
 	ImageServiceEndpoint     string
@@ -240,6 +241,11 @@ var (
 		Usage:       "(agent/containerd) Disables containerd's fallback default registry endpoint when a mirror is configured for that registry",
 		Destination: &AgentConfig.ContainerdNoDefault,
 	}
+	NonrootDevicesFlag = &cli.BoolFlag{
+		Name:        "nonroot-devices",
+		Usage:       "(agent/containerd) Allows non-root pods to access devices by setting device_ownership_from_security_context=true in the containerd CRI config",
+		Destination: &AgentConfig.ContainerdNonrootDevices,
+	}
 	EnablePProfFlag = &cli.BoolFlag{
 		Name:        "enable-pprof",
 		Usage:       "(experimental) Enable pprof endpoint on supervisor port",
@@ -303,6 +309,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			SnapshotterFlag,
 			PrivateRegistryFlag,
 			DisableDefaultRegistryEndpointFlag,
+			NonrootDevicesFlag,
 			AirgapExtraRegistryFlag,
 			NodeIPFlag,
 			BindAddressFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -527,6 +527,7 @@ var ServerFlags = []cli.Flag{
 	DefaultRuntimeFlag,
 	ImageServiceEndpointFlag,
 	DisableDefaultRegistryEndpointFlag,
+	NonrootDevicesFlag,
 	PauseImageFlag,
 	SnapshotterFlag,
 	PrivateRegistryFlag,

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -78,19 +78,20 @@ type EtcdS3 struct {
 }
 
 type Containerd struct {
-	Address       string
-	Log           string
-	Root          string
-	State         string
-	Config        string
-	Opt           string
-	Template      string
-	BlockIOConfig string
-	RDTConfig     string
-	Registry      string
-	NoDefault     bool
-	SELinux       bool
-	Debug         bool
+	Address        string
+	Log            string
+	Root           string
+	State          string
+	Config         string
+	Opt            string
+	Template       string
+	BlockIOConfig  string
+	RDTConfig      string
+	Registry       string
+	NoDefault      bool
+	NonrootDevices bool
+	SELinux        bool
+	Debug          bool
 }
 
 type CRIDockerd struct {


### PR DESCRIPTION
#### Proposed Changes ####

Add new flag that is passed through to the `device_ownership_from_security_context` parameter in the containerd CRI config. This is not possible to change without providing a complete custom containerd.toml template so we should add a flag for it.

#### Types of Changes ####

enhancement

#### Verification ####

* Set flag, verify that param is set in containerd config.
* Verify that feature documented upstream at https://kubernetes.io/blog/2021/11/09/non-root-containers-and-devices/#see-non-root-containers-using-devices-after-the-fix works when this param is set.

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/11168

#### User-Facing Change ####
```release-note
`device_ownership_from_security_context` can now be enabled in the containerd CRI config by setting the `--nonroot-devices` flag or config key.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
