### PR TITLE
Fix E2E Startup flaky testlet

### DIFF
--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -183,9 +183,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, append(tc.Servers, tc.Agents...)))
+		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, tc.AllNodes()))
 	} else {
-		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.AllNodes())).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/embeddedmirror/embeddedmirror_test.go
+++ b/tests/e2e/embeddedmirror/embeddedmirror_test.go
@@ -132,9 +132,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		Expect(e2e.SaveJournalLogs(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.SaveJournalLogs(tc.AllNodes())).To(Succeed())
 	} else {
-		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.AllNodes())).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/externalip/externalip_test.go
+++ b/tests/e2e/externalip/externalip_test.go
@@ -151,9 +151,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		Expect(e2e.SaveJournalLogs(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.SaveJournalLogs(tc.AllNodes())).To(Succeed())
 	} else {
-		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.AllNodes())).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/privateregistry/privateregistry_test.go
+++ b/tests/e2e/privateregistry/privateregistry_test.go
@@ -137,9 +137,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		Expect(e2e.SaveJournalLogs(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.SaveJournalLogs(tc.AllNodes())).To(Succeed())
 	} else {
-		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.AllNodes())).To(Succeed())
 	}
 	if !failed || *ci {
 		r1, err := tc.Servers[0].RunCmdOnNode("docker rm -f registry")

--- a/tests/e2e/rotateca/rotateca_test.go
+++ b/tests/e2e/rotateca/rotateca_test.go
@@ -115,9 +115,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, append(tc.Servers, tc.Agents...)))
+		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, tc.AllNodes()))
 	} else {
-		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.AllNodes())).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/s3/s3_test.go
+++ b/tests/e2e/s3/s3_test.go
@@ -161,9 +161,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		Expect(e2e.SaveJournalLogs(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.SaveJournalLogs(tc.AllNodes())).To(Succeed())
 	} else {
-		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.AllNodes())).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/startup/startup_test.go
+++ b/tests/e2e/startup/startup_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 			supervisorPortYAML := "supervisor-port: 9345\napiserver-port: 6443\napiserver-bind-address: 0.0.0.0\ndisable: traefik\nnode-taint: node-role.kubernetes.io/control-plane:NoExecute"
-			err := StartK3sCluster(append(tc.Servers, tc.Agents...), supervisorPortYAML, "")
+			err := StartK3sCluster(tc.AllNodes(), supervisorPortYAML, "")
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 
 			By("CLUSTER CONFIG")
