### PR TITLE
Try running e2e on big runners

### DIFF
--- a/.github/workflows/build-k3s.yaml
+++ b/.github/workflows/build-k3s.yaml
@@ -39,18 +39,27 @@ jobs:
       run: |
         tar -czvf ../k3s-repo.tar.gz .
         mv ../k3s-repo.tar.gz .
-    - name: "Upload K3s directory"
-      if: inputs.upload-repo == true
-      uses: actions/upload-artifact@v4
-      with:
-        name: k3s-repo.tar.gz
-        path: k3s-repo.tar.gz
-    - name: "Save K3s image"
-      if: inputs.upload-image == true
-      run: docker image save rancher/k3s -o ./dist/artifacts/k3s-image.tar
-    - name: "Upload K3s binary"
-      if: inputs.upload-repo == false
-      uses: actions/upload-artifact@v4
-      with:
-        name: k3s
-        path: dist/artifacts/k3s*
+    # - name: "Upload K3s directory"
+    #   if: inputs.upload-repo == true
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: k3s-repo.tar.gz
+    #     path: k3s-repo.tar.gz
+    # - name: "Save K3s image"
+    #   if: inputs.upload-image == true
+    #   run: docker image save rancher/k3s -o ./dist/artifacts/k3s-image.tar
+    # - name: "Upload K3s binary"
+    #   if: inputs.upload-repo == false
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: k3s
+    #     path: dist/artifacts/k3s*
+    - name: "Dump CPU info"
+      run: |
+        lscpu
+        lsmem
+    - name: "htop"
+      run: |
+        sudo apt-get install -y htop
+        sleep 3 | htop  > ./htop.out
+        head -c  ./htop.out  | tail -c +10

--- a/.github/workflows/build-k3s.yaml
+++ b/.github/workflows/build-k3s.yaml
@@ -57,9 +57,5 @@ jobs:
     - name: "Dump CPU info"
       run: |
         lscpu
+        nproc
         lsmem
-    - name: "htop"
-      run: |
-        sudo apt-get install -y htop
-        sleep 3 | htop  > ./htop.out
-        head -c  ./htop.out  | tail -c +10

--- a/.github/workflows/build-k3s.yaml
+++ b/.github/workflows/build-k3s.yaml
@@ -3,6 +3,10 @@ name: Build K3s
 on: 
   workflow_call:
    inputs:
+    runner:
+      type: string
+      description: 'Runner to build on'
+      default: 'ubuntu-latest'
     upload-repo:
       type: boolean
       required: false
@@ -18,7 +22,7 @@ permissions:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 20
     steps:
     - name: Checkout K3s

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,15 +28,35 @@ permissions:
   contents: read
 
 jobs:
+  test-8cpu:
+    uses: ./.github/workflows/build-k3s.yaml
+    with:
+      runner: ${{ github.repository == 'k3s-io/k3s' && 'equinix-8cpu-32gb' || 'ubuntu-latest' }}
+      upload-image: true
+  test-4cpu:
+    uses: ./.github/workflows/build-k3s.yaml
+    with:
+      runner: ${{ github.repository == 'k3s-io/k3s' && 'equinix-4cpu-16gb' || 'ubuntu-latest' }}
+      upload-image: true
+  test-gha:
+    uses: ./.github/workflows/build-k3s.yaml
+    with:
+      runner: ${{ github.repository == 'k3s-io/k3s' && 'ubuntu-latest' || 'ubuntu-latest' }}
+      upload-image: true
+  test-keda:
+    uses: ./.github/workflows/build-k3s.yaml
+    with:
+      runner: ${{ github.repository == 'k3s-io/k3s' && 'equinix-keda-runner' || 'ubuntu-latest' }}
+      upload-image: true
   build:
     uses: ./.github/workflows/build-k3s.yaml
     with:
-      runner: ${{ github.repository == "k3s-io/k3s" && 'equinix-16cpu-64gb' || 'ubuntu-latest' }}
+      runner: ${{ github.repository == 'k3s-io/k3s' && 'equinix-8cpu-32gb' || 'ubuntu-latest' }}
       upload-image: true
   e2e:
     name: "E2E Tests"
     needs: build
-    runs-on:  ${{ github.repository == "k3s-io/k3s" && 'equinix-16cpu-64gb' || 'ubuntu-latest' }}
+    runs-on:  ${{ github.repository == 'k3s-io/k3s' && 'equinix-8cpu-32gb' || 'ubuntu-latest' }}
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -47,7 +67,6 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
         with: {fetch-depth: 1}
-      
       - name: Set up vagrant and libvirt
         uses: ./.github/actions/vagrant-setup
       - name: "Vagrant Cache"
