### PR TITLE
add IPv6 to cluster-dns Usage Docs

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -143,7 +143,7 @@ var (
 	}
 	ClusterDNS = &cli.StringSliceFlag{
 		Name:  "cluster-dns",
-		Usage: "(networking) IPv4 Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
+		Usage: "(networking) IPv4/IPv6 Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
 		Value: &ServerConfig.ClusterDNS,
 	}
 	ClusterDomain = &cli.StringFlag{


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This update is based on the related PR/MR: [rancher/rke2-docs#303](https://github.com/rancher/rke2-docs/pull/303).

While the RKE2/K3s clusterDNS variable (cluster-dns) supports both IPv4 and IPv6, the current documentation does not explicitly mention the option to use an IPv6 address for the cluster DNS. Users can configure the cluster DNS to use an IPv4, IPv6, or dual-stack address, as supported by the [relevant script logic](https://github.com/rancher/rke2/blob/9255fd8fa411695fc93573a6e6dfa9470e13e938/scripts/validate-charts#L54).

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Add explicit documentation for IPv6 support in the ClusterDNS usage section, highlighting its capability to handle IPv6 addresses.

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
The ClusterDNS can be configured to use IPv4/IPv6 addresses based on the CIDRs specified in config.yaml. By default, the IPv4 ClusterIP is 10.43.0.10. If an address from an IPv6 CIDR is specified, the ClusterDNS service will also receive an IPv6 address.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->
Ensure that IPv6 addresses are correctly assigned to the ClusterDNS service when an IPv6 CIDR is configured under `IPs:` when using `kubectl describe svc rke2-coredns-rke2-coredns`

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
This update is based on the related PR/MR: [rancher/rke2-docs#303](https://github.com/rancher/rke2-docs/pull/303).

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
