### PR TITLE
Fix Branch Name logic for Dependabot and UpdateCLI pushes to k3s-io

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -146,13 +146,17 @@ jobs:
     # For upgrade and skew tests, we need to know the branch name this run is based off.
     # Since this is predetermined, we can run this step before the docker-go job, saving time.
     # For PRs we can use the base_ref (ie the target branch of the PR).
-    # For pushes to k3s-io/k3s, the branch_name is a valid ref, master or release-x.y.
+    # For pushes to k3s-io/k3s from dependabot or updatecli, use master
+    # All other pushes should be a valid ref, master or release-1.XX.
     # For pushes to a fork, we need to determine the branch name by finding the parent branch from git show-branch history.
     - name: Determine branch name
       id: branch_step
       run: |
         if [ ${{ github.repository }} = "k3s-io/k3s" ]; then 
           BRANCH_NAME=$(echo ${{ github.base_ref || github.ref_name }})
+          if [[ $BRANCH_NAME =~ ^(dependabot|updatecli) ]]; then
+            BRANCH_NAME=master
+          fi
         elif [ -z "${{ github.base_ref }}" ]; then
           # We are in a fork, and need some git history to determine the branch name
           git fetch origin --depth=100 +refs/heads/*:refs/remotes/origin/*
@@ -162,7 +166,14 @@ jobs:
         fi
         echo "Branch Name is $BRANCH_NAME"
         echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
-     
+    # branch name should be either master or release-1.XX
+    - name: Fail if branch name does not match pattern
+      run: |
+        if [[ ! ${{ steps.branch_step.outputs.branch_name }} =~ ^(master|release-[0-9]+\.[0-9]+)$ ]]; then
+          echo "Branch name ${{ steps.branch_step.outputs.branch_name }} does not match pattern"
+          exit 1
+        fi
+
   docker-go:
     needs: [build, build-go-tests]
     name: Docker Tests In GO
@@ -193,7 +204,7 @@ jobs:
         name: docker-go-tests
         path: ./dist/artifacts
     - name: Run ${{ matrix.dtest }} Test
-      # Put the compied test binary back in the same place as the test source
+      # Put the compiled test binary back in the same place as the test source
       run: |
         chmod +x ./dist/artifacts/${{ matrix.dtest }}.test
         mv ./dist/artifacts/${{ matrix.dtest }}.test ./tests/docker/${{ matrix.dtest }}/

--- a/tests/docker/etcd/etcd_test.go
+++ b/tests/docker/etcd/etcd_test.go
@@ -32,9 +32,8 @@ var _ = Describe("Etcd Tests", Ordered, func() {
 			Eventually(func() error {
 				return tester.DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
 			}, "60s", "5s").Should(Succeed())
-			Eventually(func(g Gomega) {
-				g.Expect(tester.ParseNodes(config.KubeconfigFile)).To(HaveLen(3))
-				g.Expect(tester.NodesReady(config.KubeconfigFile)).To(Succeed())
+			Eventually(func() error {
+				return tester.NodesReady(config.KubeconfigFile, config.GetNodeNames()...)
 			}, "60s", "5s").Should(Succeed())
 		})
 		It("should destroy the cluster", func() {
@@ -59,10 +58,9 @@ var _ = Describe("Etcd Tests", Ordered, func() {
 			Eventually(func() error {
 				return tester.DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
 			}, "90s", "5s").Should(Succeed())
-			Eventually(func(g Gomega) {
-				g.Expect(tester.ParseNodes(config.KubeconfigFile)).To(HaveLen(6))
-				g.Expect(tester.NodesReady(config.KubeconfigFile)).To(Succeed())
-			}, "60s", "5s").Should(Succeed())
+			Eventually(func() error {
+				return tester.NodesReady(config.KubeconfigFile, config.GetNodeNames()...)
+			}, "90s", "5s").Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Add more logic and checks around determining parent branch name for Docker Upgrade and Skew tests.
- Extend timeout for etcd split role docker test, 5 nodes takes more than 60s
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CI Test Fix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI is green. 
Note that this branch is specifically prefixed with `dependabot` to simulate a typical dependabot branch name. 
Additionally, this PR is from a branch on k3s-io not from my personal fork, just like the bots make.
https://github.com/k3s-io/k3s/actions/runs/12039503425
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/11374
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
