### PR TITLE
Consolidate test utility functions into top level package

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -108,10 +108,10 @@ jobs:
   
   build-go-tests:
     name: "Build Go Tests"
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     outputs:
       channel: ${{ steps.channel_step.outputs.channel }}
     steps:
@@ -122,7 +122,7 @@ jobs:
     - name: Build Go Tests
       run: |
         mkdir -p ./dist/artifacts
-        GOOS=linux GOARCH=${{ matrix.arch }} go test -c -ldflags="-w -s" -o ./dist/artifacts ./tests/docker/...
+        go test -c -ldflags="-w -s" -o ./dist/artifacts ./tests/docker/...
     - name: Upload Go Tests
       uses: actions/upload-artifact@v4
       with:

--- a/tests/client.go
+++ b/tests/client.go
@@ -1,0 +1,130 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/set"
+)
+
+// This file consolidates functions that are used across multiple testing frameworks.
+// Most of it relates to interacting with the Kubernetes API and checking the status of resources.
+
+// CheckDefaultDeployments checks if the standard array of K3s deployments are ready, otherwise returns an error
+func CheckDefaultDeployments(kubeconfigFile string) error {
+	return CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, kubeconfigFile)
+}
+
+// CheckDeployments checks if the provided list of deployments are ready, otherwise returns an error
+func CheckDeployments(deployments []string, kubeconfigFile string) error {
+
+	deploymentSet := make(map[string]bool)
+	for _, d := range deployments {
+		deploymentSet[d] = false
+	}
+
+	client, err := K8sClient(kubeconfigFile)
+	if err != nil {
+		return err
+	}
+	deploymentList, err := client.AppsV1().Deployments("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, deployment := range deploymentList.Items {
+		if _, ok := deploymentSet[deployment.Name]; ok && deployment.Status.ReadyReplicas == deployment.Status.Replicas {
+			deploymentSet[deployment.Name] = true
+		}
+	}
+	for d, found := range deploymentSet {
+		if !found {
+			return fmt.Errorf("failed to deploy %s", d)
+		}
+	}
+
+	return nil
+}
+
+func ParseNodes(kubeconfigFile string) ([]corev1.Node, error) {
+	clientSet, err := K8sClient(kubeconfigFile)
+	if err != nil {
+		return nil, err
+	}
+	nodes, err := clientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return nodes.Items, nil
+}
+
+func ParsePods(kubeconfigFile string) ([]corev1.Pod, error) {
+	clientSet, err := K8sClient(kubeconfigFile)
+	if err != nil {
+		return nil, err
+	}
+	pods, err := clientSet.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return pods.Items, nil
+}
+
+// PodReady checks if a pod is ready by querying its status
+func PodReady(podName, namespace, kubeconfigFile string) (bool, error) {
+	clientSet, err := K8sClient(kubeconfigFile)
+	if err != nil {
+		return false, err
+	}
+	pod, err := clientSet.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to get pod: %v", err)
+	}
+	// Check if the pod is running
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.Name == podName && containerStatus.Ready {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Checks if provided nodes are ready, otherwise returns an error
+func NodesReady(kubeconfigFile string, nodeNames []string) error {
+	nodes, err := ParseNodes(kubeconfigFile)
+	if err != nil {
+		return err
+	}
+	nodesToCheck := set.New(nodeNames...)
+	readyNodes := make(set.Set[string], 0)
+	for _, node := range nodes {
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady && condition.Status != corev1.ConditionTrue {
+				return fmt.Errorf("node %s is not ready", node.Name)
+			}
+			readyNodes.Insert(node.Name)
+		}
+	}
+	// Check if all nodes are ready
+	if !nodesToCheck.Equal(readyNodes) {
+		return fmt.Errorf("expected nodes %v, found %v", nodesToCheck, readyNodes)
+	}
+	return nil
+}
+
+func K8sClient(kubeconfigFile string) (*kubernetes.Clientset, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigFile)
+	if err != nil {
+		return nil, err
+	}
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return clientSet, nil
+}

--- a/tests/docker/basics/basics_test.go
+++ b/tests/docker/basics/basics_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,10 +32,10 @@ var _ = Describe("Basic Tests", Ordered, func() {
 			Expect(config.ProvisionServers(1)).To(Succeed())
 			Expect(config.ProvisionAgents(1)).To(Succeed())
 			Eventually(func() error {
-				return tester.DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
 			}, "60s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tester.NodesReady(config.KubeconfigFile, config.GetNodeNames())
+				return tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())
 			}, "40s", "5s").Should(Succeed())
 		})
 	})
@@ -46,7 +47,7 @@ var _ = Describe("Basic Tests", Ordered, func() {
 		})
 		It("should validate local storage volume", func() {
 			Eventually(func() (bool, error) {
-				return tester.PodReady("volume-test", "kube-system", config.KubeconfigFile)
+				return tests.PodReady("volume-test", "kube-system", config.KubeconfigFile)
 			}, "20s", "5s").Should(BeTrue())
 		})
 	})

--- a/tests/docker/bootstraptoken/bootstraptoken_test.go
+++ b/tests/docker/bootstraptoken/bootstraptoken_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -28,7 +29,7 @@ var _ = Describe("Boostrap Token Tests", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(config.ProvisionServers(1)).To(Succeed())
 			Eventually(func() error {
-				return tester.DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
 			}, "60s", "5s").Should(Succeed())
 		})
 	})
@@ -46,10 +47,10 @@ var _ = Describe("Boostrap Token Tests", Ordered, func() {
 			config.Token = newSecret
 			Expect(config.ProvisionAgents(1)).To(Succeed())
 			Eventually(func(g Gomega) {
-				nodes, err := tester.ParseNodes(config.KubeconfigFile)
+				nodes, err := tests.ParseNodes(config.KubeconfigFile)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(nodes).To(HaveLen(2))
-				g.Expect(tester.NodesReady(config.KubeconfigFile, config.GetNodeNames())).To(Succeed())
+				g.Expect(tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())).To(Succeed())
 			}, "40s", "5s").Should(Succeed())
 		})
 	})

--- a/tests/docker/cacerts/cacerts_test.go
+++ b/tests/docker/cacerts/cacerts_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -62,7 +63,7 @@ var _ = Describe("CA Certs Tests", Ordered, func() {
 			Expect(config.ProvisionServers(1)).To(Succeed())
 			Expect(config.ProvisionAgents(1)).To(Succeed())
 			Eventually(func() error {
-				return tester.DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
 			}, "60s", "5s").Should(Succeed())
 		})
 	})

--- a/tests/docker/etcd/etcd_test.go
+++ b/tests/docker/etcd/etcd_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -30,10 +31,10 @@ var _ = Describe("Etcd Tests", Ordered, func() {
 		It("should provision servers", func() {
 			Expect(config.ProvisionServers(3)).To(Succeed())
 			Eventually(func() error {
-				return tester.DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
 			}, "60s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tester.NodesReady(config.KubeconfigFile, config.GetNodeNames())
+				return tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())
 			}, "60s", "5s").Should(Succeed())
 		})
 		It("should destroy the cluster", func() {
@@ -56,10 +57,10 @@ var _ = Describe("Etcd Tests", Ordered, func() {
 			Expect(config.ProvisionServers(5)).To(Succeed())
 			Expect(config.ProvisionAgents(1)).To(Succeed())
 			Eventually(func() error {
-				return tester.DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
 			}, "90s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tester.NodesReady(config.KubeconfigFile, config.GetNodeNames())
+				return tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())
 			}, "90s", "5s").Should(Succeed())
 		})
 	})

--- a/tests/docker/lazypull/lazypull_test.go
+++ b/tests/docker/lazypull/lazypull_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -30,10 +31,10 @@ var _ = Describe("LazyPull Tests", Ordered, func() {
 			config.ServerYaml = "snapshotter: stargz"
 			Expect(config.ProvisionServers(1)).To(Succeed())
 			Eventually(func() error {
-				return tester.DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
 			}, "60s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tester.NodesReady(config.KubeconfigFile, config.GetNodeNames())
+				return tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())
 			}, "40s", "5s").Should(Succeed())
 		})
 	})
@@ -45,7 +46,7 @@ var _ = Describe("LazyPull Tests", Ordered, func() {
 		})
 		It("should have the pod come up", func() {
 			Eventually(func() (bool, error) {
-				return tester.PodReady("stargz-snapshot-test", "default", config.KubeconfigFile)
+				return tests.PodReady("stargz-snapshot-test", "default", config.KubeconfigFile)
 			}, "30s", "5s").Should(BeTrue())
 		})
 		var topLayer string

--- a/tests/docker/skew/skew_test.go
+++ b/tests/docker/skew/skew_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/k3s-io/k3s/tests"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -62,7 +63,7 @@ var _ = Describe("Skew Tests", Ordered, func() {
 			config.K3sImage = "rancher/k3s:" + lastMinorVersion
 			Expect(config.ProvisionAgents(1)).To(Succeed())
 			Eventually(func() error {
-				return tester.DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
 			}, "60s", "5s").Should(Succeed())
 		})
 		It("should match respective versions", func() {
@@ -85,7 +86,7 @@ var _ = Describe("Skew Tests", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to apply volume test manifest")
 
 			Eventually(func() (bool, error) {
-				return tester.PodReady("volume-test", "kube-system", config.KubeconfigFile)
+				return tests.PodReady("volume-test", "kube-system", config.KubeconfigFile)
 			}, "20s", "5s").Should(BeTrue())
 		})
 		It("should destroy the cluster", func() {
@@ -103,11 +104,11 @@ var _ = Describe("Skew Tests", Ordered, func() {
 			config.K3sImage = *k3sImage
 			Expect(config.ProvisionServers(3)).To(Succeed())
 			Eventually(func() error {
-				return tester.DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
 			}, "60s", "5s").Should(Succeed())
 			Eventually(func(g Gomega) {
-				g.Expect(tester.ParseNodes(config.KubeconfigFile)).To(HaveLen(3))
-				g.Expect(tester.NodesReady(config.KubeconfigFile, config.GetNodeNames())).To(Succeed())
+				g.Expect(tests.ParseNodes(config.KubeconfigFile)).To(HaveLen(3))
+				g.Expect(tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())).To(Succeed())
 			}, "60s", "5s").Should(Succeed())
 		})
 		It("should match respective versions", func() {

--- a/tests/docker/snapshotrestore/snapshotrestore_test.go
+++ b/tests/docker/snapshotrestore/snapshotrestore_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,10 +36,10 @@ var _ = Describe("Verify snapshots and cluster restores work", Ordered, func() {
 			Expect(config.ProvisionServers(*serverCount)).To(Succeed())
 			Expect(config.ProvisionAgents(*agentCount)).To(Succeed())
 			Eventually(func() error {
-				return tester.CheckDefaultDeployments(config.KubeconfigFile)
+				return tests.CheckDefaultDeployments(config.KubeconfigFile)
 			}, "60s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tester.NodesReady(config.KubeconfigFile, config.GetNodeNames())
+				return tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())
 			}, "40s", "5s").Should(Succeed())
 		})
 	})
