### PR TITLE
Add support for privileged_without_host_devices containerd option

### DIFF
--- a/pkg/agent/containerd/config_linux.go
+++ b/pkg/agent/containerd/config_linux.go
@@ -82,16 +82,17 @@ func SetupContainerdConfig(cfg *config.Node) error {
 	}
 
 	containerdConfig := templates.ContainerdConfig{
-		NodeConfig:            cfg,
-		DisableCgroup:         disableCgroup,
-		SystemdCgroup:         cfg.AgentConfig.Systemd,
-		IsRunningInUserNS:     isRunningInUserNS,
-		EnableUnprivileged:    kernel.CheckKernelVersion(4, 11, 0),
-		NonrootDevices:        cfg.Containerd.NonrootDevices,
-		PrivateRegistryConfig: cfg.AgentConfig.Registry,
-		ExtraRuntimes:         extraRuntimes,
-		Program:               version.Program,
-		NoDefaultEndpoint:     cfg.Containerd.NoDefault,
+		NodeConfig:                   cfg,
+		DisableCgroup:                disableCgroup,
+		SystemdCgroup:                cfg.AgentConfig.Systemd,
+		IsRunningInUserNS:            isRunningInUserNS,
+		EnableUnprivileged:           kernel.CheckKernelVersion(4, 11, 0),
+		NonrootDevices:               cfg.Containerd.NonrootDevices,
+		PrivilegedWithoutHostDevices: cfg.Containerd.PrivilegedWithoutHostDevices,
+		PrivateRegistryConfig:        cfg.AgentConfig.Registry,
+		ExtraRuntimes:                extraRuntimes,
+		Program:                      version.Program,
+		NoDefaultEndpoint:            cfg.Containerd.NoDefault,
 	}
 
 	selEnabled, selConfigured, err := selinuxStatus()

--- a/pkg/agent/containerd/runtimes.go
+++ b/pkg/agent/containerd/runtimes.go
@@ -71,10 +71,10 @@ func findNvidiaContainerRuntimes(foundRuntimes runtimeConfigs) {
 			RuntimeType: "io.containerd.runc.v2",
 			BinaryName:  "nvidia-container-runtime-experimental",
 		},
-                "nvidia-cdi": {
-                        RuntimeType: "io.containerd.runc.v2",
-                        BinaryName:  "nvidia-container-runtime.cdi",
-                },
+		"nvidia-cdi": {
+			RuntimeType: "io.containerd.runc.v2",
+			BinaryName:  "nvidia-container-runtime.cdi",
+		},
 	}
 
 	searchForRuntimes(potentialRuntimes, foundRuntimes)

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -9,54 +9,55 @@ import (
 )
 
 type Agent struct {
-	Token                    string
-	TokenFile                string
-	ClusterSecret            string
-	ServerURL                string
-	APIAddressCh             chan []string
-	DisableLoadBalancer      bool
-	DisableServiceLB         bool
-	ETCDAgent                bool
-	LBServerPort             int
-	ResolvConf               string
-	DataDir                  string
-	BindAddress              string
-	NodeIP                   cli.StringSlice
-	NodeExternalIP           cli.StringSlice
-	NodeInternalDNS          cli.StringSlice
-	NodeExternalDNS          cli.StringSlice
-	NodeName                 string
-	PauseImage               string
-	Snapshotter              string
-	Docker                   bool
-	ContainerdNoDefault      bool
-	ContainerdNonrootDevices bool
-	ContainerRuntimeEndpoint string
-	DefaultRuntime           string
-	ImageServiceEndpoint     string
-	FlannelIface             string
-	FlannelConf              string
-	FlannelCniConfFile       string
-	VPNAuth                  string
-	VPNAuthFile              string
-	Debug                    bool
-	EnablePProf              bool
-	Rootless                 bool
-	RootlessAlreadyUnshared  bool
-	WithNodeID               bool
-	EnableSELinux            bool
-	ProtectKernelDefaults    bool
-	ClusterReset             bool
-	PrivateRegistry          string
-	SystemDefaultRegistry    string
-	AirgapExtraRegistry      cli.StringSlice
-	ExtraKubeletArgs         cli.StringSlice
-	ExtraKubeProxyArgs       cli.StringSlice
-	Labels                   cli.StringSlice
-	Taints                   cli.StringSlice
-	ImageCredProvBinDir      string
-	ImageCredProvConfig      string
-	ContainerRuntimeReady    chan<- struct{}
+	Token                                  string
+	TokenFile                              string
+	ClusterSecret                          string
+	ServerURL                              string
+	APIAddressCh                           chan []string
+	DisableLoadBalancer                    bool
+	DisableServiceLB                       bool
+	ETCDAgent                              bool
+	LBServerPort                           int
+	ResolvConf                             string
+	DataDir                                string
+	BindAddress                            string
+	NodeIP                                 cli.StringSlice
+	NodeExternalIP                         cli.StringSlice
+	NodeInternalDNS                        cli.StringSlice
+	NodeExternalDNS                        cli.StringSlice
+	NodeName                               string
+	PauseImage                             string
+	Snapshotter                            string
+	Docker                                 bool
+	ContainerdNoDefault                    bool
+	ContainerdNonrootDevices               bool
+	ContainerdPrivilegedWithoutHostDevices bool
+	ContainerRuntimeEndpoint               string
+	DefaultRuntime                         string
+	ImageServiceEndpoint                   string
+	FlannelIface                           string
+	FlannelConf                            string
+	FlannelCniConfFile                     string
+	VPNAuth                                string
+	VPNAuthFile                            string
+	Debug                                  bool
+	EnablePProf                            bool
+	Rootless                               bool
+	RootlessAlreadyUnshared                bool
+	WithNodeID                             bool
+	EnableSELinux                          bool
+	ProtectKernelDefaults                  bool
+	ClusterReset                           bool
+	PrivateRegistry                        string
+	SystemDefaultRegistry                  string
+	AirgapExtraRegistry                    cli.StringSlice
+	ExtraKubeletArgs                       cli.StringSlice
+	ExtraKubeProxyArgs                     cli.StringSlice
+	Labels                                 cli.StringSlice
+	Taints                                 cli.StringSlice
+	ImageCredProvBinDir                    string
+	ImageCredProvConfig                    string
+	ContainerRuntimeReady                  chan<- struct{}
 	AgentShared
 }
 
