### PR TITLE
Publish k3s image to Github Container Registry

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -105,6 +105,26 @@ steps:
     event:
     - tag
 
+- name: ghcr-publish
+  image: plugins/docker
+  settings:
+    registry: ghcr.io
+    dockerfile: package/Dockerfile
+    username: "k3s-io"
+    password:
+      from_secret: github_token
+    repo: "ghcr.io/k3s-io/k3s"
+    build_args_from_env:
+      - DRONE_TAG
+  when:
+    instance:
+    - drone-publish.k3s.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
 - name: test
   image: rancher/dapper:v0.6.0
   secrets: [ AWS_SECRET_ACCESS_KEY-k3s-ci-uploader, AWS_ACCESS_KEY_ID-k3s-ci-uploader ]
@@ -258,6 +278,26 @@ steps:
     event:
     - tag
 
+- name: ghcr-publish
+  image: plugins/docker
+  settings:
+    registry: ghcr.io
+    dockerfile: package/Dockerfile
+    username: "k3s-io"
+    password:
+      from_secret: github_token
+    repo: "ghcr.io/k3s-io/k3s"
+    build_args_from_env:
+      - DRONE_TAG
+  when:
+    instance:
+    - drone-publish.k3s.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
 - name: test
   image: rancher/dapper:v0.6.0
   secrets: [ AWS_SECRET_ACCESS_KEY-k3s-ci-uploader, AWS_ACCESS_KEY_ID-k3s-ci-uploader ]
@@ -363,6 +403,26 @@ steps:
     repo: "rancher/k3s"
     username:
       from_secret: docker_username
+    build_args_from_env:
+      - DRONE_TAG
+  when:
+    instance:
+    - drone-publish.k3s.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+- name: ghcr-publish
+  image: plugins/docker:linux-arm
+  settings:
+    registry: ghcr.io
+    dockerfile: package/Dockerfile
+    username: "k3s-io"
+    password:
+      from_secret: github_token
+    repo: "ghcr.io/k3s-io/k3s"
     build_args_from_env:
       - DRONE_TAG
   when:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- In light of dockerhubs reduced rate limits for users, we should consider dual publishing the k3s image to ghcr.io and dockerhub.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CI/Release
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Ran by hand with `dereknola` replacing `k3s-io` on my personal k3s fork
```
DRONE_TAG=v1.32.2-ds1 drone exec --trusted --pipeline=amd64 --event tag --secret-file=/home/derek/tmp/secrets.txt --instance=drone-publish.k3s.io --include=ghcr-publish
```

See it at https://github.com/dereknola/k3s/pkgs/container/k3s
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The k3s image in now published to `ghcr.io` in addition to dockerhub. You can `docker pull ghcr.io/k3s-io/k3s:<TAG>` 
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
