### PR TITLE
Implement certificate check with file-oriented view and usage types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/docker v27.1.1+incompatible
+	github.com/dustin/go-humanize v1.0.1
 	github.com/erikdubbelboer/gspt v0.0.0-20190125194910-e68493906b83
 	github.com/flannel-io/flannel v0.26.7
 	github.com/fsnotify/fsnotify v1.7.0
@@ -249,7 +250,6 @@ require (
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elastic/gosigar v0.14.3 // indirect
 	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect

--- a/pkg/cli/cert/cert.go
+++ b/pkg/cli/cert/cert.go
@@ -2,14 +2,17 @@ package cert
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/k3s-io/k3s/pkg/agent/util"
 	"github.com/k3s-io/k3s/pkg/bootstrap"
 	"github.com/k3s-io/k3s/pkg/cli/cmds"
@@ -19,6 +22,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/datadir"
 	"github.com/k3s-io/k3s/pkg/proctitle"
 	"github.com/k3s-io/k3s/pkg/server"
+	k3sutil "github.com/k3s-io/k3s/pkg/util"
 	"github.com/k3s-io/k3s/pkg/util/services"
 	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/otiai10/copy"
@@ -26,7 +30,142 @@ import (
 	certutil "github.com/rancher/dynamiclistener/cert"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	"gopkg.in/yaml.v2"
 )
+
+// Certificate defines a single certificate data structure
+type Certificate struct {
+	Filename     string
+	Subject      string
+	Issuer       string
+	Usages       []string
+	ExpiryTime   time.Time
+	ResidualTime time.Duration
+	Status       string // "OK", "WARNING", "EXPIRED", "NOT YET VALID"
+}
+
+// CertificateInfo defines the structure for storing certificate information
+type CertificateInfo struct {
+	Certificates  []Certificate
+	ReferenceTime time.Time `json:"-" yaml:"-"`
+}
+
+// collectCertInfo collects information about certificates
+func collectCertInfo(controlConfig config.Control, ServicesList []string) (*CertificateInfo, error) {
+	result := &CertificateInfo{}
+	now := time.Now()
+	warn := now.Add(time.Hour * 24 * config.CertificateRenewDays)
+
+	fileMap, err := services.FilesForServices(controlConfig, ServicesList)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, files := range fileMap {
+		for _, file := range files {
+			certs, err := certutil.CertsFromFile(file)
+			if err != nil {
+				logrus.Debugf("%v", err)
+				continue
+			}
+
+			for _, cert := range certs {
+
+				expiration := cert.NotAfter
+				status := k3sutil.GetCertStatus(cert, now, warn)
+				if status == k3sutil.CertStatusNotYetValid {
+					expiration = cert.NotBefore
+				}
+				usages := k3sutil.GetCertUsages(cert)
+				result.Certificates = append(result.Certificates, Certificate{
+					Filename:     filepath.Base(file),
+					Subject:      cert.Subject.CommonName,
+					Issuer:       cert.Issuer.CommonName,
+					Usages:       usages,
+					ExpiryTime:   expiration,
+					ResidualTime: cert.NotAfter.Sub(now),
+					Status:       status,
+				})
+			}
+		}
+	}
+	result.ReferenceTime = now
+	return result, nil
+}
+
+// CertFormatter defines the interface for formatting certificate information
+type CertFormatter interface {
+	Format(*CertificateInfo) error
+}
+
+// TextFormatter implements text format output
+type TextFormatter struct {
+	Writer io.Writer
+}
+
+func (f *TextFormatter) Format(certInfo *CertificateInfo) error {
+	for _, cert := range certInfo.Certificates {
+		usagesStr := strings.Join(cert.Usages, ",")
+		switch cert.Status {
+		case k3sutil.CertStatusNotYetValid:
+			logrus.Errorf("%s: certificate %s (%s) is not valid before %s",
+				cert.Filename, cert.Subject, usagesStr, cert.ExpiryTime.Format(time.RFC3339))
+		case k3sutil.CertStatusExpired:
+			logrus.Errorf("%s: certificate %s (%s) expired at %s",
+				cert.Filename, cert.Subject, usagesStr, cert.ExpiryTime.Format(time.RFC3339))
+		case k3sutil.CertStatusWarning:
+			logrus.Warnf("%s: certificate %s (%s) will expire within %d days at %s",
+				cert.Filename, cert.Subject, usagesStr, config.CertificateRenewDays, cert.ExpiryTime.Format(time.RFC3339))
+		default:
+			logrus.Infof("%s: certificate %s (%s) is ok, expires at %s",
+				cert.Filename, cert.Subject, usagesStr, cert.ExpiryTime.Format(time.RFC3339))
+		}
+	}
+	return nil
+}
+
+// TableFormatter implements table format output
+type TableFormatter struct {
+	Writer io.Writer
+}
+
+func (f *TableFormatter) Format(certInfo *CertificateInfo) error {
+	w := tabwriter.NewWriter(f.Writer, 0, 0, 3, ' ', 0)
+	now := certInfo.ReferenceTime
+	defer w.Flush()
+
+	fmt.Fprintf(w, "\nFILENAME\tSUBJECT\tUSAGES\tEXPIRES\tRESIDUAL TIME\tSTATUS\n")
+	fmt.Fprintf(w, "--------\t-------\t------\t-------\t-------------\t------\n")
+
+	for _, cert := range certInfo.Certificates {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			cert.Filename,
+			cert.Subject,
+			strings.Join(cert.Usages, ","),
+			cert.ExpiryTime.Format("Jan 02, 2006 15:04 MST"),
+			humanize.RelTime(now, now.Add(cert.ResidualTime), "", ""),
+			cert.Status)
+	}
+	return nil
+}
+
+// JSONFormatter implements JSON format output
+type JSONFormatter struct {
+	Writer io.Writer
+}
+
+func (f *JSONFormatter) Format(certInfo *CertificateInfo) error {
+	return json.NewEncoder(f.Writer).Encode(certInfo)
+}
+
+// YAMLFormatter implements YAML format output
+type YAMLFormatter struct {
+	Writer io.Writer
+}
+
+func (f *YAMLFormatter) Format(certInfo *CertificateInfo) error {
+	return yaml.NewEncoder(f.Writer).Encode(certInfo)
+}
 
 func commandSetup(app *cli.Context, cfg *cmds.Server, sc *server.Config) (string, error) {
 	proctitle.SetProcTitle(os.Args[0])
@@ -58,6 +197,7 @@ func Check(app *cli.Context) error {
 	return check(app, &cmds.ServerConfig)
 }
 
+// check checks the status of the certificates
 func check(app *cli.Context, cfg *cmds.Server) error {
 	var serverConfig server.Config
 
@@ -87,76 +227,27 @@ func check(app *cli.Context, cfg *cmds.Server) error {
 		}
 	}
 
-	fileMap, err := services.FilesForServices(serverConfig.ControlConfig, cmds.ServicesList.Value())
+	certInfo, err := collectCertInfo(serverConfig.ControlConfig, cmds.ServicesList.Value())
 	if err != nil {
 		return err
 	}
-
-	now := time.Now()
-	warn := now.Add(time.Hour * 24 * config.CertificateRenewDays)
 	outFmt := app.String("output")
+
+	var formatter CertFormatter
 	switch outFmt {
 	case "text":
-		for service, files := range fileMap {
-			logrus.Infof("Checking certificates for %s", service)
-			for _, file := range files {
-				// ignore errors, as some files may not exist, or may not contain certs.
-				// Only check whatever exists and has certs.
-				certs, err := certutil.CertsFromFile(file)
-				if err != nil {
-					logrus.Debugf("%v", err)
-					continue
-				}
-				for _, cert := range certs {
-					if now.Before(cert.NotBefore) {
-						logrus.Errorf("%s: certificate %s is not valid before %s", file, cert.Subject, cert.NotBefore.Format(time.RFC3339))
-					} else if now.After(cert.NotAfter) {
-						logrus.Errorf("%s: certificate %s expired at %s", file, cert.Subject, cert.NotAfter.Format(time.RFC3339))
-					} else if warn.After(cert.NotAfter) {
-						logrus.Warnf("%s: certificate %s will expire within %d days at %s", file, cert.Subject, config.CertificateRenewDays, cert.NotAfter.Format(time.RFC3339))
-					} else {
-						logrus.Infof("%s: certificate %s is ok, expires at %s", file, cert.Subject, cert.NotAfter.Format(time.RFC3339))
-					}
-				}
-			}
-		}
+		formatter = &TextFormatter{Writer: os.Stdout}
 	case "table":
-		var tabBuffer bytes.Buffer
-		w := tabwriter.NewWriter(&tabBuffer, 0, 0, 2, ' ', 0)
-		fmt.Fprintf(w, "\n")
-		fmt.Fprintf(w, "CERTIFICATE\tSUBJECT\tSTATUS\tEXPIRES\n")
-		fmt.Fprintf(w, "-----------\t-------\t------\t-------")
-		for _, files := range fileMap {
-			for _, file := range files {
-				certs, err := certutil.CertsFromFile(file)
-				if err != nil {
-					logrus.Debugf("%v", err)
-					continue
-				}
-				for _, cert := range certs {
-					baseName := filepath.Base(file)
-					var status string
-					expiration := cert.NotAfter.Format(time.RFC3339)
-					if now.Before(cert.NotBefore) {
-						status = "NOT YET VALID"
-						expiration = cert.NotBefore.Format(time.RFC3339)
-					} else if now.After(cert.NotAfter) {
-						status = "EXPIRED"
-					} else if warn.After(cert.NotAfter) {
-						status = "WARNING"
-					} else {
-						status = "OK"
-					}
-					fmt.Fprintf(w, "\n%s\t%s\t%s\t%s", baseName, cert.Subject, status, expiration)
-				}
-			}
-		}
-		w.Flush()
-		fmt.Println(tabBuffer.String())
+		formatter = &TableFormatter{Writer: os.Stdout}
+	case "json":
+		formatter = &JSONFormatter{Writer: os.Stdout}
+	case "yaml":
+		formatter = &YAMLFormatter{Writer: os.Stdout}
 	default:
 		return fmt.Errorf("invalid output format %s", outFmt)
 	}
-	return nil
+
+	return formatter.Format(certInfo)
 }
 
 func Rotate(app *cli.Context) error {

--- a/pkg/cli/cmds/certs.go
+++ b/pkg/cli/cmds/certs.go
@@ -66,7 +66,7 @@ func NewCertCommands(check, rotate, rotateCA func(ctx *cli.Context) error) *cli.
 				Flags: append(CertRotateCommandFlags, &cli.StringFlag{
 					Name:    "output",
 					Aliases: []string{"o"},
-					Usage:   "Format output. Options: text, table",
+					Usage:   "Format output. Options: text, table, json, yaml",
 					Value:   "text",
 				}),
 			},

