### PR TITLE
[release-1.30] Render CNI dir config whenever vars are set

### DIFF
--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -102,10 +102,10 @@ enable_keychain = true
 {{end}}
 {{end}}
 
-{{- if not .NodeConfig.NoFlannel }}
+{{- if or .NodeConfig.AgentConfig.CNIBinDir .NodeConfig.AgentConfig.CNIConfDir }}
 [plugins."io.containerd.grpc.v1.cri".cni]
-  bin_dir = {{ printf "%q" .NodeConfig.AgentConfig.CNIBinDir }}
-  conf_dir = {{ printf "%q" .NodeConfig.AgentConfig.CNIConfDir }}
+  {{ if .NodeConfig.AgentConfig.CNIBinDir }}bin_dir = {{ printf "%q" .NodeConfig.AgentConfig.CNIBinDir }}{{end}}
+  {{ if .NodeConfig.AgentConfig.CNIConfDir }}conf_dir = {{ printf "%q" .NodeConfig.AgentConfig.CNIConfDir }}{{end}}
 {{end}}
 
 {{- if or .NodeConfig.Containerd.BlockIOConfig .NodeConfig.Containerd.RDTConfig }}

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 					if !strings.HasPrefix(pod.Name, "ds-clusterip-pod") {
 						continue
 					}
-					cmd := fmt.Sprintf("curl -L --insecure http://%s", ip)
+					cmd := fmt.Sprintf("curl -m 5 -s -f http://%s", ip)
 					Eventually(func() (string, error) {
 						return tc.Servers[0].RunCmdOnNode(cmd)
 					}, "60s", "5s").Should(ContainSubstring("Welcome to nginx!"), "failed cmd: "+cmd)
@@ -121,11 +121,11 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 			nodeIPs, err := e2e.GetNodeIPs(tc.KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred(), "failed cmd: "+cmd)
 			for _, node := range nodeIPs {
-				cmd := fmt.Sprintf("curl  --header host:%s http://%s/name.html", hostName, node.IPv4)
+				cmd := fmt.Sprintf("curl --header host:%s -m 5 -s -f http://%s/name.html", hostName, node.IPv4)
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)
 				}, "10s", "2s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
-				cmd = fmt.Sprintf("curl  --header host:%s http://[%s]/name.html", hostName, node.IPv6)
+				cmd = fmt.Sprintf("curl --header host:%s -m 5 -s -f http://[%s]/name.html", hostName, node.IPv6)
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)
 				}, "5s", "1s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
@@ -141,11 +141,11 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 			nodeIPs, err := e2e.GetNodeIPs(tc.KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred())
 			for _, node := range nodeIPs {
-				cmd = "curl -L --insecure http://" + node.IPv4 + ":" + nodeport + "/name.html"
+				cmd = "curl -m 5 -s -f http://" + node.IPv4 + ":" + nodeport + "/name.html"
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)
 				}, "10s", "1s").Should(ContainSubstring("ds-nodeport-pod"), "failed cmd: "+cmd)
-				cmd = "curl -L --insecure http://[" + node.IPv6 + "]:" + nodeport + "/name.html"
+				cmd = "curl -m 5 -s -f http://[" + node.IPv6 + "]:" + nodeport + "/name.html"
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)
 				}, "10s", "1s").Should(ContainSubstring("ds-nodeport-pod"), "failed cmd: "+cmd)
