### PR TITLE
[master] Stagger E2E Drone and Delete k3s pause in cacerts test

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -601,9 +601,12 @@ steps:
   # Cleanup VMs that are older than 2h. Happens if a previous test panics or is canceled
   - tests/e2e/scripts/cleanup_vms.sh
   - tests/e2e/scripts/drone_registries.sh
+   # Stagger the launch of this test with the parallel splitserver test
+   # to prevent conflicts over libvirt network interfaces
   - |
     cd tests/e2e/validatecluster
     ../scripts/cleanup_vms.sh 'validatecluster_([0-9]+)_(server|agent)'
+    sleep 15
     go test -v -timeout=45m ./validatecluster_test.go -ci -local
     cp ./coverage.out /tmp/artifacts/validate-coverage.out
   volumes:

--- a/tests/docker/cacerts/cacerts_test.go
+++ b/tests/docker/cacerts/cacerts_test.go
@@ -102,6 +102,9 @@ var _ = AfterSuite(func() {
 		cmd = fmt.Sprintf("docker rm -v k3s-pause-%s", testID)
 		_, err = tester.RunCommand(cmd)
 		Expect(err).NotTo(HaveOccurred())
+		cmd = fmt.Sprintf("docker volume rm k3s-pause-%s", testID)
+		_, err = tester.RunCommand(cmd)
+		Expect(err).NotTo(HaveOccurred())
 	}
 
 })


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
During backports of https://github.com/k3s-io/k3s/pull/12069 and https://github.com/k3s-io/k3s/pull/12086, two additional commits were added to cover issues found at scale with the CI. This "forward-ports" these two commits to master.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CI/Testing
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
No more k3s-pause volumes left behind on Drone arm runner
E2E Drone tests past more consistently
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
