### PR TITLE
fix: Use proper key when signing kubelet certificate

### DIFF
--- a/pkg/server/handlers/handlers.go
+++ b/pkg/server/handlers/handlers.go
@@ -95,7 +95,7 @@ func ClientKubeletCert(control *config.Control, auth nodepassword.NodeAuthValida
 			util.SendError(err, resp, req, errCode)
 			return
 		}
-		signAndSend(resp, req, control.Runtime.ClientCA, control.Runtime.ClientCAKey, control.Runtime.ClientKubeProxyKey, certutil.Config{
+		signAndSend(resp, req, control.Runtime.ClientCA, control.Runtime.ClientCAKey, control.Runtime.ClientKubeletKey, certutil.Config{
 			CommonName:   "system:node:" + nodeName,
 			Organization: []string{user.NodesGroup},
 			Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},


### PR DESCRIPTION
#### Proposed Changes ####

This uses the correct key when signing a key for the kubelet.

I assume this was a mistake when copying and the kubelet key should have been used here.

This bug was introduced in #11471.

#### Types of Changes ####

Bugfix

#### Verification ####

I'm actually not sure, I noticed this when looking through the code, but I'm not familiar with K3s enough to fully understand the impact of this change.

#### Testing ####

I don't think a test is necessary.
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12012

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