@@ -245,6 +246,11 @@ var (
 		Name:        "nonroot-devices",
 		Usage:       "(agent/containerd) Allows non-root pods to access devices by setting device_ownership_from_security_context=true in the containerd CRI config",
 		Destination: &AgentConfig.ContainerdNonrootDevices,
+	}
+	PrivilegedWithoutHostDevicesFlag = &cli.BoolFlag{
+		Name:        "privileged-without-host-devices",
+		Usage:       "(agent/containerd) Allows privileged containers to access devices by setting privileged_without_host_devices=true in the containerd CRI config",
+		Destination: &AgentConfig.ContainerdPrivilegedWithoutHostDevices,
 	}
 	EnablePProfFlag = &cli.BoolFlag{
 		Name:        "enable-pprof",

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -79,21 +79,22 @@ type EtcdS3 struct {
 }
 
 type Containerd struct {
-	Address        string
-	Log            string
-	Root           string
-	State          string
-	Config         string
-	Opt            string
-	Template       string
-	BlockIOConfig  string
-	RDTConfig      string
-	Registry       string
-	NoDefault      bool
-	NonrootDevices bool
-	SELinux        bool
-	Debug          bool
-	ConfigVersion  int
+	Address                      string
+	Log                          string
+	Root                         string
+	State                        string
+	Config                       string
+	Opt                          string
+	Template                     string
+	BlockIOConfig                string
+	RDTConfig                    string
+	Registry                     string
+	NoDefault                    bool
+	NonrootDevices               bool
+	PrivilegedWithoutHostDevices bool
+	SELinux                      bool
+	Debug                        bool
+	ConfigVersion                int
 }
 
 type CRIDockerd struct {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

This is a small tweak that adds a `--privileged-without-host-devices` flag. The result of the flag is that the `privileged_without_host_devices` option will be set on the containerd runtimes. 

```
[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
  runtime_type = "io.containerd.runc.v2"
  privileged_without_host_devices = true # Prevents host devices from being automatically injected 
```

When running a container in privileged mode, by default all of the host devices are injected. This is problematic if you want your container to only have access to a single GPU. This can be achieved using the `NVIDIA_VISIBLE_DEVICES` environment variable, but that is not a very secure way of isolating the devices.  

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
New Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
You can verify the effect of this change by running a cluster on a multi-GPU node and then making a privileged pod request with a single GPU. Currently, running `nvidia-smi` will show all of the GPUs. After this change, if the `--privileged-without-host-devices` flag is passed only one GPU will appear. 

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->
I didn't see any tests for the templating in place.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
optional use of --privileged-without-host-devices flag
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