@@ -154,13 +154,13 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 		It("Verifies podSelector Network Policy", func() {
 			_, err := tc.DeployWorkload("pod_client.yaml")
 			Expect(err).NotTo(HaveOccurred())
-			cmd := "kubectl exec svc/client-curl -- curl -m7 ds-clusterip-svc/name.html"
+			cmd := "kubectl exec svc/client-curl -- curl -m 5 -s -f http://ds-clusterip-svc/name.html"
 			Eventually(func() (string, error) {
 				return e2e.RunCommand(cmd)
 			}, "20s", "3s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)
 			_, err = tc.DeployWorkload("netpol-fail.yaml")
 			Expect(err).NotTo(HaveOccurred())
-			cmd = "kubectl exec svc/client-curl -- curl -m7 ds-clusterip-svc/name.html"
+			cmd = "kubectl exec svc/client-curl -- curl -m 5 -s -f http://ds-clusterip-svc/name.html"
 			Eventually(func() error {
 				_, err = e2e.RunCommand(cmd)
 				Expect(err).To(HaveOccurred())
@@ -168,7 +168,7 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 			}, "20s", "3s")
 			_, err = tc.DeployWorkload("netpol-work.yaml")
 			Expect(err).NotTo(HaveOccurred())
-			cmd = "kubectl exec svc/client-curl -- curl -m7 ds-clusterip-svc/name.html"
+			cmd = "kubectl exec svc/client-curl -- curl -m 5 -s -f http://ds-clusterip-svc/name.html"
 			Eventually(func() (string, error) {
 				return e2e.RunCommand(cmd)
 			}, "20s", "3s").Should(ContainSubstring("ds-clusterip-pod"), "failed cmd: "+cmd)

--- a/tests/e2e/externalip/externalip_test.go
+++ b/tests/e2e/externalip/externalip_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Verify External-IP config", Ordered, func() {
 			clientIPs, err := getClientIPs(tc.KubeConfigFile)
 			Expect(err).NotTo(HaveOccurred())
 			for _, ip := range clientIPs {
-				cmd := "kubectl exec svc/client-curl -- curl -m7 " + ip.IPv4 + "/name.html"
+				cmd := "kubectl exec svc/client-curl -- curl -m 5 -s -f http://" + ip.IPv4 + "/name.html"
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)
 				}, "20s", "3s").Should(ContainSubstring("client-deployment"), "failed cmd: "+cmd)

--- a/tests/e2e/privateregistry/privateregistry_test.go
+++ b/tests/e2e/privateregistry/privateregistry_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 				g.Expect(string(pod.Status.Phase)).Should(Equal("Running"))
 			}, "60s", "5s").Should(Succeed())
 
-			cmd := "curl " + pod.Status.PodIP
+			cmd := "curl -m 5 -s -f http://" + pod.Status.PodIP
 			Expect(tc.Servers[0].RunCmdOnNode(cmd)).To(ContainSubstring("Welcome to nginx!"))
 		})
 

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			}, "240s", "5s").Should(ContainSubstring("test-clusterip"), "failed cmd: "+cmd)
 
 			clusterip, _ := e2e.FetchClusterIP(tc.KubeConfigFile, "nginx-clusterip-svc", false)
-			cmd = "curl -L --insecure http://" + clusterip + "/name.html"
+			cmd = "curl -m 5 -s -f http://" + clusterip + "/name.html"
 			for _, node := range cpNodes {
 				Eventually(func() (string, error) {
 					return node.RunCmdOnNode(cmd)
@@ -198,7 +198,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 					return e2e.RunCommand(cmd)
 				}, "240s", "5s").Should(ContainSubstring("test-nodeport"), "nodeport pod was not created")
 
-				cmd = "curl -L --insecure http://" + nodeExternalIP + ":" + nodeport + "/name.html"
+				cmd = "curl -m 5 -s -f http://" + nodeExternalIP + ":" + nodeport + "/name.html"
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)
 				}, "240s", "5s").Should(ContainSubstring("test-nodeport"), "failed cmd: "+cmd)
@@ -221,7 +221,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 					return e2e.RunCommand(cmd)
 				}, "240s", "5s").Should(ContainSubstring("test-loadbalancer"), "failed cmd: "+cmd)
 
-				cmd = "curl -L --insecure http://" + ip + ":" + port + "/name.html"
+				cmd = "curl -m 5 -s -f http://" + ip + ":" + port + "/name.html"
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)
 				}, "240s", "5s").Should(ContainSubstring("test-loadbalancer"), "failed cmd: "+cmd)
@@ -234,7 +234,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			for _, node := range cpNodes {
 				ip, _ := node.FetchNodeExternalIP()
-				cmd := "curl  --header host:foo1.bar.com" + " http://" + ip + "/name.html"
+				cmd := "curl --header host:foo1.bar.com -m 5 -s -f http://" + ip + "/name.html"
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)
 				}, "240s", "5s").Should(ContainSubstring("test-ingress"), "failed cmd: "+cmd)