@@ -117,12 +117,8 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 
 		It("Checks node and pod status", func() {
 			By("Fetching node status")
-			Eventually(func(g Gomega) {
-				nodes, err := e2e.ParseNodes(tc.KubeconfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, node := range nodes {
-					g.Expect(node.Status).Should(Equal("Ready"))
-				}
+			Eventually(func() error {
+				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.AllNodes()))
 			}, "360s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.AllPodsUp(tc.KubeconfigFile)
@@ -157,13 +153,13 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 		})
 
 		It("Kills the cluster", func() {
-			err := KillK3sCluster(append(tc.Servers, tc.Agents...))
+			err := KillK3sCluster(tc.AllNodes())
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 	Context("Verify kubelet config file", func() {
 		It("Starts K3s with no issues", func() {
-			for _, node := range append(tc.Servers, tc.Agents...) {
+			for _, node := range tc.AllNodes() {
 				cmd := "mkdir -p --mode=0777 /tmp/kubelet.conf.d; echo 'apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nshutdownGracePeriod: 19s\nshutdownGracePeriodCriticalPods: 13s' > /tmp/kubelet.conf.d/99-shutdownGracePeriod.conf"
 				res, err := node.RunCmdOnNode(cmd)
 				By("checking command results: " + res)
@@ -171,7 +167,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			}
 
 			kubeletConfigDirYAML := "kubelet-arg: config-dir=/tmp/kubelet.conf.d"
-			err := StartK3sCluster(append(tc.Servers, tc.Agents...), kubeletConfigDirYAML, kubeletConfigDirYAML)
+			err := StartK3sCluster(tc.AllNodes(), kubeletConfigDirYAML, kubeletConfigDirYAML)
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 
 			By("CLUSTER CONFIG")
@@ -183,12 +179,8 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 
 		It("Checks node and pod status", func() {
 			By("Fetching node status")
-			Eventually(func(g Gomega) {
-				nodes, err := e2e.ParseNodes(tc.KubeconfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, node := range nodes {
-					g.Expect(node.Status).Should(Equal("Ready"))
-				}
+			Eventually(func() error {
+				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.AllNodes()))
 			}, "360s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.AllPodsUp(tc.KubeconfigFile)
@@ -197,21 +189,21 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 		})
 
 		It("Returns kubelet configuration", func() {
-			for _, node := range append(tc.Servers, tc.Agents...) {
+			for _, node := range tc.AllNodes() {
 				cmd := "kubectl get --raw /api/v1/nodes/" + node.String() + "/proxy/configz"
 				Expect(e2e.RunCommand(cmd)).To(ContainSubstring(`"shutdownGracePeriod":"19s","shutdownGracePeriodCriticalPods":"13s"`))
 			}
 		})
 
 		It("Kills the cluster", func() {
-			err := KillK3sCluster(append(tc.Servers, tc.Agents...))
+			err := KillK3sCluster(tc.AllNodes())
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 	Context("Verify CRI-Dockerd", func() {
 		It("Starts K3s with no issues", func() {
 			dockerYAML := "docker: true"
-			err := StartK3sCluster(append(tc.Servers, tc.Agents...), dockerYAML, dockerYAML)
+			err := StartK3sCluster(tc.AllNodes(), dockerYAML, dockerYAML)
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 
 			By("CLUSTER CONFIG")
@@ -223,12 +215,8 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 
 		It("Checks node and pod status", func() {
 			By("Fetching node status")
-			Eventually(func(g Gomega) {
-				nodes, err := e2e.ParseNodes(tc.KubeconfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, node := range nodes {
-					g.Expect(node.Status).Should(Equal("Ready"))
-				}
+			Eventually(func() error {
+				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.AllNodes()))
 			}, "360s", "5s").Should(Succeed())
 
 			Eventually(func() error {
@@ -237,14 +225,14 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			e2e.DumpPods(tc.KubeconfigFile)
 		})
 		It("Kills the cluster", func() {
-			err := KillK3sCluster(append(tc.Servers, tc.Agents...))
+			err := KillK3sCluster(tc.AllNodes())
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 	Context("Verify prefer-bundled-bin flag", func() {
 		It("Starts K3s with no issues", func() {
 			preferBundledYAML := "prefer-bundled-bin: true"
-			err := StartK3sCluster(append(tc.Servers, tc.Agents...), preferBundledYAML, preferBundledYAML)
+			err := StartK3sCluster(tc.AllNodes(), preferBundledYAML, preferBundledYAML)
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 
 			By("CLUSTER CONFIG")
@@ -256,12 +244,8 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 
 		It("Checks node and pod status", func() {
 			By("Fetching node status")
-			Eventually(func(g Gomega) {
-				nodes, err := e2e.ParseNodes(tc.KubeconfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, node := range nodes {
-					g.Expect(node.Status).Should(Equal("Ready"))
-				}
+			Eventually(func() error {
+				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.AllNodes()))
 			}, "360s", "5s").Should(Succeed())
 
 			Eventually(func() error {
@@ -270,14 +254,14 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			e2e.DumpPods(tc.KubeconfigFile)
 		})
 		It("Kills the cluster", func() {
-			err := KillK3sCluster(append(tc.Servers, tc.Agents...))
+			err := KillK3sCluster(tc.AllNodes())
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 	Context("Verify disable-agent and egress-selector-mode flags", func() {
 		It("Starts K3s with no issues", func() {
 			disableAgentYAML := "disable-agent: true\negress-selector-mode: cluster"
-			err := StartK3sCluster(append(tc.Servers, tc.Agents...), disableAgentYAML, "")
+			err := StartK3sCluster(tc.AllNodes(), disableAgentYAML, "")
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 
 			By("CLUSTER CONFIG")
@@ -289,16 +273,12 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 
 		It("Checks node and pod status", func() {
 			By("Fetching node status")
-			Eventually(func(g Gomega) {
-				nodes, err := e2e.ParseNodes(tc.KubeconfigFile, false)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, node := range nodes {
-					g.Expect(node.Status).Should(Equal("Ready"))
-				}
+			Eventually(func() error {
+				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.AllNodes()))
 			}, "360s", "5s").Should(Succeed())
 
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.CheckDefaultDeployments(tc.KubeconfigFile)
 			}, "360s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})
@@ -330,7 +310,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 		})
 
 		It("Kills the cluster", func() {
-			err := KillK3sCluster(append(tc.Servers, tc.Agents...))
+			err := KillK3sCluster(tc.AllNodes())
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -346,7 +326,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("Starts K3s with no issues", func() {
-			err := StartK3sCluster(append(tc.Servers, tc.Agents...), "", "")
+			err := StartK3sCluster(tc.AllNodes(), "", "")
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 
 			By("CLUSTER CONFIG")
@@ -362,14 +342,14 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			}, "120s", "5s").Should(ContainSubstring("ranchertest/mytestcontainer"))
 		})
 		It("Kills the cluster", func() {
-			err := KillK3sCluster(append(tc.Servers, tc.Agents...))
+			err := KillK3sCluster(tc.AllNodes())
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 	Context("Verify server fails to start with bootstrap token", func() {
 		It("Fails to start with a meaningful error", func() {
 			tokenYAML := "token: aaaaaa.bbbbbbbbbbbbbbbb"
-			err := StartK3sCluster(append(tc.Servers, tc.Agents...), tokenYAML, tokenYAML)
+			err := StartK3sCluster(tc.AllNodes(), tokenYAML, tokenYAML)
 			Expect(err).To(HaveOccurred())
 			Eventually(func(g Gomega) {
 				logs, err := tc.Servers[0].GetJournalLogs()
@@ -379,7 +359,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 
 		})
 		It("Kills the cluster", func() {
-			err := KillK3sCluster(append(tc.Servers, tc.Agents...))
+			err := KillK3sCluster(tc.AllNodes())
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -392,10 +372,10 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		AddReportEntry("config", e2e.GetConfig(append(tc.Servers, tc.Agents...)))
-		Expect(e2e.SaveJournalLogs(append(tc.Servers, tc.Agents...))).To(Succeed())
+		AddReportEntry("config", e2e.GetConfig(tc.AllNodes()))
+		Expect(e2e.SaveJournalLogs(tc.AllNodes())).To(Succeed())
 	} else {
-		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.AllNodes())).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/svcpoliciesandfirewall/svcpoliciesandfirewall_test.go
+++ b/tests/e2e/svcpoliciesandfirewall/svcpoliciesandfirewall_test.go
@@ -350,9 +350,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, append(tc.Servers, tc.Agents...)))
+		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, tc.AllNodes()))
 	} else {
-		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.AllNodes())).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/tailscale/tailscale_test.go
+++ b/tests/e2e/tailscale/tailscale_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Verify Tailscale Configuration", Ordered, func() {
 	It("Verify routing is correct and uses tailscale0 interface for internode traffic", func() {
 		// table 52 is the one configured by tailscale
 		cmd := "ip route show table 52"
-		for _, node := range append(tc.Servers, tc.Agents...) {
+		for _, node := range tc.AllNodes() {
 			output, err := node.RunCmdOnNode(cmd)
 			fmt.Println(err)
 			Expect(err).NotTo(HaveOccurred())
@@ -113,9 +113,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, append(tc.Servers, tc.Agents...)))
+		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, tc.AllNodes()))
 	} else {
-		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.AllNodes())).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -41,6 +41,10 @@ type TestConfig struct {
 	Agents         []VagrantNode
 }
 
+func (tc *TestConfig) AllNodes() []VagrantNode {
+	return tc.AllNodes()
+}
+
 func (tc *TestConfig) Status() string {
 	sN := strings.Join(VagrantSlice(tc.Servers), " ")
 	aN := strings.Join(VagrantSlice(tc.Agents), " ")

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -230,8 +230,8 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 
 		It("Upgrades with no issues", func() {
 			var err error
-			Expect(e2e.UpgradeCluster(append(tc.Servers, tc.Agents...), *local)).To(Succeed())
-			Expect(e2e.RestartCluster(append(tc.Servers, tc.Agents...))).To(Succeed())
+			Expect(e2e.UpgradeCluster(tc.AllNodes(), *local)).To(Succeed())
+			Expect(e2e.RestartCluster(tc.AllNodes())).To(Succeed())
 			fmt.Println("CLUSTER UPGRADED")
 			tc.KubeconfigFile, err = e2e.GenKubeconfigFile(tc.Servers[0].String())
 			Expect(err).NotTo(HaveOccurred())
@@ -352,9 +352,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, append(tc.Servers, tc.Agents...)))
+		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, tc.AllNodes()))
 	} else {
-		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.AllNodes())).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -258,7 +258,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 	Context("Validate restart", func() {
 		It("Restarts normally", func() {
-			errRestart := e2e.RestartCluster(append(tc.Servers, tc.Agents...))
+			errRestart := e2e.RestartCluster(tc.AllNodes())
 			Expect(errRestart).NotTo(HaveOccurred(), "Restart Nodes not happened correctly")
 
 			Eventually(func(g Gomega) {
@@ -350,9 +350,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, append(tc.Servers, tc.Agents...)))
+		AddReportEntry("journald-logs", e2e.TailJournalLogs(1000, tc.AllNodes()))
 	} else {
-		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.AllNodes())).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())

--- a/tests/e2e/wasm/wasm_test.go
+++ b/tests/e2e/wasm/wasm_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Verify K3s can run Wasm workloads", Ordered, func() {
 
 		It("Verify wasm-related containerd shims are installed", func() {
 			expected_shims := []string{"containerd-shim-spin-v2", "containerd-shim-slight-v1"}
-			for _, node := range append(tc.Servers, tc.Agents...) {
+			for _, node := range tc.AllNodes() {
 				for _, shim := range expected_shims {
 					cmd := fmt.Sprintf("which %s", shim)
 					_, err := node.RunCmdOnNode(cmd)
@@ -126,9 +126,9 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	if failed {
-		Expect(e2e.SaveJournalLogs(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.SaveJournalLogs(tc.AllNodes())).To(Succeed())
 	} else {
-		Expect(e2e.GetCoverageReport(append(tc.Servers, tc.Agents...))).To(Succeed())
+		Expect(e2e.GetCoverageReport(tc.AllNodes())).To(Succeed())
 	}
 	if !failed || *ci {
 		Expect(e2e.DestroyCluster()).To(Succeed())


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Containerd 2.0 seemed to deploy pods much faster than before, leading to new race conditions in E2E tests. 
- Fix flaky startup test, use better "CheckDefaultDeployments" function instead of checking pod readiness with no context
- Add `AllNodes()` function to reduce all the `append(server, agent...)` all over the E2E tests.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI is green
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
