### PR TITLE
Fix e2e ingress IP helper

### DIFF
--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -348,9 +348,11 @@ func FetchIngressIP(kubeconfig string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	ingressIP := strings.Trim(res, " ")
-	ingressIPs := strings.Split(ingressIP, " ")
-	return ingressIPs, nil
+	res = strings.TrimSpace(res)
+	if res == "" {
+		return nil, errors.New("no ingress IPs found")
+	}
+	return strings.Split(res, " "), nil
 }
 
 func (v VagrantNode) FetchNodeExternalIP() (string, error) {

--- a/tests/e2e/wasm/wasm_test.go
+++ b/tests/e2e/wasm/wasm_test.go
@@ -59,6 +59,9 @@ var _ = Describe("Verify K3s can run Wasm workloads", Ordered, func() {
 			Eventually(func() error {
 				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "620s", "10s").Should(Succeed())
+			Eventually(func() error {
+				return tests.CheckDefaultDeployments(tc.KubeConfigFile)
+			}, "300s", "10s").Should(Succeed())
 		})
 
 		It("Verify wasm-related containerd shims are installed", func() {
@@ -94,9 +97,13 @@ var _ = Describe("Verify K3s can run Wasm workloads", Ordered, func() {
 		})
 
 		It("Interact with Wasm applications", func() {
-			ingressIPs, err := e2e.FetchIngressIP(tc.KubeConfigFile)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ingressIPs).To(HaveLen(1))
+			var ingressIPs []string
+			var err error
+			Eventually(func(g Gomega) {
+				ingressIPs, err = e2e.FetchIngressIP(tc.KubeConfigFile)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ingressIPs).To(HaveLen(1))
+			}, "120s", "5s").Should(Succeed())
 
 			endpoints := []string{"slight/hello", "spin/go-hello", "spin/hello"}
 			for _, endpoint := range endpoints {


### PR DESCRIPTION
#### Proposed Changes ####

Fix e2e ingress IP helper

Fix the helper to return an error if the ingress doesn't have any IPs yet, and add an Eventually in the test to avoid race condition. Just because the ingress has been deployed doesn't mean that traefik has sync'd it yet.

#### Types of Changes ####

e2e bugfix

#### Verification ####

Check CI

#### Testing ####

#### Linked Issues ####

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