--- a/tests/e2e/startup/startup_test.go
+++ b/tests/e2e/startup/startup_test.go
@@ -127,6 +127,9 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			Eventually(func() error {
 				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "360s", "5s").Should(Succeed())
+			Eventually(func() error {
+				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server"}, tc.KubeConfigFile)
+			}, "300s", "10s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
 
@@ -193,6 +196,9 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			Eventually(func() error {
 				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "360s", "5s").Should(Succeed())
+			Eventually(func() error {
+				return tests.CheckDefaultDeployments(tc.KubeConfigFile)
+			}, "300s", "10s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
 
@@ -234,6 +240,9 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			Eventually(func() error {
 				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "360s", "5s").Should(Succeed())
+			Eventually(func() error {
+				return tests.CheckDefaultDeployments(tc.KubeConfigFile)
+			}, "300s", "10s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
 		It("Kills the cluster", func() {
@@ -267,6 +276,9 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			Eventually(func() error {
 				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "360s", "5s").Should(Succeed())
+			Eventually(func() error {
+				return tests.CheckDefaultDeployments(tc.KubeConfigFile)
+			}, "300s", "10s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
 		It("Kills the cluster", func() {
@@ -300,6 +312,9 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			Eventually(func() error {
 				return tests.AllPodsUp(tc.KubeConfigFile)
 			}, "360s", "5s").Should(Succeed())
+			Eventually(func() error {
+				return tests.CheckDefaultDeployments(tc.KubeConfigFile)
+			}, "300s", "10s").Should(Succeed())
 			e2e.DumpPods(tc.KubeConfigFile)
 		})
 

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 			}, "240s", "5s").Should(ContainSubstring("test-clusterip"), "failed cmd: "+cmd)
 
 			clusterip, _ := e2e.FetchClusterIP(tc.KubeConfigFile, "nginx-clusterip-svc", false)
-			cmd = "curl -L --insecure http://" + clusterip + "/name.html"
+			cmd = "curl -m 5 -s -f http://" + clusterip + "/name.html"
 			for _, node := range tc.Servers {
 				Eventually(func() (string, error) {
 					return node.RunCmdOnNode(cmd)
@@ -103,7 +103,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 					return e2e.RunCommand(cmd)
 				}, "240s", "5s").Should(ContainSubstring("test-nodeport"), "nodeport pod was not created")
 
-				cmd = "curl -L --insecure http://" + nodeExternalIP + ":" + nodeport + "/name.html"
+				cmd = "curl -m 5 -s -f http://" + nodeExternalIP + ":" + nodeport + "/name.html"
 				fmt.Println(cmd)
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)
@@ -125,7 +125,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 					return e2e.RunCommand(cmd)
 				}, "240s", "5s").Should(ContainSubstring("test-loadbalancer"))
 
-				cmd = "curl -L --insecure http://" + ip + ":" + port + "/name.html"
+				cmd = "curl -m 5 -s -f http://" + ip + ":" + port + "/name.html"
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)
 				}, "240s", "5s").Should(ContainSubstring("test-loadbalancer"), "failed cmd: "+cmd)
@@ -138,7 +138,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 
 			for _, node := range tc.Servers {
 				ip, _ := node.FetchNodeExternalIP()
-				cmd := "curl  --header host:foo1.bar.com" + " http://" + ip + "/name.html"
+				cmd := "curl --header host:foo1.bar.com -m 5 -s -f http://" + ip + "/name.html"
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)
 				}, "240s", "5s").Should(ContainSubstring("test-ingress"), "failed cmd: "+cmd)
@@ -260,7 +260,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 			}, "420s", "5s").Should(ContainSubstring("test-clusterip"))
 
 			clusterip, _ := e2e.FetchClusterIP(tc.KubeConfigFile, "nginx-clusterip-svc", false)
-			cmd := "curl -L --insecure http://" + clusterip + "/name.html"
+			cmd := "curl -m 5 -s -f http://" + clusterip + "/name.html"
 			fmt.Println(cmd)
 			for _, node := range tc.Servers {
 				Eventually(func() (string, error) {
@@ -282,7 +282,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 					return e2e.RunCommand(cmd)
 				}, "240s", "5s").Should(ContainSubstring("test-nodeport"), "nodeport pod was not created")
 
-				cmd = "curl -L --insecure http://" + nodeExternalIP + ":" + nodeport + "/name.html"
+				cmd = "curl -m 5 -s -f http://" + nodeExternalIP + ":" + nodeport + "/name.html"
 				fmt.Println(cmd)
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)
@@ -297,7 +297,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 				port, err := e2e.RunCommand(cmd)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(func() (string, error) {
-					cmd := "curl -L --insecure http://" + ip + ":" + port + "/name.html"
+					cmd := "curl -m 5 -s -f http://" + ip + ":" + port + "/name.html"
 					return e2e.RunCommand(cmd)
 				}, "240s", "5s").Should(ContainSubstring("test-loadbalancer"))
 
