### PR TITLE
[release-1.29] Fix handler panic when bootstrapper returns empty peer list

### DIFF
--- a/pkg/agent/https/https.go
+++ b/pkg/agent/https/https.go
@@ -56,7 +56,7 @@ func Start(ctx context.Context, nodeConfig *config.Node, runtime *config.Control
 			runtime.Handler = router
 		}
 
-		router.Use(auth.Delegated(nodeConfig.AgentConfig.ClientCA, nodeConfig.AgentConfig.KubeConfigKubelet, config))
+		router.Use(auth.RequestInfo(), auth.Delegated(nodeConfig.AgentConfig.ClientCA, nodeConfig.AgentConfig.KubeConfigKubelet, config))
 
 		if config.SecureServing != nil {
 			_, _, err = config.SecureServing.Serve(router, 0, ctx.Done())

--- a/pkg/server/auth/auth.go
+++ b/pkg/server/auth/auth.go
@@ -121,9 +121,16 @@ func Delegated(clientCA, kubeConfig string, config *server.Config) mux.Middlewar
 	return func(handler http.Handler) http.Handler {
 		handler = genericapifilters.WithAuthorization(handler, config.Authorization.Authorizer, scheme.Codecs)
 		handler = genericapifilters.WithAuthentication(handler, config.Authentication.Authenticator, failedHandler, nil, nil)
-		handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 		handler = genericapifilters.WithCacheControl(handler)
 		return handler
+	}
+}
+
+// RequestInfo returns a middleware function that adds verb/resource/gvk/etc info to the request context.
+// This must be set for other filters to function, but only needs to be in each middleware chain once.
+func RequestInfo() mux.MiddlewareFunc {
+	return func(handler http.Handler) http.Handler {
+		return genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 	}
 }
 
@@ -131,9 +138,6 @@ func Delegated(clientCA, kubeConfig string, config *server.Config) mux.Middlewar
 // This is not strictly auth related, but it also uses the core Kubernetes request filters.
 func MaxInFlight(nonMutatingLimit, mutatingLimit int) mux.MiddlewareFunc {
 	return func(handler http.Handler) http.Handler {
-		handler = genericfilters.WithMaxInFlightLimit(handler, nonMutatingLimit, mutatingLimit, nil)
-		handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
-		handler = genericapifilters.WithCacheControl(handler)
-		return handler
+		return genericfilters.WithMaxInFlightLimit(handler, nonMutatingLimit, mutatingLimit, nil)
 	}
 }

--- a/pkg/server/handlers/router.go
+++ b/pkg/server/handlers/router.go
@@ -33,7 +33,7 @@ func NewHandler(ctx context.Context, control *config.Control, cfg *cmds.Server) 
 	prefix := "/v1-{program}"
 	authed := mux.NewRouter().SkipClean(true)
 	authed.NotFoundHandler = APIServer(control, cfg)
-	authed.Use(auth.HasRole(control, version.Program+":agent", user.NodesGroup, bootstrapapi.BootstrapDefaultGroup), auth.MaxInFlight(maxNonMutatingAgentRequests, maxMutatingAgentRequests))
+	authed.Use(auth.HasRole(control, version.Program+":agent", user.NodesGroup, bootstrapapi.BootstrapDefaultGroup), auth.RequestInfo(), auth.MaxInFlight(maxNonMutatingAgentRequests, maxMutatingAgentRequests))
 	authed.Handle(prefix+"/serving-kubelet.crt", ServingKubeletCert(control, nodeAuth))
 	authed.Handle(prefix+"/client-kubelet.crt", ClientKubeletCert(control, nodeAuth))
 	authed.Handle(prefix+"/client-kube-proxy.crt", ClientKubeProxyCert(control))

--- a/pkg/spegel/bootstrap.go
+++ b/pkg/spegel/bootstrap.go
@@ -241,7 +241,7 @@ func (c *chainingBootstrapper) Get(ctx context.Context) ([]peer.AddrInfo, error)
 		as, err := b.Get(ctx)
 		if err != nil {
 			errs = append(errs, err)
-		} else {
+		} else if len(as) != 0 {
 			return as, nil
 		}
 	}

