### PR TITLE
[release-1.31] Bump to containerd v2.0.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace (
 	github.com/cilium/ebpf => github.com/cilium/ebpf v0.12.3
 	github.com/cloudnativelabs/kube-router/v2 => github.com/k3s-io/kube-router/v2 v2.2.1
 	github.com/containerd/containerd/api => github.com/containerd/containerd/api v1.8.0
-	github.com/containerd/containerd/v2 => github.com/k3s-io/containerd/v2 v2.0.3-k3s1
+	github.com/containerd/containerd/v2 => github.com/k3s-io/containerd/v2 v2.0.4-k3s2
 	github.com/containerd/imgcrypt => github.com/containerd/imgcrypt v1.1.11
 	github.com/distribution/reference => github.com/distribution/reference v0.5.0
 	github.com/docker/distribution => github.com/docker/distribution v2.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -813,8 +813,8 @@ github.com/k3s-io/api v0.1.0-k3s1.30 h1:JHjmeYaXciWnOqL5fz/Yc+L21AonLvZGJsdiHnZI
 github.com/k3s-io/api v0.1.0-k3s1.30/go.mod h1:PgSMkvAOeDd0ohsqnY7bx7Zrco6KZwzIwf/YXd+9jaY=
 github.com/k3s-io/cadvisor v0.51.0-k3s1 h1:g44OgQMVywt+UlcLOu7OW0H32h8XVkc0pm12EPn4bvo=
 github.com/k3s-io/cadvisor v0.51.0-k3s1/go.mod h1:WmF2AKcyCdI0ERO3oSvLnHmiMOjRvfd2iwvoPc6urHE=
-github.com/k3s-io/containerd/v2 v2.0.3-k3s1 h1:GMvofLdcJPaDnWmG5Eg7n7USjfkIie7cJ1Voj9haqBQ=
-github.com/k3s-io/containerd/v2 v2.0.3-k3s1/go.mod h1:thbfN8ab4MS+pe+p4/mQncBlQJ1oAPNZGO95RO3/Sxs=
+github.com/k3s-io/containerd/v2 v2.0.4-k3s2 h1:JYUwCHGgR4jXSbjM5mtAbW03hhNyPVhnfxLwqdyBTVw=
+github.com/k3s-io/containerd/v2 v2.0.4-k3s2/go.mod h1:thbfN8ab4MS+pe+p4/mQncBlQJ1oAPNZGO95RO3/Sxs=
 github.com/k3s-io/cri-dockerd v0.3.15-k3s1.31-3 h1:TH3zSbIM9zSZMeWKcWjQqeja3FsmJYwLUHglD7nuUEc=
 github.com/k3s-io/cri-dockerd v0.3.15-k3s1.31-3/go.mod h1:ny6wyM7fqfew5FABQ+MtKaU07rhsHhlXr/jtFsA2m8Y=
 github.com/k3s-io/cri-tools v1.31.0-k3s2 h1:nekOdJe5Hecm+C5eswg688uXTI0enUZOJYadmyU9pYw=


### PR DESCRIPTION
#### Proposed Changes ####

Bump containerd to v2.0.4
Includes backported commit from https://github.com/containerd/containerd/pull/11576: https://github.com/k3s-io/containerd/commit/2879c0790c5c8e3a26e67f19e37a8c73d7ccf0ec

#### Types of Changes ####

version bump
bugfix

#### Verification ####

check version

#### Testing ####

#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/12002

#### User-Facing Change ####

```release-note

```

#### Further Comments ####

