### PR TITLE
Fix bootstrapping on non-init servers

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -91,7 +91,7 @@ jobs:
         run: | 
           chmod +x ./dist/artifacts/k3s
           cd tests/e2e/${{ matrix.etest }}
-          go test -v -timeout=45m ./${{ matrix.etest}}_test.go -ci -local
+          go test -timeout=45m ./${{ matrix.etest}}_test.go -test.v -ginkgo.v -ci -local
       - name: On Failure, Upload Journald Logs
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
@@ -211,9 +211,9 @@ jobs:
         # These tests use rancher/systemd-node and have different flags.
         CI_TESTS="autoimport hardened secretsencryption snapshotrestore token"
         if [ ${{ matrix.dtest }} = "upgrade" ] || [ ${{ matrix.dtest }} = "skew" ]; then
-          ./${{ matrix.dtest }}.test -k3sImage=$K3S_IMAGE -channel=$CHANNEL
+          ./${{ matrix.dtest }}.test -test.timeout=0 -test.v -ginkgo.v -k3sImage=$K3S_IMAGE -channel=$CHANNEL
         elif [[ $CI_TESTS =~ ${{ matrix.dtest }} ]]; then
-          ./${{ matrix.dtest }}.test -ci 
+          ./${{ matrix.dtest }}.test -test.timeout=0 -test.v -ginkgo.v -ci
         else
-          ./${{ matrix.dtest }}.test -k3sImage=$K3S_IMAGE
+          ./${{ matrix.dtest }}.test -test.timeout=0 -test.v -ginkgo.v -k3sImage=$K3S_IMAGE
         fi

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -3,7 +3,6 @@ package bootstrap
 import (
 	"encoding/json"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -12,13 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
-
-func Handler(bootstrap *config.ControlRuntimeBootstrap) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		rw.Header().Set("Content-Type", "application/json")
-		ReadFromDisk(rw, bootstrap)
-	})
-}
 
 // ReadFromDisk reads the bootstrap data from the files on disk and
 // writes their content in JSON form to the given io.Writer.

