### PR TITLE
[Release-1.31] Improve readiness polling on node startup

### DIFF
--- a/pkg/agent/cri/cri.go
+++ b/pkg/agent/cri/cri.go
@@ -5,9 +5,36 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	k8sutil "k8s.io/cri-client/pkg/util"
 )
 
 const maxMsgSize = 1024 * 1024 * 16
+
+// Connection connects to a CRI socket at the given path.
+func Connection(ctx context.Context, address string) (*grpc.ClientConn, error) {
+	addr, dialer, err := k8sutil.GetAddressAndDialer(socketPrefix + address)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(3*time.Second), grpc.WithContextDialer(dialer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
+	if err != nil {
+		return nil, err
+	}
+
+	c := runtimeapi.NewRuntimeServiceClient(conn)
+	_, err = c.Version(ctx, &runtimeapi.VersionRequest{
+		Version: "0.1.0",
+	})
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}
 
 // WaitForService blocks in a retry loop until the CRI service
 // is functional at the provided socket address. It will return only on success,

--- a/pkg/agent/cri/cri_linux.go
+++ b/pkg/agent/cri/cri_linux.go
@@ -3,37 +3,4 @@
 
 package cri
 
-import (
-	"context"
-	"time"
-
-	"google.golang.org/grpc"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
-	k8sutil "k8s.io/cri-client/pkg/util"
-)
-
 const socketPrefix = "unix://"
-
-// Connection connects to a CRI socket at the given path.
-func Connection(ctx context.Context, address string) (*grpc.ClientConn, error) {
-	addr, dialer, err := k8sutil.GetAddressAndDialer(socketPrefix + address)
-	if err != nil {
-		return nil, err
-	}
-
-	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(3*time.Second), grpc.WithContextDialer(dialer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
-	if err != nil {
-		return nil, err
-	}
-
-	c := runtimeapi.NewRuntimeServiceClient(conn)
-	_, err = c.Version(ctx, &runtimeapi.VersionRequest{
-		Version: "0.1.0",
-	})
-	if err != nil {
-		conn.Close()
-		return nil, err
-	}
-
-	return conn, nil
-}

--- a/pkg/agent/cri/cri_windows.go
+++ b/pkg/agent/cri/cri_windows.go
@@ -3,35 +3,4 @@
 
 package cri
 
-import (
-	"context"
-	"time"
-
-	"google.golang.org/grpc"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
-	"k8s.io/cri-client/pkg/util"
-)
-
-// Connection connects to a CRI socket at the given path.
-func Connection(ctx context.Context, address string) (*grpc.ClientConn, error) {
-	addr, dialer, err := util.GetAddressAndDialer(address)
-	if err != nil {
-		return nil, err
-	}
-
-	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(3*time.Second), grpc.WithContextDialer(dialer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
-	if err != nil {
-		return nil, err
-	}
-
-	c := runtimeapi.NewRuntimeServiceClient(conn)
-	_, err = c.Version(ctx, &runtimeapi.VersionRequest{
-		Version: "0.1.0",
-	})
-	if err != nil {
-		conn.Close()
-		return nil, err
-	}
-
-	return conn, nil
-}
+const socketPrefix = "npipe://"

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -351,7 +351,7 @@ func createProxyAndValidateToken(ctx context.Context, cfg *cmds.Agent) (proxy.Pr
 	for {
 		newToken, err := clientaccess.ParseAndValidateToken(proxy.SupervisorURL(), cfg.Token, options...)
 		if err != nil {
-			logrus.Error(err)
+			logrus.Errorf("Failed to validate connection to cluster at %s: %v", cfg.ServerURL, err)
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()

--- a/pkg/cli/agent/agent.go
+++ b/pkg/cli/agent/agent.go
@@ -130,5 +130,10 @@ func Run(ctx *cli.Context) error {
 		return https.Start(ctx, nodeConfig, nil)
 	}
 
-	return agent.Run(contextCtx, cfg)
+	if err := agent.Run(contextCtx, cfg); err != nil {
+		return err
+	}
+
+	<-contextCtx.Done()
+	return contextCtx.Err()
 }

--- a/pkg/cli/cert/cert.go
+++ b/pkg/cli/cert/cert.go
@@ -46,7 +46,7 @@ func commandSetup(app *cli.Context, cfg *cmds.Server, sc *server.Config) (string
 		cfg.Token = string(bytes.TrimRight(tokenByte, "\n"))
 	}
 	sc.ControlConfig.Token = cfg.Token
-	sc.ControlConfig.Runtime = config.NewRuntime(nil)
+	sc.ControlConfig.Runtime = config.NewRuntime()
 
 	return dataDir, nil
 }
@@ -287,7 +287,7 @@ func rotateCA(app *cli.Context, cfg *cmds.Server, sync *cmds.CertRotateCA) error
 
 	// Set up dummy server config for reading new bootstrap data from disk.
 	tmpServer := &config.Control{
-		Runtime: config.NewRuntime(nil),
+		Runtime: config.NewRuntime(),
 		DataDir: sync.CACertPath,
 	}
 	deps.CreateRuntimeCertFiles(tmpServer)

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -56,7 +56,6 @@ type Agent struct {
 	Taints                   cli.StringSlice
 	ImageCredProvBinDir      string
 	ImageCredProvConfig      string
-	ContainerRuntimeReady    chan<- struct{}
 	AgentShared
 }
 

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -597,7 +597,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 
 	go func() {
 		if !serverConfig.ControlConfig.DisableETCD {
-			<-serverConfig.ControlConfig.Runtime.ETCDReady
+			<-executor.ETCDReadyChan()
 			logrus.Info("ETCD server is now running")
 		}
 		if !serverConfig.ControlConfig.DisableAPIServer {

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -113,11 +113,9 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		}
 	}
 
-	containerRuntimeReady := make(chan struct{})
-
 	serverConfig := server.Config{}
 	serverConfig.DisableAgent = cfg.DisableAgent
-	serverConfig.ControlConfig.Runtime = config.NewRuntime(containerRuntimeReady)
+	serverConfig.ControlConfig.Runtime = config.NewRuntime()
 	serverConfig.ControlConfig.Token = cfg.Token
 	serverConfig.ControlConfig.AgentToken = cfg.AgentToken
 	serverConfig.ControlConfig.JoinURL = cfg.ServerURL
@@ -525,7 +523,6 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	}
 
 	agentConfig := cmds.AgentConfig
-	agentConfig.ContainerRuntimeReady = containerRuntimeReady
 	agentConfig.Debug = app.Bool("debug")
 	agentConfig.DataDir = filepath.Dir(serverConfig.ControlConfig.DataDir)
 	agentConfig.ServerURL = url

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -27,16 +27,17 @@ type Cluster struct {
 	cnFilterFunc     func(...string) []string
 }
 
-// Start creates the dynamic tls listener, http request handler,
-// handles starting and writing/reading bootstrap data, and returns a channel
+// ListenAndServe creates the dynamic tls listener, registers http request
+// handlers, and starts the supervisor API server loop.
+func (c *Cluster) ListenAndServe(ctx context.Context) error {
+	// Set up the dynamiclistener and http request handlers
+	return c.initClusterAndHTTPS(ctx)
+}
+
+// Start handles writing/reading bootstrap data, and returns a channel
 // that will be closed when datastore is ready. If embedded etcd is in use,
 // a secondary call to Cluster.save is made.
 func (c *Cluster) Start(ctx context.Context) (<-chan struct{}, error) {
-	// Set up the dynamiclistener and http request handlers
-	if err := c.initClusterAndHTTPS(ctx); err != nil {
-		return nil, pkgerrors.WithMessage(err, "init cluster datastore and https")
-	}
-
 	if c.config.DisableETCD {
 		ready := make(chan struct{})
 		defer close(ready)

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -23,36 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// testClusterDB returns a channel that will be closed when the datastore connection is available.
-// The datastore is tested for readiness every 5 seconds until the test succeeds.
-func (c *Cluster) testClusterDB(ctx context.Context) <-chan struct{} {
-	result := make(chan struct{})
-	if c.managedDB == nil {
-		close(result)
-		return result
-	}
-
-	go func() {
-		defer close(result)
-		for {
-			if err := c.managedDB.Test(ctx); err != nil {
-				logrus.Infof("Failed to test data store connection: %v", err)
-			} else {
-				logrus.Info(c.managedDB.EndpointName() + " data store connection OK")
-				return
-			}
-
-			select {
-			case <-time.After(5 * time.Second):
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	return result
-}
-
 // start starts the database, unless a cluster reset has been requested, in which case
 // it does that instead.
 func (c *Cluster) start(ctx context.Context) error {

--- a/pkg/cluster/managed/drivers.go
+++ b/pkg/cluster/managed/drivers.go
@@ -20,7 +20,6 @@ type Driver interface {
 	IsReset() (bool, error)
 	ResetFile() string
 	Start(ctx context.Context, clientAccessInfo *clientaccess.Info) error
-	Test(ctx context.Context) error
 	Restore(ctx context.Context) error
 	EndpointName() string
 	Snapshot(ctx context.Context) (*SnapshotResult, error)

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -255,6 +255,7 @@ type Control struct {
 	SANSecurity bool
 	PrivateIP   string
 	Runtime     *ControlRuntime `json:"-"`
+	Cluster     Cluster         `json:"-"`
 }
 
 // BindAddressOrLoopback returns an IPv4 or IPv6 address suitable for embedding in
@@ -312,7 +313,6 @@ type ControlRuntimeBootstrap struct {
 type ControlRuntime struct {
 	ControlRuntimeBootstrap
 
-	APIServerReady                       <-chan struct{}
 	ContainerRuntimeReady                <-chan struct{}
 	ETCDReady                            <-chan struct{}
 	StartupHooksWg                       *sync.WaitGroup
@@ -379,6 +379,12 @@ type ControlRuntime struct {
 	Core       CoreFactory
 	Event      record.EventRecorder
 	EtcdConfig endpoint.ETCDConfig
+}
+
+type Cluster interface {
+	Bootstrap(ctx context.Context, reset bool) error
+	ListenAndServe(ctx context.Context) error
+	Start(ctx context.Context) (<-chan struct{}, error)
 }
 
 type CoreFactory interface {

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -313,7 +313,6 @@ type ControlRuntimeBootstrap struct {
 type ControlRuntime struct {
 	ControlRuntimeBootstrap
 
-	ContainerRuntimeReady                <-chan struct{}
 	ETCDReady                            <-chan struct{}
 	StartupHooksWg                       *sync.WaitGroup
 	ClusterControllerStarts              map[string]leader.Callback
@@ -393,9 +392,8 @@ type CoreFactory interface {
 	Start(ctx context.Context, defaultThreadiness int) error
 }
 
-func NewRuntime(containerRuntimeReady <-chan struct{}) *ControlRuntime {
+func NewRuntime() *ControlRuntime {
 	return &ControlRuntime{
-		ContainerRuntimeReady:                containerRuntimeReady,
 		ClusterControllerStarts:              map[string]leader.Callback{},
 		LeaderElectedClusterControllerStarts: map[string]leader.Callback{},
 	}

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -313,7 +313,6 @@ type ControlRuntimeBootstrap struct {
 type ControlRuntime struct {
 	ControlRuntimeBootstrap
 
-	ETCDReady                            <-chan struct{}
 	StartupHooksWg                       *sync.WaitGroup
 	ClusterControllerStarts              map[string]leader.Callback
 	LeaderElectedClusterControllerStarts map[string]leader.Callback
@@ -383,7 +382,7 @@ type ControlRuntime struct {
 type Cluster interface {
 	Bootstrap(ctx context.Context, reset bool) error
 	ListenAndServe(ctx context.Context) error
-	Start(ctx context.Context) (<-chan struct{}, error)
+	Start(ctx context.Context) error
 }
 
 type CoreFactory interface {

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -70,10 +70,8 @@ func Prepare(ctx context.Context, cfg *config.Control) error {
 // Server starts the apiserver and whatever other control-plane components are
 // not disabled on this node.
 func Server(ctx context.Context, cfg *config.Control) error {
-	if ready, err := cfg.Cluster.Start(ctx); err != nil {
+	if err := cfg.Cluster.Start(ctx); err != nil {
 		return pkgerrors.WithMessage(err, "failed to start cluster")
-	} else {
-		cfg.Runtime.ETCDReady = ready
 	}
 
 	if !cfg.DisableAPIServer {
@@ -264,7 +262,7 @@ func apiServer(ctx context.Context, cfg *config.Control) error {
 
 	logrus.Infof("Running kube-apiserver %s", config.ArgString(args))
 
-	return executor.APIServer(ctx, runtime.ETCDReady, args)
+	return executor.APIServer(ctx, args)
 }
 
 func defaults(config *config.Control) {

--- a/pkg/daemons/executor/etcd.go
+++ b/pkg/daemons/executor/etcd.go
@@ -13,8 +13,11 @@ import (
 	"go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp"
 )
 
+// Embedded is defined here so that we can use embedded.ETCD even when the rest
+// of the embedded execututor is disabled by build flags
 type Embedded struct {
-	nodeConfig *daemonconfig.Node
+	apiServerReady <-chan struct{}
+	nodeConfig     *daemonconfig.Node
 }
 
 func (e *Embedded) ETCD(ctx context.Context, args ETCDConfig, extraArgs []string) error {

--- a/pkg/daemons/executor/etcd.go
+++ b/pkg/daemons/executor/etcd.go
@@ -17,6 +17,7 @@ import (
 // of the embedded execututor is disabled by build flags
 type Embedded struct {
 	apiServerReady <-chan struct{}
+	criReady       chan struct{}
 	nodeConfig     *daemonconfig.Node
 }
 

--- a/pkg/daemons/executor/etcd.go
+++ b/pkg/daemons/executor/etcd.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"time"
 
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/version"
@@ -17,11 +18,40 @@ import (
 // of the embedded execututor is disabled by build flags
 type Embedded struct {
 	apiServerReady <-chan struct{}
+	etcdReady      chan struct{}
 	criReady       chan struct{}
 	nodeConfig     *daemonconfig.Node
 }
 
-func (e *Embedded) ETCD(ctx context.Context, args ETCDConfig, extraArgs []string) error {
+func (e *Embedded) ETCD(ctx context.Context, args *ETCDConfig, extraArgs []string, test TestFunc) error {
+	// An unbootstrapped executor is used to start up a temporary embedded etcd when reconciling.
+	// This temporary executor doesn't have any ready channels set up, so don't bother testing.
+	if e.etcdReady != nil {
+		go func() {
+			defer close(e.etcdReady)
+			for {
+				if err := test(ctx); err != nil {
+					logrus.Infof("Failed to test etcd connection: %v", err)
+				} else {
+					logrus.Info("Connection to etcd is ready")
+					return
+				}
+
+				select {
+				case <-time.After(5 * time.Second):
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	// nil args indicates a no-op start; all we need to do is wait for the test
+	// func to indicate readiness and close the channel.
+	if args == nil {
+		return nil
+	}
+
 	configFile, err := args.ToConfigFile(extraArgs)
 	if err != nil {
 		return err

--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -33,7 +33,9 @@ type Executor interface {
 	CloudControllerManager(ctx context.Context, ccmRBACReady <-chan struct{}, args []string) error
 	Containerd(ctx context.Context, node *daemonconfig.Node) error
 	Docker(ctx context.Context, node *daemonconfig.Node) error
+	CRI(ctx context.Context, node *daemonconfig.Node) error
 	APIServerReadyChan() <-chan struct{}
+	CRIReadyChan() <-chan struct{}
 }
 
 type ETCDConfig struct {
@@ -183,6 +185,14 @@ func Docker(ctx context.Context, config *daemonconfig.Node) error {
 	return executor.Docker(ctx, config)
 }
 
+func CRI(ctx context.Context, config *daemonconfig.Node) error {
+	return executor.CRI(ctx, config)
+}
+
 func APIServerReadyChan() <-chan struct{} {
 	return executor.APIServerReadyChan()
+}
+
+func CRIReadyChan() <-chan struct{} {
+	return executor.CRIReadyChan()
 }

--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -26,13 +26,14 @@ type Executor interface {
 	KubeProxy(ctx context.Context, args []string) error
 	APIServerHandlers(ctx context.Context) (authenticator.Request, http.Handler, error)
 	APIServer(ctx context.Context, etcdReady <-chan struct{}, args []string) error
-	Scheduler(ctx context.Context, apiReady <-chan struct{}, args []string) error
-	ControllerManager(ctx context.Context, apiReady <-chan struct{}, args []string) error
+	Scheduler(ctx context.Context, nodeReady <-chan struct{}, args []string) error
+	ControllerManager(ctx context.Context, args []string) error
 	CurrentETCDOptions() (InitialOptions, error)
 	ETCD(ctx context.Context, args ETCDConfig, extraArgs []string) error
 	CloudControllerManager(ctx context.Context, ccmRBACReady <-chan struct{}, args []string) error
 	Containerd(ctx context.Context, node *daemonconfig.Node) error
 	Docker(ctx context.Context, node *daemonconfig.Node) error
+	APIServerReadyChan() <-chan struct{}
 }
 
 type ETCDConfig struct {
@@ -154,12 +155,12 @@ func APIServer(ctx context.Context, etcdReady <-chan struct{}, args []string) er
 	return executor.APIServer(ctx, etcdReady, args)
 }
 
-func Scheduler(ctx context.Context, apiReady <-chan struct{}, args []string) error {
-	return executor.Scheduler(ctx, apiReady, args)
+func Scheduler(ctx context.Context, nodeReady <-chan struct{}, args []string) error {
+	return executor.Scheduler(ctx, nodeReady, args)
 }
 
-func ControllerManager(ctx context.Context, apiReady <-chan struct{}, args []string) error {
-	return executor.ControllerManager(ctx, apiReady, args)
+func ControllerManager(ctx context.Context, args []string) error {
+	return executor.ControllerManager(ctx, args)
 }
 
 func CurrentETCDOptions() (InitialOptions, error) {
@@ -180,4 +181,8 @@ func Containerd(ctx context.Context, config *daemonconfig.Node) error {
 
 func Docker(ctx context.Context, config *daemonconfig.Node) error {
 	return executor.Docker(ctx, config)
+}
+
+func APIServerReadyChan() <-chan struct{} {
+	return executor.APIServerReadyChan()
 }

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -343,7 +343,7 @@ func (e *ETCD) IsInitialized() (bool, error) {
 func (e *ETCD) Reset(ctx context.Context, rebootstrap func() error) error {
 	// Wait for etcd to come up as a new single-node cluster, then exit
 	go func() {
-		<-e.config.Runtime.ContainerRuntimeReady
+		<-executor.CRIReadyChan()
 		t := time.NewTicker(5 * time.Second)
 		defer t.Stop()
 		for range t.C {
@@ -497,7 +497,7 @@ func (e *ETCD) Start(ctx context.Context, clientAccessInfo *clientaccess.Info) e
 			select {
 			case <-time.After(30 * time.Second):
 				logrus.Infof("Waiting for container runtime to become ready before joining etcd cluster")
-			case <-e.config.Runtime.ContainerRuntimeReady:
+			case <-executor.CRIReadyChan():
 				if err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
 					if err := e.join(ctx, clientAccessInfo); err != nil {
 						// Retry the join if waiting for another member to be promoted, or waiting for peers to connect after promotion
@@ -726,11 +726,15 @@ func (e *ETCD) handler(next http.Handler) http.Handler {
 }
 
 // infoHandler returns etcd cluster information. This is used by new members when joining the cluster.
-// If we can't retrieve an actual MemberList from etcd, we return a canned response with only the local node listed.
 func (e *ETCD) infoHandler() http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodGet {
 			util.SendError(fmt.Errorf("method not allowed"), rw, req, http.StatusMethodNotAllowed)
+			return
+		}
+
+		if e.client == nil {
+			util.SendError(errors.New("failed to get etcd MemberList: etcd not started"), rw, req, http.StatusInternalServerError)
 			return
 		}
 
@@ -1157,7 +1161,7 @@ func (e *ETCD) RemovePeer(ctx context.Context, name, address string, allowSelfRe
 // being promoted to full voting member. The checks only run on the cluster member that is
 // the etcd leader.
 func (e *ETCD) manageLearners(ctx context.Context) {
-	<-e.config.Runtime.ContainerRuntimeReady
+	<-executor.CRIReadyChan()
 	t := time.NewTicker(manageTickerTime)
 	defer t.Stop()
 

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -1009,7 +1009,7 @@ func (e *ETCD) listenClientHTTPURLs() string {
 // cluster calls the executor to start etcd running with the provided configuration.
 func (e *ETCD) cluster(ctx context.Context, reset bool, options executor.InitialOptions) error {
 	ctx, e.cancel = context.WithCancel(ctx)
-	return executor.ETCD(ctx, executor.ETCDConfig{
+	return executor.ETCD(ctx, &executor.ETCDConfig{
 		Name:                e.name,
 		InitialOptions:      options,
 		ForceNewCluster:     reset,
@@ -1039,7 +1039,7 @@ func (e *ETCD) cluster(ctx context.Context, reset bool, options executor.Initial
 
 		ExperimentalInitialCorruptCheck:         true,
 		ExperimentalWatchProgressNotifyInterval: e.config.Datastore.NotifyInterval,
-	}, e.config.ExtraEtcdArgs)
+	}, e.config.ExtraEtcdArgs, e.Test)
 }
 
 func (e *ETCD) StartEmbeddedTemporary(ctx context.Context) error {
@@ -1089,7 +1089,7 @@ func (e *ETCD) StartEmbeddedTemporary(ctx context.Context) error {
 
 	embedded := executor.Embedded{}
 	ctx, e.cancel = context.WithCancel(ctx)
-	return embedded.ETCD(ctx, executor.ETCDConfig{
+	return embedded.ETCD(ctx, &executor.ETCDConfig{
 		InitialOptions:       executor.InitialOptions{AdvertisePeerURL: peerURL},
 		DataDir:              tmpDataDir,
 		ForceNewCluster:      true,
@@ -1106,7 +1106,7 @@ func (e *ETCD) StartEmbeddedTemporary(ctx context.Context) error {
 
 		ExperimentalInitialCorruptCheck:         true,
 		ExperimentalWatchProgressNotifyInterval: e.config.Datastore.NotifyInterval,
-	}, append(e.config.ExtraEtcdArgs, "--max-snapshots=0", "--max-wals=0"))
+	}, append(e.config.ExtraEtcdArgs, "--max-snapshots=0", "--max-wals=0"), e.Test)
 }
 
 func addPort(address string, offset int) (string, error) {

--- a/pkg/etcd/etcd_linux_test.go
+++ b/pkg/etcd/etcd_linux_test.go
@@ -61,7 +61,7 @@ func generateTestConfig() *config.Control {
 	}
 	return &config.Control{
 		ServerNodeName:        hostname,
-		Runtime:               config.NewRuntime(containerRuntimeReady),
+		Runtime:               config.NewRuntime(),
 		HTTPSPort:             6443,
 		SupervisorPort:        6443,
 		AdvertisePort:         6443,

--- a/pkg/etcd/etcd_linux_test.go
+++ b/pkg/etcd/etcd_linux_test.go
@@ -399,11 +399,10 @@ func Test_UnitETCD_Start(t *testing.T) {
 			}
 
 			if err := tt.setup(e, &tt.fields.context); err != nil {
-				t.Errorf("Setup for ETCD.Start() failed = %v", err)
-				return
+				t.Fatalf("Setup for ETCD.Start() failed = %v", err)
 			}
 			if err := e.Start(tt.fields.context.ctx, tt.args.clientAccessInfo); (err != nil) != tt.wantErr {
-				t.Errorf("ETCD.Start() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("ETCD.Start() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr {
 				memberAddr = e.address

--- a/pkg/server/handlers/cert.go
+++ b/pkg/server/handlers/cert.go
@@ -56,7 +56,7 @@ func caCertReplace(control *config.Control, buf io.ReadCloser, force bool) error
 	}
 	defer os.RemoveAll(tmpdir)
 
-	runtime := config.NewRuntime(nil)
+	runtime := config.NewRuntime()
 	runtime.EtcdConfig = control.Runtime.EtcdConfig
 	runtime.ServerToken = control.Runtime.ServerToken
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/clientaccess"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/control"
+	"github.com/k3s-io/k3s/pkg/daemons/executor"
 	"github.com/k3s-io/k3s/pkg/datadir"
 	"github.com/k3s-io/k3s/pkg/deploy"
 	"github.com/k3s-io/k3s/pkg/node"
@@ -44,7 +45,10 @@ func ResolveDataDir(dataDir string) (string, error) {
 	return filepath.Join(dataDir, "server"), err
 }
 
-func StartServer(ctx context.Context, config *Config, cfg *cmds.Server) error {
+// PrepareServer prepares the server for operation. This includes setting paths
+// in ControlConfig, creating any certificates not extracted from the bootstrap
+// data, and binding request handlers.
+func PrepareServer(ctx context.Context, config *Config, cfg *cmds.Server) error {
 	if err := setupDataDirAndChdir(&config.ControlConfig); err != nil {
 		return err
 	}
@@ -53,6 +57,19 @@ func StartServer(ctx context.Context, config *Config, cfg *cmds.Server) error {
 		return err
 	}
 
+	if err := control.Prepare(ctx, &config.ControlConfig); err != nil {
+		return err
+	}
+
+	config.ControlConfig.Runtime.Handler = handlers.NewHandler(ctx, &config.ControlConfig, cfg)
+
+	return nil
+}
+
+// StartServer starts whatever control-plane and etcd components are enabled by
+// the current server configuration, runs startup hooks, starts controllers,
+// and writes the admin kubeconfig.
+func StartServer(ctx context.Context, config *Config, cfg *cmds.Server) error {
 	if err := control.Server(ctx, &config.ControlConfig); err != nil {
 		return pkgerrors.WithMessage(err, "starting kubernetes")
 	}
@@ -60,11 +77,10 @@ func StartServer(ctx context.Context, config *Config, cfg *cmds.Server) error {
 	wg := &sync.WaitGroup{}
 	wg.Add(len(config.StartupHooks))
 
-	config.ControlConfig.Runtime.Handler = handlers.NewHandler(ctx, &config.ControlConfig, cfg)
 	config.ControlConfig.Runtime.StartupHooksWg = wg
 
 	shArgs := cmds.StartupHookArgs{
-		APIServerReady:       config.ControlConfig.Runtime.APIServerReady,
+		APIServerReady:       executor.APIServerReadyChan(),
 		KubeConfigSupervisor: config.ControlConfig.Runtime.KubeConfigSupervisor,
 		Skips:                config.ControlConfig.Skips,
 		Disables:             config.ControlConfig.Disables,
@@ -87,7 +103,7 @@ func startOnAPIServerReady(ctx context.Context, config *Config) {
 	select {
 	case <-ctx.Done():
 		return
-	case <-config.ControlConfig.Runtime.APIServerReady:
+	case <-executor.APIServerReadyChan():
 		if err := runControllers(ctx, config); err != nil {
 			logrus.Fatalf("failed to start controllers: %v", err)
 		}

--- a/pkg/util/api.go
+++ b/pkg/util/api.go
@@ -3,14 +3,12 @@ package util
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"strconv"
 	"time"
 
-	pkgerrors "github.com/pkg/errors"
 	"github.com/rancher/wrangler/v3/pkg/merr"
 	"github.com/rancher/wrangler/v3/pkg/schemes"
 	"github.com/sirupsen/logrus"
@@ -53,15 +51,19 @@ func GetAddresses(endpoint *v1.Endpoints) []string {
 	return serverAddresses
 }
 
-// WaitForAPIServerReady waits for the API Server's /readyz endpoint to report "ok" with timeout.
+// WaitForAPIServerReady waits for the API server's /readyz endpoint to report "ok" with timeout.
 // This is modified from WaitForAPIServer from the Kubernetes controller-manager app, but checks the
 // readyz endpoint instead of the deprecated healthz endpoint, and supports context.
 func WaitForAPIServerReady(ctx context.Context, kubeconfigPath string, timeout time.Duration) error {
-	var lastErr error
+	lastErr := errors.New("API server not polled")
 	restConfig, err := GetRESTConfig(kubeconfigPath)
 	if err != nil {
 		return err
 	}
+
+	// Probe apiserver readiness with a 15 second timeout
+	// https://github.com/kubernetes/kubernetes/blob/v1.24.0/cmd/kubeadm/app/util/staticpod/utils.go#L252
+	restConfig.Timeout = time.Second * 15
 
 	// By default, idle connections to the apiserver are returned to a global pool
 	// between requests.  Explicitly flag this client's request for closure so that
@@ -80,17 +82,15 @@ func WaitForAPIServerReady(ctx context.Context, kubeconfigPath string, timeout t
 		return err
 	}
 
-	err = wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		healthStatus := 0
-		result := restClient.Get().AbsPath("/readyz").Do(ctx).StatusCode(&healthStatus)
-		if rerr := result.Error(); rerr != nil {
-			lastErr = pkgerrors.WithMessage(rerr, "failed to get apiserver /readyz status")
-			return false, nil
-		}
-		if healthStatus != http.StatusOK {
-			content, _ := result.Raw()
-			lastErr = fmt.Errorf("APIServer isn't ready: %v", string(content))
-			logrus.Warnf("APIServer isn't ready yet: %v. Waiting a little while.", string(content))
+	err = wait.PollUntilContextTimeout(ctx, time.Second*2, timeout, true, func(ctx context.Context) (bool, error) {
+		// DoRaw returns an error if the response code is < 200 OK or > 206 Partial Content
+		if _, err := restClient.Get().AbsPath("/readyz").Param("verbose", "").DoRaw(ctx); err != nil {
+			if err.Error() != lastErr.Error() {
+				logrus.Infof("Polling for API server readiness: GET /readyz failed: %v", err)
+			} else {
+				logrus.Debug("Polling for API server readiness: GET /readyz failed: status unchanged")
+			}
+			lastErr = err
 			return false, nil
 		}
 

--- a/tests/mock/executor.go
+++ b/tests/mock/executor.go
@@ -30,7 +30,7 @@ func (e *Executor) APIServerHandlers(ctx context.Context) (authenticator.Request
 	return nil, nil, errors.New("not implemented")
 }
 
-func (e *Executor) APIServer(ctx context.Context, etcdReady <-chan struct{}, args []string) error {
+func (e *Executor) APIServer(ctx context.Context, args []string) error {
 	return errors.New("not implemented")
 }
 
@@ -46,9 +46,9 @@ func (e *Executor) CurrentETCDOptions() (executor.InitialOptions, error) {
 	return executor.InitialOptions{}, nil
 }
 
-func (e *Executor) ETCD(ctx context.Context, args executor.ETCDConfig, extraArgs []string) error {
+func (e *Executor) ETCD(ctx context.Context, args *executor.ETCDConfig, extraArgs []string, test executor.TestFunc) error {
 	embed := &executor.Embedded{}
-	return embed.ETCD(ctx, args, extraArgs)
+	return embed.ETCD(ctx, args, extraArgs, test)
 }
 
 func (e *Executor) CloudControllerManager(ctx context.Context, ccmRBACReady <-chan struct{}, args []string) error {
@@ -68,6 +68,12 @@ func (e *Executor) CRI(ctx context.Context, node *config.Node) error {
 }
 
 func (e *Executor) APIServerReadyChan() <-chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
+}
+
+func (e *Executor) ETCDReadyChan() <-chan struct{} {
 	c := make(chan struct{})
 	close(c)
 	return c

--- a/tests/mock/executor.go
+++ b/tests/mock/executor.go
@@ -1,0 +1,80 @@
+package mock
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/daemons/config"
+	"github.com/k3s-io/k3s/pkg/daemons/executor"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+)
+
+// mock executor that does not actually start anything
+type Executor struct{}
+
+func (e *Executor) Bootstrap(ctx context.Context, nodeConfig *config.Node, cfg cmds.Agent) error {
+	return errors.New("not implemented")
+}
+
+func (e *Executor) Kubelet(ctx context.Context, args []string) error {
+	return errors.New("not implemented")
+}
+
+func (e *Executor) KubeProxy(ctx context.Context, args []string) error {
+	return errors.New("not implemented")
+}
+
+func (e *Executor) APIServerHandlers(ctx context.Context) (authenticator.Request, http.Handler, error) {
+	return nil, nil, errors.New("not implemented")
+}
+
+func (e *Executor) APIServer(ctx context.Context, etcdReady <-chan struct{}, args []string) error {
+	return errors.New("not implemented")
+}
+
+func (e *Executor) Scheduler(ctx context.Context, nodeReady <-chan struct{}, args []string) error {
+	return errors.New("not implemented")
+}
+
+func (e *Executor) ControllerManager(ctx context.Context, args []string) error {
+	return errors.New("not implemented")
+}
+
+func (e *Executor) CurrentETCDOptions() (executor.InitialOptions, error) {
+	return executor.InitialOptions{}, nil
+}
+
+func (e *Executor) ETCD(ctx context.Context, args executor.ETCDConfig, extraArgs []string) error {
+	embed := &executor.Embedded{}
+	return embed.ETCD(ctx, args, extraArgs)
+}
+
+func (e *Executor) CloudControllerManager(ctx context.Context, ccmRBACReady <-chan struct{}, args []string) error {
+	return errors.New("not implemented")
+}
+
+func (e *Executor) Containerd(ctx context.Context, node *config.Node) error {
+	return errors.New("not implemented")
+}
+
+func (e *Executor) Docker(ctx context.Context, node *config.Node) error {
+	return errors.New("not implemented")
+}
+
+func (e *Executor) CRI(ctx context.Context, node *config.Node) error {
+	return errors.New("not implemented")
+}
+
+func (e *Executor) APIServerReadyChan() <-chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
+}
+
+func (e *Executor) CRIReadyChan() <-chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
+}

--- a/tests/unit.go
+++ b/tests/unit.go
@@ -44,11 +44,7 @@ func CleanupDataDir(cnf *config.Control) {
 // config.ControlRuntime with all the appropriate certificate keys.
 func GenerateRuntime(cnf *config.Control) error {
 	// reuse ready channel from existing runtime if set
-	var readyCh <-chan struct{}
-	if cnf.Runtime != nil {
-		readyCh = cnf.Runtime.ContainerRuntimeReady
-	}
-	cnf.Runtime = config.NewRuntime(readyCh)
+	cnf.Runtime = config.NewRuntime()
 	if err := GenerateDataDir(cnf); err != nil {
 		return err
 	}

--- a/tests/unit.go
+++ b/tests/unit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/control/deps"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
+	"github.com/k3s-io/k3s/tests/mock"
 )
 
 // GenerateDataDir creates a temporary directory at "/tmp/k3s/<RANDOM_STRING>/".

--- a/tests/unit.go
+++ b/tests/unit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/control/deps"
+	"github.com/k3s-io/k3s/pkg/daemons/executor"
 )
 
 // GenerateDataDir creates a temporary directory at "/tmp/k3s/<RANDOM_STRING>/".
@@ -43,6 +44,9 @@ func CleanupDataDir(cnf *config.Control) {
 // GenerateRuntime creates a temporary data dir and configures
 // config.ControlRuntime with all the appropriate certificate keys.
 func GenerateRuntime(cnf *config.Control) error {
+	// use mock executor that does not actually start things
+	executor.Set(&mock.Executor{})
+
 	// reuse ready channel from existing runtime if set
 	cnf.Runtime = config.NewRuntime()
 	if err := GenerateDataDir(cnf); err != nil {


### PR DESCRIPTION
* **Backport https://github.com/k3s-io/k3s/pull/11878**

#### Proposed Changes ####

This PR eliminates the scattered creation of ready channels that are passed around via struct fields. Ready channels for all components started by the Executor are now exposed by the Executor, providing a consistent interface that different portions of the codebase can use to wait for components to be available.

* Add context to agent token validation error
  Makes the error message nice when agents are retrying retrieval of cacerts from cluster
* Increase log output while waiting for apiserver ready.
    We were never actually logging anything here, as we would always take the `result.Error()` path whenever the apiserver isn't ready - and log nothing.
* Move apiserver ready wait into common channel
    Splits server startup into prepare/start phases. Server's agent is now started after server is prepared, but before the datastore and control-plane components are started. This allows us to properly bootstrap the executor before starting server components, and use the executor to provide a shared channel to wait on apiserver readiness.
    This allows us to replace four separate callers of WaitForAPIServerReady with reads from a common ready channel.
* Move container runtime ready channel into executor
  Move the container runtime ready channel into the executor interface, instead of passing it awkwardly between server and agent config structs. This is for parity with the apiserver ready channel, and also adds validation that user-provided CRI services are up, something that was previously only done for containerd and cri-dockerd.
* Move container etcd ready channel into executor
  This eliminates the final channel that was being passed around in an internal struct. The ETCD management code passes in a func that can be polled until etcd is ready; the executor is responsible for polling this after etcd is started and closing the etcd ready channel at the correct time.

#### Types of Changes ####

tech debt
bugfix

#### Verification ####

Check logs

#### Testing ####

RKE2 validation:
* https://github.com/rancher/rke2/pull/7933

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12033

#### User-Facing Change ####
```release-note

```

#### Further Comments ####
