### PR TITLE
Add error in certificate check

### DIFF
--- a/pkg/cli/cert/cert.go
+++ b/pkg/cli/cert/cert.go
@@ -102,7 +102,11 @@ func check(app *cli.Context, cfg *cmds.Server) error {
 			for _, file := range files {
 				// ignore errors, as some files may not exist, or may not contain certs.
 				// Only check whatever exists and has certs.
-				certs, _ := certutil.CertsFromFile(file)
+				certs, err := certutil.CertsFromFile(file)
+				if err != nil {
+					logrus.Debugf(err.Error())
+					continue
+				}
 				for _, cert := range certs {
 					if now.Before(cert.NotBefore) {
 						logrus.Errorf("%s: certificate %s is not valid before %s", file, cert.Subject, cert.NotBefore.Format(time.RFC3339))
@@ -124,7 +128,11 @@ func check(app *cli.Context, cfg *cmds.Server) error {
 		fmt.Fprintf(w, "-----------\t-------\t------\t-------")
 		for _, files := range fileMap {
 			for _, file := range files {
-				certs, _ := certutil.CertsFromFile(file)
+				certs, err := certutil.CertsFromFile(file)
+				if err != nil {
+					logrus.Debugf(err.Error())
+					continue
+				}
 				for _, cert := range certs {
 					baseName := filepath.Base(file)
 					var status string


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

If there is a problem when running "k3s certificate check" and getting information from the certificate, it is impossible to understand what is going on. This PR prints  the error when using `--debug`. I thought about printing it always as an error but in that case, there will always be error lines because the current algorithm reads over all files in the directory, keys included.

Imagine running k3s without being root

Before (no error & no output):
```
azureuser@terraform-mbuil-vm0:~$ k3s certificate check --debug
DEBU[0000] Asset dir /var/lib/rancher/k3s/data/f4fcc0d3214aa5b93214da39de2fc1bde3f8cdabcdd9c245c2599ce46ce3b78a 
DEBU[0000] Running /var/lib/rancher/k3s/data/f4fcc0d3214aa5b93214da39de2fc1bde3f8cdabcdd9c245c2599ce46ce3b78a/bin/k3s-certificate [k3s certificate check --debug]
INFO[0000] Agent detected, checking agent certificates  
INFO[0000] Checking certificates for kubelet            
INFO[0000] Checking certificates for k3s-controller     
INFO[0000] Checking certificates for kube-proxy    
```

Now (error):
```
azureuser@terraform-mbuil-vm0:~$ k3s certificate check --debug
DEBU[0000] Asset dir /var/lib/rancher/k3s/data/f4fcc0d3214aa5b93214da39de2fc1bde3f8cdabcdd9c245c2599ce46ce3b78a 
DEBU[0000] Running /var/lib/rancher/k3s/data/f4fcc0d3214aa5b93214da39de2fc1bde3f8cdabcdd9c245c2599ce46ce3b78a/bin/k3s-certificate [k3s certificate check --debug] 
INFO[0000] Agent detected, checking agent certificates  
INFO[0000] Checking certificates for kube-proxy         
DEBU[0000] open /home/azureuser/.rancher/k3s/server/tls/client-kube-proxy.crt: no such file or directory 
DEBU[0000] open /home/azureuser/.rancher/k3s/server/tls/client-kube-proxy.key: no such file or directory 
DEBU[0000] open /home/azureuser/.rancher/k3s/agent/client-kube-proxy.crt: no such file or directory 
DEBU[0000] open /home/azureuser/.rancher/k3s/agent/client-kube-proxy.key: no such file or directory 
INFO[0000] Checking certificates for kubelet            
DEBU[0000] open /home/azureuser/.rancher/k3s/server/tls/client-kubelet.key: no such file or directory 
DEBU[0000] open /home/azureuser/.rancher/k3s/server/tls/serving-kubelet.key: no such file or directory 
DEBU[0000] open /home/azureuser/.rancher/k3s/agent/client-kubelet.crt: no such file or directory 
DEBU[0000] open /home/azureuser/.rancher/k3s/agent/client-kubelet.key: no such file or directory 
DEBU[0000] open /home/azureuser/.rancher/k3s/agent/serving-kubelet.crt: no such file or directory 
DEBU[0000] open /home/azureuser/.rancher/k3s/agent/serving-kubelet.key: no such file or directory 
INFO[0000] Checking certificates for k3s-controller     
DEBU[0000] open /home/azureuser/.rancher/k3s/server/tls/client-k3s-controller.crt: no such file or directory 
DEBU[0000] open /home/azureuser/.rancher/k3s/server/tls/client-k3s-controller.key: no such file or directory 
DEBU[0000] open /home/azureuser/.rancher/k3s/agent/client-k3s-controller.crt: no such file or directory 
DEBU[0000] open /home/azureuser/.rancher/k3s/agent/client-k3s-controller.key: no such file or directory 
```

I'm combining this PR with a docs update: https://github.com/k3s-io/docs/pull/399 to clarify

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
New feature?

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

1 - Install k3s without being root
2 - Run `k3s certificate check --debug` without being root

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/12048

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add extra logs to k3s certificate check when using --debug flag
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
