### PR TITLE
Cleanup anonymous and named volumes for docker tests

### DIFF
--- a/tests/docker/cacerts/cacerts_test.go
+++ b/tests/docker/cacerts/cacerts_test.go
@@ -99,10 +99,7 @@ var _ = AfterSuite(func() {
 		cmd := fmt.Sprintf("docker stop k3s-pause-%s", testID)
 		_, err := tester.RunCommand(cmd)
 		Expect(err).NotTo(HaveOccurred())
-		cmd = fmt.Sprintf("docker rm k3s-pause-%s", testID)
-		_, err = tester.RunCommand(cmd)
-		Expect(err).NotTo(HaveOccurred())
-		cmd = fmt.Sprintf("docker volume ls -q | grep -F %s | xargs -r docker volume rm -f", testID)
+		cmd = fmt.Sprintf("docker rm -v k3s-pause-%s", testID)
 		_, err = tester.RunCommand(cmd)
 		Expect(err).NotTo(HaveOccurred())
 	}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Cleanup anonymous volumes associated with the server and agent nodes for docker tests. Be double sure and cleanup the named volumes as well. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Test/CI
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Run the basic go docker test
`go test -v ./tests/docker/basics/basics_test.go -k3sImage=rancher/k3s:v1.32.3-k3s1-amd64`
Check the volumes left behind, should see no new volumes added
```
docker volume ls
```

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
All testing
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/12068
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