--- a/pkg/spegel/spegel.go
+++ b/pkg/spegel/spegel.go
@@ -256,7 +256,7 @@ func (c *Config) Start(ctx context.Context, nodeConfig *config.Node) error {
 func (c *Config) peerInfo() http.HandlerFunc {
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		info, err := c.Bootstrapper.Get(req.Context())
-		if err != nil || len(info) == 0 {
+		if err != nil {
 			http.Error(resp, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -266,6 +266,11 @@ func (c *Config) peerInfo() http.HandlerFunc {
 			for _, ma := range ai.Addrs {
 				addrs = append(addrs, fmt.Sprintf("%s/p2p/%s", ma, ai.ID))
 			}
+		}
+
+		if len(addrs) == 0 {
+			http.Error(resp, "no peer addresses available", http.StatusServiceUnavailable)
+			return
 		}
 
 		client, _, _ := net.SplitHostPort(req.RemoteAddr)


### PR DESCRIPTION
#### Proposed Changes ####

* Fix handler panic when bootstrapper returned empty peer list
   Panic gets rescued by the http server, and was only visible when running in debug mode, but should be handled properly.

Found when load testing master following merge of https://github.com/k3s-io/k3s/pull/12154

<details><summary>Stack Trace</summary>

```
INFO[0026] Cluster-Http-Server 2025/04/18 07:36:18 http: panic serving 172.17.0.10:54992: runtime error: invalid memory address or nil pointer dereference
INFO[0026] goroutine 25337 [running]:
INFO[0026] net/http.(*conn).serve.func1()
INFO[0026] 	/usr/local/go/src/net/http/server.go:1947 +0xbe
INFO[0026] panic({0x5f6a3a0?, 0xb5ae5e0?})
INFO[0026] 	/usr/local/go/src/runtime/panic.go:785 +0x132
INFO[0026] github.com/k3s-io/k3s/pkg/spegel.(*Config).Start.(*Config).peerInfo.func13({0x79cf490, 0xc00d00c700}, 0xc001cd0b40)
INFO[0026] 	/go/src/github.com/k3s-io/k3s/pkg/spegel/spegel.go:260 +0x8b
INFO[0026] net/http.HandlerFunc.ServeHTTP(0xb61f8c0?, {0x79cf490?, 0xc00d00c700?}, 0x3?)
INFO[0026] 	/usr/local/go/src/net/http/server.go:2220 +0x29
INFO[0026] k8s.io/apiserver/pkg/server/filters.WithMaxInFlightLimit.func1({0x79cf490, 0xc00d00c700}, 0xc001cd0b40)
INFO[0026] 	/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apiserver@v1.32.3-k3s2/pkg/server/filters/maxinflight.go:196 +0x254
INFO[0026] net/http.HandlerFunc.ServeHTTP(0x79f7138?, {0x79cf490?, 0xc00d00c700?}, 0x7957cf8?)
INFO[0026] 	/usr/local/go/src/net/http/server.go:2220 +0x29
INFO[0026] k8s.io/apiserver/pkg/endpoints/filters.WithRequestInfo.func1({0x79cf490, 0xc00d00c700}, 0xc001cd0a00)
INFO[0026] 	/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apiserver@v1.32.3-k3s2/pkg/endpoints/filters/requestinfo.go:39 +0x1ce
INFO[0026] net/http.HandlerFunc.ServeHTTP(0x675e640?, {0x79cf490?, 0xc00d00c700?}, 0xd?)
INFO[0026] 	/usr/local/go/src/net/http/server.go:2220 +0x29
INFO[0026] k8s.io/apiserver/pkg/endpoints/filters.WithCacheControl.func1({0x79cf490, 0xc00d00c700}, 0xc001cd0a00)
INFO[0026] 	/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apiserver@v1.32.3-k3s2/pkg/endpoints/filters/cachecontrol.go:31 +0x124
INFO[0026] net/http.HandlerFunc.ServeHTTP(0x79f7138?, {0x79cf490?, 0xc00d00c700?}, 0x4?)
INFO[0026] 	/usr/local/go/src/net/http/server.go:2220 +0x29
INFO[0026] k8s.io/apiserver/pkg/endpoints/filters.withAuthorization.func1({0x79cf490, 0xc00d00c700}, 0xc001cd0a00)
INFO[0026] 	/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apiserver@v1.32.3-k3s2/pkg/endpoints/filters/authorization.go:83 +0x606
INFO[0026] net/http.HandlerFunc.ServeHTTP(0x79f7138?, {0x79cf490?, 0xc00d00c700?}, 0x7949f68?)
INFO[0026] 	/usr/local/go/src/net/http/server.go:2220 +0x29
INFO[0026] k8s.io/apiserver/pkg/endpoints/filters.withAuthentication.func1({0x79cf490, 0xc00d00c700}, 0xc001cd0a00)
INFO[0026] 	/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apiserver@v1.32.3-k3s2/pkg/endpoints/filters/authentication.go:123 +0x7bf
INFO[0026] net/http.HandlerFunc.ServeHTTP(0xc001cd03c0?, {0x79cf490?, 0xc00d00c700?}, 0xc006a84e10?)
INFO[0026] 	/usr/local/go/src/net/http/server.go:2220 +0x29
INFO[0026] github.com/k3s-io/k3s/pkg/server/auth.Delegated.func1.WithRequestInfo.1({0x79cf490, 0xc00d00c700}, 0xc001cd03c0)
INFO[0026] 	/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apiserver@v1.32.3-k3s2/pkg/endpoints/filters/requestinfo.go:39 +0x119
INFO[0026] net/http.HandlerFunc.ServeHTTP(0xc00cad75f0?, {0x79cf490?, 0xc00d00c700?}, 0x6a8d55e?)
INFO[0026] 	/usr/local/go/src/net/http/server.go:2220 +0x29
INFO[0026] github.com/k3s-io/k3s/pkg/server/auth.Delegated.func1.WithCacheControl.2({0x79cf490, 0xc00d00c700}, 0xc001cd03c0)
INFO[0026] 	/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apiserver@v1.32.3-k3s2/pkg/endpoints/filters/cachecontrol.go:31 +0xa7
INFO[0026] net/http.HandlerFunc.ServeHTTP(0xc001cd0280?, {0x79cf490?, 0xc00d00c700?}, 0x1bb9ba58?)
INFO[0026] 	/usr/local/go/src/net/http/server.go:2220 +0x29
INFO[0026] github.com/gorilla/mux.(*Router).ServeHTTP(0xc001174cc0, {0x79cf490, 0xc00d00c700}, 0xc001cd0140)
INFO[0026] 	/go/pkg/mod/github.com/gorilla/mux@v1.8.1/mux.go:212 +0x1e2
INFO[0026] github.com/k3s-io/k3s/pkg/cluster.(*Cluster).initClusterAndHTTPS.func1({0x79cf490?, 0xc00d00c700?}, 0xc00cad76b0?)
INFO[0026] 	/go/src/github.com/k3s-io/k3s/pkg/cluster/https.go:106 +0x50
INFO[0026] net/http.HandlerFunc.ServeHTTP(0xc00061ba40?, {0x79cf490?, 0xc00d00c700?}, 0xa?)
INFO[0026] 	/usr/local/go/src/net/http/server.go:2220 +0x29
INFO[0026] github.com/gorilla/mux.(*Router).ServeHTTP(0xc000f17440, {0x79cf490, 0xc00d00c700}, 0xc00061b900)
INFO[0026] 	/go/pkg/mod/github.com/gorilla/mux@v1.8.1/mux.go:212 +0x1e2
INFO[0026] github.com/k3s-io/k3s/pkg/cluster.(*Cluster).initClusterAndHTTPS.func2({0x79cf490, 0xc00d00c700}, 0xc00061b900)
INFO[0026] 	/go/src/github.com/k3s-io/k3s/pkg/cluster/https.go:123 +0x68
INFO[0026] net/http.HandlerFunc.ServeHTTP(0x4753f9?, {0x79cf490?, 0xc00d00c700?}, 0xc005a1db70?)
INFO[0026] 	/usr/local/go/src/net/http/server.go:2220 +0x29
INFO[0026] net/http.serverHandler.ServeHTTP({0xc00cad7530?}, {0x79cf490?, 0xc00d00c700?}, 0x6?)
INFO[0026] 	/usr/local/go/src/net/http/server.go:3210 +0x8e
INFO[0026] net/http.(*conn).serve(0xc00da50fc0, {0x79f7138, 0xc00082ff20})
INFO[0026] 	/usr/local/go/src/net/http/server.go:2092 +0x5d0
INFO[0026] created by net/http.(*Server).Serve in goroutine 349
INFO[0026] 	/usr/local/go/src/net/http/server.go:3360 +0x485
```
</details> 

#### Types of Changes ####

bugfix

#### Verification ####


#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12162

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
