### PR TITLE
Fix e2e pipeline due to vagrant cloud infra issues

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -36,15 +36,23 @@ ENTRYPOINT ["./scripts/entry.sh"]
 CMD ["test"]
 
 
-FROM vagrantlibvirt/vagrant-libvirt:0.12.1 AS test-e2e
-RUN apt-get update && apt-get install -y docker.io
+FROM vagrantlibvirt/vagrant-libvirt:sha-a94ce0d AS test-e2e
+RUN apt-get update && apt-get install -y docker.io wget
+
 ENV VAGRANT_DISABLE_STRICT_DEPENDENCY_ENFORCEMENT=1
 RUN vagrant plugin install vagrant-k3s vagrant-reload vagrant-scp
-RUN vagrant box add bento/ubuntu-24.04 --provider libvirt --force
+
+# Workaround for older vagrant-libvirt image and new vagrant infra wesbites
+# See https://github.com/hashicorp/vagrant/issues/13571 and
+# https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1840
+RUN wget https://app.vagrantup.com/bento/boxes/ubuntu-24.04/versions/202404.26.0/providers/libvirt.box -O bento-ubuntu24.04-202404.26.0.box
+RUN vagrant box add bento/ubuntu-24.04 bento-ubuntu24.04-202404.26.0.box
+RUN cd /.vagrant.d/boxes/bento-VAGRANTSLASH-ubuntu-24.04/ && mv 0 202404.26.0 && echo -n "https://app.vagrantup.com/bento/boxes/ubuntu-24.04" > metadata_url
+
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"; \
     chmod +x ./kubectl; \
     mv ./kubectl /usr/local/bin/kubectl
-RUN GO_VERSION=go1.21.5; \
+RUN GO_VERSION=go1.22.5; \
     curl -O -L "https://golang.org/dl/${GO_VERSION}.linux-amd64.tar.gz"; \
     rm -rf /usr/local/go; \
     tar -C /usr/local -xzf ${GO_VERSION}.linux-amd64.tar.gz;


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Implement workaround to handle ttps://github.com/vagrant-libvirt/vagrant-libvirt/issues/1840 and  https://github.com/hashicorp/vagrant/issues/13571. For now we will manually download and install the ubuntu boxes used for E2E testing
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CI fixes
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Drone E2E passes again
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
