### PR TITLE
[Release-1.30] Testing backports for 2025 May

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -20,7 +20,7 @@ mkdir -p $artifacts
 docker ps
 
 export K3S_IMAGE="rancher/k3s:${VERSION_TAG}${SUFFIX}"
-
+export VERSION_K8S # used by the sonobuoy tests subprocess
 # ---
 # Only run PR tests on arm arch, we use GitHub Actions for amd64 and arm64
 # Run all tests on tag events, as we want test failures to block the release

--- a/tests/docker/skew/skew_test.go
+++ b/tests/docker/skew/skew_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Skew Tests", Ordered, func() {
 			Expect(config.ProvisionServers(3)).To(Succeed())
 			Eventually(func() error {
 				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
-			}, "180s", "5s").Should(Succeed())
+			}, "240s", "10s").Should(Succeed())
 			Eventually(func(g Gomega) {
 				g.Expect(tests.ParseNodes(config.KubeconfigFile)).To(HaveLen(3))
 				g.Expect(tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())).To(Succeed())

--- a/tests/e2e/rootless/rootless_test.go
+++ b/tests/e2e/rootless/rootless_test.go
@@ -115,16 +115,18 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 
 		It("Returns pod metrics", func() {
 			cmd := "kubectl top pod -A"
+			var res string
+			var err error
 			Eventually(func() error {
-				_, err := e2e.RunCommand(cmd)
+				res, err = e2e.RunCommand(cmd)
 				return err
-			}, "600s", "5s").Should(Succeed())
+			}, "600s", "5s").Should(Succeed(), "failed to get pod metrics: %s", res)
 		})
 
 		It("Returns node metrics", func() {
 			cmd := "kubectl top node"
-			_, err := e2e.RunCommand(cmd)
-			Expect(err).NotTo(HaveOccurred())
+			res, err := e2e.RunCommand(cmd)
+			Expect(err).NotTo(HaveOccurred(), "failed to get node metrics: %s", res)
 		})
 
 		It("Runs an interactive command a pod", func() {

--- a/tests/e2e/startup/startup_test.go
+++ b/tests/e2e/startup/startup_test.go
@@ -139,8 +139,8 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 
 		It("Returns node metrics", func() {
 			cmd := "kubectl top node"
-			_, err := e2e.RunCommand(cmd)
-			Expect(err).NotTo(HaveOccurred())
+			res, err := e2e.RunCommand(cmd)
+			Expect(err).NotTo(HaveOccurred(), "failed to get node metrics: %s", res)
 		})
 
 		It("Runs an interactive command a pod", func() {
@@ -308,8 +308,8 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 
 		It("Returns node metrics", func() {
 			cmd := "kubectl top node"
-			_, err := e2e.RunCommand(cmd)
-			Expect(err).NotTo(HaveOccurred())
+			res, err := e2e.RunCommand(cmd)
+			Expect(err).NotTo(HaveOccurred(), "failed to get node metrics: %s", res)
 		})
 
 		It("Runs an interactive command a pod", func() {

--- a/tests/e2e/startup/startup_test.go
+++ b/tests/e2e/startup/startup_test.go
@@ -290,9 +290,6 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 			}, "360s", "5s").Should(Succeed())
 
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
-			}, "360s", "5s").Should(Succeed())
-			Eventually(func() error {
 				return tests.CheckDefaultDeployments(tc.KubeconfigFile)
 			}, "300s", "10s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
@@ -300,16 +297,30 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 
 		It("Returns pod metrics", func() {
 			cmd := "kubectl top pod -A"
+			var res, logs string
+			var err error
 			Eventually(func() error {
-				_, err := e2e.RunCommand(cmd)
+				res, err = e2e.RunCommand(cmd)
+				// Common error: metrics not available yet, pull more logs
+				if err != nil && strings.Contains(res, "metrics not available yet") {
+					logs, _ = e2e.RunCommand("kubectl logs -n kube-system -l k8s-app=metrics-server")
+				}
 				return err
-			}, "600s", "5s").Should(Succeed())
+			}, "300s", "10s").Should(Succeed(), "failed to get pod metrics: %s: %s", res, logs)
 		})
 
 		It("Returns node metrics", func() {
+			var res, logs string
+			var err error
 			cmd := "kubectl top node"
-			res, err := e2e.RunCommand(cmd)
-			Expect(err).NotTo(HaveOccurred(), "failed to get node metrics: %s", res)
+			Eventually(func() error {
+				res, err = e2e.RunCommand(cmd)
+				// Common error: metrics not available yet, pull more logs
+				if err != nil && strings.Contains(res, "metrics not available yet") {
+					logs, _ = e2e.RunCommand("kubectl logs -n kube-system -l k8s-app=metrics-server")
+				}
+				return err
+			}, "30s", "5s").Should(Succeed(), "failed to get node metrics: %s: %s", res, logs)
 		})
 
 		It("Runs an interactive command a pod", func() {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Backports the following PRs:
- https://github.com/k3s-io/k3s/pull/12163
- https://github.com/k3s-io/k3s/pull/12214
- https://github.com/k3s-io/k3s/pull/12198

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Testing fixes
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
CI still green (with more logs)
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/11714
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
