### PR TITLE
Fix the "Standalone"-mode of oidc-login in the wrapped kubectl library

### DIFF
--- a/pkg/kubectl/main.go
+++ b/pkg/kubectl/main.go
@@ -13,6 +13,9 @@ import (
 	"k8s.io/component-base/cli"
 	"k8s.io/kubectl/pkg/cmd"
 	"k8s.io/kubectl/pkg/cmd/util"
+
+	// Import to initialize client auth plugins.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func Main() {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Currently K3s fails to work with the "standalone mode" of oidc-login, where the kube.config file contains an Auth-provider section for the users. Trying to use any subcommand that requires a valid login will fail with the error: 
'error: no Auth Provider found for name "oidc"'

This PR fixes this, and allows the usage of this oidc-login mode for the embedded kubectl library in K3s.
For background info on that oidc-login mode: https://github.com/int128/kubelogin/blob/master/docs/standalone-mode.md

#### Types of Changes ####

This is a simple one-liner bugfix copied from the upstream kubectl-cli implementation.
Source of the fix: https://github.com/kubernetes/kubernetes/blob/master/cmd/kubectl/kubectl.go#L25

#### Verification ####

Use an example kube.config like described in the kubelogin documentation:
```
- name: keycloak
  user:
    auth-provider:
      config:
        client-id: YOUR_CLIENT_ID
        client-secret: YOUR_CLIENT_SECRET
        idp-issuer-url: https://issuer.example.com
      name: oidc
```

Login through the normal oidc-login works correctly:
```
ludo@ludo-Nitro-Laptop:~/projects/k3s$ bin/k3s kubectl oidc-login 
Opening in existing browser session.
You got a valid token until 2024-11-07 14:41:30 +0100 CET
```

Then trying to use this login fails, without this fix:
```
ludo@ludo-Nitro-Laptop:~/projects/k3s$ bin/k3s kubectl auth whoami
error: no Auth Provider found for name "oidc"
```

However, the upstream kubectl cli command worked correctly:
```
ludo@ludo-Nitro-Laptop:~/projects/k3s$ kubectl auth whoami
ATTRIBUTE   VALUE
Username    6b3dbab6-f44c-45af-8b55-418ff6f0115c
Groups      [default-roles-development system:authenticated]
```

Similarly, after applying the fix in this PR:
```
ludo@ludo-Nitro-Laptop:~/projects/k3s$ bin/k3s kubectl auth whoami
ATTRIBUTE   VALUE
Username    6b3dbab6-f44c-45af-8b55-418ff6f0115c
Groups      [default-roles-development system:authenticated]
```

#### Testing ####

Although no separate test is built for this, K3s might want to consider creating a specific test for this use case.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/11268

#### User-Facing Change ####
```release-note
Fixes 'no Auth Provider found for name "oidc"' when using oidc-login in standalone mode.
```

#### Further Comments ####