@@ -135,12 +136,12 @@ var _ = Describe("Verify snapshots and cluster restores work", Ordered, func() {
 		It("Checks that all nodes and pods are ready", func() {
 			By("Fetching node status")
 			Eventually(func() error {
-				return tester.NodesReady(config.KubeconfigFile, config.GetNodeNames())
+				return tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())
 			}, "60s", "5s").Should(Succeed())
 
 			By("Fetching Pods status")
 			Eventually(func(g Gomega) {
-				pods, err := tester.ParsePods(config.KubeconfigFile)
+				pods, err := tests.ParsePods(config.KubeconfigFile)
 				g.Expect(err).NotTo(HaveOccurred())
 				for _, pod := range pods {
 					if strings.Contains(pod.Name, "helm-install") {

--- a/tests/docker/test-helpers.go
+++ b/tests/docker/test-helpers.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"net"
@@ -15,11 +14,6 @@ import (
 
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/utils/set"
 )
 
 type TestConfig struct {
@@ -490,122 +484,4 @@ func (config TestConfig) DeployWorkload(workload string) (string, error) {
 		}
 	}
 	return "", nil
-}
-
-// TODO the below functions are duplicated in the integration test utils. Consider combining into commmon package
-
-// CheckDefaultDeployments checks if the default deployments: coredns, local-path-provisioner, metrics-server, traefik
-// for K3s are ready, otherwise returns an error
-func CheckDefaultDeployments(kubeconfigFile string) error {
-	return DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, kubeconfigFile)
-}
-
-// DeploymentsReady checks if the provided list of deployments are ready, otherwise returns an error
-func DeploymentsReady(deployments []string, kubeconfigFile string) error {
-
-	deploymentSet := make(map[string]bool)
-	for _, d := range deployments {
-		deploymentSet[d] = false
-	}
-
-	client, err := k8sClient(kubeconfigFile)
-	if err != nil {
-		return err
-	}
-	deploymentList, err := client.AppsV1().Deployments("").List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for _, deployment := range deploymentList.Items {
-		if _, ok := deploymentSet[deployment.Name]; ok && deployment.Status.ReadyReplicas == deployment.Status.Replicas {
-			deploymentSet[deployment.Name] = true
-		}
-	}
-	for d, found := range deploymentSet {
-		if !found {
-			return fmt.Errorf("failed to deploy %s", d)
-		}
-	}
-
-	return nil
-}
-
-func ParseNodes(kubeconfigFile string) ([]corev1.Node, error) {
-	clientSet, err := k8sClient(kubeconfigFile)
-	if err != nil {
-		return nil, err
-	}
-	nodes, err := clientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return nodes.Items, nil
-}
-
-func ParsePods(kubeconfigFile string) ([]corev1.Pod, error) {
-	clientSet, err := k8sClient(kubeconfigFile)
-	if err != nil {
-		return nil, err
-	}
-	pods, err := clientSet.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return pods.Items, nil
-}
-
-// PodReady checks if a pod is ready by querying its status
-func PodReady(podName, namespace, kubeconfigFile string) (bool, error) {
-	clientSet, err := k8sClient(kubeconfigFile)
-	if err != nil {
-		return false, err
-	}
-	pod, err := clientSet.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
-	if err != nil {
-		return false, fmt.Errorf("failed to get pod: %v", err)
-	}
-	// Check if the pod is running
-	for _, containerStatus := range pod.Status.ContainerStatuses {
-		if containerStatus.Name == podName && containerStatus.Ready {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// Checks if provided nodes are ready, otherwise returns an error
-func NodesReady(kubeconfigFile string, nodeNames []string) error {
-	nodes, err := ParseNodes(kubeconfigFile)
-	if err != nil {
-		return err
-	}
-	nodesToCheck := set.New(nodeNames...)
-	readyNodes := make(set.Set[string], 0)
-	for _, node := range nodes {
-		for _, condition := range node.Status.Conditions {
-			if condition.Type == corev1.NodeReady && condition.Status != corev1.ConditionTrue {
-				return fmt.Errorf("node %s is not ready", node.Name)
-			}
-			readyNodes.Insert(node.Name)
-		}
-	}
-	// Check if all nodes are ready
-	if !nodesToCheck.Equal(readyNodes) {
-		return fmt.Errorf("expected nodes %v, found %v", nodesToCheck, readyNodes)
-	}
-	return nil
-}
-
-func k8sClient(kubeconfigFile string) (*kubernetes.Clientset, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigFile)
-	if err != nil {
-		return nil, err
-	}
-	clientSet, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return clientSet, nil
 }

--- a/tests/docker/upgrade/upgrade_test.go
+++ b/tests/docker/upgrade/upgrade_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -69,7 +70,7 @@ var _ = Describe("Upgrade Tests", Ordered, func() {
 			Expect(config.ProvisionServers(numServers)).To(Succeed())
 			Expect(config.ProvisionAgents(numAgents)).To(Succeed())
 			Eventually(func() error {
-				return tester.DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
 			}, "60s", "5s").Should(Succeed())
 		})
 		It("should confirm latest version", func() {
@@ -84,7 +85,7 @@ var _ = Describe("Upgrade Tests", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to apply volume test manifest")
 
 			Eventually(func() (bool, error) {
-				return tester.PodReady("volume-test", "kube-system", config.KubeconfigFile)
+				return tests.PodReady("volume-test", "kube-system", config.KubeconfigFile)
 			}, "20s", "5s").Should(BeTrue())
 		})
 		It("should upgrade to current commit build", func() {
@@ -111,7 +112,7 @@ var _ = Describe("Upgrade Tests", Ordered, func() {
 			Expect(config.ProvisionAgents(numAgents)).To(Succeed())
 
 			Eventually(func() error {
-				return tester.DeploymentsReady([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
 			}, "60s", "5s").Should(Succeed())
 		})
 		It("should confirm commit version", func() {
@@ -131,7 +132,7 @@ var _ = Describe("Upgrade Tests", Ordered, func() {
 		})
 		It("should confirm test pod is still Running", func() {
 			Eventually(func() (bool, error) {
-				return tester.PodReady("volume-test", "kube-system", config.KubeconfigFile)
+				return tests.PodReady("volume-test", "kube-system", config.KubeconfigFile)
 			}, "20s", "5s").Should(BeTrue())
 		})
 

--- a/tests/e2e/autoimport/autoimport_test.go
+++ b/tests/e2e/autoimport/autoimport_test.go
@@ -3,9 +3,9 @@ package autoimport
 import (
 	"flag"
 	"os"
-	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	"github.com/k3s-io/k3s/tests/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -50,7 +50,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			By(tc.Status())
 		})
 
-		It("Checks Node and Pod Status", func() {
+		It("Checks node and pod status", func() {
 			By("Fetching Nodes status")
 			Eventually(func(g Gomega) {
 				nodes, err := e2e.ParseNodes(tc.KubeConfigFile, false)
@@ -61,17 +61,8 @@ var _ = Describe("Verify Create", Ordered, func() {
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 
-			By("Fetching Pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})

--- a/tests/e2e/btrfs/btrfs_test.go
+++ b/tests/e2e/btrfs/btrfs_test.go
@@ -3,9 +3,9 @@ package rotateca
 import (
 	"flag"
 	"os"
-	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	"github.com/k3s-io/k3s/tests/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -54,17 +54,8 @@ var _ = Describe("Verify that btrfs based servers work", Ordered, func() {
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 
-			By("Fetching Pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	"github.com/k3s-io/k3s/tests/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,17 +60,9 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Checks Pod Status", func() {
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+		It("Checks pod status", func() {
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
@@ -106,7 +99,7 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 				if strings.Contains(ip, "::") {
 					ip = "[" + ip + "]"
 				}
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
+				pods, err := tests.ParsePods(tc.KubeConfigFile)
 				Expect(err).NotTo(HaveOccurred())
 				for _, pod := range pods {
 					if !strings.HasPrefix(pod.Name, "ds-clusterip-pod") {

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -27,11 +27,7 @@ func Test_E2EDualStack(t *testing.T) {
 	RunSpecs(t, "DualStack Test Suite", suiteConfig, reporterConfig)
 }
 
-var (
-	kubeConfigFile string
-	serverNodes    []e2e.VagrantNode
-	agentNodes     []e2e.VagrantNode
-)
+var tc *e2e.TestConfig
 
 var _ = ReportAfterEach(e2e.GenReport)
 
@@ -40,34 +36,32 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 	It("Starts up with no issues", func() {
 		var err error
 		if *local {
-			serverNodes, agentNodes, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
+			tc, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
 		} else {
-			serverNodes, agentNodes, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
+			tc, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 		}
 		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
-		fmt.Println("CLUSTER CONFIG")
-		fmt.Println("OS:", *nodeOS)
-		fmt.Println("Server Nodes:", serverNodes)
-		fmt.Println("Agent Nodes:", agentNodes)
-		kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodes[0].String())
-		Expect(err).NotTo(HaveOccurred())
+		tc.Hardened = *hardened
+		By("CLUSTER CONFIG")
+		By("OS: " + *nodeOS)
+		By(tc.Status())
 	})
 
 	It("Checks Node Status", func() {
 		Eventually(func(g Gomega) {
-			nodes, err := e2e.ParseNodes(kubeConfigFile, false)
+			nodes, err := e2e.ParseNodes(tc.KubeConfigFile, false)
 			g.Expect(err).NotTo(HaveOccurred())
 			for _, node := range nodes {
 				g.Expect(node.Status).Should(Equal("Ready"))
 			}
 		}, "620s", "5s").Should(Succeed())
-		_, err := e2e.ParseNodes(kubeConfigFile, true)
+		_, err := e2e.ParseNodes(tc.KubeConfigFile, true)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("Checks Pod Status", func() {
 		Eventually(func(g Gomega) {
-			pods, err := e2e.ParsePods(kubeConfigFile, false)
+			pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
 			g.Expect(err).NotTo(HaveOccurred())
 			for _, pod := range pods {
 				if strings.Contains(pod.Name, "helm-install") {
@@ -77,12 +71,11 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 				}
 			}
 		}, "620s", "5s").Should(Succeed())
-		_, err := e2e.ParsePods(kubeConfigFile, true)
-		Expect(err).NotTo(HaveOccurred())
+		e2e.DumpPods(tc.KubeConfigFile)
 	})
 
 	It("Verifies that each node has IPv4 and IPv6", func() {
-		nodeIPs, err := e2e.GetNodeIPs(kubeConfigFile)
+		nodeIPs, err := e2e.GetNodeIPs(tc.KubeConfigFile)
 		Expect(err).NotTo(HaveOccurred())
 		for _, node := range nodeIPs {
 			Expect(node.IPv4).Should(ContainSubstring("10.10.10"))
@@ -90,7 +83,7 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 		}
 	})
 	It("Verifies that each pod has IPv4 and IPv6", func() {
-		podIPs, err := e2e.GetPodIPs(kubeConfigFile)
+		podIPs, err := e2e.GetPodIPs(tc.KubeConfigFile)
 		Expect(err).NotTo(HaveOccurred())
 		for _, pod := range podIPs {
 			Expect(pod.IPv4).Should(Or(ContainSubstring("10.10.10"), ContainSubstring("10.42.")), pod.Name)
@@ -99,21 +92,21 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 	})
 
 	It("Verifies ClusterIP Service", func() {
-		_, err := e2e.DeployWorkload("dualstack_clusterip.yaml", kubeConfigFile, *hardened)
+		_, err := tc.DeployWorkload("dualstack_clusterip.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(func() (string, error) {
-			cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
+			cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + tc.KubeConfigFile
 			return e2e.RunCommand(cmd)
 		}, "120s", "5s").Should(ContainSubstring("ds-clusterip-pod"))
 
 		// Checks both IPv4 and IPv6
-		clusterips, err := e2e.FetchClusterIP(kubeConfigFile, "ds-clusterip-svc", true)
+		clusterips, err := e2e.FetchClusterIP(tc.KubeConfigFile, "ds-clusterip-svc", true)
 		Expect(err).NotTo(HaveOccurred())
 		for _, ip := range strings.Split(clusterips, ",") {
 			if strings.Contains(ip, "::") {
 				ip = "[" + ip + "]"
 			}
-			pods, err := e2e.ParsePods(kubeConfigFile, false)
+			pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
 			Expect(err).NotTo(HaveOccurred())
 			for _, pod := range pods {
 				if !strings.HasPrefix(pod.Name, "ds-clusterip-pod") {
@@ -121,18 +114,18 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 				}
 				cmd := fmt.Sprintf("curl -L --insecure http://%s", ip)
 				Eventually(func() (string, error) {
-					return serverNodes[0].RunCmdOnNode(cmd)
+					return tc.Servers[0].RunCmdOnNode(cmd)
 				}, "60s", "5s").Should(ContainSubstring("Welcome to nginx!"), "failed cmd: "+cmd)
 			}
 		}
 	})
 	It("Verifies Ingress", func() {
-		_, err := e2e.DeployWorkload("dualstack_ingress.yaml", kubeConfigFile, *hardened)
+		_, err := tc.DeployWorkload("dualstack_ingress.yaml")
 		Expect(err).NotTo(HaveOccurred(), "Ingress manifest not deployed")
-		cmd := "kubectl get ingress ds-ingress --kubeconfig=" + kubeConfigFile + " -o jsonpath=\"{.spec.rules[*].host}\""
+		cmd := "kubectl get ingress ds-ingress -o jsonpath=\"{.spec.rules[*].host}\""
 		hostName, err := e2e.RunCommand(cmd)
 		Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd)
-		nodeIPs, err := e2e.GetNodeIPs(kubeConfigFile)
+		nodeIPs, err := e2e.GetNodeIPs(tc.KubeConfigFile)
 		Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd)
 		for _, node := range nodeIPs {
 			cmd := fmt.Sprintf("curl  --header host:%s http://%s/name.html", hostName, node.IPv4)
@@ -147,12 +140,12 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 	})
 
 	It("Verifies NodePort Service", func() {
-		_, err := e2e.DeployWorkload("dualstack_nodeport.yaml", kubeConfigFile, *hardened)
+		_, err := tc.DeployWorkload("dualstack_nodeport.yaml")
 		Expect(err).NotTo(HaveOccurred())
-		cmd := "kubectl get service ds-nodeport-svc --kubeconfig=" + kubeConfigFile + " --output jsonpath=\"{.spec.ports[0].nodePort}\""
+		cmd := "kubectl get service ds-nodeport-svc --output jsonpath=\"{.spec.ports[0].nodePort}\""
 		nodeport, err := e2e.RunCommand(cmd)
 		Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd)
-		nodeIPs, err := e2e.GetNodeIPs(kubeConfigFile)
+		nodeIPs, err := e2e.GetNodeIPs(tc.KubeConfigFile)
 		Expect(err).NotTo(HaveOccurred())
 		for _, node := range nodeIPs {
 			cmd = "curl -L --insecure http://" + node.IPv4 + ":" + nodeport + "/name.html"
@@ -166,23 +159,23 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 		}
 	})
 	It("Verifies podSelector Network Policy", func() {
-		_, err := e2e.DeployWorkload("pod_client.yaml", kubeConfigFile, *hardened)
+		_, err := tc.DeployWorkload("pod_client.yaml")
 		Expect(err).NotTo(HaveOccurred())
-		cmd := "kubectl exec svc/client-curl --kubeconfig=" + kubeConfigFile + " -- curl -m7 ds-clusterip-svc/name.html"
+		cmd := "kubectl exec svc/client-curl -- curl -m7 ds-clusterip-svc/name.html"
 		Eventually(func() (string, error) {
 			return e2e.RunCommand(cmd)
 		}, "20s", "3s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
-		_, err = e2e.DeployWorkload("netpol-fail.yaml", kubeConfigFile, *hardened)
+		_, err = tc.DeployWorkload("netpol-fail.yaml")
 		Expect(err).NotTo(HaveOccurred())
-		cmd = "kubectl exec svc/client-curl --kubeconfig=" + kubeConfigFile + " -- curl -m7 ds-clusterip-svc/name.html"
+		cmd = "kubectl exec svc/client-curl -- curl -m7 ds-clusterip-svc/name.html"
 		Eventually(func() error {
 			_, err = e2e.RunCommand(cmd)
 			Expect(err).To(HaveOccurred())
 			return err
 		}, "20s", "3s")
-		_, err = e2e.DeployWorkload("netpol-work.yaml", kubeConfigFile, *hardened)
+		_, err = tc.DeployWorkload("netpol-work.yaml")
 		Expect(err).NotTo(HaveOccurred())
-		cmd = "kubectl exec svc/client-curl --kubeconfig=" + kubeConfigFile + " -- curl -m7 ds-clusterip-svc/name.html"
+		cmd = "kubectl exec svc/client-curl -- curl -m7 ds-clusterip-svc/name.html"
 		Eventually(func() (string, error) {
 			return e2e.RunCommand(cmd)
 		}, "20s", "3s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
@@ -196,12 +189,12 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, append(serverNodes, agentNodes...)))
+		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, append(tc.Servers, tc.Agents...)))
 	} else {
-		Expect(e2e.GetCoverageReport(append(serverNodes, agentNodes...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())
-		Expect(os.Remove(kubeConfigFile)).To(Succeed())
+		Expect(os.Remove(tc.KubeConfigFile)).To(Succeed())
 	}
 })

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -32,153 +32,154 @@ var tc *e2e.TestConfig
 var _ = ReportAfterEach(e2e.GenReport)
 
 var _ = Describe("Verify DualStack Configuration", Ordered, func() {
-
-	It("Starts up with no issues", func() {
-		var err error
-		if *local {
-			tc, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
-		} else {
-			tc, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
-		}
-		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
-		tc.Hardened = *hardened
-		By("CLUSTER CONFIG")
-		By("OS: " + *nodeOS)
-		By(tc.Status())
-	})
-
-	It("Checks Node Status", func() {
-		Eventually(func(g Gomega) {
-			nodes, err := e2e.ParseNodes(tc.KubeConfigFile, false)
-			g.Expect(err).NotTo(HaveOccurred())
-			for _, node := range nodes {
-				g.Expect(node.Status).Should(Equal("Ready"))
+	Context("Cluster Deploys with both IPv6 and IPv4 networks", func() {
+		It("Starts up with no issues", func() {
+			var err error
+			if *local {
+				tc, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
+			} else {
+				tc, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 			}
-		}, "620s", "5s").Should(Succeed())
-		_, err := e2e.ParseNodes(tc.KubeConfigFile, true)
-		Expect(err).NotTo(HaveOccurred())
-	})
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
+			tc.Hardened = *hardened
+			By("CLUSTER CONFIG")
+			By("OS: " + *nodeOS)
+			By(tc.Status())
+		})
 
-	It("Checks Pod Status", func() {
-		Eventually(func(g Gomega) {
-			pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-			g.Expect(err).NotTo(HaveOccurred())
-			for _, pod := range pods {
-				if strings.Contains(pod.Name, "helm-install") {
-					g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-				} else {
-					g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
+		It("Checks Node Status", func() {
+			Eventually(func(g Gomega) {
+				nodes, err := e2e.ParseNodes(tc.KubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, node := range nodes {
+					g.Expect(node.Status).Should(Equal("Ready"))
 				}
-			}
-		}, "620s", "5s").Should(Succeed())
-		e2e.DumpPods(tc.KubeConfigFile)
-	})
-
-	It("Verifies that each node has IPv4 and IPv6", func() {
-		nodeIPs, err := e2e.GetNodeIPs(tc.KubeConfigFile)
-		Expect(err).NotTo(HaveOccurred())
-		for _, node := range nodeIPs {
-			Expect(node.IPv4).Should(ContainSubstring("10.10.10"))
-			Expect(node.IPv6).Should(ContainSubstring("fd11:decf:c0ff"))
-		}
-	})
-	It("Verifies that each pod has IPv4 and IPv6", func() {
-		podIPs, err := e2e.GetPodIPs(tc.KubeConfigFile)
-		Expect(err).NotTo(HaveOccurred())
-		for _, pod := range podIPs {
-			Expect(pod.IPv4).Should(Or(ContainSubstring("10.10.10"), ContainSubstring("10.42.")), pod.Name)
-			Expect(pod.IPv6).Should(Or(ContainSubstring("fd11:decf:c0ff"), ContainSubstring("2001:cafe:42")), pod.Name)
-		}
-	})
-
-	It("Verifies ClusterIP Service", func() {
-		_, err := tc.DeployWorkload("dualstack_clusterip.yaml")
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(func() (string, error) {
-			cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + tc.KubeConfigFile
-			return e2e.RunCommand(cmd)
-		}, "120s", "5s").Should(ContainSubstring("ds-clusterip-pod"))
-
-		// Checks both IPv4 and IPv6
-		clusterips, err := e2e.FetchClusterIP(tc.KubeConfigFile, "ds-clusterip-svc", true)
-		Expect(err).NotTo(HaveOccurred())
-		for _, ip := range strings.Split(clusterips, ",") {
-			if strings.Contains(ip, "::") {
-				ip = "[" + ip + "]"
-			}
-			pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
+			}, "620s", "5s").Should(Succeed())
+			_, err := e2e.ParseNodes(tc.KubeConfigFile, true)
 			Expect(err).NotTo(HaveOccurred())
-			for _, pod := range pods {
-				if !strings.HasPrefix(pod.Name, "ds-clusterip-pod") {
-					continue
-				}
-				cmd := fmt.Sprintf("curl -L --insecure http://%s", ip)
-				Eventually(func() (string, error) {
-					return tc.Servers[0].RunCmdOnNode(cmd)
-				}, "60s", "5s").Should(ContainSubstring("Welcome to nginx!"), "failed cmd: "+cmd)
-			}
-		}
-	})
-	It("Verifies Ingress", func() {
-		_, err := tc.DeployWorkload("dualstack_ingress.yaml")
-		Expect(err).NotTo(HaveOccurred(), "Ingress manifest not deployed")
-		cmd := "kubectl get ingress ds-ingress -o jsonpath=\"{.spec.rules[*].host}\""
-		hostName, err := e2e.RunCommand(cmd)
-		Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd)
-		nodeIPs, err := e2e.GetNodeIPs(tc.KubeConfigFile)
-		Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd)
-		for _, node := range nodeIPs {
-			cmd := fmt.Sprintf("curl  --header host:%s http://%s/name.html", hostName, node.IPv4)
-			Eventually(func() (string, error) {
-				return e2e.RunCommand(cmd)
-			}, "10s", "2s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
-			cmd = fmt.Sprintf("curl  --header host:%s http://[%s]/name.html", hostName, node.IPv6)
-			Eventually(func() (string, error) {
-				return e2e.RunCommand(cmd)
-			}, "5s", "1s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
-		}
-	})
+		})
 
-	It("Verifies NodePort Service", func() {
-		_, err := tc.DeployWorkload("dualstack_nodeport.yaml")
-		Expect(err).NotTo(HaveOccurred())
-		cmd := "kubectl get service ds-nodeport-svc --output jsonpath=\"{.spec.ports[0].nodePort}\""
-		nodeport, err := e2e.RunCommand(cmd)
-		Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd)
-		nodeIPs, err := e2e.GetNodeIPs(tc.KubeConfigFile)
-		Expect(err).NotTo(HaveOccurred())
-		for _, node := range nodeIPs {
-			cmd = "curl -L --insecure http://" + node.IPv4 + ":" + nodeport + "/name.html"
+		It("Checks Pod Status", func() {
+			Eventually(func(g Gomega) {
+				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, pod := range pods {
+					if strings.Contains(pod.Name, "helm-install") {
+						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
+					} else {
+						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
+					}
+				}
+			}, "620s", "5s").Should(Succeed())
+			e2e.DumpPods(tc.KubeConfigFile)
+		})
+
+		It("Verifies that each node has IPv4 and IPv6", func() {
+			nodeIPs, err := e2e.GetNodeIPs(tc.KubeConfigFile)
+			Expect(err).NotTo(HaveOccurred())
+			for _, node := range nodeIPs {
+				Expect(node.IPv4).Should(ContainSubstring("10.10.10"))
+				Expect(node.IPv6).Should(ContainSubstring("fd11:decf:c0ff"))
+			}
+		})
+		It("Verifies that each pod has IPv4 and IPv6", func() {
+			podIPs, err := e2e.GetPodIPs(tc.KubeConfigFile)
+			Expect(err).NotTo(HaveOccurred())
+			for _, pod := range podIPs {
+				Expect(pod.IPv4).Should(Or(ContainSubstring("10.10.10"), ContainSubstring("10.42.")), pod.Name)
+				Expect(pod.IPv6).Should(Or(ContainSubstring("fd11:decf:c0ff"), ContainSubstring("2001:cafe:42")), pod.Name)
+			}
+		})
+
+		It("Verifies ClusterIP Service", func() {
+			_, err := tc.DeployWorkload("dualstack_clusterip.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() (string, error) {
+				cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + tc.KubeConfigFile
+				return e2e.RunCommand(cmd)
+			}, "120s", "5s").Should(ContainSubstring("ds-clusterip-pod"))
+
+			// Checks both IPv4 and IPv6
+			clusterips, err := e2e.FetchClusterIP(tc.KubeConfigFile, "ds-clusterip-svc", true)
+			Expect(err).NotTo(HaveOccurred())
+			for _, ip := range strings.Split(clusterips, ",") {
+				if strings.Contains(ip, "::") {
+					ip = "[" + ip + "]"
+				}
+				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
+				Expect(err).NotTo(HaveOccurred())
+				for _, pod := range pods {
+					if !strings.HasPrefix(pod.Name, "ds-clusterip-pod") {
+						continue
+					}
+					cmd := fmt.Sprintf("curl -L --insecure http://%s", ip)
+					Eventually(func() (string, error) {
+						return tc.Servers[0].RunCmdOnNode(cmd)
+					}, "60s", "5s").Should(ContainSubstring("Welcome to nginx!"), "failed cmd: "+cmd)
+				}
+			}
+		})
+		It("Verifies Ingress", func() {
+			_, err := tc.DeployWorkload("dualstack_ingress.yaml")
+			Expect(err).NotTo(HaveOccurred(), "Ingress manifest not deployed")
+			cmd := "kubectl get ingress ds-ingress -o jsonpath=\"{.spec.rules[*].host}\""
+			hostName, err := e2e.RunCommand(cmd)
+			Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd)
+			nodeIPs, err := e2e.GetNodeIPs(tc.KubeConfigFile)
+			Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd)
+			for _, node := range nodeIPs {
+				cmd := fmt.Sprintf("curl  --header host:%s http://%s/name.html", hostName, node.IPv4)
+				Eventually(func() (string, error) {
+					return e2e.RunCommand(cmd)
+				}, "10s", "2s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
+				cmd = fmt.Sprintf("curl  --header host:%s http://[%s]/name.html", hostName, node.IPv6)
+				Eventually(func() (string, error) {
+					return e2e.RunCommand(cmd)
+				}, "5s", "1s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
+			}
+		})
+
+		It("Verifies NodePort Service", func() {
+			_, err := tc.DeployWorkload("dualstack_nodeport.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			cmd := "kubectl get service ds-nodeport-svc --output jsonpath=\"{.spec.ports[0].nodePort}\""
+			nodeport, err := e2e.RunCommand(cmd)
+			Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd)
+			nodeIPs, err := e2e.GetNodeIPs(tc.KubeConfigFile)
+			Expect(err).NotTo(HaveOccurred())
+			for _, node := range nodeIPs {
+				cmd = "curl -L --insecure http://" + node.IPv4 + ":" + nodeport + "/name.html"
+				Eventually(func() (string, error) {
+					return e2e.RunCommand(cmd)
+				}, "10s", "1s").Should(ContainSubstring("ds-nodeport-pod"), "failed cmd: "+cmd)
+				cmd = "curl -L --insecure http://[" + node.IPv6 + "]:" + nodeport + "/name.html"
+				Eventually(func() (string, error) {
+					return e2e.RunCommand(cmd)
+				}, "10s", "1s").Should(ContainSubstring("ds-nodeport-pod"), "failed cmd: "+cmd)
+			}
+		})
+		It("Verifies podSelector Network Policy", func() {
+			_, err := tc.DeployWorkload("pod_client.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			cmd := "kubectl exec svc/client-curl -- curl -m7 ds-clusterip-svc/name.html"
 			Eventually(func() (string, error) {
 				return e2e.RunCommand(cmd)
-			}, "10s", "1s").Should(ContainSubstring("ds-nodeport-pod"), "failed cmd: "+cmd)
-			cmd = "curl -L --insecure http://[" + node.IPv6 + "]:" + nodeport + "/name.html"
+			}, "20s", "3s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
+			_, err = tc.DeployWorkload("netpol-fail.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			cmd = "kubectl exec svc/client-curl -- curl -m7 ds-clusterip-svc/name.html"
+			Eventually(func() error {
+				_, err = e2e.RunCommand(cmd)
+				Expect(err).To(HaveOccurred())
+				return err
+			}, "20s", "3s")
+			_, err = tc.DeployWorkload("netpol-work.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			cmd = "kubectl exec svc/client-curl -- curl -m7 ds-clusterip-svc/name.html"
 			Eventually(func() (string, error) {
 				return e2e.RunCommand(cmd)
-			}, "10s", "1s").Should(ContainSubstring("ds-nodeport-pod"), "failed cmd: "+cmd)
-		}
-	})
-	It("Verifies podSelector Network Policy", func() {
-		_, err := tc.DeployWorkload("pod_client.yaml")
-		Expect(err).NotTo(HaveOccurred())
-		cmd := "kubectl exec svc/client-curl -- curl -m7 ds-clusterip-svc/name.html"
-		Eventually(func() (string, error) {
-			return e2e.RunCommand(cmd)
-		}, "20s", "3s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
-		_, err = tc.DeployWorkload("netpol-fail.yaml")
-		Expect(err).NotTo(HaveOccurred())
-		cmd = "kubectl exec svc/client-curl -- curl -m7 ds-clusterip-svc/name.html"
-		Eventually(func() error {
-			_, err = e2e.RunCommand(cmd)
-			Expect(err).To(HaveOccurred())
-			return err
-		}, "20s", "3s")
-		_, err = tc.DeployWorkload("netpol-work.yaml")
-		Expect(err).NotTo(HaveOccurred())
-		cmd = "kubectl exec svc/client-curl -- curl -m7 ds-clusterip-svc/name.html"
-		Eventually(func() (string, error) {
-			return e2e.RunCommand(cmd)
-		}, "20s", "3s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
+			}, "20s", "3s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
+		})
 	})
 })
 

--- a/tests/e2e/externalip/externalip_test.go
+++ b/tests/e2e/externalip/externalip_test.go
@@ -56,9 +56,9 @@ func Test_E2EExternalIP(t *testing.T) {
 }
 
 var (
-	kubeConfigFile  string
-	serverNodeNames []string
-	agentNodeNames  []string
+	kubeConfigFile string
+	serverNodes    []e2e.VagrantNode
+	agentNodes     []e2e.VagrantNode
 )
 
 var _ = ReportAfterEach(e2e.GenReport)
@@ -68,16 +68,16 @@ var _ = Describe("Verify External-IP config", Ordered, func() {
 	It("Starts up with no issues", func() {
 		var err error
 		if *local {
-			serverNodeNames, agentNodeNames, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
+			serverNodes, agentNodes, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
 		} else {
-			serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
+			serverNodes, agentNodes, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 		}
 		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 		fmt.Println("CLUSTER CONFIG")
 		fmt.Println("OS:", *nodeOS)
-		fmt.Println("Server Nodes:", serverNodeNames)
-		fmt.Println("Agent Nodes:", agentNodeNames)
-		kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodeNames[0])
+		fmt.Println("Server Nodes:", serverNodes)
+		fmt.Println("Agent Nodes:", agentNodes)
+		kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodes[0].String())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -166,9 +166,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		Expect(e2e.SaveJournalLogs(append(serverNodeNames, agentNodeNames...))).To(Succeed())
+		Expect(e2e.SaveJournalLogs(append(serverNodes, agentNodes...))).To(Succeed())
 	} else {
-		Expect(e2e.GetCoverageReport(append(serverNodeNames, agentNodeNames...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(append(serverNodes, agentNodes...))).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/externalip/externalip_test.go
+++ b/tests/e2e/externalip/externalip_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	"github.com/k3s-io/k3s/tests/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -84,19 +85,11 @@ var _ = Describe("Verify External-IP config", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Checks Pod Status", func() {
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
-			}, "620s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
+		It("Checks pod status", func() {
+			By("Fetching pod status")
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
+			}, "620s", "10s").Should(Succeed())
 		})
 	})
 	Context("Deploy workloads to check cluster connectivity of the nodes", func() {

--- a/tests/e2e/rootless/rootless_test.go
+++ b/tests/e2e/rootless/rootless_test.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	"github.com/k3s-io/k3s/tests/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -110,17 +110,8 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			}, "360s", "5s").Should(Succeed())
 			_, _ = e2e.ParseNodes(tc.KubeConfigFile, false)
 
-			By("Fetching Pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "360s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})

--- a/tests/e2e/rootless/rootless_utils.go
+++ b/tests/e2e/rootless/rootless_utils.go
@@ -8,8 +8,8 @@ import (
 	"github.com/k3s-io/k3s/tests/e2e"
 )
 
-// RunCmdOnRootlesNode executes a command from within the given node as user vagrant
-func RunCmdOnRootlesNode(cmd string, nodename string) (string, error) {
+// RunCmdOnRootlessNode executes a command from within the given node as user vagrant
+func RunCmdOnRootlessNode(cmd string, nodename string) (string, error) {
 	injectEnv := ""
 	if _, ok := os.LookupEnv("E2E_GOCOVER"); ok && strings.HasPrefix(cmd, "k3s") {
 		injectEnv = "GOCOVERDIR=/tmp/k3scov "
@@ -23,11 +23,12 @@ func RunCmdOnRootlesNode(cmd string, nodename string) (string, error) {
 }
 
 func GenRootlessKubeConfigFile(serverName string) (string, error) {
-	kubeConfig, err := RunCmdOnRootlesNode("cat /home/vagrant/.kube/k3s.yaml", serverName)
+	kubeConfig, err := RunCmdOnRootlessNode("cat /home/vagrant/.kube/k3s.yaml", serverName)
 	if err != nil {
 		return "", err
 	}
-	nodeIP, err := e2e.FetchNodeExternalIP(serverName)
+	vNode := e2e.VagrantNode(serverName)
+	nodeIP, err := vNode.FetchNodeExternalIP()
 	if err != nil {
 		return "", err
 	}

--- a/tests/e2e/rotateca/rotateca_test.go
+++ b/tests/e2e/rotateca/rotateca_test.go
@@ -3,9 +3,9 @@ package rotateca
 import (
 	"flag"
 	"os"
-	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	"github.com/k3s-io/k3s/tests/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -57,19 +57,10 @@ var _ = Describe("Verify Custom CA Rotation", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "620s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
+			e2e.ParseNodes(tc.KubeConfigFile, true)
 
-			By("Fetching Pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
@@ -109,16 +100,8 @@ var _ = Describe("Verify Custom CA Rotation", Ordered, func() {
 				}
 			}, "420s", "5s").Should(Succeed())
 
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "420s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})

--- a/tests/e2e/s3/s3_test.go
+++ b/tests/e2e/s3/s3_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k3s-io/k3s/tests"
 	"github.com/k3s-io/k3s/tests/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -49,7 +50,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			By("OS: " + *nodeOS)
 			By(tc.Status())
 		})
-		It("Checks Node and Pod Status", func() {
+		It("Checks node and pod status", func() {
 			By("Fetching Nodes status")
 			Eventually(func(g Gomega) {
 				nodes, err := e2e.ParseNodes(tc.KubeConfigFile, false)
@@ -58,19 +59,10 @@ var _ = Describe("Verify Create", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "620s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
+			e2e.ParseNodes(tc.KubeConfigFile, true)
 
-			By("Fetching Pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})

--- a/tests/e2e/s3/s3_test.go
+++ b/tests/e2e/s3/s3_test.go
@@ -32,9 +32,9 @@ func Test_E2ES3(t *testing.T) {
 }
 
 var (
-	kubeConfigFile  string
-	serverNodeNames []string
-	agentNodeNames  []string
+	kubeConfigFile string
+	serverNodes    []e2e.VagrantNode
+	agentNodes     []e2e.VagrantNode
 )
 
 var _ = ReportAfterEach(e2e.GenReport)
@@ -44,20 +44,20 @@ var _ = Describe("Verify Create", Ordered, func() {
 		It("Starts up with no issues", func() {
 			var err error
 			if *local {
-				serverNodeNames, agentNodeNames, err = e2e.CreateLocalCluster(*nodeOS, 1, 0)
+				serverNodes, agentNodes, err = e2e.CreateLocalCluster(*nodeOS, 1, 0)
 			} else {
-				serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, 1, 0)
+				serverNodes, agentNodes, err = e2e.CreateCluster(*nodeOS, 1, 0)
 			}
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
-			fmt.Println("Server Nodes:", serverNodeNames)
-			fmt.Println("Agent Nodes:", agentNodeNames)
-			kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodeNames[0])
+			fmt.Println("Server Nodes:", serverNodes)
+			fmt.Println("Agent Nodes:", agentNodes)
+			kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodes[0].String())
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("Checks Node and Pod Status", func() {
-			fmt.Printf("\nFetching node status\n")
+			By("Fetching Nodes status")
 			Eventually(func(g Gomega) {
 				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -65,9 +65,9 @@ var _ = Describe("Verify Create", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "620s", "5s").Should(Succeed())
-			_, _ = e2e.ParseNodes(kubeConfigFile, true)
+			e2e.DumpPods(kubeConfigFile)
 
-			fmt.Printf("\nFetching Pods status\n")
+			By("Fetching Pods status")
 			Eventually(func(g Gomega) {
 				pods, err := e2e.ParsePods(kubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -79,58 +79,56 @@ var _ = Describe("Verify Create", Ordered, func() {
 					}
 				}
 			}, "620s", "5s").Should(Succeed())
-			_, _ = e2e.ParsePods(kubeConfigFile, true)
+			e2e.DumpPods(kubeConfigFile)
 		})
 
 		It("ensures s3 mock is working", func() {
-			res, err := e2e.RunCmdOnNode("docker ps -a | grep mock\n", serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode("docker ps -a | grep mock\n")
 			fmt.Println(res)
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("save s3 snapshot using CLI", func() {
-			res, err := e2e.RunCmdOnNode("k3s etcd-snapshot save "+
-				"--etcd-s3-insecure=true "+
-				"--etcd-s3-bucket=test-bucket "+
-				"--etcd-s3-folder=test-folder "+
-				"--etcd-s3-endpoint=localhost:9090 "+
-				"--etcd-s3-skip-ssl-verify=true "+
-				"--etcd-s3-access-key=test ",
-				serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode("k3s etcd-snapshot save " +
+				"--etcd-s3-insecure=true " +
+				"--etcd-s3-bucket=test-bucket " +
+				"--etcd-s3-folder=test-folder " +
+				"--etcd-s3-endpoint=localhost:9090 " +
+				"--etcd-s3-skip-ssl-verify=true " +
+				"--etcd-s3-access-key=test ")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(ContainSubstring("Snapshot on-demand-server-0"))
 		})
 		It("creates s3 config secret", func() {
-			res, err := e2e.RunCmdOnNode("k3s kubectl create secret generic k3s-etcd-s3-config --namespace=kube-system "+
-				"--from-literal=etcd-s3-insecure=true "+
-				"--from-literal=etcd-s3-bucket=test-bucket "+
-				"--from-literal=etcd-s3-folder=test-folder "+
-				"--from-literal=etcd-s3-endpoint=localhost:9090 "+
-				"--from-literal=etcd-s3-skip-ssl-verify=true "+
-				"--from-literal=etcd-s3-access-key=test ",
-				serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode("k3s kubectl create secret generic k3s-etcd-s3-config --namespace=kube-system " +
+				"--from-literal=etcd-s3-insecure=true " +
+				"--from-literal=etcd-s3-bucket=test-bucket " +
+				"--from-literal=etcd-s3-folder=test-folder " +
+				"--from-literal=etcd-s3-endpoint=localhost:9090 " +
+				"--from-literal=etcd-s3-skip-ssl-verify=true " +
+				"--from-literal=etcd-s3-access-key=test ")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(ContainSubstring("secret/k3s-etcd-s3-config created"))
 		})
 		It("save s3 snapshot using secret", func() {
-			res, err := e2e.RunCmdOnNode("k3s etcd-snapshot save", serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode("k3s etcd-snapshot save")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(ContainSubstring("Snapshot on-demand-server-0"))
 		})
 		It("lists saved s3 snapshot", func() {
-			res, err := e2e.RunCmdOnNode("k3s etcd-snapshot list", serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode("k3s etcd-snapshot list")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(ContainSubstring("file:///var/lib/rancher/k3s/server/db/snapshots/on-demand-server-0"))
 			Expect(res).To(ContainSubstring("s3://test-bucket/test-folder/on-demand-server-0"))
 		})
 		It("save 3 more s3 snapshots", func() {
 			for _, i := range []string{"1", "2", "3"} {
-				res, err := e2e.RunCmdOnNode("k3s etcd-snapshot save --name special-"+i, serverNodeNames[0])
+				res, err := serverNodes[0].RunCmdOnNode("k3s etcd-snapshot save --name special-" + i)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res).To(ContainSubstring("Snapshot special-" + i + "-server-0"))
 			}
 		})
 		It("lists saved s3 snapshot", func() {
-			res, err := e2e.RunCmdOnNode("k3s etcd-snapshot list", serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode("k3s etcd-snapshot list")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(ContainSubstring("s3://test-bucket/test-folder/on-demand-server-0"))
 			Expect(res).To(ContainSubstring("s3://test-bucket/test-folder/special-1-server-0"))
@@ -138,25 +136,25 @@ var _ = Describe("Verify Create", Ordered, func() {
 			Expect(res).To(ContainSubstring("s3://test-bucket/test-folder/special-3-server-0"))
 		})
 		It("delete first on-demand s3 snapshot", func() {
-			_, err := e2e.RunCmdOnNode("sudo k3s etcd-snapshot ls >> ./snapshotname.txt", serverNodeNames[0])
+			_, err := serverNodes[0].RunCmdOnNode("sudo k3s etcd-snapshot ls >> ./snapshotname.txt")
 			Expect(err).NotTo(HaveOccurred())
-			snapshotName, err := e2e.RunCmdOnNode("grep -Eo 'on-demand-server-0-([0-9]+)' ./snapshotname.txt | head -1", serverNodeNames[0])
+			snapshotName, err := serverNodes[0].RunCmdOnNode("grep -Eo 'on-demand-server-0-([0-9]+)' ./snapshotname.txt | head -1")
 			Expect(err).NotTo(HaveOccurred())
-			res, err := e2e.RunCmdOnNode("sudo k3s etcd-snapshot delete "+snapshotName, serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode("sudo k3s etcd-snapshot delete " + snapshotName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(ContainSubstring("Snapshot " + strings.TrimSpace(snapshotName) + " deleted"))
 		})
 		It("prunes s3 snapshots", func() {
-			_, err := e2e.RunCmdOnNode("k3s etcd-snapshot save", serverNodeNames[0])
+			_, err := serverNodes[0].RunCmdOnNode("k3s etcd-snapshot save")
 			Expect(err).NotTo(HaveOccurred())
 			time.Sleep(time.Second)
-			_, err = e2e.RunCmdOnNode("k3s etcd-snapshot save", serverNodeNames[0])
+			_, err = serverNodes[0].RunCmdOnNode("k3s etcd-snapshot save")
 			Expect(err).NotTo(HaveOccurred())
 			time.Sleep(time.Second)
-			res, err := e2e.RunCmdOnNode("k3s etcd-snapshot prune", serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode("k3s etcd-snapshot prune")
 			Expect(err).NotTo(HaveOccurred())
 			// There should now be 4 on-demand snapshots - 2 local, and 2 on s3
-			res, err = e2e.RunCmdOnNode("k3s etcd-snapshot ls 2>/dev/null | grep on-demand | wc -l", serverNodeNames[0])
+			res, err = serverNodes[0].RunCmdOnNode("k3s etcd-snapshot ls 2>/dev/null | grep on-demand | wc -l")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(strings.TrimSpace(res)).To(Equal("4"))
 		})
@@ -164,7 +162,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			// Wait until the retention works with 3 minutes
 			fmt.Printf("\nWaiting 3 minutes until retention works\n")
 			time.Sleep(3 * time.Minute)
-			res, err := e2e.RunCmdOnNode("k3s etcd-snapshot ls 2>/dev/null | grep etcd-snapshot | wc -l", serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode("k3s etcd-snapshot ls 2>/dev/null | grep etcd-snapshot | wc -l")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(strings.TrimSpace(res)).To(Equal("4"))
 		})
@@ -178,9 +176,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		Expect(e2e.SaveJournalLogs(append(serverNodeNames, agentNodeNames...))).To(Succeed())
+		Expect(e2e.SaveJournalLogs(append(serverNodes, agentNodes...))).To(Succeed())
 	} else {
-		Expect(e2e.GetCoverageReport(append(serverNodeNames, agentNodeNames...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(append(serverNodes, agentNodes...))).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/secretsencryption/secretsencryption_test.go
+++ b/tests/e2e/secretsencryption/secretsencryption_test.go
@@ -3,9 +3,9 @@ package secretsencryption
 import (
 	"flag"
 	"os"
-	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	"github.com/k3s-io/k3s/tests/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -61,19 +61,10 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "620s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
+			e2e.ParseNodes(tc.KubeConfigFile, true)
 
-			By("Fetching Pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})

--- a/tests/e2e/secretsencryption/secretsencryption_test.go
+++ b/tests/e2e/secretsencryption/secretsencryption_test.go
@@ -2,7 +2,6 @@ package secretsencryption
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -32,10 +31,7 @@ func Test_E2ESecretsEncryption(t *testing.T) {
 	RunSpecs(t, "Secrets Encryption Test Suite", suiteConfig, reporterConfig)
 }
 
-var (
-	kubeConfigFile string
-	serverNodes    []e2e.VagrantNode
-)
+var tc *e2e.TestConfig
 
 var _ = ReportAfterEach(e2e.GenReport)
 
@@ -44,32 +40,32 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		It("Starts up with no issues", func() {
 			var err error
 			if *local {
-				serverNodes, _, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, 0)
+				tc, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, 0)
 			} else {
-				serverNodes, _, err = e2e.CreateCluster(*nodeOS, *serverCount, 0)
+				tc, err = e2e.CreateCluster(*nodeOS, *serverCount, 0)
 			}
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
-			fmt.Println("CLUSTER CONFIG")
-			fmt.Println("OS:", *nodeOS)
-			fmt.Println("Server Nodes:", serverNodes)
-			kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodes[0].String())
+			tc.Hardened = *hardened
+			By("CLUSTER CONFIG")
+			By("OS: " + *nodeOS)
+			By(tc.Status())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Checks node and pod status", func() {
 			By("Fetching Nodes status")
 			Eventually(func(g Gomega) {
-				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
+				nodes, err := e2e.ParseNodes(tc.KubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
 				for _, node := range nodes {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "620s", "5s").Should(Succeed())
-			e2e.DumpPods(kubeConfigFile)
+			e2e.DumpPods(tc.KubeConfigFile)
 
 			By("Fetching Pods status")
 			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(kubeConfigFile, false)
+				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
 				for _, pod := range pods {
 					if strings.Contains(pod.Name, "helm-install") {
@@ -79,17 +75,17 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 					}
 				}
 			}, "620s", "5s").Should(Succeed())
-			e2e.DumpPods(kubeConfigFile)
+			e2e.DumpPods(tc.KubeConfigFile)
 		})
 
 		It("Deploys several secrets", func() {
-			_, err := e2e.DeployWorkload("secrets.yaml", kubeConfigFile, *hardened)
+			_, err := tc.DeployWorkload("secrets.yaml")
 			Expect(err).NotTo(HaveOccurred(), "Secrets not deployed")
 		})
 
 		It("Verifies encryption start stage", func() {
 			cmd := "k3s secrets-encrypt status"
-			for _, node := range serverNodes {
+			for _, node := range tc.Servers {
 				res, err := node.RunCmdOnNode(cmd)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res).Should(ContainSubstring("Encryption Status: Enabled"))
@@ -100,9 +96,9 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 
 		It("Rotates the Secrets-Encryption Keys", func() {
 			cmd := "k3s secrets-encrypt rotate-keys"
-			res, err := serverNodes[0].RunCmdOnNode(cmd)
+			res, err := tc.Servers[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred(), res)
-			for i, node := range serverNodes {
+			for i, node := range tc.Servers {
 				Eventually(func(g Gomega) {
 					cmd := "k3s secrets-encrypt status"
 					res, err := node.RunCmdOnNode(cmd)
@@ -118,12 +114,12 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		})
 
 		It("Restarts K3s servers", func() {
-			Expect(e2e.RestartCluster(serverNodes)).To(Succeed(), e2e.GetVagrantLog(nil))
+			Expect(e2e.RestartCluster(tc.Servers)).To(Succeed(), e2e.GetVagrantLog(nil))
 		})
 
 		It("Verifies reencryption_finished stage", func() {
 			cmd := "k3s secrets-encrypt status"
-			for _, node := range serverNodes {
+			for _, node := range tc.Servers {
 				Eventually(func(g Gomega) {
 					res, err := node.RunCmdOnNode(cmd)
 					g.Expect(err).NotTo(HaveOccurred())
@@ -139,15 +135,15 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 	Context("Disabling Secrets-Encryption", func() {
 		It("Disables encryption", func() {
 			cmd := "k3s secrets-encrypt disable"
-			res, err := serverNodes[0].RunCmdOnNode(cmd)
+			res, err := tc.Servers[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred(), res)
 
 			cmd = "k3s secrets-encrypt status"
 			Eventually(func() (string, error) {
-				return serverNodes[0].RunCmdOnNode(cmd)
+				return tc.Servers[0].RunCmdOnNode(cmd)
 			}, "240s", "10s").Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
 
-			for i, node := range serverNodes {
+			for i, node := range tc.Servers {
 				Eventually(func(g Gomega) {
 					res, err := node.RunCmdOnNode(cmd)
 					g.Expect(err).NotTo(HaveOccurred(), res)
@@ -161,12 +157,12 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		})
 
 		It("Restarts K3s servers", func() {
-			Expect(e2e.RestartCluster(serverNodes)).To(Succeed())
+			Expect(e2e.RestartCluster(tc.Servers)).To(Succeed())
 		})
 
 		It("Verifies encryption disabled on all nodes", func() {
 			cmd := "k3s secrets-encrypt status"
-			for _, node := range serverNodes {
+			for _, node := range tc.Servers {
 				Eventually(func(g Gomega) {
 					g.Expect(node.RunCmdOnNode(cmd)).Should(ContainSubstring("Encryption Status: Disabled"))
 				}, "420s", "2s").Should(Succeed())
@@ -178,15 +174,15 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 	Context("Enabling Secrets-Encryption", func() {
 		It("Enables encryption", func() {
 			cmd := "k3s secrets-encrypt enable"
-			res, err := serverNodes[0].RunCmdOnNode(cmd)
+			res, err := tc.Servers[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred(), res)
 
 			cmd = "k3s secrets-encrypt status"
 			Eventually(func() (string, error) {
-				return serverNodes[0].RunCmdOnNode(cmd)
+				return tc.Servers[0].RunCmdOnNode(cmd)
 			}, "180s", "5s").Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
 
-			for i, node := range serverNodes {
+			for i, node := range tc.Servers {
 				Eventually(func(g Gomega) {
 					res, err := node.RunCmdOnNode(cmd)
 					g.Expect(err).NotTo(HaveOccurred(), res)
@@ -200,12 +196,12 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		})
 
 		It("Restarts K3s servers", func() {
-			Expect(e2e.RestartCluster(serverNodes)).To(Succeed())
+			Expect(e2e.RestartCluster(tc.Servers)).To(Succeed())
 		})
 
 		It("Verifies encryption enabled on all nodes", func() {
 			cmd := "k3s secrets-encrypt status"
-			for _, node := range serverNodes {
+			for _, node := range tc.Servers {
 				Eventually(func(g Gomega) {
 					g.Expect(node.RunCmdOnNode(cmd)).Should(ContainSubstring("Encryption Status: Enabled"))
 				}, "420s", "2s").Should(Succeed())
@@ -222,12 +218,12 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, serverNodes))
+		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, tc.Servers))
 	} else {
-		Expect(e2e.GetCoverageReport(serverNodes)).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.Servers)).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())
-		Expect(os.Remove(kubeConfigFile)).To(Succeed())
+		Expect(os.Remove(tc.KubeConfigFile)).To(Succeed())
 	}
 })

--- a/tests/e2e/secretsencryption_old/secretsencryption_test.go
+++ b/tests/e2e/secretsencryption_old/secretsencryption_test.go
@@ -30,8 +30,8 @@ func Test_E2ESecretsEncryptionOld(t *testing.T) {
 }
 
 var (
-	kubeConfigFile  string
-	serverNodeNames []string
+	kubeConfigFile string
+	serverNodes    []e2e.VagrantNode
 )
 
 var _ = ReportAfterEach(e2e.GenReport)
@@ -41,20 +41,20 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		It("Starts up with no issues", func() {
 			var err error
 			if *local {
-				serverNodeNames, _, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, 0)
+				serverNodes, _, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, 0)
 			} else {
-				serverNodeNames, _, err = e2e.CreateCluster(*nodeOS, *serverCount, 0)
+				serverNodes, _, err = e2e.CreateCluster(*nodeOS, *serverCount, 0)
 			}
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
-			fmt.Println("Server Nodes:", serverNodeNames)
-			kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodeNames[0])
+			fmt.Println("Server Nodes:", serverNodes)
+			kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodes[0].String())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Checks node and pod status", func() {
-			fmt.Printf("\nFetching node status\n")
+			By("Fetching Nodes status")
 			Eventually(func(g Gomega) {
 				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -62,9 +62,9 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "620s", "5s").Should(Succeed())
-			_, _ = e2e.ParseNodes(kubeConfigFile, true)
+			e2e.DumpPods(kubeConfigFile)
 
-			fmt.Printf("\nFetching pods status\n")
+			By("Fetching Pods status")
 			Eventually(func(g Gomega) {
 				pods, err := e2e.ParsePods(kubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -76,7 +76,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 					}
 				}
 			}, "620s", "5s").Should(Succeed())
-			_, _ = e2e.ParsePods(kubeConfigFile, true)
+			e2e.DumpPods(kubeConfigFile)
 		})
 
 		It("Deploys several secrets", func() {
@@ -86,8 +86,8 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 
 		It("Verifies encryption start stage", func() {
 			cmd := "k3s secrets-encrypt status"
-			for _, nodeName := range serverNodeNames {
-				res, err := e2e.RunCmdOnNode(cmd, nodeName)
+			for _, node := range serverNodes {
+				res, err := node.RunCmdOnNode(cmd)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res).Should(ContainSubstring("Encryption Status: Enabled"))
 				Expect(res).Should(ContainSubstring("Current Rotation Stage: start"))
@@ -97,11 +97,11 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 
 		It("Prepares for Secrets-Encryption Rotation", func() {
 			cmd := "k3s secrets-encrypt prepare"
-			res, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred(), res)
-			for i, nodeName := range serverNodeNames {
+			for i, node := range serverNodes {
 				cmd := "k3s secrets-encrypt status"
-				res, err := e2e.RunCmdOnNode(cmd, nodeName)
+				res, err := node.RunCmdOnNode(cmd)
 				Expect(err).NotTo(HaveOccurred(), res)
 				Expect(res).Should(ContainSubstring("Server Encryption Hashes: hash does not match"))
 				if i == 0 {
@@ -113,7 +113,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		})
 
 		It("Restarts K3s servers", func() {
-			Expect(e2e.RestartCluster(serverNodeNames)).To(Succeed(), e2e.GetVagrantLog(nil))
+			Expect(e2e.RestartCluster(serverNodes)).To(Succeed(), e2e.GetVagrantLog(nil))
 		})
 
 		It("Checks node and pod status", func() {
@@ -136,14 +136,14 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 					}
 				}
 			}, "420s", "5s").Should(Succeed())
-			_, _ = e2e.ParseNodes(kubeConfigFile, true)
+			e2e.DumpPods(kubeConfigFile)
 		})
 
 		It("Verifies encryption prepare stage", func() {
 			cmd := "k3s secrets-encrypt status"
-			for _, nodeName := range serverNodeNames {
+			for _, node := range serverNodes {
 				Eventually(func(g Gomega) {
-					res, err := e2e.RunCmdOnNode(cmd, nodeName)
+					res, err := node.RunCmdOnNode(cmd)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(res).Should(ContainSubstring("Encryption Status: Enabled"))
 					g.Expect(res).Should(ContainSubstring("Current Rotation Stage: prepare"))
@@ -154,12 +154,12 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 
 		It("Rotates the Secrets-Encryption Keys", func() {
 			cmd := "k3s secrets-encrypt rotate"
-			res, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred(), res)
-			for i, nodeName := range serverNodeNames {
+			for i, node := range serverNodes {
 				Eventually(func(g Gomega) {
 					cmd := "k3s secrets-encrypt status"
-					res, err := e2e.RunCmdOnNode(cmd, nodeName)
+					res, err := node.RunCmdOnNode(cmd)
 					g.Expect(err).NotTo(HaveOccurred(), res)
 					g.Expect(res).Should(ContainSubstring("Server Encryption Hashes: hash does not match"))
 					if i == 0 {
@@ -172,14 +172,14 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		})
 
 		It("Restarts K3s servers", func() {
-			Expect(e2e.RestartCluster(serverNodeNames)).To(Succeed(), e2e.GetVagrantLog(nil))
+			Expect(e2e.RestartCluster(serverNodes)).To(Succeed(), e2e.GetVagrantLog(nil))
 		})
 
 		It("Verifies encryption rotate stage", func() {
 			cmd := "k3s secrets-encrypt status"
-			for _, nodeName := range serverNodeNames {
+			for _, node := range serverNodes {
 				Eventually(func(g Gomega) {
-					res, err := e2e.RunCmdOnNode(cmd, nodeName)
+					res, err := node.RunCmdOnNode(cmd)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(res).Should(ContainSubstring("Encryption Status: Enabled"))
 					g.Expect(res).Should(ContainSubstring("Current Rotation Stage: rotate"))
@@ -190,16 +190,16 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 
 		It("Reencrypts the Secrets-Encryption Keys", func() {
 			cmd := "k3s secrets-encrypt reencrypt"
-			res, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred(), res)
 
 			cmd = "k3s secrets-encrypt status"
 			Eventually(func() (string, error) {
-				return e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+				return serverNodes[0].RunCmdOnNode(cmd)
 			}, "240s", "10s").Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
 
-			for _, nodeName := range serverNodeNames[1:] {
-				res, err := e2e.RunCmdOnNode(cmd, nodeName)
+			for _, node := range serverNodes[1:] {
+				res, err := node.RunCmdOnNode(cmd)
 				Expect(err).NotTo(HaveOccurred(), res)
 				Expect(res).Should(ContainSubstring("Server Encryption Hashes: hash does not match"))
 				Expect(res).Should(ContainSubstring("Current Rotation Stage: rotate"))
@@ -207,14 +207,14 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		})
 
 		It("Restarts K3s Servers", func() {
-			Expect(e2e.RestartCluster(serverNodeNames)).To(Succeed(), e2e.GetVagrantLog(nil))
+			Expect(e2e.RestartCluster(serverNodes)).To(Succeed(), e2e.GetVagrantLog(nil))
 		})
 
 		It("Verifies Encryption Reencrypt Stage", func() {
 			cmd := "k3s secrets-encrypt status"
-			for _, nodeName := range serverNodeNames {
+			for _, node := range serverNodes {
 				Eventually(func(g Gomega) {
-					res, err := e2e.RunCmdOnNode(cmd, nodeName)
+					res, err := node.RunCmdOnNode(cmd)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(res).Should(ContainSubstring("Encryption Status: Enabled"))
 					g.Expect(res).Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
@@ -227,21 +227,21 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 	Context("Disabling Secrets-Encryption", func() {
 		It("Disables encryption", func() {
 			cmd := "k3s secrets-encrypt disable"
-			res, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred(), res)
 
 			cmd = "k3s secrets-encrypt reencrypt -f --skip"
-			res, err = e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			res, err = serverNodes[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred(), res)
 
 			cmd = "k3s secrets-encrypt status"
 			Eventually(func() (string, error) {
-				return e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+				return serverNodes[0].RunCmdOnNode(cmd)
 			}, "240s", "10s").Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
 
-			for i, nodeName := range serverNodeNames {
+			for i, node := range serverNodes {
 				Eventually(func(g Gomega) {
-					res, err := e2e.RunCmdOnNode(cmd, nodeName)
+					res, err := node.RunCmdOnNode(cmd)
 					g.Expect(err).NotTo(HaveOccurred(), res)
 					if i == 0 {
 						g.Expect(res).Should(ContainSubstring("Encryption Status: Disabled"))
@@ -253,14 +253,14 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		})
 
 		It("Restarts K3s servers", func() {
-			Expect(e2e.RestartCluster(serverNodeNames)).To(Succeed())
+			Expect(e2e.RestartCluster(serverNodes)).To(Succeed())
 		})
 
 		It("Verifies encryption disabled on all nodes", func() {
 			cmd := "k3s secrets-encrypt status"
-			for _, nodeName := range serverNodeNames {
+			for _, node := range serverNodes {
 				Eventually(func(g Gomega) {
-					g.Expect(e2e.RunCmdOnNode(cmd, nodeName)).Should(ContainSubstring("Encryption Status: Disabled"))
+					g.Expect(node.RunCmdOnNode(cmd)).Should(ContainSubstring("Encryption Status: Disabled"))
 				}, "420s", "2s").Should(Succeed())
 			}
 		})
@@ -270,28 +270,28 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 	Context("Enabling Secrets-Encryption", func() {
 		It("Enables encryption", func() {
 			cmd := "k3s secrets-encrypt enable"
-			res, err := e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred(), res)
 
 			cmd = "k3s secrets-encrypt reencrypt -f --skip"
-			res, err = e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+			res, err = serverNodes[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred(), res)
 
 			cmd = "k3s secrets-encrypt status"
 			Eventually(func() (string, error) {
-				return e2e.RunCmdOnNode(cmd, serverNodeNames[0])
+				return serverNodes[0].RunCmdOnNode(cmd)
 			}, "180s", "5s").Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
 		})
 
 		It("Restarts K3s servers", func() {
-			Expect(e2e.RestartCluster(serverNodeNames)).To(Succeed())
+			Expect(e2e.RestartCluster(serverNodes)).To(Succeed())
 		})
 
 		It("Verifies encryption enabled on all nodes", func() {
 			cmd := "k3s secrets-encrypt status"
-			for _, nodeName := range serverNodeNames {
+			for _, node := range serverNodes {
 				Eventually(func(g Gomega) {
-					g.Expect(e2e.RunCmdOnNode(cmd, nodeName)).Should(ContainSubstring("Encryption Status: Enabled"))
+					g.Expect(node.RunCmdOnNode(cmd)).Should(ContainSubstring("Encryption Status: Enabled"))
 				}, "420s", "2s").Should(Succeed())
 			}
 
@@ -307,7 +307,7 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if !failed {
-		Expect(e2e.GetCoverageReport(serverNodeNames)).To(Succeed())
+		Expect(e2e.GetCoverageReport(serverNodes)).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/secretsencryption_old/secretsencryption_test.go
+++ b/tests/e2e/secretsencryption_old/secretsencryption_test.go
@@ -3,9 +3,9 @@ package secretsencryption
 import (
 	"flag"
 	"os"
-	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	"github.com/k3s-io/k3s/tests/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -58,19 +58,9 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "620s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
 
-			By("Fetching Pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
@@ -121,17 +111,9 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 				}
 			}, "420s", "5s").Should(Succeed())
 
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
-			}, "420s", "5s").Should(Succeed())
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
+			}, "360s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
 

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k3s-io/k3s/tests"
 	"github.com/k3s-io/k3s/tests/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -148,7 +149,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Checks Node and Pod Status", func() {
+		It("Checks node and pod status", func() {
 			By("Fetching Nodes status")
 			Eventually(func(g Gomega) {
 				nodes, err := e2e.ParseNodes(tc.KubeConfigFile, false)
@@ -157,19 +158,9 @@ var _ = Describe("Verify Create", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "620s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
 
-			By("Fetching Pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -255,13 +255,9 @@ var _ = Describe("Verify Create", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "Daemonset manifest not deployed")
 
 			Eventually(func(g Gomega) {
-				pods, _ := e2e.ParsePods(tc.KubeConfigFile, false)
-				count := e2e.CountOfStringInSlice("test-daemonset", pods)
-				fmt.Println("POD COUNT")
-				fmt.Println(count)
-				fmt.Println("CP COUNT")
-				fmt.Println(len(cpNodes))
-				g.Expect(len(cpNodes)).Should((Equal(count)), "Daemonset pod count does not match cp node count")
+				count, err := e2e.GetDaemonsetReady("test-daemonset", tc.KubeConfigFile)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cpNodes).To(HaveLen(count), "Daemonset pod count does not match cp node count")
 			}, "240s", "10s").Should(Succeed())
 		})
 

--- a/tests/e2e/startup/startup_test.go
+++ b/tests/e2e/startup/startup_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	"github.com/k3s-io/k3s/tests/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -123,19 +124,8 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "360s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
-
-			By("Fetching pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "360s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
@@ -200,19 +190,8 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "360s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
-
-			By("Fetching pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "360s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
@@ -251,19 +230,9 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "360s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
 
-			By("Fetching pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "360s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
@@ -294,19 +263,9 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "360s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
 
-			By("Fetching pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "360s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
@@ -337,19 +296,9 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "360s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
 
-			By("Fetching pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "360s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})

--- a/tests/e2e/svcpoliciesandfirewall/svcpoliciesandfirewall_test.go
+++ b/tests/e2e/svcpoliciesandfirewall/svcpoliciesandfirewall_test.go
@@ -41,309 +41,312 @@ var _ = ReportAfterEach(e2e.GenReport)
 
 var _ = Describe("Verify Services Traffic policies and firewall config", Ordered, func() {
 
-	It("Starts up with no issues", func() {
-		var err error
-		if *local {
-			tc, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
-		} else {
-			tc, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
-		}
-		Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
-		By("CLUSTER CONFIG")
-		By("OS: " + *nodeOS)
-		By(tc.Status())
-	})
-
-	It("Checks Node Status", func() {
-		Eventually(func(g Gomega) {
+	Context("Start cluster with minimal configuration", func() {
+		It("Starts up with no issues", func() {
 			var err error
-			nodes, err = e2e.ParseNodes(tc.KubeConfigFile, false)
-			g.Expect(err).NotTo(HaveOccurred())
-			for _, node := range nodes {
-				g.Expect(node.Status).Should(Equal("Ready"))
+			if *local {
+				tc, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
+			} else {
+				tc, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 			}
-		}, "300s", "5s").Should(Succeed())
-		_, err := e2e.ParseNodes(tc.KubeConfigFile, true)
-		Expect(err).NotTo(HaveOccurred())
-	})
+			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
+			By("CLUSTER CONFIG")
+			By("OS: " + *nodeOS)
+			By(tc.Status())
+		})
 
-	It("Checks Pod Status", func() {
-		Eventually(func(g Gomega) {
-			pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-			g.Expect(err).NotTo(HaveOccurred())
-			for _, pod := range pods {
-				if strings.Contains(pod.Name, "helm-install") {
-					g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-				} else {
-					g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
+		It("Checks Node Status", func() {
+			Eventually(func(g Gomega) {
+				var err error
+				nodes, err = e2e.ParseNodes(tc.KubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, node := range nodes {
+					g.Expect(node.Status).Should(Equal("Ready"))
 				}
-			}
-		}, "300s", "5s").Should(Succeed())
-		e2e.DumpPods(tc.KubeConfigFile)
-	})
-
-	// Verifies that the service with external traffic policy=local is deployed
-	// Verifies that the external-ip is only set to the node IP where the server runs
-	// It also verifies that the service with external traffic policy=cluster has both node IPs as externalIP
-	It("Verify external traffic policy=local gets set up correctly", func() {
-		_, err := tc.DeployWorkload("loadbalancer.yaml")
-		Expect(err).NotTo(HaveOccurred(), "loadbalancer not deployed")
-		_, err = tc.DeployWorkload("loadbalancer-extTrafficPol.yaml")
-		Expect(err).NotTo(HaveOccurred(), "loadbalancer-extTrafficPol not deployed")
-
-		// Check where the server pod is running
-		var serverNodeName string
-		Eventually(func() (string, error) {
-			pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-			Expect(err).NotTo(HaveOccurred(), "failed to parse pods")
-			for _, pod := range pods {
-				if strings.Contains(pod.Name, "test-loadbalancer-ext") {
-					serverNodeName = pod.Node
-					break
-				}
-			}
-			return serverNodeName, nil
-		}, "25s", "5s").ShouldNot(BeEmpty(), "server pod not found")
-
-		var serverNodeIP string
-		for _, node := range nodes {
-			if node.Name == serverNodeName {
-				serverNodeIP = node.InternalIP
-			}
-		}
-
-		// Verify there is only one external-ip and it is matching the node IP
-		lbSvc := "nginx-loadbalancer-svc"
-		lbSvcExt := "nginx-loadbalancer-svc-ext"
-		Eventually(func() ([]string, error) {
-			return e2e.FetchExternalIPs(tc.KubeConfigFile, lbSvc)
-		}, "25s", "5s").Should(HaveLen(2), "external IP count not equal to 2")
-
-		Eventually(func(g Gomega) {
-			externalIPs, _ := e2e.FetchExternalIPs(tc.KubeConfigFile, lbSvcExt)
-			g.Expect(externalIPs).To(HaveLen(1), "more than 1 exernalIP found")
-			g.Expect(externalIPs[0]).To(Equal(serverNodeIP), "external IP does not match servernodeIP")
-		}, "25s", "5s").Should(Succeed())
-	})
-
-	// Verifies that the service is reachable from the outside and the source IP is nos MASQ
-	// It also verifies that the service with external traffic policy=cluster can be accessed and the source IP is MASQ
-	It("Verify connectivity in external traffic policy=local", func() {
-		lbSvc := "nginx-loadbalancer-svc"
-		lbSvcExternalIPs, _ := e2e.FetchExternalIPs(tc.KubeConfigFile, lbSvc)
-		lbSvcExt := "nginx-loadbalancer-svc-ext"
-		lbSvcExtExternalIPs, _ := e2e.FetchExternalIPs(tc.KubeConfigFile, lbSvcExt)
-
-		// Verify connectivity to the external IP of the lbsvc service and the IP should be the flannel interface IP because of MASQ
-		for _, externalIP := range lbSvcExternalIPs {
-			Eventually(func() (string, error) {
-				cmd := "curl -s " + externalIP + ":81/ip"
-				return e2e.RunCommand(cmd)
-			}, "25s", "5s").Should(ContainSubstring("10.42"))
-		}
-
-		// Verify connectivity to the external IP of the lbsvcExt service and the IP should not be the flannel interface IP
-		Eventually(func() (string, error) {
-			cmd := "curl -s " + lbSvcExtExternalIPs[0] + ":82/ip"
-			return e2e.RunCommand(cmd)
-		}, "25s", "5s").ShouldNot(ContainSubstring("10.42"))
-
-		// Verify connectivity to the other nodeIP does not work because of external traffic policy=local
-		for _, externalIP := range lbSvcExternalIPs {
-			if externalIP == lbSvcExtExternalIPs[0] {
-				// This IP we already test and it shuold work
-				continue
-			}
-			Eventually(func() error {
-				cmd := "curl -s --max-time 5 " + externalIP + ":82/ip"
-				_, err := e2e.RunCommand(cmd)
-				return err
-			}, "40s", "5s").Should(MatchError(ContainSubstring("exit status")))
-		}
-	})
-
-	// Verifies that the internal traffic policy=local is deployed
-	It("Verify internal traffic policy=local gets set up correctly", func() {
-		_, err := tc.DeployWorkload("loadbalancer-intTrafficPol.yaml")
-		Expect(err).NotTo(HaveOccurred(), "loadbalancer-intTrafficPol not deployed")
-		_, err = tc.DeployWorkload("pod_client.yaml")
-		Expect(err).NotTo(HaveOccurred(), "pod client not deployed")
-
-		// Check that service exists
-		Eventually(func() (string, error) {
-			clusterIP, _ := e2e.FetchClusterIP(tc.KubeConfigFile, "nginx-loadbalancer-svc-int", false)
-			return clusterIP, nil
-		}, "25s", "5s").Should(ContainSubstring("10.43"))
-
-		// Check that client pods are running
-		Eventually(func() string {
-			pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
+			}, "300s", "5s").Should(Succeed())
+			_, err := e2e.ParseNodes(tc.KubeConfigFile, true)
 			Expect(err).NotTo(HaveOccurred())
-			for _, pod := range pods {
-				if strings.Contains(pod.Name, "client-deployment") {
-					return pod.Status
-				}
-			}
-			return ""
-		}, "50s", "5s").Should(Equal("Running"))
-	})
+		})
 
-	// Verifies that only the client pod running in the same node as the server pod can access the service
-	// It also verifies that the service with internal traffic policy=cluster can be accessed by both client pods
-	It("Verify connectivity in internal traffic policy=local", func() {
-		var clientPod1, clientPod1Node, clientPod1IP, clientPod2, clientPod2Node, clientPod2IP, serverNodeName string
-		Eventually(func(g Gomega) {
-			pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-			Expect(err).NotTo(HaveOccurred(), "failed to parse pods")
-			for _, pod := range pods {
-				if strings.Contains(pod.Name, "test-loadbalancer-int") {
-					serverNodeName = pod.Node
-				}
-				if strings.Contains(pod.Name, "client-deployment") {
-					if clientPod1 == "" {
-						clientPod1 = pod.Name
-						clientPod1Node = pod.Node
-						clientPod1IP = pod.IP
+		It("Checks Pod Status", func() {
+			Eventually(func(g Gomega) {
+				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, pod := range pods {
+					if strings.Contains(pod.Name, "helm-install") {
+						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
 					} else {
-						clientPod2 = pod.Name
-						clientPod2Node = pod.Node
-						clientPod2IP = pod.IP
+						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
 					}
 				}
-			}
-			// As we need those variables for the connectivity test, let's check they are not emtpy
-			g.Expect(serverNodeName).ShouldNot(BeEmpty(), "server pod for internalTrafficPolicy=local not found")
-			g.Expect(clientPod1).ShouldNot(BeEmpty(), "client pod1 not found")
-			g.Expect(clientPod2).ShouldNot(BeEmpty(), "client pod2 not found")
-			g.Expect(clientPod1Node).ShouldNot(BeEmpty(), "client pod1 node not found")
-			g.Expect(clientPod2Node).ShouldNot(BeEmpty(), "client pod2 node not found")
-			g.Expect(clientPod1IP).ShouldNot(BeEmpty(), "client pod1 IP not found")
-			g.Expect(clientPod2IP).ShouldNot(BeEmpty(), "client pod2 IP not found")
-		}, "25s", "5s").Should(Succeed(), "All pod and names and IPs should be non-empty")
+			}, "300s", "5s").Should(Succeed())
+			e2e.DumpPods(tc.KubeConfigFile)
+		})
+	})
+	Context("Deploy external traffic workloads to test external traffic policies", func() {
+		// Verifies that the service with external traffic policy=local is deployed
+		// Verifies that the external-ip is only set to the node IP where the server runs
+		// It also verifies that the service with external traffic policy=cluster has both node IPs as externalIP
+		It("Verify external traffic policy=local gets set up correctly", func() {
+			_, err := tc.DeployWorkload("loadbalancer.yaml")
+			Expect(err).NotTo(HaveOccurred(), "loadbalancer not deployed")
+			_, err = tc.DeployWorkload("loadbalancer-extTrafficPol.yaml")
+			Expect(err).NotTo(HaveOccurred(), "loadbalancer-extTrafficPol not deployed")
 
-		// Check that clientPod1Node and clientPod2Node are not equal
-		Expect(clientPod1Node).ShouldNot(Equal(clientPod2Node))
-
-		var workingCmd, nonWorkingCmd string
-		if serverNodeName == clientPod1Node {
-			workingCmd = "kubectl exec " + clientPod1 + " -- curl -s --max-time 5 nginx-loadbalancer-svc-int:83/ip"
-			nonWorkingCmd = "kubectl exec " + clientPod2 + " -- curl -s --max-time 5 nginx-loadbalancer-svc-int:83/ip"
-		}
-		if serverNodeName == clientPod2Node {
-			workingCmd = "kubectl exec " + clientPod2 + " -- curl -s --max-time 5 nginx-loadbalancer-svc-int:83/ip"
-			nonWorkingCmd = "kubectl exec " + clientPod1 + " -- curl -s --max-time 5 nginx-loadbalancer-svc-int:83/ip"
-		}
-
-		Eventually(func() (string, error) {
-			out, err := e2e.RunCommand(workingCmd)
-			return out, err
-		}, "25s", "5s").Should(SatisfyAny(
-			ContainSubstring(clientPod1IP),
-			ContainSubstring(clientPod2IP),
-		))
-
-		// Check the non working command fails because of internal traffic policy=local
-		Eventually(func() bool {
-			_, err := e2e.RunCommand(nonWorkingCmd)
-			if err != nil && strings.Contains(err.Error(), "exit status") {
-				// Treat exit status as a successful condition
-				return true
-			}
-			return false
-		}, "40s", "5s").Should(BeTrue())
-
-		// curling a service with internal traffic policy=cluster. It should work on both pods
-		for _, pod := range []string{clientPod1, clientPod2} {
-			cmd := "kubectl exec " + pod + " -- curl -s --max-time 5 nginx-loadbalancer-svc:81/ip"
+			// Check where the server pod is running
+			var serverNodeName string
 			Eventually(func() (string, error) {
+				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
+				Expect(err).NotTo(HaveOccurred(), "failed to parse pods")
+				for _, pod := range pods {
+					if strings.Contains(pod.Name, "test-loadbalancer-ext") {
+						serverNodeName = pod.Node
+						break
+					}
+				}
+				return serverNodeName, nil
+			}, "25s", "5s").ShouldNot(BeEmpty(), "server pod not found")
+
+			var serverNodeIP string
+			for _, node := range nodes {
+				if node.Name == serverNodeName {
+					serverNodeIP = node.InternalIP
+				}
+			}
+
+			// Verify there is only one external-ip and it is matching the node IP
+			lbSvc := "nginx-loadbalancer-svc"
+			lbSvcExt := "nginx-loadbalancer-svc-ext"
+			Eventually(func() ([]string, error) {
+				return e2e.FetchExternalIPs(tc.KubeConfigFile, lbSvc)
+			}, "25s", "5s").Should(HaveLen(2), "external IP count not equal to 2")
+
+			Eventually(func(g Gomega) {
+				externalIPs, _ := e2e.FetchExternalIPs(tc.KubeConfigFile, lbSvcExt)
+				g.Expect(externalIPs).To(HaveLen(1), "more than 1 exernalIP found")
+				g.Expect(externalIPs[0]).To(Equal(serverNodeIP), "external IP does not match servernodeIP")
+			}, "25s", "5s").Should(Succeed())
+		})
+
+		// Verifies that the service is reachable from the outside and the source IP is nos MASQ
+		// It also verifies that the service with external traffic policy=cluster can be accessed and the source IP is MASQ
+		It("Verify connectivity in external traffic policy=local", func() {
+			lbSvc := "nginx-loadbalancer-svc"
+			lbSvcExternalIPs, _ := e2e.FetchExternalIPs(tc.KubeConfigFile, lbSvc)
+			lbSvcExt := "nginx-loadbalancer-svc-ext"
+			lbSvcExtExternalIPs, _ := e2e.FetchExternalIPs(tc.KubeConfigFile, lbSvcExt)
+
+			// Verify connectivity to the external IP of the lbsvc service and the IP should be the flannel interface IP because of MASQ
+			for _, externalIP := range lbSvcExternalIPs {
+				Eventually(func() (string, error) {
+					cmd := "curl -s " + externalIP + ":81/ip"
+					return e2e.RunCommand(cmd)
+				}, "25s", "5s").Should(ContainSubstring("10.42"))
+			}
+
+			// Verify connectivity to the external IP of the lbsvcExt service and the IP should not be the flannel interface IP
+			Eventually(func() (string, error) {
+				cmd := "curl -s " + lbSvcExtExternalIPs[0] + ":82/ip"
 				return e2e.RunCommand(cmd)
-			}, "20s", "5s").Should(SatisfyAny(
+			}, "25s", "5s").ShouldNot(ContainSubstring("10.42"))
+
+			// Verify connectivity to the other nodeIP does not work because of external traffic policy=local
+			for _, externalIP := range lbSvcExternalIPs {
+				if externalIP == lbSvcExtExternalIPs[0] {
+					// This IP we already test and it shuold work
+					continue
+				}
+				Eventually(func() error {
+					cmd := "curl -s --max-time 5 " + externalIP + ":82/ip"
+					_, err := e2e.RunCommand(cmd)
+					return err
+				}, "40s", "5s").Should(MatchError(ContainSubstring("exit status")))
+			}
+		})
+
+		// Verifies that the internal traffic policy=local is deployed
+		It("Verify internal traffic policy=local gets set up correctly", func() {
+			_, err := tc.DeployWorkload("loadbalancer-intTrafficPol.yaml")
+			Expect(err).NotTo(HaveOccurred(), "loadbalancer-intTrafficPol not deployed")
+			_, err = tc.DeployWorkload("pod_client.yaml")
+			Expect(err).NotTo(HaveOccurred(), "pod client not deployed")
+
+			// Check that service exists
+			Eventually(func() (string, error) {
+				clusterIP, _ := e2e.FetchClusterIP(tc.KubeConfigFile, "nginx-loadbalancer-svc-int", false)
+				return clusterIP, nil
+			}, "25s", "5s").Should(ContainSubstring("10.43"))
+
+			// Check that client pods are running
+			Eventually(func() string {
+				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
+				Expect(err).NotTo(HaveOccurred())
+				for _, pod := range pods {
+					if strings.Contains(pod.Name, "client-deployment") {
+						return pod.Status
+					}
+				}
+				return ""
+			}, "50s", "5s").Should(Equal("Running"))
+		})
+
+		// Verifies that only the client pod running in the same node as the server pod can access the service
+		// It also verifies that the service with internal traffic policy=cluster can be accessed by both client pods
+		It("Verify connectivity in internal traffic policy=local", func() {
+			var clientPod1, clientPod1Node, clientPod1IP, clientPod2, clientPod2Node, clientPod2IP, serverNodeName string
+			Eventually(func(g Gomega) {
+				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
+				Expect(err).NotTo(HaveOccurred(), "failed to parse pods")
+				for _, pod := range pods {
+					if strings.Contains(pod.Name, "test-loadbalancer-int") {
+						serverNodeName = pod.Node
+					}
+					if strings.Contains(pod.Name, "client-deployment") {
+						if clientPod1 == "" {
+							clientPod1 = pod.Name
+							clientPod1Node = pod.Node
+							clientPod1IP = pod.IP
+						} else {
+							clientPod2 = pod.Name
+							clientPod2Node = pod.Node
+							clientPod2IP = pod.IP
+						}
+					}
+				}
+				// As we need those variables for the connectivity test, let's check they are not emtpy
+				g.Expect(serverNodeName).ShouldNot(BeEmpty(), "server pod for internalTrafficPolicy=local not found")
+				g.Expect(clientPod1).ShouldNot(BeEmpty(), "client pod1 not found")
+				g.Expect(clientPod2).ShouldNot(BeEmpty(), "client pod2 not found")
+				g.Expect(clientPod1Node).ShouldNot(BeEmpty(), "client pod1 node not found")
+				g.Expect(clientPod2Node).ShouldNot(BeEmpty(), "client pod2 node not found")
+				g.Expect(clientPod1IP).ShouldNot(BeEmpty(), "client pod1 IP not found")
+				g.Expect(clientPod2IP).ShouldNot(BeEmpty(), "client pod2 IP not found")
+			}, "25s", "5s").Should(Succeed(), "All pod and names and IPs should be non-empty")
+
+			// Check that clientPod1Node and clientPod2Node are not equal
+			Expect(clientPod1Node).ShouldNot(Equal(clientPod2Node))
+
+			var workingCmd, nonWorkingCmd string
+			if serverNodeName == clientPod1Node {
+				workingCmd = "kubectl exec " + clientPod1 + " -- curl -s --max-time 5 nginx-loadbalancer-svc-int:83/ip"
+				nonWorkingCmd = "kubectl exec " + clientPod2 + " -- curl -s --max-time 5 nginx-loadbalancer-svc-int:83/ip"
+			}
+			if serverNodeName == clientPod2Node {
+				workingCmd = "kubectl exec " + clientPod2 + " -- curl -s --max-time 5 nginx-loadbalancer-svc-int:83/ip"
+				nonWorkingCmd = "kubectl exec " + clientPod1 + " -- curl -s --max-time 5 nginx-loadbalancer-svc-int:83/ip"
+			}
+
+			Eventually(func() (string, error) {
+				out, err := e2e.RunCommand(workingCmd)
+				return out, err
+			}, "25s", "5s").Should(SatisfyAny(
 				ContainSubstring(clientPod1IP),
 				ContainSubstring(clientPod2IP),
 			))
-		}
-	})
 
-	// Set up the service manifest with loadBalancerSourceRanges
-	It("Applies service manifest with loadBalancerSourceRanges", func() {
-		// Define the service manifest with a placeholder for the IP
-		serviceManifest := `
+			// Check the non working command fails because of internal traffic policy=local
+			Eventually(func() bool {
+				_, err := e2e.RunCommand(nonWorkingCmd)
+				if err != nil && strings.Contains(err.Error(), "exit status") {
+					// Treat exit status as a successful condition
+					return true
+				}
+				return false
+			}, "40s", "5s").Should(BeTrue())
+
+			// curling a service with internal traffic policy=cluster. It should work on both pods
+			for _, pod := range []string{clientPod1, clientPod2} {
+				cmd := "kubectl exec " + pod + " -- curl -s --max-time 5 nginx-loadbalancer-svc:81/ip"
+				Eventually(func() (string, error) {
+					return e2e.RunCommand(cmd)
+				}, "20s", "5s").Should(SatisfyAny(
+					ContainSubstring(clientPod1IP),
+					ContainSubstring(clientPod2IP),
+				))
+			}
+		})
+
+		// Set up the service manifest with loadBalancerSourceRanges
+		It("Applies service manifest with loadBalancerSourceRanges", func() {
+			// Define the service manifest with a placeholder for the IP
+			serviceManifest := `
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginx-loadbalancer-svc-ext-firewall
+name: nginx-loadbalancer-svc-ext-firewall
 spec:
-  type: LoadBalancer
-  loadBalancerSourceRanges:
-  - {{.NodeIP}}/32
-  ports:
-  - port: 82
-    targetPort: 80
-    protocol: TCP
-    name: http
-  selector:
-    k8s-app: nginx-app-loadbalancer-ext
+type: LoadBalancer
+loadBalancerSourceRanges:
+- {{.NodeIP}}/32
+ports:
+- port: 82
+	targetPort: 80
+	protocol: TCP
+	name: http
+selector:
+	k8s-app: nginx-app-loadbalancer-ext
 `
-		// Remove the service nginx-loadbalancer-svc-ext
-		_, err := e2e.RunCommand("kubectl delete svc nginx-loadbalancer-svc-ext")
-		Expect(err).NotTo(HaveOccurred(), "failed to remove service nginx-loadbalancer-svc-ext")
+			// Remove the service nginx-loadbalancer-svc-ext
+			_, err := e2e.RunCommand("kubectl delete svc nginx-loadbalancer-svc-ext")
+			Expect(err).NotTo(HaveOccurred(), "failed to remove service nginx-loadbalancer-svc-ext")
 
-		// Parse and execute the template with the node IP
-		tmpl, err := template.New("service").Parse(serviceManifest)
-		Expect(err).NotTo(HaveOccurred())
+			// Parse and execute the template with the node IP
+			tmpl, err := template.New("service").Parse(serviceManifest)
+			Expect(err).NotTo(HaveOccurred())
 
-		var filledManifest strings.Builder
-		err = tmpl.Execute(&filledManifest, struct{ NodeIP string }{NodeIP: nodes[0].InternalIP})
-		Expect(err).NotTo(HaveOccurred())
+			var filledManifest strings.Builder
+			err = tmpl.Execute(&filledManifest, struct{ NodeIP string }{NodeIP: nodes[0].InternalIP})
+			Expect(err).NotTo(HaveOccurred())
 
-		// Write the filled manifest to a temporary file
-		tmpFile, err := os.CreateTemp("", "service-*.yaml")
-		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(tmpFile.Name())
+			// Write the filled manifest to a temporary file
+			tmpFile, err := os.CreateTemp("", "service-*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(tmpFile.Name())
 
-		_, err = tmpFile.WriteString(filledManifest.String())
-		Expect(err).NotTo(HaveOccurred())
-		tmpFile.Close()
+			_, err = tmpFile.WriteString(filledManifest.String())
+			Expect(err).NotTo(HaveOccurred())
+			tmpFile.Close()
 
-		// Apply the manifest using kubectl
-		applyCmd := fmt.Sprintf("kubectl apply -f %s", tmpFile.Name())
-		out, err := e2e.RunCommand(applyCmd)
-		Expect(err).NotTo(HaveOccurred(), out)
+			// Apply the manifest using kubectl
+			applyCmd := fmt.Sprintf("kubectl apply -f %s", tmpFile.Name())
+			out, err := e2e.RunCommand(applyCmd)
+			Expect(err).NotTo(HaveOccurred(), out)
 
-		Eventually(func() (string, error) {
-			clusterIP, _ := e2e.FetchClusterIP(tc.KubeConfigFile, "nginx-loadbalancer-svc-ext-firewall", false)
-			return clusterIP, nil
-		}, "25s", "5s").Should(ContainSubstring("10.43"))
-	})
-
-	// Verify that only the allowed node can curl. That node should be able to curl both externalIPs (i.e. node.InternalIP)
-	It("Verify firewall is working", func() {
-		for _, node := range nodes {
-			var sNode, aNode e2e.VagrantNode
-			for _, n := range tc.Servers {
-				if n.String() == nodes[0].Name {
-					sNode = n
-				}
-			}
-			for _, n := range tc.Agents {
-				if n.String() == nodes[1].Name {
-					aNode = n
-				}
-			}
-
-			// Verify connectivity from nodes[0] works because we passed its IP to the loadBalancerSourceRanges
 			Eventually(func() (string, error) {
-				cmd := "curl -s --max-time 5 " + node.InternalIP + ":82"
-				return sNode.RunCmdOnNode(cmd)
-			}, "40s", "5s").Should(ContainSubstring("Welcome to nginx"))
+				clusterIP, _ := e2e.FetchClusterIP(tc.KubeConfigFile, "nginx-loadbalancer-svc-ext-firewall", false)
+				return clusterIP, nil
+			}, "25s", "5s").Should(ContainSubstring("10.43"))
+		})
 
-			// Verify connectivity from nodes[1] fails because we did not pass its IP to the loadBalancerSourceRanges
-			Eventually(func(g Gomega) error {
-				cmd := "curl -s --max-time 5 " + node.InternalIP + ":82"
-				_, err := aNode.RunCmdOnNode(cmd)
-				return err
-			}, "40s", "5s").Should(MatchError(ContainSubstring("exit status")))
-		}
+		// Verify that only the allowed node can curl. That node should be able to curl both externalIPs (i.e. node.InternalIP)
+		It("Verify firewall is working", func() {
+			for _, node := range nodes {
+				var sNode, aNode e2e.VagrantNode
+				for _, n := range tc.Servers {
+					if n.String() == nodes[0].Name {
+						sNode = n
+					}
+				}
+				for _, n := range tc.Agents {
+					if n.String() == nodes[1].Name {
+						aNode = n
+					}
+				}
+
+				// Verify connectivity from nodes[0] works because we passed its IP to the loadBalancerSourceRanges
+				Eventually(func() (string, error) {
+					cmd := "curl -s --max-time 5 " + node.InternalIP + ":82"
+					return sNode.RunCmdOnNode(cmd)
+				}, "40s", "5s").Should(ContainSubstring("Welcome to nginx"))
+
+				// Verify connectivity from nodes[1] fails because we did not pass its IP to the loadBalancerSourceRanges
+				Eventually(func(g Gomega) error {
+					cmd := "curl -s --max-time 5 " + node.InternalIP + ":82"
+					_, err := aNode.RunCmdOnNode(cmd)
+					return err
+				}, "40s", "5s").Should(MatchError(ContainSubstring("exit status")))
+			}
+		})
 	})
 })
 

--- a/tests/e2e/token/token_test.go
+++ b/tests/e2e/token/token_test.go
@@ -34,9 +34,9 @@ func Test_E2EToken(t *testing.T) {
 }
 
 var (
-	kubeConfigFile  string
-	serverNodeNames []string
-	agentNodeNames  []string
+	kubeConfigFile string
+	serverNodes    []e2e.VagrantNode
+	agentNodes     []e2e.VagrantNode
 )
 
 var _ = ReportAfterEach(e2e.GenReport)
@@ -46,21 +46,21 @@ var _ = Describe("Use the token CLI to create and join agents", Ordered, func() 
 		It("Starts up with no issues", func() {
 			var err error
 			if *local {
-				serverNodeNames, agentNodeNames, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
+				serverNodes, agentNodes, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
 			} else {
-				serverNodeNames, agentNodeNames, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
+				serverNodes, agentNodes, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 			}
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 			fmt.Println("CLUSTER CONFIG")
 			fmt.Println("OS:", *nodeOS)
-			fmt.Println("Server Nodes:", serverNodeNames)
-			fmt.Println("Agent Nodes:", agentNodeNames)
-			kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodeNames[0])
+			fmt.Println("Server Nodes:", serverNodes)
+			fmt.Println("Agent Nodes:", agentNodes)
+			kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodes[0].String())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Checks Node and Pod Status", func() {
-			fmt.Printf("\nFetching node status\n")
+			By("Fetching Nodes status")
 			Eventually(func(g Gomega) {
 				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -68,9 +68,9 @@ var _ = Describe("Use the token CLI to create and join agents", Ordered, func() 
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "420s", "5s").Should(Succeed())
-			_, _ = e2e.ParseNodes(kubeConfigFile, true)
+			e2e.DumpPods(kubeConfigFile)
 
-			fmt.Printf("\nFetching Pods status\n")
+			By("Fetching Pods status")
 			Eventually(func(g Gomega) {
 				pods, err := e2e.ParsePods(kubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -82,30 +82,30 @@ var _ = Describe("Use the token CLI to create and join agents", Ordered, func() 
 					}
 				}
 			}, "420s", "5s").Should(Succeed())
-			_, _ = e2e.ParsePods(kubeConfigFile, true)
+			e2e.DumpPods(kubeConfigFile)
 		})
 
 		var permToken string
 		It("Creates a permanent agent token", func() {
 			permToken = "perage.s0xt4u0hl5guoyi6"
-			_, err := e2e.RunCmdOnNode("k3s token create --ttl=0 "+permToken, serverNodeNames[0])
+			_, err := serverNodes[0].RunCmdOnNode("k3s token create --ttl=0 " + permToken)
 			Expect(err).NotTo(HaveOccurred())
 
-			res, err := e2e.RunCmdOnNode("k3s token list", serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode("k3s token list")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(MatchRegexp(`perage\s+<forever>\s+<never>`))
 		})
 		It("Joins an agent with the permanent token", func() {
 			cmd := fmt.Sprintf("echo 'token: %s' | sudo tee -a /etc/rancher/k3s/config.yaml > /dev/null", permToken)
-			_, err := e2e.RunCmdOnNode(cmd, agentNodeNames[0])
+			_, err := agentNodes[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = e2e.RunCmdOnNode("systemctl start k3s-agent", agentNodeNames[0])
+			_, err = agentNodes[0].RunCmdOnNode("systemctl start k3s-agent")
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(nodes)).Should(Equal(len(serverNodeNames) + 1))
+				g.Expect(len(nodes)).Should(Equal(len(serverNodes) + 1))
 				for _, node := range nodes {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
@@ -114,38 +114,38 @@ var _ = Describe("Use the token CLI to create and join agents", Ordered, func() 
 	})
 	Context("Agent joins with temporary token:", func() {
 		It("Creates a 20s agent token", func() {
-			_, err := e2e.RunCmdOnNode("k3s token create --ttl=20s 20sect.jxnpve6vg8dqm895", serverNodeNames[0])
+			_, err := serverNodes[0].RunCmdOnNode("k3s token create --ttl=20s 20sect.jxnpve6vg8dqm895")
 			Expect(err).NotTo(HaveOccurred())
-			res, err := e2e.RunCmdOnNode("k3s token list", serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode("k3s token list")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(MatchRegexp(`20sect\s+[0-9]{2}s`))
 		})
 		It("Cleans up 20s token automatically", func() {
 			Eventually(func() (string, error) {
-				return e2e.RunCmdOnNode("k3s token list", serverNodeNames[0])
+				return serverNodes[0].RunCmdOnNode("k3s token list")
 			}, "25s", "5s").ShouldNot(ContainSubstring("20sect"))
 		})
 		var tempToken string
 		It("Creates a 10m agent token", func() {
 			tempToken = "10mint.ida18trbbk43szwk"
-			_, err := e2e.RunCmdOnNode("k3s token create --ttl=10m "+tempToken, serverNodeNames[0])
+			_, err := serverNodes[0].RunCmdOnNode("k3s token create --ttl=10m " + tempToken)
 			Expect(err).NotTo(HaveOccurred())
 			time.Sleep(2 * time.Second)
-			res, err := e2e.RunCmdOnNode("k3s token list", serverNodeNames[0])
+			res, err := serverNodes[0].RunCmdOnNode("k3s token list")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(MatchRegexp(`10mint\s+[0-9]m`))
 		})
 		It("Joins an agent with the 10m token", func() {
 			cmd := fmt.Sprintf("echo 'token: %s' | sudo tee -a /etc/rancher/k3s/config.yaml > /dev/null", tempToken)
-			_, err := e2e.RunCmdOnNode(cmd, agentNodeNames[1])
+			_, err := agentNodes[1].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = e2e.RunCmdOnNode("systemctl start k3s-agent", agentNodeNames[1])
+			_, err = agentNodes[1].RunCmdOnNode("systemctl start k3s-agent")
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(nodes)).Should(Equal(len(serverNodeNames) + 2))
+				g.Expect(len(nodes)).Should(Equal(len(serverNodes) + 2))
 				for _, node := range nodes {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
@@ -155,23 +155,23 @@ var _ = Describe("Use the token CLI to create and join agents", Ordered, func() 
 	Context("Rotate server bootstrap token", func() {
 		serverToken := "1234"
 		It("Creates a new server token", func() {
-			Expect(e2e.RunCmdOnNode("k3s token rotate -t vagrant --new-token="+serverToken, serverNodeNames[0])).
+			Expect(serverNodes[0].RunCmdOnNode("k3s token rotate -t vagrant --new-token=" + serverToken)).
 				To(ContainSubstring("Token rotated, restart k3s nodes with new token"))
 		})
 		It("Restarts servers with the new token", func() {
 			cmd := fmt.Sprintf("sed -i 's/token:.*/token: %s/' /etc/rancher/k3s/config.yaml", serverToken)
-			for _, node := range serverNodeNames {
-				_, err := e2e.RunCmdOnNode(cmd, node)
+			for _, node := range serverNodes {
+				_, err := node.RunCmdOnNode(cmd)
 				Expect(err).NotTo(HaveOccurred())
 			}
-			for _, node := range serverNodeNames {
-				_, err := e2e.RunCmdOnNode("systemctl restart k3s", node)
+			for _, node := range serverNodes {
+				_, err := node.RunCmdOnNode("systemctl restart k3s")
 				Expect(err).NotTo(HaveOccurred())
 			}
 			Eventually(func(g Gomega) {
 				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(nodes)).Should(Equal(len(serverNodeNames) + 2))
+				g.Expect(len(nodes)).Should(Equal(len(serverNodes) + 2))
 				for _, node := range nodes {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
@@ -179,15 +179,15 @@ var _ = Describe("Use the token CLI to create and join agents", Ordered, func() 
 		})
 		It("Rejoins an agent with the new server token", func() {
 			cmd := fmt.Sprintf("sed -i 's/token:.*/token: %s/' /etc/rancher/k3s/config.yaml", serverToken)
-			_, err := e2e.RunCmdOnNode(cmd, agentNodeNames[0])
+			_, err := agentNodes[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = e2e.RunCmdOnNode("systemctl restart k3s-agent", agentNodeNames[0])
+			_, err = agentNodes[0].RunCmdOnNode("systemctl restart k3s-agent")
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
 				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(nodes)).Should(Equal(len(serverNodeNames) + 2))
+				g.Expect(len(nodes)).Should(Equal(len(serverNodes) + 2))
 				for _, node := range nodes {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
@@ -203,9 +203,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, append(serverNodeNames, agentNodeNames...)))
+		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, append(serverNodes, agentNodes...)))
 	} else {
-		Expect(e2e.GetCoverageReport(append(serverNodeNames, agentNodeNames...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(append(serverNodes, agentNodes...))).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -159,16 +159,12 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 			_, err := tc.DeployWorkload("daemonset.yaml")
 			Expect(err).NotTo(HaveOccurred(), "Daemonset manifest not deployed")
 
-			nodes, _ := e2e.ParseNodes(tc.KubeConfigFile, false) //nodes :=
+			nodes, _ := e2e.ParseNodes(tc.KubeConfigFile, false)
 
 			Eventually(func(g Gomega) {
-				pods, _ := e2e.ParsePods(tc.KubeConfigFile, false)
-				count := e2e.CountOfStringInSlice("test-daemonset", pods)
-				fmt.Println("POD COUNT")
-				fmt.Println(count)
-				fmt.Println("NODE COUNT")
-				fmt.Println(len(nodes))
-				g.Expect(len(nodes)).Should((Equal(count)), "Daemonset pod count does not match node count")
+				count, err := e2e.GetDaemonsetReady("test-daemonset", tc.KubeConfigFile)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(nodes).To(HaveLen(count), "Daemonset pod count does not match node count")
 			}, "240s", "10s").Should(Succeed())
 		})
 
@@ -345,17 +341,13 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 		})
 
 		It("After upgrade verifies Daemonset", func() {
-			nodes, _ := e2e.ParseNodes(tc.KubeConfigFile, false) //nodes :=
+			nodes, _ := e2e.ParseNodes(tc.KubeConfigFile, false)
 
 			Eventually(func(g Gomega) {
-				pods, _ := e2e.ParsePods(tc.KubeConfigFile, false)
-				count := e2e.CountOfStringInSlice("test-daemonset", pods)
-				fmt.Println("POD COUNT")
-				fmt.Println(count)
-				fmt.Println("NODE COUNT")
-				fmt.Println(len(nodes))
-				g.Expect(len(nodes)).Should(Equal(count), "Daemonset pod count does not match node count")
-			}, "420s", "1s").Should(Succeed())
+				count, err := e2e.GetDaemonsetReady("test-daemonset", tc.KubeConfigFile)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(nodes).To(HaveLen(count), "Daemonset pod count does not match node count")
+			}, "240s", "10s").Should(Succeed())
 		})
 		It("After upgrade verifies dns access", func() {
 			Eventually(func() (string, error) {

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -181,14 +181,10 @@ var _ = Describe("Verify Create", Ordered, func() {
 			nodes, _ := e2e.ParseNodes(tc.KubeConfigFile, false)
 
 			Eventually(func(g Gomega) {
-				pods, _ := e2e.ParsePods(tc.KubeConfigFile, false)
-				count := e2e.CountOfStringInSlice("test-daemonset", pods)
-				fmt.Println("POD COUNT")
-				fmt.Println(count)
-				fmt.Println("NODE COUNT")
-				fmt.Println(len(nodes))
-				g.Expect(len(nodes)).Should((Equal(count)), "Daemonset pod count does not match node count")
-			}, "420s", "10s").Should(Succeed())
+				count, err := e2e.GetDaemonsetReady("test-daemonset", tc.KubeConfigFile)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(nodes).To(HaveLen(count), "Daemonset pod count does not match node count")
+			}, "240s", "10s").Should(Succeed())
 		})
 
 		It("Verifies dns access", func() {
@@ -278,9 +274,10 @@ var _ = Describe("Verify Create", Ordered, func() {
 				for _, node := range nodes {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
-				pods, _ := e2e.ParsePods(tc.KubeConfigFile, false)
-				count := e2e.CountOfStringInSlice("test-daemonset", pods)
+				count, err := e2e.GetDaemonsetReady("test-daemonset", tc.KubeConfigFile)
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(len(nodes)).Should((Equal(count)), "Daemonset pod count does not match node count")
+				pods, _ := e2e.ParsePods(tc.KubeConfigFile, false)
 				podsRunningAr := 0
 				for _, pod := range pods {
 					if strings.Contains(pod.Name, "test-daemonset") && pod.Status == "Running" && pod.Ready == "1/1" {

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -35,11 +35,7 @@ func Test_E2EClusterValidation(t *testing.T) {
 	RunSpecs(t, "Create Cluster Test Suite", suiteConfig, reporterConfig)
 }
 
-var (
-	kubeConfigFile string
-	serverNodes    []e2e.VagrantNode
-	agentNodes     []e2e.VagrantNode
-)
+var tc *e2e.TestConfig
 
 var _ = ReportAfterEach(e2e.GenReport)
 
@@ -48,33 +44,31 @@ var _ = Describe("Verify Create", Ordered, func() {
 		It("Starts up with no issues", func() {
 			var err error
 			if *local {
-				serverNodes, agentNodes, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
+				tc, err = e2e.CreateLocalCluster(*nodeOS, *serverCount, *agentCount)
 			} else {
-				serverNodes, agentNodes, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
+				tc, err = e2e.CreateCluster(*nodeOS, *serverCount, *agentCount)
 			}
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
-			fmt.Println("CLUSTER CONFIG")
-			fmt.Println("OS:", *nodeOS)
-			fmt.Println("Server Nodes:", serverNodes)
-			fmt.Println("Agent Nodes:", agentNodes)
-			kubeConfigFile, err = e2e.GenKubeConfigFile(serverNodes[0].String())
-			Expect(err).NotTo(HaveOccurred())
+			tc.Hardened = *hardened
+			By("CLUSTER CONFIG")
+			By("OS: " + *nodeOS)
+			By(tc.Status())
 		})
 
 		It("Checks Node and Pod Status", func() {
 			fmt.Printf("\nFetching node status\n")
 			Eventually(func(g Gomega) {
-				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
+				nodes, err := e2e.ParseNodes(tc.KubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
 				for _, node := range nodes {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "620s", "5s").Should(Succeed())
-			_, _ = e2e.ParseNodes(kubeConfigFile, true)
+			_, _ = e2e.ParseNodes(tc.KubeConfigFile, true)
 
 			fmt.Printf("\nFetching Pods status\n")
 			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(kubeConfigFile, false)
+				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
 				for _, pod := range pods {
 					if strings.Contains(pod.Name, "helm-install") {
@@ -84,23 +78,23 @@ var _ = Describe("Verify Create", Ordered, func() {
 					}
 				}
 			}, "620s", "5s").Should(Succeed())
-			_, _ = e2e.ParsePods(kubeConfigFile, true)
+			e2e.DumpPods(tc.KubeConfigFile)
 		})
 
 		It("Verifies ClusterIP Service", func() {
-			res, err := e2e.DeployWorkload("clusterip.yaml", kubeConfigFile, *hardened)
+			res, err := tc.DeployWorkload("clusterip.yaml")
 			Expect(err).NotTo(HaveOccurred(), "Cluster IP manifest not deployed: "+res)
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
+				cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-clusterip --field-selector=status.phase=Running --kubeconfig=" + tc.KubeConfigFile
 				res, err := e2e.RunCommand(cmd)
 				Expect(err).NotTo(HaveOccurred())
 				g.Expect(res).Should((ContainSubstring("test-clusterip")), "failed cmd: %q result: %s", cmd, res)
 			}, "240s", "5s").Should(Succeed())
 
-			clusterip, _ := e2e.FetchClusterIP(kubeConfigFile, "nginx-clusterip-svc", false)
+			clusterip, _ := e2e.FetchClusterIP(tc.KubeConfigFile, "nginx-clusterip-svc", false)
 			cmd := "curl -L --insecure http://" + clusterip + "/name.html"
-			for _, node := range serverNodes {
+			for _, node := range tc.Servers {
 				Eventually(func(g Gomega) {
 					res, err := node.RunCmdOnNode(cmd)
 					g.Expect(err).NotTo(HaveOccurred())
@@ -110,17 +104,17 @@ var _ = Describe("Verify Create", Ordered, func() {
 		})
 
 		It("Verifies NodePort Service", func() {
-			_, err := e2e.DeployWorkload("nodeport.yaml", kubeConfigFile, *hardened)
+			_, err := tc.DeployWorkload("nodeport.yaml")
 			Expect(err).NotTo(HaveOccurred(), "NodePort manifest not deployed")
 
-			for _, node := range serverNodes {
+			for _, node := range tc.Servers {
 				nodeExternalIP, _ := node.FetchNodeExternalIP()
-				cmd := "kubectl get service nginx-nodeport-svc --kubeconfig=" + kubeConfigFile + " --output jsonpath=\"{.spec.ports[0].nodePort}\""
+				cmd := "kubectl get service nginx-nodeport-svc --kubeconfig=" + tc.KubeConfigFile + " --output jsonpath=\"{.spec.ports[0].nodePort}\""
 				nodeport, err := e2e.RunCommand(cmd)
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(func(g Gomega) {
-					cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-nodeport --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
+					cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-nodeport --field-selector=status.phase=Running --kubeconfig=" + tc.KubeConfigFile
 					res, err := e2e.RunCommand(cmd)
 					Expect(err).NotTo(HaveOccurred())
 					g.Expect(res).Should(ContainSubstring("test-nodeport"), "nodeport pod was not created")
@@ -137,18 +131,18 @@ var _ = Describe("Verify Create", Ordered, func() {
 		})
 
 		It("Verifies LoadBalancer Service", func() {
-			_, err := e2e.DeployWorkload("loadbalancer.yaml", kubeConfigFile, *hardened)
+			_, err := tc.DeployWorkload("loadbalancer.yaml")
 			Expect(err).NotTo(HaveOccurred(), "Loadbalancer manifest not deployed")
 
-			for _, node := range serverNodes {
+			for _, node := range tc.Servers {
 				ip, _ := node.FetchNodeExternalIP()
 
-				cmd := "kubectl get service nginx-loadbalancer-svc --kubeconfig=" + kubeConfigFile + " --output jsonpath=\"{.spec.ports[0].port}\""
+				cmd := "kubectl get service nginx-loadbalancer-svc --kubeconfig=" + tc.KubeConfigFile + " --output jsonpath=\"{.spec.ports[0].port}\""
 				port, err := e2e.RunCommand(cmd)
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(func(g Gomega) {
-					cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-loadbalancer --field-selector=status.phase=Running --kubeconfig=" + kubeConfigFile
+					cmd := "kubectl get pods -o=name -l k8s-app=nginx-app-loadbalancer --field-selector=status.phase=Running --kubeconfig=" + tc.KubeConfigFile
 					res, err := e2e.RunCommand(cmd)
 					g.Expect(err).NotTo(HaveOccurred(), "failed cmd: %q result: %s", cmd, res)
 					g.Expect(res).Should(ContainSubstring("test-loadbalancer"))
@@ -164,10 +158,10 @@ var _ = Describe("Verify Create", Ordered, func() {
 		})
 
 		It("Verifies Ingress", func() {
-			_, err := e2e.DeployWorkload("ingress.yaml", kubeConfigFile, *hardened)
+			_, err := tc.DeployWorkload("ingress.yaml")
 			Expect(err).NotTo(HaveOccurred(), "Ingress manifest not deployed")
 
-			for _, node := range serverNodes {
+			for _, node := range tc.Servers {
 				ip, _ := node.FetchNodeExternalIP()
 				cmd := "curl  --header host:foo1.bar.com" + " http://" + ip + "/name.html"
 				fmt.Println(cmd)
@@ -181,13 +175,13 @@ var _ = Describe("Verify Create", Ordered, func() {
 		})
 
 		It("Verifies Daemonset", func() {
-			_, err := e2e.DeployWorkload("daemonset.yaml", kubeConfigFile, *hardened)
+			_, err := tc.DeployWorkload("daemonset.yaml")
 			Expect(err).NotTo(HaveOccurred(), "Daemonset manifest not deployed")
 
-			nodes, _ := e2e.ParseNodes(kubeConfigFile, false)
+			nodes, _ := e2e.ParseNodes(tc.KubeConfigFile, false)
 
 			Eventually(func(g Gomega) {
-				pods, _ := e2e.ParsePods(kubeConfigFile, false)
+				pods, _ := e2e.ParsePods(tc.KubeConfigFile, false)
 				count := e2e.CountOfStringInSlice("test-daemonset", pods)
 				fmt.Println("POD COUNT")
 				fmt.Println(count)
@@ -198,18 +192,18 @@ var _ = Describe("Verify Create", Ordered, func() {
 		})
 
 		It("Verifies dns access", func() {
-			_, err := e2e.DeployWorkload("dnsutils.yaml", kubeConfigFile, *hardened)
+			_, err := tc.DeployWorkload("dnsutils.yaml")
 			Expect(err).NotTo(HaveOccurred(), "dnsutils manifest not deployed")
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods dnsutils --kubeconfig=" + kubeConfigFile
+				cmd := "kubectl get pods dnsutils --kubeconfig=" + tc.KubeConfigFile
 				res, err := e2e.RunCommand(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "failed cmd: %q result: %s", cmd, res)
 				g.Expect(res).Should(ContainSubstring("dnsutils"))
 			}, "420s", "2s").Should(Succeed())
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl --kubeconfig=" + kubeConfigFile + " exec -i -t dnsutils -- nslookup kubernetes.default"
+				cmd := "kubectl --kubeconfig=" + tc.KubeConfigFile + " exec -i -t dnsutils -- nslookup kubernetes.default"
 
 				res, err := e2e.RunCommand(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "failed cmd: %q result: %s", cmd, res)
@@ -218,11 +212,11 @@ var _ = Describe("Verify Create", Ordered, func() {
 		})
 
 		It("Verifies Local Path Provisioner storage ", func() {
-			res, err := e2e.DeployWorkload("local-path-provisioner.yaml", kubeConfigFile, *hardened)
+			res, err := tc.DeployWorkload("local-path-provisioner.yaml")
 			Expect(err).NotTo(HaveOccurred(), "local-path-provisioner manifest not deployed: "+res)
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pvc local-path-pvc --kubeconfig=" + kubeConfigFile
+				cmd := "kubectl get pvc local-path-pvc --kubeconfig=" + tc.KubeConfigFile
 				res, err := e2e.RunCommand(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "failed cmd: %q result: %s", cmd, res)
 				g.Expect(res).Should(ContainSubstring("local-path-pvc"))
@@ -230,32 +224,32 @@ var _ = Describe("Verify Create", Ordered, func() {
 			}, "420s", "2s").Should(Succeed())
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pod volume-test --kubeconfig=" + kubeConfigFile
+				cmd := "kubectl get pod volume-test --kubeconfig=" + tc.KubeConfigFile
 				res, err := e2e.RunCommand(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "failed cmd: %q result: %s", cmd, res)
 				g.Expect(res).Should(ContainSubstring("volume-test"))
 				g.Expect(res).Should(ContainSubstring("Running"))
 			}, "420s", "2s").Should(Succeed())
 
-			cmd := "kubectl --kubeconfig=" + kubeConfigFile + " exec volume-test -- sh -c 'echo local-path-test > /data/test'"
+			cmd := "kubectl --kubeconfig=" + tc.KubeConfigFile + " exec volume-test -- sh -c 'echo local-path-test > /data/test'"
 			res, err = e2e.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred(), "failed cmd: %q result: %s", cmd, res)
 
-			cmd = "kubectl delete pod volume-test --kubeconfig=" + kubeConfigFile
+			cmd = "kubectl delete pod volume-test --kubeconfig=" + tc.KubeConfigFile
 			res, err = e2e.RunCommand(cmd)
 			Expect(err).NotTo(HaveOccurred(), "failed cmd: %q result: %s", cmd, res)
 
-			_, err = e2e.DeployWorkload("local-path-provisioner.yaml", kubeConfigFile, *hardened)
+			_, err = tc.DeployWorkload("local-path-provisioner.yaml")
 			Expect(err).NotTo(HaveOccurred(), "local-path-provisioner manifest not deployed")
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pods -o=name -l app=local-path-provisioner --field-selector=status.phase=Running -n kube-system --kubeconfig=" + kubeConfigFile
+				cmd := "kubectl get pods -o=name -l app=local-path-provisioner --field-selector=status.phase=Running -n kube-system --kubeconfig=" + tc.KubeConfigFile
 				res, _ := e2e.RunCommand(cmd)
 				g.Expect(res).Should(ContainSubstring("local-path-provisioner"))
 			}, "420s", "2s").Should(Succeed())
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl get pod volume-test --kubeconfig=" + kubeConfigFile
+				cmd := "kubectl get pod volume-test --kubeconfig=" + tc.KubeConfigFile
 				res, err := e2e.RunCommand(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "failed cmd: %q result: %s", cmd, res)
 
@@ -264,7 +258,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			}, "420s", "2s").Should(Succeed())
 
 			Eventually(func(g Gomega) {
-				cmd := "kubectl exec volume-test --kubeconfig=" + kubeConfigFile + " -- cat /data/test"
+				cmd := "kubectl exec volume-test --kubeconfig=" + tc.KubeConfigFile + " -- cat /data/test"
 				res, err = e2e.RunCommand(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "failed cmd: %q result: %s", cmd, res)
 				fmt.Println("Data after re-creation", res)
@@ -275,16 +269,16 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 	Context("Validate restart", func() {
 		It("Restarts normally", func() {
-			errRestart := e2e.RestartCluster(append(serverNodes, agentNodes...))
+			errRestart := e2e.RestartCluster(append(tc.Servers, tc.Agents...))
 			Expect(errRestart).NotTo(HaveOccurred(), "Restart Nodes not happened correctly")
 
 			Eventually(func(g Gomega) {
-				nodes, err := e2e.ParseNodes(kubeConfigFile, false)
+				nodes, err := e2e.ParseNodes(tc.KubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
 				for _, node := range nodes {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
-				pods, _ := e2e.ParsePods(kubeConfigFile, false)
+				pods, _ := e2e.ParsePods(tc.KubeConfigFile, false)
 				count := e2e.CountOfStringInSlice("test-daemonset", pods)
 				g.Expect(len(nodes)).Should((Equal(count)), "Daemonset pod count does not match node count")
 				podsRunningAr := 0
@@ -300,10 +294,10 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 	Context("Valdiate Certificate Rotation", func() {
 		It("Stops K3s and rotates certificates", func() {
-			errStop := e2e.StopCluster(serverNodes)
+			errStop := e2e.StopCluster(tc.Servers)
 			Expect(errStop).NotTo(HaveOccurred(), "Cluster could not be stopped successfully")
 
-			for _, node := range serverNodes {
+			for _, node := range tc.Servers {
 				cmd := "k3s certificate rotate"
 				_, err := node.RunCmdOnNode(cmd)
 				Expect(err).NotTo(HaveOccurred(), "Certificate could not be rotated successfully on "+node.String())
@@ -313,13 +307,13 @@ var _ = Describe("Verify Create", Ordered, func() {
 		It("Start normally", func() {
 			// Since we stopped all the server, we have to start 2 at once to get it back up
 			// If we only start one at a time, the first will hang waiting for the second to be up
-			_, err := serverNodes[0].RunCmdOnNode("systemctl --no-block start k3s")
+			_, err := tc.Servers[0].RunCmdOnNode("systemctl --no-block start k3s")
 			Expect(err).NotTo(HaveOccurred())
-			err = e2e.StartCluster(serverNodes[1:])
+			err = e2e.StartCluster(tc.Servers[1:])
 			Expect(err).NotTo(HaveOccurred(), "Cluster could not be started successfully")
 
 			Eventually(func(g Gomega) {
-				for _, node := range serverNodes {
+				for _, node := range tc.Servers {
 					cmd := "test ! -e /var/lib/rancher/k3s/server/tls/dynamic-cert-regenerate"
 					_, err := node.RunCmdOnNode(cmd)
 					Expect(err).NotTo(HaveOccurred(), "Dynamic cert regenerate file not removed on "+node.String())
@@ -327,7 +321,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			}, "620s", "5s").Should(Succeed())
 
 			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(kubeConfigFile, false)
+				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
 				g.Expect(err).NotTo(HaveOccurred())
 				for _, pod := range pods {
 					if strings.Contains(pod.Name, "helm-install") {
@@ -354,7 +348,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 				"",
 			}
 
-			for _, node := range serverNodes {
+			for _, node := range tc.Servers {
 				grCert, errGrep := node.RunCmdOnNode(grepCert)
 				Expect(errGrep).NotTo(HaveOccurred(), "TLS dirs could not be listed on "+node.String())
 				re := regexp.MustCompile("tls-[0-9]+")
@@ -368,7 +362,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 				Expect((certArray)).Should((Equal(expectResult)), "Certificate diff does not match the expected results on "+node.String())
 			}
 
-			errRestartAgent := e2e.RestartCluster(agentNodes)
+			errRestartAgent := e2e.RestartCluster(tc.Agents)
 			Expect(errRestartAgent).NotTo(HaveOccurred(), "Agent could not be restart successfully")
 		})
 
@@ -382,12 +376,12 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, append(serverNodes, agentNodes...)))
+		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, append(tc.Servers, tc.Agents...)))
 	} else {
-		Expect(e2e.GetCoverageReport(append(serverNodes, agentNodes...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())
-		Expect(os.Remove(kubeConfigFile)).To(Succeed())
+		Expect(os.Remove(tc.KubeConfigFile)).To(Succeed())
 	}
 })

--- a/tests/e2e/wasm/wasm_test.go
+++ b/tests/e2e/wasm/wasm_test.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
+	"github.com/k3s-io/k3s/tests"
 	"github.com/k3s-io/k3s/tests/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -45,8 +45,7 @@ var _ = Describe("Verify K3s can run Wasm workloads", Ordered, func() {
 			By(tc.Status())
 		})
 
-		// Server node needs to be ready before we continue
-		It("Checks Node and Pod Status", func() {
+		It("Checks node and pod status", func() {
 			By("Fetching Nodes status")
 			Eventually(func(g Gomega) {
 				nodes, err := e2e.ParseNodes(tc.KubeConfigFile, false)
@@ -55,21 +54,11 @@ var _ = Describe("Verify K3s can run Wasm workloads", Ordered, func() {
 					g.Expect(node.Status).Should(Equal("Ready"))
 				}
 			}, "620s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
 
-			By("Fetching Pods status")
-			Eventually(func(g Gomega) {
-				pods, err := e2e.ParsePods(tc.KubeConfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(pod.Status).Should(Equal("Completed"), pod.Name)
-					} else {
-						g.Expect(pod.Status).Should(Equal("Running"), pod.Name)
-					}
-				}
-			}, "620s", "5s").Should(Succeed())
-			e2e.DumpPods(tc.KubeConfigFile)
+			By("Fetching pod status")
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeConfigFile)
+			}, "620s", "10s").Should(Succeed())
 		})
 
 		It("Verify wasm-related containerd shims are installed", func() {

--- a/tests/integration/cacertrotation/cacertrotation_int_test.go
+++ b/tests/integration/cacertrotation/cacertrotation_int_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	tests "github.com/k3s-io/k3s/tests"
 	testutil "github.com/k3s-io/k3s/tests/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,7 +37,7 @@ var _ = Describe("ca certificate rotation", Ordered, func() {
 	When("a new server is created", func() {
 		It("starts up with no problems", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "5s").Should(Succeed())
 		})
 		It("get certificate hash", func() {
@@ -69,7 +70,7 @@ var _ = Describe("ca certificate rotation", Ordered, func() {
 		})
 		It("starts up with no problems", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "360s", "5s").Should(Succeed())
 		})
 		It("get certificate hash", func() {

--- a/tests/integration/certrotation/certrotation_int_test.go
+++ b/tests/integration/certrotation/certrotation_int_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	tests "github.com/k3s-io/k3s/tests"
 	testutil "github.com/k3s-io/k3s/tests/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +36,7 @@ var _ = Describe("certificate rotation", Ordered, func() {
 	When("a new server is created", func() {
 		It("starts up with no problems", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "5s").Should(Succeed())
 		})
 		It("get certificate hash", func() {
@@ -61,7 +62,7 @@ var _ = Describe("certificate rotation", Ordered, func() {
 		})
 		It("starts up with no problems", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "360s", "5s").Should(Succeed())
 		})
 		It("checks the certificate status", func() {

--- a/tests/integration/dualstack/dualstack_int_test.go
+++ b/tests/integration/dualstack/dualstack_int_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	tests "github.com/k3s-io/k3s/tests"
 	testutil "github.com/k3s-io/k3s/tests/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,7 +41,7 @@ var _ = Describe("dual stack", Ordered, func() {
 	When("a ipv4 and ipv6 cidr is present", func() {
 		It("starts up with no problems", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "10s").Should(Succeed())
 		})
 		It("creates pods with two IPs", func() {

--- a/tests/integration/etcdrestore/etcd_restore_int_test.go
+++ b/tests/integration/etcdrestore/etcd_restore_int_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	tests "github.com/k3s-io/k3s/tests"
 	testutil "github.com/k3s-io/k3s/tests/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,7 +34,7 @@ var _ = Describe("etcd snapshot restore", Ordered, func() {
 	When("a snapshot is restored on existing node", func() {
 		It("etcd starts up with no problems", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "5s").Should(Succeed())
 		})
 		It("create a workload", func() {
@@ -85,7 +86,7 @@ var _ = Describe("etcd snapshot restore", Ordered, func() {
 		})
 		It("starts up with no problems", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "360s", "5s").Should(Succeed())
 		})
 		It("make sure workload 1 exists", func() {

--- a/tests/integration/etcdsnapshot/etcdsnapshot_int_test.go
+++ b/tests/integration/etcdsnapshot/etcdsnapshot_int_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	tests "github.com/k3s-io/k3s/tests"
 	testutil "github.com/k3s-io/k3s/tests/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,7 +41,7 @@ var _ = Describe("etcd snapshots", Ordered, func() {
 	When("a new etcd is created", func() {
 		It("starts up with no problems", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "10s").Should(Succeed())
 		})
 		It("saves an etcd snapshot", func() {
@@ -130,7 +131,7 @@ var _ = Describe("etcd snapshots", Ordered, func() {
 			server, err = testutil.K3sStartServer(localServerArgs...)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "5s").Should(Succeed())
 
 		})
@@ -156,7 +157,7 @@ var _ = Describe("etcd snapshots", Ordered, func() {
 			server, err = testutil.K3sStartServer(localServerArgs...)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "5s").Should(Succeed())
 
 		})

--- a/tests/integration/flannelipv6masq/flannelipv6masq_int_test.go
+++ b/tests/integration/flannelipv6masq/flannelipv6masq_int_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	tests "github.com/k3s-io/k3s/tests"
 	testutil "github.com/k3s-io/k3s/tests/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -41,7 +42,7 @@ var _ = Describe("flannel-ipv6-masq", Ordered, func() {
 	When("a ipv4 and ipv6 cidr is present", func() {
 		It("starts up with no problems", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "10s").Should(Succeed())
 		})
 		It("creates pods with two IPs", func() {

--- a/tests/integration/flannelnone/flannelnone_int_test.go
+++ b/tests/integration/flannelnone/flannelnone_int_test.go
@@ -1,5 +1,5 @@
 /*
-This test verifies that even if we use flannel-backend=none, kube-api starts correctly so that it can 
+This test verifies that even if we use flannel-backend=none, kube-api starts correctly so that it can
 accept the custom CNI plugin manifest. We want to catch regressions in which kube-api is unresponsive.
 To do so we check for 25s that we can consistently query kube-api. We check that pods are in pending
 state, which is what should happen if there is no cni plugin
@@ -14,8 +14,6 @@ import (
 	testutil "github.com/k3s-io/k3s/tests/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var server *testutil.K3sServer
@@ -44,25 +42,24 @@ var _ = Describe("flannel-backend=none", Ordered, func() {
 		It("checks pods status", func() {
 			// Wait for pods to come up before running the real test
 			Eventually(func() int {
-				pods, _ := testutil.ParsePods("kube-system", metav1.ListOptions{})
+				pods, _ := testutil.ParsePodsInNS("kube-system")
 				return len(pods)
 			}, "180s", "5s").Should(BeNumerically(">", 0))
 
-
-			pods, err := testutil.ParsePods("kube-system", metav1.ListOptions{})
+			pods, err := testutil.ParsePodsInNS("kube-system")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Pods should remain in Pending state because there is no network plugin
-			Consistently(func () bool {
+			Consistently(func() bool {
 				for _, pod := range pods {
 					if !strings.Contains(string(pod.Status.Phase), "Pending") {
 						return false
 					}
 				}
 				return true
-				}, "25s").Should(BeTrue())
-			})
+			}, "25s").Should(BeTrue())
 		})
+	})
 })
 
 var failed bool

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -15,20 +15,20 @@ import (
 	"time"
 
 	"github.com/k3s-io/k3s/pkg/flock"
+	"github.com/k3s-io/k3s/tests"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Compile-time variable
 var existingServer = "False"
 
 const lockFile = "/tmp/k3s-test.lock"
+const DefaultConfig = "/etc/rancher/k3s/k3s.yaml"
 
 type K3sServer struct {
 	cmd *exec.Cmd
@@ -128,60 +128,8 @@ func K3sServerArgs() []string {
 	return args
 }
 
-// K3sDefaultDeployments checks if the default deployments for K3s are ready, otherwise returns an error
-func K3sDefaultDeployments() error {
-	return CheckDeployments(metav1.NamespaceSystem, []string{"coredns", "local-path-provisioner", "metrics-server", "traefik"})
-}
-
-// CheckDeployments checks if the provided list of deployments are ready, otherwise returns an error
-func CheckDeployments(namespace string, deployments []string) error {
-	client, err := k8sClient()
-	if err != nil {
-		return err
-	}
-
-	for _, deploymentName := range deployments {
-		deployment, err := client.AppsV1().Deployments(namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		if deployment.Status.ReadyReplicas != deployment.Status.Replicas || deployment.Status.AvailableReplicas != deployment.Status.Replicas {
-			return fmt.Errorf("deployment %s not ready: replicas=%d readyReplicas=%d availableReplicas=%d",
-				deploymentName, deployment.Status.Replicas, deployment.Status.ReadyReplicas, deployment.Status.AvailableReplicas)
-		}
-	}
-
-	return nil
-}
-
-func ParsePods(namespace string, opts metav1.ListOptions) ([]corev1.Pod, error) {
-	clientSet, err := k8sClient()
-	if err != nil {
-		return nil, err
-	}
-	pods, err := clientSet.CoreV1().Pods(namespace).List(context.Background(), opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return pods.Items, nil
-}
-
-func ParseNodes() ([]corev1.Node, error) {
-	clientSet, err := k8sClient()
-	if err != nil {
-		return nil, err
-	}
-	nodes, err := clientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return nodes.Items, nil
-}
-
 func GetPod(namespace, name string) (*corev1.Pod, error) {
-	client, err := k8sClient()
+	client, err := tests.K8sClient(DefaultConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +137,7 @@ func GetPod(namespace, name string) (*corev1.Pod, error) {
 }
 
 func GetPersistentVolumeClaim(namespace, name string) (*corev1.PersistentVolumeClaim, error) {
-	client, err := k8sClient()
+	client, err := tests.K8sClient(DefaultConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +145,7 @@ func GetPersistentVolumeClaim(namespace, name string) (*corev1.PersistentVolumeC
 }
 
 func GetPersistentVolume(name string) (*corev1.PersistentVolume, error) {
-	client, err := k8sClient()
+	client, err := tests.K8sClient(DefaultConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +303,7 @@ func K3sSaveLog(server *K3sServer, dump bool) error {
 }
 
 func GetEndpointsAddresses() (string, error) {
-	client, err := k8sClient()
+	client, err := tests.K8sClient(DefaultConfig)
 	if err != nil {
 		return "", err
 	}
@@ -414,14 +362,15 @@ func unmountFolder(folder string) error {
 	return nil
 }
 
-func k8sClient() (*kubernetes.Clientset, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", "/etc/rancher/k3s/k3s.yaml")
+func ParsePodsInNS(namespace string) ([]corev1.Pod, error) {
+	clientSet, err := tests.K8sClient(DefaultConfig)
 	if err != nil {
 		return nil, err
 	}
-	clientSet, err := kubernetes.NewForConfig(config)
+	pods, err := clientSet.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
-	return clientSet, nil
+
+	return pods.Items, nil
 }

--- a/tests/integration/kubeflags/kubeflags_test.go
+++ b/tests/integration/kubeflags/kubeflags_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	tests "github.com/k3s-io/k3s/tests"
 	testutil "github.com/k3s-io/k3s/tests/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -126,7 +127,7 @@ var _ = Describe("create a new cluster with kube-* flags", Ordered, func() {
 
 				// Pods should not be healthy without kube-proxy
 				Consistently(func() error {
-					return testutil.K3sDefaultDeployments()
+					return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 				}, "100s", "5s").Should(HaveOccurred())
 			})
 			It("should not find kube-proxy starting", func() {
@@ -178,7 +179,7 @@ var _ = Describe("create a new cluster with kube-* flags", Ordered, func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() error {
-					return testutil.K3sDefaultDeployments()
+					return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 				}, "180s", "5s").Should(Succeed())
 
 			})

--- a/tests/integration/localstorage/localstorage_int_test.go
+++ b/tests/integration/localstorage/localstorage_int_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	tests "github.com/k3s-io/k3s/tests"
 	testutil "github.com/k3s-io/k3s/tests/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +36,7 @@ var _ = Describe("local storage", Ordered, func() {
 	When("a new local storage is created", func() {
 		It("starts up with no problems", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "120s", "5s").Should(Succeed())
 		})
 		It("creates a new pvc", func() {

--- a/tests/integration/longhorn/longhorn_int_test.go
+++ b/tests/integration/longhorn/longhorn_int_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	tests "github.com/k3s-io/k3s/tests"
 	testutil "github.com/k3s-io/k3s/tests/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var server *testutil.K3sServer
@@ -38,7 +38,7 @@ var _ = Describe("longhorn", Ordered, func() {
 	When("a new cluster is created", func() {
 		It("starts up with no problems", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "120s", "5s").Should(Succeed())
 		})
 	})
@@ -57,7 +57,7 @@ var _ = Describe("longhorn", Ordered, func() {
 		})
 		It("starts the longhorn pods with no problems", func() {
 			Eventually(func() error {
-				pods, err := testutil.ParsePods("longhorn-system", metav1.ListOptions{})
+				pods, err := testutil.ParsePodsInNS("longhorn-system")
 				if err != nil {
 					return err
 				}

--- a/tests/integration/secretsencryption/secretsencryption_int_test.go
+++ b/tests/integration/secretsencryption/secretsencryption_int_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	tests "github.com/k3s-io/k3s/tests"
 	testutil "github.com/k3s-io/k3s/tests/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +36,7 @@ var _ = Describe("secrets encryption rotation", Ordered, func() {
 	When("A server starts with secrets encryption", func() {
 		It("starts up with no problems", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "5s").Should(Succeed())
 		})
 		It("it creates a encryption key", func() {
@@ -66,7 +67,7 @@ var _ = Describe("secrets encryption rotation", Ordered, func() {
 			secretsEncryptionServer, err = testutil.K3sStartServer(secretsEncryptionServerArgs...)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "5s").Should(Succeed())
 			Eventually(func() (string, error) {
 				return testutil.K3sCmd("secrets-encrypt status -d", secretsEncryptionDataDir)
@@ -91,7 +92,7 @@ var _ = Describe("secrets encryption rotation", Ordered, func() {
 			secretsEncryptionServer, err = testutil.K3sStartServer(secretsEncryptionServerArgs...)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "5s").Should(Succeed())
 
 			Eventually(func() (string, error) {
@@ -128,7 +129,7 @@ var _ = Describe("secrets encryption rotation", Ordered, func() {
 			secretsEncryptionServer, err = testutil.K3sStartServer(secretsEncryptionServerArgs...)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "5s").Should(Succeed())
 			time.Sleep(10 * time.Second)
 		})

--- a/tests/integration/startup/startup_int_test.go
+++ b/tests/integration/startup/startup_int_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	tests "github.com/k3s-io/k3s/tests"
 	testutil "github.com/k3s-io/k3s/tests/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,7 +38,7 @@ var _ = Describe("startup tests", Ordered, func() {
 		})
 		It("has the default pods deployed", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "120s", "5s").Should(Succeed())
 		})
 		It("has kine without tls", func() {
@@ -78,7 +79,7 @@ var _ = Describe("startup tests", Ordered, func() {
 		})
 		It("has the default pods deployed", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "120s", "5s").Should(Succeed())
 		})
 		It("set kine to use tls", func() {
@@ -107,7 +108,7 @@ var _ = Describe("startup tests", Ordered, func() {
 		})
 		It("has the default pods deployed", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "120s", "5s").Should(Succeed())
 		})
 		It("dies cleanly", func() {
@@ -124,9 +125,9 @@ var _ = Describe("startup tests", Ordered, func() {
 		})
 		It("has the default pods without traefik deployed", func() {
 			Eventually(func() error {
-				return testutil.CheckDeployments("kube-system", []string{"coredns", "local-path-provisioner", "metrics-server"})
+				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server"}, testutil.DefaultConfig)
 			}, "90s", "10s").Should(Succeed())
-			nodes, err := testutil.ParseNodes()
+			nodes, err := tests.ParseNodes(testutil.DefaultConfig)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nodes).To(HaveLen(1))
 		})
@@ -156,10 +157,10 @@ var _ = Describe("startup tests", Ordered, func() {
 		})
 		It("has the node deployed with correct IPs", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "120s", "10s").Should(Succeed())
 
-			nodes, err := testutil.ParseNodes()
+			nodes, err := tests.ParseNodes(testutil.DefaultConfig)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nodes).To(HaveLen(1))
 			Expect(nodes[0].Status.Addresses).To(ContainElements([]v1.NodeAddress{
@@ -201,9 +202,9 @@ var _ = Describe("startup tests", Ordered, func() {
 		})
 		It("has the default pods deployed", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "120s", "5s").Should(Succeed())
-			nodes, err := testutil.ParseNodes()
+			nodes, err := tests.ParseNodes(testutil.DefaultConfig)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nodes).To(HaveLen(1))
 		})
@@ -229,16 +230,16 @@ var _ = Describe("startup tests", Ordered, func() {
 		})
 		It("has the default pods deployed", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "120s", "5s").Should(Succeed())
-			nodes, err := testutil.ParseNodes()
+			nodes, err := tests.ParseNodes(testutil.DefaultConfig)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nodes).To(HaveLen(1))
 		})
 		var nodes []v1.Node
 		It("has a custom node name with id appended", func() {
 			var err error
-			nodes, err = testutil.ParseNodes()
+			nodes, err = tests.ParseNodes(testutil.DefaultConfig)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nodes).To(HaveLen(1))
 			Expect(nodes[0].Name).To(MatchRegexp(`-[0-9a-f]*`))
@@ -264,9 +265,9 @@ var _ = Describe("startup tests", Ordered, func() {
 		})
 		It("has the default pods deployed", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "120s", "5s").Should(Succeed())
-			nodes, err := testutil.ParseNodes()
+			nodes, err := tests.ParseNodes(testutil.DefaultConfig)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nodes).To(HaveLen(1))
 		})
@@ -285,7 +286,7 @@ var _ = Describe("startup tests", Ordered, func() {
 		})
 		It("has the default pods deployed", func() {
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "120s", "5s").Should(Succeed())
 		})
 		It("creates a new pod", func() {
@@ -301,7 +302,7 @@ var _ = Describe("startup tests", Ordered, func() {
 			startupServer, err = testutil.K3sStartServer(startupServerArgs...)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() error {
-				return testutil.K3sDefaultDeployments()
+				return tests.CheckDefaultDeployments(testutil.DefaultConfig)
 			}, "180s", "5s").Should(Succeed())
 		})
 		It("has the dummy pod not restarted", func() {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Consolidate relevant "client-go" type helper functions into a single package for use across Integration, Docker, and E2E tests. Docker and Integration were already directly using their respective client-go functions, E2E reqiured more work (as those relied on `kubectl` calls on the host, not client-go API calls).
- Add missing `Context` levels in several E2E tests. 
- Convert several E2E test functions into methods, consolidate common variables into Test Config struct. This brings E2E closer to how the docker tests are constructed, enabling easier "translation" between a docker or a E2E test. 

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Testing
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI still green for all tests.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
Testing all the way down
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/11710
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
