### PR TITLE
Set kubelet read-only-port via CLI flag

### DIFF
--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -185,7 +185,6 @@ func defaultKubeletConfig(cfg *daemonconfig.Agent) (*kubeletconfig.KubeletConfig
 		NodeStatusReportFrequency:        metav1.Duration{Duration: time.Minute * 5},
 		NodeStatusUpdateFrequency:        metav1.Duration{Duration: time.Second * 10},
 		ProtectKernelDefaults:            cfg.ProtectKernelDefaults,
-		ReadOnlyPort:                     0,
 		RuntimeRequestTimeout:            metav1.Duration{Duration: time.Minute * 2},
 		StreamingConnectionIdleTimeout:   metav1.Duration{Duration: time.Hour * 4},
 		SyncFrequency:                    metav1.Duration{Duration: time.Minute},

--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -77,6 +77,9 @@ func kubeletArgsAndConfig(cfg *config.Agent) (map[string]string, *kubeletconfig.
 	argsMap := map[string]string{
 		"config-dir": cfg.KubeletConfigDir,
 		"kubeconfig": cfg.KubeConfigKubelet,
+		// note: KubeletConfiguration will omit this field when marshalling if it is set to 0, so we set it via CLI
+		// https://github.com/k3s-io/k3s/issues/12164
+		"read-only-port": "0",
 	}
 
 	if cfg.RootDir != "" {

--- a/pkg/daemons/agent/agent_windows.go
+++ b/pkg/daemons/agent/agent_windows.go
@@ -50,6 +50,9 @@ func kubeletArgsAndConfig(cfg *config.Agent) (map[string]string, *kubeletconfig.
 	argsMap := map[string]string{
 		"config-dir": cfg.KubeletConfigDir,
 		"kubeconfig": cfg.KubeConfigKubelet,
+		// note: KubeletConfiguration will omit this field when marshalling if it is set to 0, so we set it via CLI
+		// https://github.com/k3s-io/k3s/issues/12164
+		"read-only-port": "0",
 	}
 	if cfg.RootDir != "" {
 		argsMap["root-dir"] = cfg.RootDir


### PR DESCRIPTION

#### Proposed Changes ####
* Set kubelet read-only-port via CLI flag
  Set kubelet read-only-port via cli flag due to inability to marshal the config struct with value set to 0.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12164

#### User-Facing Change ####
```release-note
```

#### Further Comments ####