### PR TITLE
[release-1.31] add node-internal-dns/node-external-dns address pass-through support …

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -640,6 +640,18 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		nodeConfig.AgentConfig.NodeExternalIP = nodeConfig.AgentConfig.NodeExternalIPs[0].String()
 	}
 
+	var nodeExternalDNSs []string
+	for _, dnsString := range envInfo.NodeExternalDNS.Value() {
+		nodeExternalDNSs = append(nodeExternalDNSs, strings.Split(dnsString, ",")...)
+	}
+	nodeConfig.AgentConfig.NodeExternalDNSs = nodeExternalDNSs
+
+	var nodeInternalDNSs []string
+	for _, dnsString := range envInfo.NodeInternalDNS.Value() {
+		nodeInternalDNSs = append(nodeInternalDNSs, strings.Split(dnsString, ",")...)
+	}
+	nodeConfig.AgentConfig.NodeInternalDNSs = nodeInternalDNSs
+
 	nodeConfig.NoFlannel = nodeConfig.FlannelBackend == config.FlannelBackendNone
 	if !nodeConfig.NoFlannel {
 		hostLocal, err := exec.LookPath("host-local")

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -491,6 +491,17 @@ func updateAddressAnnotations(nodeConfig *daemonconfig.Node, nodeAnnotations map
 		}
 	}
 
+	if len(agentConfig.NodeInternalDNSs) > 0 {
+		result[cp.InternalDNSKey] = strings.Join(agentConfig.NodeInternalDNSs, ",")
+	} else {
+		delete(result, cp.InternalDNSKey)
+	}
+	if len(agentConfig.NodeExternalDNSs) > 0 {
+		result[cp.ExternalDNSKey] = strings.Join(agentConfig.NodeExternalDNSs, ",")
+	} else {
+		delete(result, cp.ExternalDNSKey)
+	}
+
 	result = labels.Merge(nodeAnnotations, result)
 	return result, !equality.Semantic.DeepEqual(nodeAnnotations, result)
 }

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -23,6 +23,8 @@ type Agent struct {
 	BindAddress              string
 	NodeIP                   cli.StringSlice
 	NodeExternalIP           cli.StringSlice
+	NodeInternalDNS          cli.StringSlice
+	NodeExternalDNS          cli.StringSlice
 	NodeName                 string
 	PauseImage               string
 	Snapshotter              string
@@ -80,6 +82,16 @@ var (
 		Name:  "node-external-ip",
 		Usage: "(agent/networking) IPv4/IPv6 external IP addresses to advertise for node",
 		Value: &AgentConfig.NodeExternalIP,
+	}
+	NodeInternalDNSFlag = &cli.StringSliceFlag{
+		Name:  "node-internal-dns",
+		Usage: "(agent/networking) internal DNS addresses to advertise for node",
+		Value: &AgentConfig.NodeInternalDNS,
+	}
+	NodeExternalDNSFlag = &cli.StringSliceFlag{
+		Name:  "node-external-dns",
+		Usage: "(agent/networking) external DNS addresses to advertise for node",
+		Value: &AgentConfig.NodeExternalDNS,
 	}
 	NodeNameFlag = &cli.StringFlag{
 		Name:        "node-name",
@@ -302,6 +314,8 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			NodeIPFlag,
 			BindAddressFlag,
 			NodeExternalIPFlag,
+			NodeInternalDNSFlag,
+			NodeExternalDNSFlag,
 			ResolvConfFlag,
 			FlannelIfaceFlag,
 			FlannelConfFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -561,6 +561,8 @@ var ServerFlags = []cli.Flag{
 	AirgapExtraRegistryFlag,
 	NodeIPFlag,
 	NodeExternalIPFlag,
+	NodeInternalDNSFlag,
+	NodeExternalDNSFlag,
 	ResolvConfFlag,
 	FlannelIfaceFlag,
 	FlannelConfFlag,

--- a/pkg/cloudprovider/instances.go
+++ b/pkg/cloudprovider/instances.go
@@ -15,6 +15,8 @@ import (
 var (
 	InternalIPKey = version.Program + ".io/internal-ip"
 	ExternalIPKey = version.Program + ".io/external-ip"
+	InternalDNSKey = version.Program + ".io/internal-dns"
+	ExternalDNSKey = version.Program + ".io/external-dns"
 	HostnameKey   = version.Program + ".io/hostname"
 )
 
@@ -77,6 +79,20 @@ func (k *k3s) InstanceMetadata(ctx context.Context, node *corev1.Node) (*cloudpr
 		}
 	} else if address = node.Labels[ExternalIPKey]; address != "" {
 		metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: address})
+	}
+
+	// check internal dns
+	if address := node.Annotations[InternalDNSKey]; address != "" {
+		for _, v := range strings.Split(address, ",") {
+			metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeInternalDNS, Address: v})
+		}
+	}
+
+	// check external dns
+	if address := node.Annotations[ExternalDNSKey]; address != "" {
+		for _, v := range strings.Split(address, ",") {
+			metadata.NodeAddresses = append(metadata.NodeAddresses, corev1.NodeAddress{Type: corev1.NodeExternalDNS, Address: v})
+		}
 	}
 
 	// check hostname

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -125,6 +125,8 @@ type Agent struct {
 	NodeIPs                 []net.IP
 	NodeExternalIP          string
 	NodeExternalIPs         []net.IP
+	NodeInternalDNSs        []string
+	NodeExternalDNSs        []string
 	RuntimeSocket           string
 	ImageServiceSocket      string
 	ListenAddress           string


### PR DESCRIPTION
#### Proposed Changes ####

* **Backport https://github.com/k3s-io/k3s/pull/10852**
Add support for setting NodeInternalDNS and NodeExternalDNS addresses via stub cloud provider

#### Types of Changes ####

enhancement

#### Verification ####

```
k3s server --node-external-dns node.example.com
```

now yields:

![image](https://github.com/user-attachments/assets/73072a3e-99fd-42f3-818a-395b09e05fd0)

As you can see it correctly sets the ExternalDNS address.

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10854
#### User-Facing Change ####

#### Further Comments ####

