### PR TITLE
Migrate test-mods from Drone to GHA

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,26 +10,12 @@ trigger:
   event:
     exclude:
     - cron
+    - pull_request
 
 clone:
   retries: 3
 
 steps:
-- name: skipfiles
-  image: plugins/git
-  commands:
-  - export NAME=$(test $DRONE_BUILD_EVENT = pull_request && echo remotes/origin/${DRONE_COMMIT_BRANCH:-master} || echo ${DRONE_COMMIT_SHA}~)
-  - export DIFF=$(git --no-pager diff --name-only $NAME | grep -v -f .droneignore);
-  - if [ -z "$DIFF" ]; then
-        echo "All files in PR are on ignore list";
-        exit 78;
-    else
-        echo "Some files in PR are not ignored, $DIFF";
-    fi;
-  when:
-    event:
-    - pull_request
-
 - name: build
   image: rancher/dapper:v0.6.0
   secrets: [ AWS_SECRET_ACCESS_KEY-k3s-ci-uploader, AWS_ACCESS_KEY_ID-k3s-ci-uploader, unprivileged_github_token ]
@@ -202,26 +188,12 @@ trigger:
   event:
     exclude:
     - cron
+    - pull_request
 
 clone:
   retries: 3
 
 steps:
-- name: skipfiles
-  image: plugins/git
-  commands:
-  - export NAME=$(test $DRONE_BUILD_EVENT = pull_request && echo remotes/origin/${DRONE_COMMIT_BRANCH:-master} || echo ${DRONE_COMMIT_SHA}~)
-  - export DIFF=$(git --no-pager diff --name-only $NAME | grep -v -f .droneignore);
-  - if [ -z "$DIFF" ]; then
-        echo "All files in PR are on ignore list";
-        exit 78;
-    else
-        echo "Some files in PR are not ignored, $DIFF";
-    fi;
-  when:
-    event:
-    - pull_request
-
 - name: build
   image: rancher/dapper:v0.6.0
   secrets: [ AWS_SECRET_ACCESS_KEY-k3s-ci-uploader, AWS_ACCESS_KEY_ID-k3s-ci-uploader ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -460,51 +460,6 @@ volumes:
 
 ---
 kind: pipeline
-name: validate_go_mods
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  event:
-    exclude:
-    - cron
-
-steps:
-- name: skipfiles
-  image: plugins/git
-  commands:
-  - export NAME=$(test $DRONE_BUILD_EVENT = pull_request && echo remotes/origin/${DRONE_COMMIT_BRANCH:-master} || echo ${DRONE_COMMIT_SHA}~)
-  - export DIFF=$(git --no-pager diff --name-only $NAME | grep -v -f .droneignore);
-  - if [ -z "$DIFF" ]; then
-        echo "All files in PR are on ignore list";
-        exit 78;
-    else
-        echo "Some files in PR are not ignored, $DIFF";
-    fi;
-  when:
-    event:
-    - push
-    - pull_request
-
-- name: validate_go_mods
-  image: rancher/dapper:v0.6.0
-  commands:
-  - docker build --target test-mods -t k3s:mod -f Dockerfile.test .
-  - docker run -i k3s:mod
-
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
-
----
-kind: pipeline
 name: manifest
 
 platform:

--- a/.github/workflows/unitcoverage.yaml
+++ b/.github/workflows/unitcoverage.yaml
@@ -77,3 +77,13 @@ jobs:
         files: ./coverage.out
         flags: unittests # optional
         verbose: true # optional (default = false)
+  test-mods:
+    name: Test K8s Modules
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build test-mods
+      run: docker build --target test-mods -t k3s:mod -f Dockerfile.test .
+    - name: Run test-mods
+      run: docker run -i k3s:mod


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Move the small `test-mods` pipeline from Drone to GHA, set as a "Unit Test" because it really what it us, we don't need to build K3s, and it just a sanity check that we match correct use the k3s-io fork of k8s dependencies.
- Don't run `amd64` and `arm64` Drone pipelines on PR anymore. As you can see from [this example run](https://drone-pr.k3s.io/k3s-io/k3s/11033), these pipelines don't run any tests anymore on PR, they just build the binary and exit. Our new CI in GHA covers builds and test on both these platforms.

| OLD | NEW |
|  - | - |
| ![image](https://github.com/user-attachments/assets/edb89162-d1ea-49ab-9a1d-8f3b5bd27d25) |  ![image](https://github.com/user-attachments/assets/99bd9794-c680-4de7-88a8-fa66863fe365)|

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CI
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
New CI is green https://github.com/k3s-io/k3s/actions/runs/14475488372/job/40600013584?pr=12137
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
It is a test
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/12136
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
