### PR TITLE
Bump containerd to -k3s2 to fix rewrites

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/Mirantis/cri-dockerd => github.com/k3s-io/cri-dockerd v0.3.15-k3s1.31-3 //v1.31
 	github.com/cilium/ebpf => github.com/cilium/ebpf v0.12.3
 	github.com/cloudnativelabs/kube-router/v2 => github.com/k3s-io/kube-router/v2 v2.2.1
-	github.com/containerd/containerd => github.com/k3s-io/containerd v1.7.23-k3s1
+	github.com/containerd/containerd => github.com/k3s-io/containerd v1.7.23-k3s2
 	github.com/containerd/imgcrypt => github.com/containerd/imgcrypt v1.1.11
 	github.com/distribution/reference => github.com/distribution/reference v0.5.0
 	github.com/docker/distribution => github.com/docker/distribution v2.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -938,8 +938,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k3s-io/containerd v1.7.23-k3s1 h1:icB7N6TuuDcr8cqCZMr5TRNPUKoBq45Y9Jjv2qqBpnw=
-github.com/k3s-io/containerd v1.7.23-k3s1/go.mod h1:+vNritUoqQTlFedsBErSkyu1yqf3eYikE3oGbEICi+g=
+github.com/k3s-io/containerd v1.7.23-k3s2 h1:QPS588RkyWooj/M+C64EAd1wDeqLmW/RB0DNW08x7ls=
+github.com/k3s-io/containerd v1.7.23-k3s2/go.mod h1:+vNritUoqQTlFedsBErSkyu1yqf3eYikE3oGbEICi+g=
 github.com/k3s-io/cri-dockerd v0.3.15-k3s1.31-3 h1:TH3zSbIM9zSZMeWKcWjQqeja3FsmJYwLUHglD7nuUEc=
 github.com/k3s-io/cri-dockerd v0.3.15-k3s1.31-3/go.mod h1:ny6wyM7fqfew5FABQ+MtKaU07rhsHhlXr/jtFsA2m8Y=
 github.com/k3s-io/cri-tools v1.31.0-k3s2 h1:nekOdJe5Hecm+C5eswg688uXTI0enUZOJYadmyU9pYw=

--- a/tests/e2e/privateregistry/Vagrantfile
+++ b/tests/e2e/privateregistry/Vagrantfile
@@ -32,10 +32,13 @@ def provision(vm, role, role_num, node_num)
   # and still using the heredoc formatting with escapped quotes
   writePrivateRegistry = <<~'SCRIPT'.chomp % {net: NETWORK_PREFIX}
   mkdir -p /etc/rancher/k3s/
-  echo "mirrors:
+  echo 'mirrors:
     my-registry.local:
       endpoint:
-        - \"http://%{net}.100:5000\"" > /etc/rancher/k3s/registries.yaml
+        - http://%{net}.100:5000
+      rewrite:
+        "^library/(.*)$": "docker-io-library/$1"
+  ' > /etc/rancher/k3s/registries.yaml
   SCRIPT
 
   setInsecureRegistryPolicy = <<~'SCRIPT'.chomp % {net: NETWORK_PREFIX}

--- a/tests/e2e/privateregistry/privateregistry_test.go
+++ b/tests/e2e/privateregistry/privateregistry_test.go
@@ -95,28 +95,32 @@ var _ = Describe("Verify Create", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 		})
+		// Mirror the image as NODEIP:5000/docker-io-library/nginx:1.27.3, but reference it as my-registry.local/library/nginx:1.27.3 -
+		// the rewrite in registries.yaml's entry for my-registry.local should ensure that it is rewritten properly when pulling from
+		// NODEIP:5000 as a mirror.
 		It("Should pull and image from dockerhub and send it to private registry", func() {
-			cmd := "docker pull nginx"
+			cmd := "docker pull docker.io/library/nginx:1.27.3"
 			_, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
 			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
 
 			nodeIP, err := e2e.FetchNodeExternalIP(serverNodeNames[0])
 			Expect(err).NotTo(HaveOccurred())
 
-			cmd = "docker tag nginx " + nodeIP + ":5000/my-webpage"
+			cmd = "docker tag docker.io/library/nginx:1.27.3 " + nodeIP + ":5000/docker-io-library/nginx:1.27.3"
 			_, err = e2e.RunCmdOnNode(cmd, serverNodeNames[0])
 			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
 
-			cmd = "docker push " + nodeIP + ":5000/my-webpage"
+			cmd = "docker push " + nodeIP + ":5000/docker-io-library/nginx:1.27.3"
 			_, err = e2e.RunCmdOnNode(cmd, serverNodeNames[0])
 			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
 
-			cmd = "docker image remove nginx " + nodeIP + ":5000/my-webpage"
+			cmd = "docker image remove docker.io/library/nginx:1.27.3 " + nodeIP + ":5000/docker-io-library/nginx:1.27.3"
 			_, err = e2e.RunCmdOnNode(cmd, serverNodeNames[0])
 			Expect(err).NotTo(HaveOccurred(), "failed: "+cmd)
 		})
+
 		It("Should create and validate deployment with private registry on", func() {
-			res, err := e2e.RunCmdOnNode("kubectl create deployment my-webpage --image=my-registry.local/my-webpage", serverNodeNames[0])
+			res, err := e2e.RunCmdOnNode("kubectl create deployment my-webpage --image=my-registry.local/library/nginx:1.27.3", serverNodeNames[0])
 			fmt.Println(res)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to fix rewrites

* The container bump in https://github.com/k3s-io/k3s/pull/11238 did not handle all cases where registry references needed to be rewritten - this is fixed in https://github.com/k3s-io/containerd/commit/d157daba6497d98750949b4f77747b96dde92f91

#### Types of Changes ####

version bump / bugfix / ci

#### Verification ####

* See linked issue
* Check e2e test results

#### Testing ####

Yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/11191

#### User-Facing Change ####
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
