### PR TITLE
Set kine EmulatedETCDVersion from embedded etcd version

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/signals"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	etcdversion "go.etcd.io/etcd/api/v3/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	kubeapiserverflag "k8s.io/component-base/cli/flag"
@@ -147,6 +148,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.ExtraSchedulerAPIArgs = cfg.ExtraSchedulerArgs
 	serverConfig.ControlConfig.ClusterDomain = cfg.ClusterDomain
 	serverConfig.ControlConfig.Datastore.NotifyInterval = 5 * time.Second
+	serverConfig.ControlConfig.Datastore.EmulatedETCDVersion = etcdversion.Version
 	serverConfig.ControlConfig.Datastore.Endpoint = cfg.DatastoreEndpoint
 	serverConfig.ControlConfig.Datastore.BackendTLSConfig.CAFile = cfg.DatastoreCAFile
 	serverConfig.ControlConfig.Datastore.BackendTLSConfig.CertFile = cfg.DatastoreCertFile

--- a/scripts/build
+++ b/scripts/build
@@ -52,7 +52,7 @@ VERSIONFLAGS="
     -X ${PKG_CRI_DOCKERD}/cmd/version.GitCommit=HEAD
     -X ${PKG_CRI_DOCKERD}/cmd/version.BuildTime=${buildDate}
 
-    -X ${PKG_ETCD}/api/version.GitSHA=HEAD
+    -X ${PKG_ETCD}/api/v3/version.GitSHA=HEAD
 "
 if [ -n "${DEBUG}" ]; then
   GCFLAGS="-N -l"


### PR DESCRIPTION
#### Proposed Changes ####

Set kine EmulatedETCDVersion from embedded etcd version

Fixes issue where kine's reported etcd version was left unset.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue for log messages to check

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/11220

#### User-Facing Change ####
```release-note

```

#### Further Comments ####