### PR TITLE
Add etcd snapshot metrics

### DIFF
--- a/pkg/agent/loadbalancer/loadbalancer.go
+++ b/pkg/agent/loadbalancer/loadbalancer.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/inetaf/tcpproxy"
+	"github.com/k3s-io/k3s/pkg/util/metrics"
 	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/sirupsen/logrus"
 )
@@ -99,13 +100,8 @@ func New(ctx context.Context, dataDir, serviceName, defaultServerURL string, lbS
 		OnDialError: onDialError,
 		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 			start := time.Now()
-			status := "success"
 			conn, err := lb.servers.dialContext(ctx, network, address)
-			latency := time.Since(start)
-			if err != nil {
-				status = "error"
-			}
-			loadbalancerDials.WithLabelValues(serviceName, status).Observe(latency.Seconds())
+			metrics.ObserveWithStatus(loadbalancerDials, start, err, serviceName)
 			return conn, err
 		},
 	})

--- a/pkg/etcd/snapshot_metrics.go
+++ b/pkg/etcd/snapshot_metrics.go
@@ -1,0 +1,57 @@
+package etcd
+
+import (
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/component-base/metrics"
+)
+
+var (
+	snapshotSaveCount = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    version.Program + "_etcd_snapshot_save_duration_seconds",
+		Help:    "Total time taken to complete the etcd snapshot process",
+		Buckets: metrics.ExponentialBuckets(0.008, 2, 15),
+	}, []string{"status"})
+
+	snapshotSaveLocalCount = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    version.Program + "_etcd_snapshot_save_local_duration_seconds",
+		Help:    "Total time taken to save a local snapshot file",
+		Buckets: metrics.ExponentialBuckets(0.008, 2, 15),
+	}, []string{"status"})
+
+	snapshotSaveS3Count = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    version.Program + "_etcd_snapshot_save_s3_duration_seconds",
+		Help:    "Total time taken to upload a snapshot file to S3",
+		Buckets: metrics.ExponentialBuckets(0.008, 2, 15),
+	}, []string{"status"})
+
+	snapshotReconcileCount = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    version.Program + "_etcd_snapshot_reconcile_duration_seconds",
+		Help:    "Total time taken to sync the list of etcd snapshots",
+		Buckets: metrics.ExponentialBuckets(0.008, 2, 15),
+	}, []string{"status"})
+
+	snapshotReconcileLocalCount = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    version.Program + "_etcd_snapshot_reconcile_local_duration_seconds",
+		Help:    "Total time taken to list local snapshot files",
+		Buckets: metrics.ExponentialBuckets(0.008, 2, 15),
+	}, []string{"status"})
+
+	snapshotReconcileS3Count = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    version.Program + "_etcd_snapshot_reconcile_s3_duration_seconds",
+		Help:    "Total time taken to list S3 snapshot files",
+		Buckets: metrics.ExponentialBuckets(0.008, 2, 15),
+	}, []string{"status"})
+)
+
+// MustRegister registers etcd snapshot metrics
+func MustRegister(registerer prometheus.Registerer) {
+	registerer.MustRegister(
+		snapshotSaveCount,
+		snapshotSaveLocalCount,
+		snapshotSaveS3Count,
+		snapshotReconcileCount,
+		snapshotReconcileLocalCount,
+		snapshotReconcileS3Count,
+	)
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -8,6 +8,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/agent/https"
 	"github.com/k3s-io/k3s/pkg/agent/loadbalancer"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/k3s-io/k3s/pkg/etcd"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	lassometrics "github.com/rancher/lasso/pkg/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -35,6 +36,8 @@ func init() {
 	lassometrics.MustRegister(DefaultRegisterer)
 	// same for loadbalancer metrics
 	loadbalancer.MustRegister(DefaultRegisterer)
+	// and etcd snapshot metrics
+	etcd.MustRegister(DefaultRegisterer)
 }
 
 // Config holds fields for the metrics listener

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -1,0 +1,16 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func ObserveWithStatus(vec *prometheus.HistogramVec, start time.Time, err error, labels ...string) {
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	labels = append(labels, status)
+	vec.WithLabelValues(labels...).Observe(time.Since(start).Seconds())
+}


### PR DESCRIPTION
#### Proposed Changes ####

Add etcd snapshot metrics:

```
# HELP k3s_etcd_snapshot_reconcile_duration_seconds Total time taken to sync the list of etcd snapshots
# HELP k3s_etcd_snapshot_reconcile_local_duration_seconds Total time taken to list local snapshot files
# HELP k3s_etcd_snapshot_reconcile_s3_duration_seconds Total time taken to list S3 snapshot files
# HELP k3s_etcd_snapshot_save_duration_seconds Total time taken to complete the etcd snapshot process
# HELP k3s_etcd_snapshot_save_local_duration_seconds Total time taken to save a local snapshot file
# HELP k3s_etcd_snapshot_save_s3_duration_seconds Total time taken to upload a snapshot file to S3
```

Note that the total number of ETCDSnapshotFile resources present does NOT have a metric here - that can already be queried from apiserver storage object count metrics:
`apiserver_storage_objects{resource="etcdsnapshotfiles.k3s.cattle.io"} 1`

#### Types of Changes ####

enhancement

#### Verification ####

Check metrics on etcd node:
```console
brandond@dev01:~$ kubectl get --raw /metrics | grep 'etcd_snapshot_.*_count'
k3s_etcd_snapshot_reconcile_duration_seconds_count{status="success"} 9
k3s_etcd_snapshot_reconcile_local_duration_seconds_count{status="success"} 11
k3s_etcd_snapshot_reconcile_s3_duration_seconds_count{status="error"} 9
k3s_etcd_snapshot_save_duration_seconds_count{status="success"} 1
k3s_etcd_snapshot_save_local_duration_seconds_count{status="success"} 1
k3s_etcd_snapshot_save_s3_duration_seconds_count{status="error"} 1
```

Note that there will be no s3 metrics if s3 is not enabled.

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/11190

#### User-Facing Change ####
```release-note
```

#### Further Comments ####