### PR TITLE
Reenable skew test for 1.32/master

### DIFF
--- a/tests/docker/skew/skew_test.go
+++ b/tests/docker/skew/skew_test.go
@@ -32,20 +32,11 @@ var _ = BeforeSuite(func() {
 	// For master and unreleased branches, we want the latest stable release
 	var upgradeChannel string
 	var err error
-	if *channel == "latest" || *channel == "v1.32" {
-		// disabled: AuthorizeNodeWithSelectors is now on by default, which breaks compat with agents < v1.32.
-		// This can be ren-enabled once the previous branch is v1.32 or higher, or when RBAC changes have been backported.
-		// ref: https://github.com/kubernetes/kubernetes/pull/128168
-		Skip("Skipping version skew tests for " + *channel + " due to AuthorizeNodeWithSelectors")
-
-		upgradeChannel = "stable"
-	} else {
-		// We want to substract one from the minor version to get the previous release
-		sV, err := semver.ParseTolerant(*channel)
-		Expect(err).NotTo(HaveOccurred(), "failed to parse version from "+*channel)
-		sV.Minor--
-		upgradeChannel = fmt.Sprintf("v%d.%d", sV.Major, sV.Minor)
-	}
+	// We want to substract one from the minor version to get the previous release
+	sV, err := semver.ParseTolerant(*channel)
+	Expect(err).NotTo(HaveOccurred(), "failed to parse version from "+*channel)
+	sV.Minor--
+	upgradeChannel = fmt.Sprintf("v%d.%d", sV.Major, sV.Minor)
 
 	lastMinorVersion, err = tester.GetVersionFromChannel(upgradeChannel)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Backports are now in 1.31 and older, so we can reenable skew test in CI for master/release-1.32
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI is green
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/11554
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
