### PR TITLE
[wip] Handle cluster join as create if current node is only cluster member

### DIFF
--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -53,7 +53,7 @@ func router(ctx context.Context, config *Config, cfg *cmds.Server) http.Handler 
 	serverConfig := &config.ControlConfig
 	nodeAuth := passwordBootstrap(ctx, config)
 
-	prefix := "/v1-" + version.Program
+	prefix := "/{apiroot:v1-[[:alnum:]]+}"
 	authed := mux.NewRouter().SkipClean(true)
 	authed.Use(auth.HasRole(serverConfig, version.Program+":agent", user.NodesGroup, bootstrapapi.BootstrapDefaultGroup))
 	authed.Path(prefix + "/serving-kubelet.crt").Handler(servingKubeletCert(serverConfig, serverConfig.Runtime.ServingKubeletKey, nodeAuth))


### PR DESCRIPTION
#### Proposed Changes ####

Handle cluster join as create if we're the only member.

Allows for coordinating cluster creation via standalone supervisor.

#### Types of Changes ####

#### Verification ####

#### Testing ####

#### Linked Issues ####

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

