### PR TITLE
Fix MustFindString returning override flags on external CLI commands

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -27,6 +28,7 @@ import (
 )
 
 var criDefaultConfigPath = "/etc/crictl.yaml"
+var externalCLIActions = []string{"crictl", "ctr", "kubectl"}
 
 // main entrypoint for the k3s multicall binary
 func main() {
@@ -105,7 +107,7 @@ func findDebug(args []string) bool {
 	if debug {
 		return debug
 	}
-	debug, _ = strconv.ParseBool(configfilearg.MustFindString(args, "debug"))
+	debug, _ = strconv.ParseBool(configfilearg.MustFindString(args, "debug", externalCLIActions...))
 	return debug
 }
 
@@ -125,7 +127,7 @@ func findDataDir(args []string) string {
 	if dataDir != "" {
 		return dataDir
 	}
-	dataDir = configfilearg.MustFindString(args, "data-dir")
+	dataDir = configfilearg.MustFindString(args, "data-dir", externalCLIActions...)
 	if d, err := datadir.Resolve(dataDir); err == nil {
 		dataDir = d
 	} else {
@@ -143,7 +145,7 @@ func findPreferBundledBin(args []string) bool {
 	fs.SetOutput(io.Discard)
 	fs.BoolVar(&preferBundledBin, "prefer-bundled-bin", false, "Prefer bundled binaries")
 
-	preferRes := configfilearg.MustFindString(args, "prefer-bundled-bin")
+	preferRes := configfilearg.MustFindString(args, "prefer-bundled-bin", externalCLIActions...)
 	if preferRes != "" {
 		preferBundledBin, _ = strconv.ParseBool(preferRes)
 	}
@@ -158,8 +160,7 @@ func findPreferBundledBin(args []string) bool {
 // it returns false so that standard CLI wrapping can occur.
 func runCLIs(dataDir string) bool {
 	progName := filepath.Base(os.Args[0])
-	switch progName {
-	case "crictl", "ctr", "kubectl":
+	if slices.Contains(externalCLIActions, progName) {
 		if err := externalCLI(progName, dataDir, os.Args[1:]); err != nil && !errors.Is(err, context.Canceled) {
 			logrus.Fatal(err)
 		}

--- a/pkg/configfilearg/defaultparser.go
+++ b/pkg/configfilearg/defaultparser.go
@@ -1,6 +1,8 @@
 package configfilearg
 
 import (
+	"slices"
+
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/sirupsen/logrus"
@@ -23,15 +25,31 @@ func MustParse(args []string) []string {
 	return result
 }
 
-func MustFindString(args []string, target string) string {
+func MustFindString(args []string, target string, commandsWithoutOverride ...string) string {
+	overrideFlags := []string{"--help", "-h", "--version", "-v"}
+	// Check to see if the command or subcommand being executed supports override flags.
+	// Some subcommands such as `k3s ctr` or just `ctr` need to be extracted out even to
+	// provide version or help text, and we cannot short-circuit loading the config file. For
+	// these commands, treat failure to load the config file as a warning instead of a fatal.
+	if len(args) > 0 && args[0] == version.Program {
+		args = args[1:]
+	}
+	if len(args) > 0 && slices.Contains(commandsWithoutOverride, args[0]) {
+		overrideFlags = nil
+	}
+
 	parser := &Parser{
-		OverrideFlags: []string{"--help", "-h", "--version", "-v"},
+		OverrideFlags: overrideFlags,
 		EnvName:       version.ProgramUpper + "_CONFIG_FILE",
 		DefaultConfig: "/etc/rancher/" + version.Program + "/config.yaml",
 	}
 	result, err := parser.FindString(args, target)
 	if err != nil {
-		logrus.Fatal(err)
+		if len(overrideFlags) > 0 {
+			logrus.Fatal(err)
+		} else {
+			logrus.Warn(err)
+		}
 	}
 	return result
 }


### PR DESCRIPTION
#### Proposed Changes ####

Fix MustFindString returning override flags on external CLI commands

External CLI actions cannot short-circuit on --help or --version, so we cannot skip loading the config file if these flags are present when running these wrapped commands. The behavior of just returning the override flag name instead of the requested flag value was breaking data-dir lookup when running wrapped commands.

This was introduced in https://github.com/k3s-io/k3s/pull/7683 - which did not account for some subcommands/wrapped commands needing to be unconditionally extracted out.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

yes

#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/11235
#### User-Facing Change ####
```release-note
```

#### Further Comments ####
