### PR TITLE
[release-1.29] Fix issue with loadbalancer failover to default server

### DIFF
--- a/pkg/agent/loadbalancer/loadbalancer.go
+++ b/pkg/agent/loadbalancer/loadbalancer.go
@@ -179,6 +179,8 @@ func (lb *LoadBalancer) dialContext(ctx context.Context, network, _ string) (net
 			if !allChecksFailed {
 				defer server.closeAll()
 			}
+		} else {
+			logrus.Debugf("Dial health check failed for %s", targetServer)
 		}
 
 		newServer, err := lb.nextServer(targetServer)

--- a/pkg/agent/loadbalancer/utility.go
+++ b/pkg/agent/loadbalancer/utility.go
@@ -28,6 +28,9 @@ func parseURL(serverURL, newHost string) (string, string, error) {
 	return address, parsedURL.String(), nil
 }
 
+// sortServers returns a sorted, unique list of strings, with any
+// empty values removed. The returned bool is true if the list
+// contains the search string.
 func sortServers(input []string, search string) ([]string, bool) {
 	result := []string{}
 	found := false

--- a/pkg/util/apierrors.go
+++ b/pkg/util/apierrors.go
@@ -40,7 +40,7 @@ func SendError(err error, resp http.ResponseWriter, req *http.Request, status ..
 
 	// Don't log "apiserver not ready" or "apiserver disabled" errors, they are frequent during startup
 	if !errors.Is(err, ErrAPINotReady) && !errors.Is(err, ErrAPIDisabled) {
-		logrus.Errorf("Sending HTTP %d response to %s: %v", code, req.RemoteAddr, err)
+		logrus.Errorf("Sending %s %d response to %s: %v", req.Proto, code, req.RemoteAddr, err)
 	}
 
 	var serr *apierrors.StatusError
@@ -61,6 +61,7 @@ func SendError(err error, resp http.ResponseWriter, req *http.Request, status ..
 		serr = apierrors.NewGenericServerResponse(code, req.Method, schema.GroupResource{}, req.URL.Path, err.Error(), 0, true)
 	}
 
+	resp.Header().Add("Connection", "close")
 	responsewriters.ErrorNegotiated(serr, scheme.Codecs.WithoutConversion(), schema.GroupVersion{}, resp, req)
 }
 


### PR DESCRIPTION
#### Proposed Changes ####

The loadbalancer should only fail over to the default server if all other server have failed, and it should force fail-back to a preferred server as soon as one passes health checks.

The loadbalancer tests have been improved to ensure that this occurs.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

yes

#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/11322

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
