### PR TITLE
Fix handling of wrapped subcommands when run with a path

### DIFF
--- a/pkg/configfilearg/defaultparser.go
+++ b/pkg/configfilearg/defaultparser.go
@@ -1,6 +1,7 @@
 package configfilearg
 
 import (
+	"path/filepath"
 	"slices"
 
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
@@ -31,10 +32,10 @@ func MustFindString(args []string, target string, commandsWithoutOverride ...str
 	// Some subcommands such as `k3s ctr` or just `ctr` need to be extracted out even to
 	// provide version or help text, and we cannot short-circuit loading the config file. For
 	// these commands, treat failure to load the config file as a warning instead of a fatal.
-	if len(args) > 0 && args[0] == version.Program {
+	if len(args) > 0 && filepath.Base(args[0]) == version.Program {
 		args = args[1:]
 	}
-	if len(args) > 0 && slices.Contains(commandsWithoutOverride, args[0]) {
+	if len(args) > 0 && slices.Contains(commandsWithoutOverride, filepath.Base(args[0])) {
 		overrideFlags = nil
 	}
 

--- a/pkg/configfilearg/defaultparser_test.go
+++ b/pkg/configfilearg/defaultparser_test.go
@@ -124,8 +124,28 @@ func Test_UnitMustFindString(t *testing.T) {
 			teardown: func() error { return os.Unsetenv("K3S_CONFIG_FILE") },
 		},
 		{
-			name:   "Override flag is not returned for specific subcommands",
+			name:   "Override flag is not returned for specific subcommands with full path",
+			args:   []string{"/usr/local/bin/k3s", "ctr", "--foo", "bar", "--version"},
+			target: "token",
+
+			want: "12345",
+
+			setup:    func() error { return os.Setenv("K3S_CONFIG_FILE", "./testdata/defaultdata.yaml") },
+			teardown: func() error { return os.Unsetenv("K3S_CONFIG_FILE") },
+		},
+		{
+			name:   "Override flag is not returned for wrapped commands",
 			args:   []string{"kubectl", "--foo", "bar", "--help"},
+			target: "token",
+
+			want: "12345",
+
+			setup:    func() error { return os.Setenv("K3S_CONFIG_FILE", "./testdata/defaultdata.yaml") },
+			teardown: func() error { return os.Unsetenv("K3S_CONFIG_FILE") },
+		},
+		{
+			name:   "Override flag is not returned for wrapped commands with full path",
+			args:   []string{"/usr/local/bin/kubectl", "--foo", "bar", "--help"},
 			target: "token",
 
 			want: "12345",


### PR DESCRIPTION
#### Proposed Changes ####

Fix handling of wrapped subcommands when run with a path

https://github.com/k3s-io/k3s/pull/11237 fixed `k3s kubectl --help` and `kubectl --help` but not `/usr/local/bin/k3s kubectl --help` or `/usr/local/bin/kubectl --help`

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/11235

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
