### PR TITLE
Add static bin dir support to k3s docker image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.21 as base
 RUN apk add -U ca-certificates zstd tzdata
 COPY build/out/data-linux.tar.zst /
-RUN mkdir -p /image/etc/ssl/certs /image/run /image/var/run /image/tmp /image/lib/modules /image/lib/firmware && \
+RUN mkdir -p /image/etc/ssl/certs /image/run /image/var/run /image/tmp /image/lib/modules /image/lib/firmware /image/var/lib/rancher/k3s/data/cni && \
     zstdcat -d /data-linux.tar.zst | tar -xa -C /image && \
+    for FILE in cni $(/image/bin/find /image/bin -lname cni -printf "%f\n"); do ln -s /bin/cni /image/var/lib/rancher/k3s/data/cni/$FILE; done && \
     echo "root:x:0:0:root:/:/bin/sh" > /image/etc/passwd && \
     echo "root:x:0:" > /image/etc/group && \
     cp /etc/ssl/certs/ca-certificates.crt /image/etc/ssl/certs/ca-certificates.crt
@@ -17,12 +18,12 @@ RUN mkdir -p /etc && \
     chmod 1777 /tmp
 
 FROM scratch
-COPY --from=collect / /
 VOLUME /var/lib/kubelet
 VOLUME /var/lib/rancher/k3s
 VOLUME /var/lib/cni
 VOLUME /var/log
-ENV PATH="$PATH:/bin/aux"
+COPY --from=collect / /
+ENV PATH="/var/lib/rancher/k3s/data/cni:$PATH:/bin/aux"
 ENV CRI_CONFIG_FILE="/var/lib/rancher/k3s/agent/etc/crictl.yaml"
 ENTRYPOINT ["/bin/k3s"]
 CMD ["agent"]


### PR DESCRIPTION
#### Proposed Changes ####

Static bin dir is first in search path and is on /var/lib/rancher/k3s volume, which can be persisted by users. If the volume is empty it will just fall back to the legacy /bin dir.

#### Types of Changes ####

enhancement

#### Verification ####

* Check config.toml when running k3s docker image:
  ```
  [plugins.'io.containerd.cri.v1.runtime'.cni]
  bin_dir = "/var/lib/rancher/k3s/data/cni"
  ```

#### Testing ####

Covered by docker tests

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/11497

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
