### PR TITLE
Fix agent tunnel address with dedicated supervisor port

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -188,6 +188,27 @@ var ServerFlags = []cli.Flag{
 		Value:       6443,
 		Destination: &ServerConfig.HTTPSPort,
 	},
+	&cli.IntFlag{
+		Name:        "supervisor-port",
+		EnvVar:      version.ProgramUpper + "_SUPERVISOR_PORT",
+		Usage:       "(experimental) Supervisor listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.SupervisorPort,
+	},
+	&cli.IntFlag{
+		Name:        "apiserver-port",
+		EnvVar:      version.ProgramUpper + "_APISERVER_PORT",
+		Usage:       "(experimental) apiserver internal listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerPort,
+	},
+	&cli.StringFlag{
+		Name:        "apiserver-bind-address",
+		EnvVar:      version.ProgramUpper + "_APISERVER_BIND_ADDRESS",
+		Usage:       "(experimental) apiserver internal bind address override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerBindAddress,
+	},
 	&cli.StringFlag{
 		Name:        "advertise-address",
 		Usage:       "(listener) IPv4/IPv6 address that apiserver uses to advertise to members of the cluster (default: node-external-ip/node-ip)",
@@ -195,7 +216,7 @@ var ServerFlags = []cli.Flag{
 	},
 	&cli.IntFlag{
 		Name:        "advertise-port",
-		Usage:       "(listener) Port that apiserver uses to advertise to members of the cluster (default: listen-port)",
+		Usage:       "(listener) Port that apiserver uses to advertise to members of the cluster (default: https-listen-port)",
 		Destination: &ServerConfig.AdvertisePort,
 	},
 	&cli.StringSliceFlag{

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -377,6 +377,19 @@ func TailJournalLogs(lines int, nodes []string) string {
 	return logs.String()
 }
 
+func GetConfig(nodes []string) string {
+	config := &strings.Builder{}
+	for _, node := range nodes {
+		cmd := "tar -Pc /etc/rancher/k3s/ | tar -vxPO"
+		if c, err := RunCmdOnNode(cmd, node); err != nil {
+			fmt.Fprintf(config, "** failed to get config for node %s ***\n%v\n", node, err)
+		} else {
+			fmt.Fprintf(config, "** config for node %s ***\n%s\n", node, c)
+		}
+	}
+	return config.String()
+}
+
 // GetVagrantLog returns the logs of on vagrant commands that initialize the nodes and provision K3s on each node.
 // It also attempts to fetch the systemctl logs of K3s on nodes where the k3s.service failed.
 func GetVagrantLog(cErr error) string {


### PR DESCRIPTION
#### Proposed Changes ####

Fix issue where rke2 tunnel was trying to connect to apiserver port instead of supervisor:

Note the incorrect port for the tunnel connection in RKE2 where the apiserver and supervisor are on different ports:
```
time="2024-12-06T20:35:57Z" level=info msg="Started tunnel to 172.17.0.2:6443"
time="2024-12-06T20:35:57Z" level=info msg="Stopped tunnel to 127.0.0.1:9345"
time="2024-12-06T20:35:57Z" level=info msg="Connecting to proxy" url="wss://172.17.0.2:6443/v1-rke2/connect"
time="2024-12-06T20:35:57Z" level=info msg="Proxy done" err="context canceled" url="wss://127.0.0.1:9345/v1-rke2/connect"
time="2024-12-06T20:35:57Z" level=info msg="error in remotedialer server [400]: websocket: close 1006 (abnormal closure): unexpected EOF"
time="2024-12-06T20:35:57Z" level=error msg="Failed to connect to proxy. Response status: 403 - 403 Forbidden. Response body: {\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"forbidden: User \\\"system:node:e8266a6ea5f6\\\" cannot get path \\\"/v1-rke2/connect\\\"\",\"reason\":\"Forbidden\",\"details\":{},\"code\":403}\n" error="websocket: bad handshake"
time="2024-12-06T20:35:57Z" level=error msg="Remotedialer proxy error; reconnecting..." error="websocket: bad handshake" url="wss://172.17.0.2:6443/v1-rke2/connect"
```

#### Types of Changes ####

bugfix

#### Verification ####

requires pull-through to rke2

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/11334

#### User-Facing Change ####
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
