### PR TITLE
Add ReusePort/ReuseAddr flags to etcd config

### DIFF
--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -55,6 +55,8 @@ type ETCDConfig struct {
 	ServerTrust          ServerTrust `json:"client-transport-security"`
 	PeerTrust            PeerTrust   `json:"peer-transport-security"`
 	ForceNewCluster      bool        `json:"force-new-cluster,omitempty"`
+	ReuseAddress         bool        `json:"reuse-address,omitempty"`
+	ReusePort            bool        `json:"reuse-port,omitempty"`
 	HeartbeatInterval    int         `json:"heartbeat-interval"`
 	ElectionTimeout      int         `json:"election-timeout"`
 	Logger               string      `json:"logger"`

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -1035,6 +1035,8 @@ func (e *ETCD) cluster(ctx context.Context, reset bool, options executor.Initial
 		HeartbeatInterval:    500,
 		Logger:               "zap",
 		LogOutputs:           []string{"stderr"},
+		ReuseAddress:         true,
+		ReusePort:            true,
 		ListenClientHTTPURLs: e.listenClientHTTPURLs(),
 
 		ExperimentalInitialCorruptCheck:         true,
@@ -1098,11 +1100,13 @@ func (e *ETCD) StartEmbeddedTemporary(ctx context.Context) error {
 		ListenClientHTTPURLs: clientHTTPURL,
 		ListenPeerURLs:       peerURL,
 		Logger:               "zap",
+		LogOutputs:           []string{"stderr"},
+		ReuseAddress:         true,
+		ReusePort:            true,
 		HeartbeatInterval:    500,
 		ElectionTimeout:      5000,
 		SnapshotCount:        10000,
 		Name:                 e.name,
-		LogOutputs:           []string{"stderr"},
 
 		ExperimentalInitialCorruptCheck:         true,
 		ExperimentalWatchProgressNotifyInterval: e.config.Datastore.NotifyInterval,


### PR DESCRIPTION
#### Proposed Changes ####

Addresses flakes in etcd CI due to the port still being in TIME_WAIT after the server is shut down between tests. Ref:
* https://github.com/etcd-io/etcd/pull/12702
* https://github.com/k3s-io/k3s/pull/12046
#### Types of Changes ####

ci fix

#### Verification ####

Check CI

#### Testing ####

yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12017

#### User-Facing Change ####
```release-note
```

#### Further Comments ####