@@ -81,6 +100,9 @@ jobs:
           chmod +x ./dist/artifacts/k3s
           cd tests/e2e/${{ matrix.etest }}
           go test -v -timeout=45m ./${{ matrix.etest}}_test.go -ci -local
+      - name: On Failure, install ssh 
+        if: ${{ failure() }} && runner.environment == 'self-hosted'
+        run: sudo apt-get -y install openssh-client
       - name: On Failure, Launch Debug Session
         uses: lhotari/action-upterm@v1
         if: ${{ failure() }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,8 @@ jobs:
   e2e:
     name: "E2E Tests"
     needs: build
-    runs-on: ubuntu-24.04
+    if: github.repository == 'k3s-io/k3s'
+    runs-on: equinix-16cpu-64gb
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,12 +31,12 @@ jobs:
   build:
     uses: ./.github/workflows/build-k3s.yaml
     with:
+      runner: ${{ github.repository == "k3s-io/k3s" && 'equinix-16cpu-64gb' || 'ubuntu-latest' }}
       upload-image: true
   e2e:
     name: "E2E Tests"
     needs: build
-    if: github.repository == 'k3s-io/k3s'
-    runs-on: equinix-16cpu-64gb
+    runs-on:  ${{ github.repository == "k3s-io/k3s" && 'equinix-16cpu-64gb' || 'ubuntu-latest' }}
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,25 +28,15 @@ permissions:
   contents: read
 
 jobs:
-  test-8cpu:
+  test-arm-2cpu:
     uses: ./.github/workflows/build-k3s.yaml
     with:
-      runner: ${{ github.repository == 'k3s-io/k3s' && 'equinix-8cpu-32gb' || 'ubuntu-latest' }}
+      runner: ${{ github.repository == 'k3s-io/k3s' && 'oracle-aarch64-2cpu-8gb' || 'ubuntu-latest' }}
       upload-image: true
-  test-4cpu:
+  test-arm-4cpu:
     uses: ./.github/workflows/build-k3s.yaml
     with:
-      runner: ${{ github.repository == 'k3s-io/k3s' && 'equinix-4cpu-16gb' || 'ubuntu-latest' }}
-      upload-image: true
-  test-gha:
-    uses: ./.github/workflows/build-k3s.yaml
-    with:
-      runner: ${{ github.repository == 'k3s-io/k3s' && 'ubuntu-latest' || 'ubuntu-latest' }}
-      upload-image: true
-  test-keda:
-    uses: ./.github/workflows/build-k3s.yaml
-    with:
-      runner: ${{ github.repository == 'k3s-io/k3s' && 'equinix-keda-runner' || 'ubuntu-latest' }}
+      runner: ${{ github.repository == 'k3s-io/k3s' && 'oracle-aarch64-4cpu-16gb' || 'ubuntu-latest' }}
       upload-image: true
   build:
     uses: ./.github/workflows/build-k3s.yaml


### PR DESCRIPTION
## Details on the CNCF Runners

| Runner | K3s Build Time |
| - | - |
| GHA native (4vcpu) | 7m 20s |
|equinux 4 cpu | 5m 13s |
| equinux 8 cpu | 4m 30s |

## Notes

Github Actions Standard Runner:
- Uses `AMD EPYC 7763 64-Core Processor`

equinix-XXcpu-XXgb
- Uses `AMD EPYC 7401P 24-Core Processor`
- No Systemd, uses init
- Possible, but difficult at this time for vagrant VMs
- has Docker installed

equinix-keda-runner
- Similar performance to 4cpu-16gb runner
- Uses `AMD EPYC 7401P 24-Core Processor` as well
- Unclear what exactly is the difference

oracle-aarch64
- Previously explored with https://github.com/k3s-io/k3s/pull/10702
- Lacks most support tools
- Can be used to build K3s image
- Lacks NAT kernel module, making any form of testing with K3s impossible
- Currently unable to test, as the runner version is currently Out of Date (which GH kills as a security risk). Waiting on CNCF backend to catch up and fix this.

While the equinux runners on the surface should be slower, they seem to build K3s faster. However, there seems to be issues with availability, as K3s appears to only have access to "one" instace of each runner at a time vs GHA native which we have effectively infinity of as long as we stay under the 50000 minutes a month usage for Github Enterprise.

## Conclusion

We should be selective in utilizing the equiniux and oracle runners. Generally GHA native runners remain preferable for most use cases. Potential exceptions are:
- Running larger E2E or Docker tests with 5+ nodes/VMs 
- Building K3s arm64/arm32 if we need to move off Drone




