### PR TITLE
Fix etcd backup/restore test and add guardrail for etcd-snapshot

### DIFF
--- a/tests/e2e/snapshotrestore/snapshotrestore_test.go
+++ b/tests/e2e/snapshotrestore/snapshotrestore_test.go
@@ -145,17 +145,6 @@ var _ = Describe("Verify snapshots and cluster restores work", Ordered, func() {
 			Expect(e2e.RunCmdOnNode(cmd, serverNodeNames[0])).Error().NotTo(HaveOccurred())
 		})
 
-		It("Resets non bootstrap nodes", func() {
-			for _, nodeName := range serverNodeNames {
-				if nodeName != serverNodeNames[0] {
-					cmd := "k3s server --cluster-reset"
-					response, err := e2e.RunCmdOnNode(cmd, nodeName)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(response).Should(ContainSubstring("Managed etcd cluster membership has been reset, restart without --cluster-reset flag now"))
-				}
-			}
-		})
-
 		It("Checks that other servers are not ready", func() {
 			fmt.Printf("\nFetching node status\n")
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This PR does two things:
1 - Fixes the e2e test doing backup/restore from a snapshot. It was failing with:
```
FATA[0000] cannot perform cluster-reset while server URL is set - remove server from configuration before resetting
```
When comparing the steps it was following and the documentation, it was indeed wrong. The rest of the servers don't have to run `--cluster-reset`. When removing the step `Resets non bootstrap nodes`, the e2e test works again

2 - I must confess that I wasted an hour trying to use `k3s etcd-snapshot` in a k3s cluster that was not using etcd. When doing that, the error we get is super confusing:
```
FATA[0000] see server log for details: Unauthorized
```
However, there is nothing in the logs. The problem is that we are treating a 404 (url does not exist) as Unauthorized https://github.com/k3s-io/k3s/blob/master/pkg/server/router.go#L87. We have been doing that for a long time, so it is probably risky to change that. Therefore, I decided to check if `kine.sock` exists and `db/etcd/config` not in the dataDir. If that's the case, we print `K3s is not deployed with an etcd datastore`


#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Test fix + guardrail

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

1 - Run the e2e test
2 - Run any `k3s etcd-snapshot` command without etcd as datastore

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/11388

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
