### PR TITLE
Split E2E Drone pipeline into matrix

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -657,7 +657,9 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 
-- name: test-e2e
+- name: test-e2e-validatecluster
+  depends_on:
+    - build-e2e-image
   image: test-e2e
   pull: never
   resources:
@@ -675,18 +677,41 @@ steps:
   - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
   - |
     cd tests/e2e/validatecluster
-    vagrant destroy -f
+    ../scripts/cleanup_vms.sh 'validatecluster_([0-9]+)_(server|agent)'
     go test -v -timeout=45m ./validatecluster_test.go -ci -local
     cp ./coverage.out /tmp/artifacts/validate-coverage.out
+  - docker stop registry && docker rm registry
+  volumes:
+  - name: libvirt
+    path: /var/run/libvirt/
+  - name: docker
+    path: /var/run/docker.sock
+  - name: cache
+    path: /tmp/artifacts
+
+- name: test-e2e-splitserver
+  depends_on:
+    - build-e2e-image
+  image: test-e2e
+  pull: never
+  resources:
+    cpu: 6000
+    memory: 10Gi
+  environment:
+    E2E_REGISTRY: 'true'
+    E2E_GOCOVER: 'true'
+  commands:
+  - mkdir -p dist/artifacts
+  - cp /tmp/artifacts/* dist/artifacts/
   - |
-    cd ../splitserver
-    vagrant destroy -f
+    cd tests/e2e/splitserver
+    ../scripts/cleanup_vms.sh 'splitserver_([0-9]+)'
     go test -v -timeout=30m ./splitserver_test.go -ci -local
     cp ./coverage.out /tmp/artifacts/split-coverage.out
   - |
     if [ "$DRONE_BUILD_EVENT" = "pull_request" ]; then
       cd ../upgradecluster
-      vagrant destroy -f
+      ../scripts/cleanup_vms.sh 'upgradecluster_([0-9]+)_(server|agent)'
       # Convert release-1.XX branch to v1.XX channel
       if [ "$DRONE_BRANCH" = "master" ]; then
         UPGRADE_CHANNEL="latest"
@@ -700,7 +725,6 @@ steps:
       E2E_RELEASE_CHANNEL=$UPGRADE_CHANNEL go test -v -timeout=45m ./upgradecluster_test.go  -ci -local -ginkgo.v
       cp ./coverage.out /tmp/artifacts/upgrade-coverage.out
     fi
-  - docker stop registry && docker rm registry
   
   volumes:
   - name: libvirt
@@ -711,6 +735,9 @@ steps:
     path: /tmp/artifacts
 
 - name: upload to codecov
+  depends_on:
+    - test-e2e-validatecluster
+    - test-e2e-splitserver
   image: robertstettner/drone-codecov
   settings:
     token: 

--- a/.drone.yml
+++ b/.drone.yml
@@ -671,16 +671,14 @@ steps:
   commands:
   - mkdir -p dist/artifacts
   - cp /tmp/artifacts/* dist/artifacts/
-  - docker stop registry && docker rm registry
   # Cleanup VMs that are older than 2h. Happens if a previous test panics or is canceled
   - tests/e2e/scripts/cleanup_vms.sh
-  - docker run -d -p 5000:5000 -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io --name registry registry:2
+  - tests/e2e/scripts/drone_registries.sh
   - |
     cd tests/e2e/validatecluster
     ../scripts/cleanup_vms.sh 'validatecluster_([0-9]+)_(server|agent)'
     go test -v -timeout=45m ./validatecluster_test.go -ci -local
     cp ./coverage.out /tmp/artifacts/validate-coverage.out
-  - docker stop registry && docker rm registry
   volumes:
   - name: libvirt
     path: /var/run/libvirt/
@@ -703,6 +701,7 @@ steps:
   commands:
   - mkdir -p dist/artifacts
   - cp /tmp/artifacts/* dist/artifacts/
+  - tests/e2e/scripts/drone_registries.sh
   - |
     cd tests/e2e/splitserver
     ../scripts/cleanup_vms.sh 'splitserver_([0-9]+)'

--- a/tests/e2e/scripts/cleanup_vms.sh
+++ b/tests/e2e/scripts/cleanup_vms.sh
@@ -1,21 +1,28 @@
 #!/bin/bash
 
-# Clean up any VMS that are older than 2 hours.
-# 
+# Usage: ./cleanup_vms.sh [regex_pattern]
+# Default pattern matches timestamped VMs older than 2 hours.
 # We embed the time in the VM name, so we can easily filter them out.
 
 # Get the current time in seconds since the epoch
 current_time=$(date +%s)
 
+
+def_pattern="_([0-9]+)_(server|agent)"
+if [ -n "$1" ]; then
+    pattern="$1"
+else
+    pattern="$def_pattern"
+fi
+
 # Get the list of VMs
 vms=$(virsh list --name --all)
-time_regex="_([0-9]+)_(server|agent)"
 # Cleanup running VMs, happens if a previous test panics
 for vm in $vms; do
-    if [[ $vm =~ $time_regex ]]; then
+    if [[ $vm =~ $pattern ]]; then
         vm_time="${BASH_REMATCH[1]}"
         age=$((current_time - vm_time))
-        if [ $age -gt 7200 ]; then
+        if [ $age -gt 7200 ] || [ "$pattern" != "$def_pattern" ]; then
             virsh destroy $vm
             virsh undefine $vm --remove-all-storage
         fi
@@ -25,10 +32,10 @@ done
 # Cleanup inactive domains, happens if previous test is canceled
 vms=$(virsh list --name --inactive)
 for vm in $vms; do
-    if [[ $vm =~ $time_regex ]]; then
+    if [[ $vm =~ $pattern ]]; then
         vm_time="${BASH_REMATCH[1]}"
         age=$((current_time - vm_time))
-        if [ $age -gt 7200 ]; then
+        if [ $age -gt 7200 ] || [ "$pattern" != "$def_pattern" ]; then
             virsh undefine $vm  --remove-all-storage
         fi
     fi

--- a/tests/e2e/scripts/drone_registries.sh
+++ b/tests/e2e/scripts/drone_registries.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Script to set up Docker registry proxies for various public registries
+# Creates proxy registries for: 
+# - registry-1.docker.io
+# - registry.k8s.io
+# - gcr.io
+# - quay.io
+# - ghcr.io
+#
+# Not persistent - containers will not survive host reboot
+
+declare -A registries
+declare -A registry_ports
+registries=(
+    ["dockerhub"]="registry-1.docker.io"
+    ["k8s_io"]="registry.k8s.io"
+    ["gcr_io"]="gcr.io"
+    ["quay_io"]="quay.io"
+    ["ghcr_io"]="ghcr.io"
+)
+registry_ports=(
+    ["dockerhub"]=15000
+    ["k8s_io"]=15001
+    ["gcr_io"]=15002
+    ["quay_io"]=15003
+    ["ghcr_io"]=15004
+)
+
+# is_registry_running checsk if a registry is already exists
+is_registry_running() {
+    local name=$1
+    docker ps --format '{{.Names}}' | grep -q "^${name}$"
+    return $?
+}
+
+create_registry_proxy() {
+    local name=$1
+    local upstream=$2
+    local port=$3
+    
+    echo "Setting up registry proxy for ${upstream} on port ${port}"
+    
+    docker run -d \
+        --name "${name}" \
+        -e "REGISTRY_PROXY_REMOTEURL=https://${upstream}" \
+        -e "REGISTRY_HTTP_SECRET=shared-secret" \
+        -e "REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY=/var/lib/registry/$name" \
+        -p "${port}:5000" \
+        registry:2
+        
+    echo "Registry proxy for ${upstream} started on port ${port}"
+}
+
+
+
+# Set up each registry proxy
+for name in "${!registries[@]}"; do
+    upstream=${registries[$name]}
+    port=${registry_ports[$name]}
+    if is_registry_running "registry_${name}"; then
+        echo "Registry proxy for ${upstream} already running"
+    else
+        create_registry_proxy "registry_${name}" "${upstream}" "${port}"
+    fi
+done

--- a/tests/e2e/scripts/registry.sh
+++ b/tests/e2e/scripts/registry.sh
@@ -8,4 +8,16 @@ mkdir -p /etc/rancher/k3s/
 echo "mirrors:
   docker.io:
     endpoint:
-      - \"http://$ip_addr:5000\"" >> /etc/rancher/k3s/registries.yaml
+      - \"http://$ip_addr:15000\"
+  registry.k8s.io:
+    endpoint:
+      - \"http://$ip_addr:15001\"
+  gcr.io:
+    endpoint:
+      - \"http://$ip_addr:15002\"
+  quay.io:
+    endpoint:
+      - \"http://$ip_addr:15003\"
+  ghcr.io:
+    endpoint:
+      - \"http://$ip_addr:15004\"" >> /etc/rancher/k3s/registries.yaml


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
An updated take on https://github.com/k3s-io/k3s/pull/11448:
- Run specific tests in parallel blocks in Drone, 2 groups (validatecluster, splitserver + upgradecluster)
- Be explicit about VM cleanup, removing any similar named VMs before a E2E test runs. This works because we continue to operate with only 1 amd64 pipeline active at any time. This should better handle edge cases by being more agressive on VM cleanup than the previous 2H time limited system.
- Running only 2 E2E tests at one time should still fit within the IO constraints of the Drone runner
- Rework the registries in E2E tests to work more like the old docker tests, registries end up as long running containers on the drone host, enabling better caching over multiple reruns of similar e2e tests.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
| Before | After |
| - | - |
|  ![image](https://github.com/user-attachments/assets/8717a7aa-409f-4413-93e4-488f0b8c9f8d)|  ![image](https://github.com/user-attachments/assets/ba7f2f80-7c73-43c4-8ad3-09e2aea6edda)
#### Types of Changes ####
CI
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI still green
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/11449
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
