### PR TITLE
Move Windows test out of Install Script workflow

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -105,29 +105,3 @@ jobs:
         with:
           ## If no one connects after 5 minutes, shut down server.
           wait-timeout-minutes: 5
-  test-windows:
-    name: "Smoke Test (windows)"
-    needs: build
-    runs-on: windows-2022
-    timeout-minutes: 10
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-        with: {fetch-depth: 1}
-      - name: "Download k3s binary"
-        uses: actions/download-artifact@v4
-        with:
-          name: k3s-windows
-          path: dist/artifacts/
-      - name: "Run K3s"
-        timeout-minutes: 5
-        run: |
-          $ErrorActionPreference = "Continue"
-          $PSNativeCommandUseErrorActionPreference = $true
-          $Server = Start-Job -ScriptBlock { ./dist/artifacts/k3s.exe server --token=token --embedded-registry --disable=metrics-server }
-          Start-Sleep -Seconds 15
-          D:/var/lib/rancher/k3s/data/current/bin/k3s.exe kubectl get node -o wide
-          D:/var/lib/rancher/k3s/data/current/bin/k3s.exe kubectl get pod -A -o wide
-          Stop-Job -Job $Server
-          Receive-Job -Wait -Job $Server
-          Remove-Job -Job $Server

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -78,3 +78,50 @@ jobs:
         files: ./${{ matrix.itest }}.out
         flags: inttests # optional
         verbose: true # optional (default = false)
+  itest-windows:
+    name: Integration Tests (windows)
+    needs: build-windows
+    runs-on: windows-2022
+    timeout-minutes: 10
+    env:
+      GOCOVERDIR: "D:/tmp/k3scov"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with: {fetch-depth: 1}
+    - name: Install Go
+      uses: ./.github/actions/setup-go
+    - name: Download k3s binary
+      uses: actions/download-artifact@v4
+      with:
+        name: k3s-windows
+        path: dist/artifacts/
+    - name: Run K3s
+      timeout-minutes: 5
+      env:
+        CONTAINERD_LOG_LEVEL: "debug"
+      run: |
+        $ErrorActionPreference = "Continue"
+        $PSNativeCommandUseErrorActionPreference = $true
+        New-Item -Type Directory -Force $Env:GOCOVERDIR | Out-Null
+        $Server = Start-Job -ScriptBlock { ./dist/artifacts/k3s.exe server --token=token --debug --disable=metrics-server }
+        Start-Sleep -Seconds 15
+        D:/var/lib/rancher/k3s/data/current/bin/k3s.exe kubectl apply -f ./tests/integration/startup/testdata/agnhost.yaml
+        D:/var/lib/rancher/k3s/data/current/bin/k3s.exe kubectl wait --for=jsonpath='{.status.phase}'=Running --timeout=5m pod/agnhost
+        D:/var/lib/rancher/k3s/data/current/bin/k3s.exe crictl ps
+        D:/var/lib/rancher/k3s/data/current/bin/k3s.exe kubectl get pod -A -o wide
+        D:/var/lib/rancher/k3s/data/current/bin/k3s.exe kubectl get node -o wide
+        $RET = $LASTEXITCODE
+        Stop-Job -Job $Server
+        Receive-Job -Wait -Job $Server
+        Remove-Job -Job $Server
+        exit $RET
+    - name: Generate coverage report
+      run: go tool covdata textfmt -i $Env:GOCOVERDIR -o windows.out
+    - name: Upload Results To Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./windows.out
+        flags: inttests # optional
+        verbose: true # optional (default = false)

--- a/pkg/agent/cri/cri.go
+++ b/pkg/agent/cri/cri.go
@@ -2,6 +2,7 @@ package cri
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -14,7 +15,11 @@ const maxMsgSize = 1024 * 1024 * 16
 
 // Connection connects to a CRI socket at the given path.
 func Connection(ctx context.Context, address string) (*grpc.ClientConn, error) {
-	addr, dialer, err := k8sutil.GetAddressAndDialer(socketPrefix + address)
+	if !strings.HasPrefix(address, socketPrefix) {
+		address = socketPrefix + address
+	}
+
+	addr, dialer, err := k8sutil.GetAddressAndDialer(address)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/integration/startup/testdata/agnhost.yaml
+++ b/tests/integration/startup/testdata/agnhost.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: agnhost
+spec:
+  containers:
+  - name: agnhost
+    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    args:
+      - inclusterclient
+      - -v=9
+      - --poll-interval=5
+  dnsConfig:
+    nameservers:
+    - 8.8.8.8
+  dnsPolicy: None


### PR DESCRIPTION
#### Proposed Changes ####

* Move Windows test out of Install Script workflow
  Placing this in the install script workflow, which only runs when specific files are changed, was preventing it from being run on code changes.
  In addition to moving this into the integration workflow, fix codecov for Windows and upload data after running a test pod.
* Fix containerd socket path on Windows
  This was broken by https://github.com/k3s-io/k3s/pull/11878 but it went undetected because the windows test wasn't getting run


#### Types of Changes ####

CI

#### Verification ####

Check CI

#### Testing ####

yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/11896
* https://github.com/k3s-io/k3s/issues/11865

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