--- a/pkg/util/cert.go
+++ b/pkg/util/cert.go
@@ -2,8 +2,25 @@ package util
 
 import (
 	"crypto/x509"
+	"time"
 
 	certutil "github.com/rancher/dynamiclistener/cert"
+)
+
+// cert usage constants
+const (
+	CertUsageCertSign   = "CertSign"
+	CertUsageServerAuth = "ServerAuth"
+	CertUsageClientAuth = "ClientAuth"
+	CertUsageUnknown    = "Unknown"
+)
+
+// cert status constants
+const (
+	CertStatusOK          = "OK"
+	CertStatusWarning     = "WARNING"
+	CertStatusExpired     = "EXPIRED"
+	CertStatusNotYetValid = "NOT YET VALID"
 )
 
 // EncodeCertsPEM is a wrapper around the EncodeCertPEM function to return the
@@ -14,4 +31,36 @@ func EncodeCertsPEM(cert *x509.Certificate, caCerts []*x509.Certificate) []byte 
 		pemBytes = append(pemBytes, certutil.EncodeCertPEM(caCert)...)
 	}
 	return pemBytes
+}
+
+// GetCertUsages returns a slice of strings representing the certificate usages
+func GetCertUsages(cert *x509.Certificate) []string {
+	usages := []string{}
+	if cert.KeyUsage&x509.KeyUsageCertSign != 0 {
+		usages = append(usages, CertUsageCertSign)
+	}
+	for _, eku := range cert.ExtKeyUsage {
+		switch eku {
+		case x509.ExtKeyUsageServerAuth:
+			usages = append(usages, CertUsageServerAuth)
+		case x509.ExtKeyUsageClientAuth:
+			usages = append(usages, CertUsageClientAuth)
+		}
+	}
+	if len(usages) == 0 {
+		usages = append(usages, CertUsageUnknown)
+	}
+	return usages
+}
+
+// GetCertStatus determines the status of a certificate based on its validity period
+func GetCertStatus(cert *x509.Certificate, now time.Time, warn time.Time) string {
+	if now.Before(cert.NotBefore) {
+		return CertStatusNotYetValid
+	} else if now.After(cert.NotAfter) {
+		return CertStatusExpired
+	} else if warn.After(cert.NotAfter) {
+		return CertStatusWarning
+	}
+	return CertStatusOK
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This PR implements a certificate check feature that:
- Adds `USAGES` field to distinguish between `CertSign`/`ServerAuth`/`ClientAuth`
- Changes `CERTIFICATE` column to `FILENAME` for clarity
- Supports multiple output formats (text, table, json, yaml)

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

New Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

``` sh
# k3s certificate check -o table -s kubelet

FILENAME              SUBJECT                    USAGES       EXPIRES                  RESIDUAL TIME   STATUS
--------              -------                    ------       -------                  -------------   ------
client-kubelet.crt    system:node:ubuntu         ClientAuth   May 07, 2026 02:31 UTC   1 year          OK
client-kubelet.crt    k3s-client-ca@1746585073   CertSign     May 05, 2035 02:31 UTC   10 years        OK
serving-kubelet.crt   ubuntu                     ServerAuth   May 07, 2026 02:31 UTC   1 year          OK
serving-kubelet.crt   k3s-server-ca@1746585073   CertSign     May 05, 2035 02:31 UTC   10 years        OK

# k3s certificate check -o text -s api-server
INFO[0000] client-kube-apiserver.crt: certificate system:apiserver (ClientAuth) is ok, expires at 2026-05-07T02:31:13Z
INFO[0000] client-kube-apiserver.crt: certificate k3s-client-ca@1746585073 (CertSign) is ok, expires at 2035-05-05T02:31:13Z
INFO[0000] serving-kube-apiserver.crt: certificate kube-apiserver (ServerAuth) is ok, expires at 2026-05-07T02:31:13Z
INFO[0000] serving-kube-apiserver.crt: certificate k3s-server-ca@1746585073 (CertSign) is ok, expires at 2035-05-05T02:31:13Z

# k3s certificate check -o yaml -s admin
certificates:
- filename: client-admin.crt
  subject: system:admin
  issuer: k3s-client-ca@1746585073
  usages:
  - ClientAuth
  expirytime: 2026-05-07T02:31:13Z
  residualtime: 8732h19m4.95429994s
  status: OK
- filename: client-admin.crt
  subject: k3s-client-ca@1746585073
  issuer: k3s-client-ca@1746585073
  usages:
  - CertSign
  expirytime: 2035-05-05T02:31:13Z
  residualtime: 87572h19m4.95429994s
  status: OK

# k3s certificate check -o json -s kube-proxy | jq
{
  "Certificates": [
    {
      "Filename": "client-kube-proxy.crt",
      "Subject": "system:kube-proxy",
      "Issuer": "k3s-client-ca@1746585073",
      "Usages": [
        "ClientAuth"
      ],
      "ExpiryTime": "2026-05-07T02:31:15Z",
      "ResidualTime": 31436339036987915,
      "Status": "OK"
    },
    {
      "Filename": "client-kube-proxy.crt",
      "Subject": "k3s-client-ca@1746585073",
      "Issuer": "k3s-client-ca@1746585073",
      "Usages": [
        "CertSign"
      ],
      "ExpiryTime": "2035-05-05T02:31:13Z",
      "ResidualTime": 315260337036987915,
      "Status": "OK"
    }
  ]
}
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/k3s-io/k3s/issues/12049

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Implement certificate check with file-oriented view and usage types
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
