### PR TITLE
Align etcd-snapshot-dir default path description

### DIFF
--- a/pkg/cli/cmds/etcd_snapshot.go
+++ b/pkg/cli/cmds/etcd_snapshot.go
@@ -34,7 +34,7 @@ var EtcdSnapshotFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:        "dir,etcd-snapshot-dir",
-		Usage:       "(db) Directory to save etcd on-demand snapshot. (default: ${data-dir}/db/snapshots)",
+		Usage:       "(db) Directory to save etcd on-demand snapshot. (default: ${data-dir}/server/db/snapshots)",
 		Destination: &ServerConfig.EtcdSnapshotDir,
 	},
 	&cli.StringFlag{

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -397,7 +397,7 @@ var ServerFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:        "etcd-snapshot-dir",
-		Usage:       "(db) Directory to save db snapshots. (default: ${data-dir}/db/snapshots)",
+		Usage:       "(db) Directory to save db snapshots. (default: ${data-dir}/server/db/snapshots)",
 		Destination: &ServerConfig.EtcdSnapshotDir,
 	},
 	&cli.BoolFlag{


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
The CLI documentation (i.e. `--help` output) should be a reliable source of truth for the end user. This PR ensures that the default etcd snapshot location matches the expectations that are being set by the CLI. It updates the `--etcd-snapshot-dir` option's description to match the effective default snapshot path (one that will be used by the `server`).

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix, a simple update to the `--etcd-snapshot-dir` option descriptions for the `server` and `etcd-snapshot` commands.

#### Verification ####

This section is mostly based on the reproduction steps from https://github.com/k3s-io/k3s/issues/11570

1. Run `k3s server --help | grep '\-dir'`.
2. Ensure the reported default value for `--etcd-snapshot-dir` matches `${data-dir}/server/db/snapshots`. That's been confirmed to be the actual path in the issue's analysis.
3. Run `k3s etcd-snapshot --help | grep '\-dir'`.
4. Repeat step 2.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->
Test coverage updates are not applicable to this PR, since it introduces no changes to the logic.

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/11570

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Align the CLI-reported default `--etcd-snapshot-dir` value with the actual one (`server`, `etcd-snapshot` commands).
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
No further comments.