### PR TITLE
[release-1.30] Fix local password validation when bind-address is set

### DIFF
--- a/pkg/nodepassword/validate.go
+++ b/pkg/nodepassword/validate.go
@@ -66,7 +66,7 @@ func GetNodeAuthValidator(ctx context.Context, control *config.Control) NodeAuth
 		// get client address, to see if deferred node password validation should be allowed when the apiserver
 		// is not available. Deferred password validation is only allowed for requests from the local client.
 		client, _, _ := net.SplitHostPort(req.RemoteAddr)
-		isLocal := client == "127.0.0.1" || client == "::1"
+		isLocal := client == "127.0.0.1" || client == "::1" || client == control.BindAddress
 
 		if secretClient == nil || nodeClient == nil {
 			if runtime.Core != nil {


### PR DESCRIPTION
#### Proposed Changes ####

* Backport https://github.com/k3s-io/k3s/pull/11607

Following a review from the security team, https://github.com/k3s-io/k3s/pull/11471 added a check to only allow node-password validation for the local node to be bypassed during startup if the request came from the loopback address. However, if bind-address is set, then the local agent will use the specified address instead of the loopback address when bootstrapping. This causes cert requests from the local agent to fail until the apiserver is up.

This is mostly fine here in k3s, it just makes the server start up a bit slower - but it breaks use of bind-address on RKE2 because the apiserver cannot come up until the agent (kubelet) is up.

#### Types of Changes ####

bugfix

#### Verification ####

* go test
* will add e2e in rke2 as well

#### Testing ####

Yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/11541
* https://github.com/rancher/security-team/issues/1097

#### User-Facing Change ####
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
