### PR TITLE
Silence vagrant progress output

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -57,7 +57,7 @@ jobs:
           name: k3s
           path: tests/install/${{ matrix.vm }}
       - name: "Vagrant Up"
-        run: vagrant up --no-provision
+        run: vagrant up --no-tty --no-provision
       - name: "Upload k3s binary to VM"
         run: |
           chmod +x k3s

--- a/.github/workflows/nightly-install.yaml
+++ b/.github/workflows/nightly-install.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: "Vagrant Plugin(s)"
         run: vagrant plugin install vagrant-k3s vagrant-reload
       - name: "Vagrant Up ⏩ Install K3s"
-        run: vagrant up
+        run: vagrant up --no-tty
       - name: "⏳ Node"
         run: vagrant provision --provision-with=k3s-wait-for-node
       - name: "⏳ CoreDNS"

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -63,7 +63,7 @@ func createSplitCluster(nodeOS string, etcdCount, controlPlaneCount, agentCount 
 
 	// Provision the first etcd node. In GitHub Actions, this also imports the VM image into libvirt, which
 	// takes time and can cause the next vagrant up to fail if it is not given enough time to complete.
-	cmd := fmt.Sprintf(`E2E_NODE_ROLES="%s" E2E_NODE_BOXES="%s" vagrant up --no-provision %s &> vagrant.log`, nodeRoles, nodeBoxes, etcdNodes[0].String())
+	cmd := fmt.Sprintf(`E2E_NODE_ROLES="%s" E2E_NODE_BOXES="%s" vagrant up --no-tty --no-provision %s &> vagrant.log`, nodeRoles, nodeBoxes, etcdNodes[0].String())
 	fmt.Println(cmd)
 	if _, err := e2e.RunCommand(cmd); err != nil {
 		return etcdNodes, cpNodes, agentNodes, err
@@ -72,7 +72,7 @@ func createSplitCluster(nodeOS string, etcdCount, controlPlaneCount, agentCount 
 	// Bring up the rest of the nodes in parallel
 	errg, _ := errgroup.WithContext(context.Background())
 	for _, node := range allNodeNames[1:] {
-		cmd := fmt.Sprintf(`E2E_NODE_ROLES="%s" E2E_NODE_BOXES="%s" vagrant up --no-provision %s &>> vagrant.log`, nodeRoles, nodeBoxes, node)
+		cmd := fmt.Sprintf(`E2E_NODE_ROLES="%s" E2E_NODE_BOXES="%s" vagrant up --no-tty --no-provision %s &>> vagrant.log`, nodeRoles, nodeBoxes, node)
 		errg.Go(func() error {
 			_, err := e2e.RunCommand(cmd)
 			return err

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -133,7 +133,7 @@ func CreateCluster(nodeOS string, serverCount, agentCount int) (*TestConfig, err
 		}
 	}
 	// Bring up the first server node
-	cmd := fmt.Sprintf(`%s %s vagrant up %s &> vagrant.log`, nodeEnvs, testOptions, serverNodes[0])
+	cmd := fmt.Sprintf(`%s %s vagrant up --no-tty %s &> vagrant.log`, nodeEnvs, testOptions, serverNodes[0])
 	fmt.Println(cmd)
 	if _, err := RunCommand(cmd); err != nil {
 		return nil, newNodeError(cmd, serverNodes[0], err)
@@ -142,7 +142,7 @@ func CreateCluster(nodeOS string, serverCount, agentCount int) (*TestConfig, err
 	// Bring up the rest of the nodes in parallel
 	errg, _ := errgroup.WithContext(context.Background())
 	for _, node := range append(serverNodes[1:], agentNodes...) {
-		cmd := fmt.Sprintf(`%s %s vagrant up %s &>> vagrant.log`, nodeEnvs, testOptions, node.String())
+		cmd := fmt.Sprintf(`%s %s vagrant up --no-tty %s &>> vagrant.log`, nodeEnvs, testOptions, node.String())
 		fmt.Println(cmd)
 		errg.Go(func() error {
 			if _, err := RunCommand(cmd); err != nil {
@@ -224,7 +224,7 @@ func CreateLocalCluster(nodeOS string, serverCount, agentCount int) (*TestConfig
 	// Bring up the rest of the nodes in parallel
 	errg, _ := errgroup.WithContext(context.Background())
 	for _, node := range append(serverNodes[1:], agentNodes...) {
-		cmd := fmt.Sprintf(`%s %s vagrant up --no-provision %s &>> vagrant.log`, nodeEnvs, testOptions, node)
+		cmd := fmt.Sprintf(`%s %s vagrant up --no-tty --no-provision %s &>> vagrant.log`, nodeEnvs, testOptions, node)
 		errg.Go(func() error {
 			if _, err := RunCommand(cmd); err != nil {
 				return newNodeError(cmd, node, err)


### PR DESCRIPTION
#### Proposed Changes ####

Add --no-tty flag to all `vagrant up` commands to silence the printing of box loading progress. Ref:
* https://github.com/hashicorp/vagrant/pull/11465

#### Types of Changes ####

CI improvement

#### Verification ####

Check CI output, for example: https://github.com/k3s-io/k3s/actions/runs/14322117288/job/40140912631

#### Testing ####

yes

#### Linked Issues ####


#### User-Facing Change ####
```release-note

```

#### Further Comments ####