--- a/pkg/cluster/storage.go
+++ b/pkg/cluster/storage.go
@@ -198,8 +198,12 @@ func (c *Cluster) storageBootstrap(ctx context.Context) error {
 
 	attempts := 0
 	tokenKey := storageKey(normalizedToken)
-	return wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextCancel(ctx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 		attempts++
+
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
 		value, saveBootstrap, err := getBootstrapKeyFromStorage(ctx, storageClient, normalizedToken, token)
 		c.saveBootstrap = saveBootstrap
 		if err != nil {

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -312,7 +312,6 @@ type ControlRuntimeBootstrap struct {
 type ControlRuntime struct {
 	ControlRuntimeBootstrap
 
-	HTTPBootstrap                        bool
 	APIServerReady                       <-chan struct{}
 	ContainerRuntimeReady                <-chan struct{}
 	ETCDReady                            <-chan struct{}
@@ -342,6 +341,7 @@ type ControlRuntime struct {
 	AgentToken         string
 	APIServer          http.Handler
 	Handler            http.Handler
+	HTTPBootstrap      http.Handler
 	Tunnel             http.Handler
 	Authenticator      authenticator.Request
 

--- a/pkg/server/handlers/handlers.go
+++ b/pkg/server/handlers/handlers.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/k3s-io/k3s/pkg/bootstrap"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/etcd"
@@ -199,8 +198,8 @@ func Readyz(control *config.Control) http.Handler {
 }
 
 func Bootstrap(control *config.Control) http.Handler {
-	if control.Runtime.HTTPBootstrap {
-		return bootstrap.Handler(&control.Runtime.ControlRuntimeBootstrap)
+	if control.Runtime.HTTPBootstrap != nil {
+		return control.Runtime.HTTPBootstrap
 	}
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		logrus.Warnf("Received HTTP bootstrap request from %s, but embedded etcd is not enabled.", req.RemoteAddr)

--- a/pkg/server/handlers/secrets-encrypt.go
+++ b/pkg/server/handlers/secrets-encrypt.go
@@ -79,6 +79,10 @@ func EncryptionStatus(control *config.Control) http.Handler {
 
 func encryptionStatus(control *config.Control) (EncryptionState, error) {
 	state := EncryptionState{}
+	if control.Runtime.Core == nil {
+		return state, util.ErrCoreNotReady
+	}
+
 	providers, err := secretsencrypt.GetEncryptionProviders(control.Runtime)
 	if os.IsNotExist(err) {
 		return state, nil

--- a/tests/docker/autoimport/autoimport_test.go
+++ b/tests/docker/autoimport/autoimport_test.go
@@ -171,6 +171,9 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("journald-logs", docker.TailJournalLogs(1000, append(tc.Servers, tc.Agents...)))
+	}
 	if *ci || (tc != nil && !failed) {
 		Expect(tc.Cleanup()).To(Succeed())
 	}

--- a/tests/docker/basics/basics_test.go
+++ b/tests/docker/basics/basics_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/k3s-io/k3s/tests"
+	"github.com/k3s-io/k3s/tests/docker"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -74,6 +75,10 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("describe", docker.DescribeNodesAndPods(config))
+		AddReportEntry("docker-logs", docker.TailDockerLogs(1000, append(config.Servers, config.Agents...)))
+	}
 	if config != nil && !failed {
 		config.Cleanup()
 	}

--- a/tests/docker/bootstraptoken/bootstraptoken_test.go
+++ b/tests/docker/bootstraptoken/bootstraptoken_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/k3s-io/k3s/tests"
+	"github.com/k3s-io/k3s/tests/docker"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -62,6 +63,10 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("describe", docker.DescribeNodesAndPods(config))
+		AddReportEntry("docker-logs", docker.TailDockerLogs(1000, append(config.Servers, config.Agents...)))
+	}
 	if config != nil && !failed {
 		config.Cleanup()
 	}

--- a/tests/docker/cacerts/cacerts_test.go
+++ b/tests/docker/cacerts/cacerts_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/k3s-io/k3s/tests"
+	"github.com/k3s-io/k3s/tests/docker"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -88,6 +89,10 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("describe", docker.DescribeNodesAndPods(config))
+		AddReportEntry("docker-logs", docker.TailDockerLogs(1000, append(config.Servers, config.Agents...)))
+	}
 	if config != nil && !failed {
 		config.Cleanup()
 		cmd := fmt.Sprintf("docker stop k3s-pause-%s", testID)

--- a/tests/docker/conformance/conformance_test.go
+++ b/tests/docker/conformance/conformance_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/k3s-io/k3s/tests"
+	"github.com/k3s-io/k3s/tests/docker"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -123,6 +124,10 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("describe", docker.DescribeNodesAndPods(config))
+		AddReportEntry("docker-logs", docker.TailDockerLogs(1000, append(config.Servers, config.Agents...)))
+	}
 	if config != nil && !failed {
 		config.Cleanup()
 	}

--- a/tests/docker/etcd/etcd_test.go
+++ b/tests/docker/etcd/etcd_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/k3s-io/k3s/tests"
+	"github.com/k3s-io/k3s/tests/docker"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -72,6 +73,10 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("describe", docker.DescribeNodesAndPods(config))
+		AddReportEntry("docker-logs", docker.TailDockerLogs(1000, append(config.Servers, config.Agents...)))
+	}
 	if config != nil && !failed {
 		config.Cleanup()
 	}

--- a/tests/docker/hardened/hardened_test.go
+++ b/tests/docker/hardened/hardened_test.go
@@ -118,6 +118,9 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("journald-logs", docker.TailJournalLogs(1000, append(config.Servers, config.Agents...)))
+	}
 	if *ci || (config != nil && !failed) {
 		Expect(config.Cleanup()).To(Succeed())
 	}

--- a/tests/docker/lazypull/lazypull_test.go
+++ b/tests/docker/lazypull/lazypull_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/k3s-io/k3s/tests"
+	"github.com/k3s-io/k3s/tests/docker"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -71,6 +72,10 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("describe", docker.DescribeNodesAndPods(config))
+		AddReportEntry("docker-logs", docker.TailDockerLogs(1000, append(config.Servers, config.Agents...)))
+	}
 	if config != nil && !failed {
 		config.Cleanup()
 	}

--- a/tests/docker/secretsencryption/secretsencryption_test.go
+++ b/tests/docker/secretsencryption/secretsencryption_test.go
@@ -178,6 +178,9 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("journald-logs", docker.TailJournalLogs(1000, append(tc.Servers, tc.Agents...)))
+	}
 	if *ci || (tc != nil && !failed) {
 		Expect(tc.Cleanup()).To(Succeed())
 	}

--- a/tests/docker/skew/skew_test.go
+++ b/tests/docker/skew/skew_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/k3s-io/k3s/tests"
+	"github.com/k3s-io/k3s/tests/docker"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -143,6 +144,10 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("describe", docker.DescribeNodesAndPods(config))
+		AddReportEntry("docker-logs", docker.TailDockerLogs(1000, append(config.Servers, config.Agents...)))
+	}
 	if config != nil && !failed {
 		config.Cleanup()
 	}

--- a/tests/docker/snapshotrestore/snapshotrestore_test.go
+++ b/tests/docker/snapshotrestore/snapshotrestore_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/k3s-io/k3s/tests"
+	"github.com/k3s-io/k3s/tests/docker"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -168,6 +169,9 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("journald-logs", docker.TailJournalLogs(1000, append(config.Servers, config.Agents...)))
+	}
 	if *ci || (config != nil && !failed) {
 		Expect(config.Cleanup()).To(Succeed())
 	}

--- a/tests/docker/token/token_test.go
+++ b/tests/docker/token/token_test.go
@@ -155,6 +155,9 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("journald-logs", docker.TailJournalLogs(1000, append(tc.Servers, tc.Agents...)))
+	}
 	if *ci || (tc != nil && !failed) {
 		Expect(tc.Cleanup()).To(Succeed())
 	}

--- a/tests/docker/upgrade/upgrade_test.go
+++ b/tests/docker/upgrade/upgrade_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/k3s-io/k3s/tests"
+	"github.com/k3s-io/k3s/tests/docker"
 	tester "github.com/k3s-io/k3s/tests/docker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -146,6 +147,10 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
+	if failed {
+		AddReportEntry("describe", docker.DescribeNodesAndPods(config))
+		AddReportEntry("docker-logs", docker.TailDockerLogs(1000, append(config.Servers, config.Agents...)))
+	}
 	if config != nil && !failed {
 		config.Cleanup()
 	}


### PR DESCRIPTION
#### Proposed Changes ####

* Serve HTTP bootstrap data from datastore before disk
  Fixes issue where CA rotation would fail on servers with join URL set due to using old data from disk on other server.
* Control-plane-only nodes try bootstrapping via etcd load-balancer if they have client certs, to avoid a dependency on the server URL
  Fixes issue where control-plane-only nodes could not come up if the server they were joined against is not up, despite other servers being available.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/11233
* https://github.com/k3s-io/k3s/issues/11333

#### User-Facing Change ####
```release-note

```

#### Further Comments ####