### PR TITLE
Fix sonobuoy conformance testing

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -20,7 +20,7 @@ mkdir -p $artifacts
 docker ps
 
 export K3S_IMAGE="rancher/k3s:${VERSION_TAG}${SUFFIX}"
-
+export VERSION_K8S # used by the sonobuoy tests subprocess
 # ---
 # Only run PR tests on arm arch, we use GitHub Actions for amd64 and arm64
 # Run all tests on tag events, as we want test failures to block the release


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
See [failures on the nightly runs ](https://drone-publish.k3s.io/k3s-io/k3s/4365/1/3)around 
```
sonobuoy run --config=scripts/sonobuoy-config.json --plugin-env=e2e.E2E_USE_GO_RUNNER=true --kubernetes-version= --wait=90 '--e2e-focus=\[Serial\].*\[Conformance\]'

[SERIAL-mysql] Error: invalid argument "" for "--kubernetes-version" flag: version "" is invalid: Malformed version: 
```

At some point the VERSION_K8S stopped getting passed correctly down the script layers to the actual sonobuoy call. 
We just need to properly export this so its available to the subprocess.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Manually run locally and SERIAL and PARALLEL tests now correctly launch.
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/11714
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####
We can't move forward with GHA migration until we are in a stable place with the old tests. 
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