@@ -311,7 +311,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 		It("After upgrade verifies Ingress", func() {
 			for _, node := range tc.Servers {
 				ip, _ := node.FetchNodeExternalIP()
-				cmd := "curl  --header host:foo1.bar.com" + " http://" + ip + "/name.html"
+				cmd := "curl --header host:foo1.bar.com -m 5 -s -f http://" + ip + "/name.html"
 				fmt.Println(cmd)
 
 				Eventually(func() (string, error) {

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			}, "240s", "5s").Should(Succeed())
 
 			clusterip, _ := e2e.FetchClusterIP(tc.KubeConfigFile, "nginx-clusterip-svc", false)
-			cmd := "curl -L --insecure http://" + clusterip + "/name.html"
+			cmd := "curl -m 5 -s -f http://" + clusterip + "/name.html"
 			for _, node := range tc.Servers {
 				Eventually(func(g Gomega) {
 					res, err := node.RunCmdOnNode(cmd)
@@ -113,7 +113,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 					g.Expect(res).Should(ContainSubstring("test-nodeport"), "nodeport pod was not created")
 				}, "240s", "5s").Should(Succeed())
 
-				cmd = "curl -L --insecure http://" + nodeExternalIP + ":" + nodeport + "/name.html"
+				cmd = "curl -m 5 -s -f http://" + nodeExternalIP + ":" + nodeport + "/name.html"
 
 				Eventually(func(g Gomega) {
 					res, err := e2e.RunCommand(cmd)
@@ -142,7 +142,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 				}, "240s", "5s").Should(Succeed())
 
 				Eventually(func(g Gomega) {
-					cmd = "curl -L --insecure http://" + ip + ":" + port + "/name.html"
+					cmd = "curl -m 5 -s -f http://" + ip + ":" + port + "/name.html"
 					res, err := e2e.RunCommand(cmd)
 					g.Expect(err).NotTo(HaveOccurred(), "failed cmd: %q result: %s", cmd, res)
 					g.Expect(res).Should(ContainSubstring("test-loadbalancer"))
@@ -156,7 +156,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			for _, node := range tc.Servers {
 				ip, _ := node.FetchNodeExternalIP()
-				cmd := "curl  --header host:foo1.bar.com" + " http://" + ip + "/name.html"
+				cmd := "curl --header host:foo1.bar.com -m 5 -s -f http://" + ip + "/name.html"
 				fmt.Println(cmd)
 
 				Eventually(func(g Gomega) {

--- a/tests/e2e/wasm/wasm_test.go
+++ b/tests/e2e/wasm/wasm_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Verify K3s can run Wasm workloads", Ordered, func() {
 			for _, endpoint := range endpoints {
 				url := fmt.Sprintf("http://%s/%s", ingressIPs[0], endpoint)
 				fmt.Printf("Connecting to Wasm web application at: %s\n", url)
-				cmd := "curl -sfv " + url
+				cmd := "curl -m 5 -s -f -v " + url
 
 				Eventually(func() (string, error) {
 					return e2e.RunCommand(cmd)


### PR DESCRIPTION
#### Proposed Changes ####

Render CNI dir config whenever vars are set

RKE2 on Windows sets CNI dirs in node config even though embedded flannel is disabled (NoFlannel=true). We need to gate rendering this config on the vars being, set NOT on NoFlannel being false.

All other configurations (K3s on Windows and Linux, RKE2 on Linux) worked fine, but RKE2 on Windows was relying on this config section not being in a conditional within the template.

#### Types of Changes ####

rke2 windows regression fix

#### Verification ####

Test RKE2 in Windows.

#### Testing ####

TODO on rke2 side.

#### Linked Issues ####

https://github.com/rancher/rke2/issues/7793

#### User-Facing Change ####
```release-note
```

#### Further Comments ####