### PR TITLE
Disable s3 transport transparent compression/decompression

### DIFF
--- a/pkg/etcd/s3/s3.go
+++ b/pkg/etcd/s3/s3.go
@@ -168,6 +168,12 @@ func (c *Controller) GetClient(ctx context.Context, etcdS3 *config.EtcdS3) (*Cli
 	}
 	tr := http.DefaultTransport.(*http.Transport).Clone()
 
+	// Set this value so that the underlying transport round-tripper
+	// doesn't try to auto decode the body of objects with
+	// content-encoding set to `gzip`.
+	// Ref: https://github.com/minio/minio-go/pull/752
+	tr.DisableCompression = true
+
 	// You can either disable SSL verification or use a custom CA bundle,
 	// it doesn't make sense to do both - if verification is disabled,
 	// the CA is not checked!


### PR DESCRIPTION
#### Proposed Changes ####

Disable s3 transport transparent compression/decompression

#### Types of Changes ####

bugfix

#### Verification ####

Cannot really verify this one as the issue only occurs on a specific vendor's S3 implementation, and there is no free version available. We can verify that it doesn't regress other users though.

#### Testing ####

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/11603

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
