### PR TITLE
flannel: Use custom type for network mode (IPv4, IPv6, dual-stack)

### DIFF
--- a/pkg/agent/flannel/setup_test.go
+++ b/pkg/agent/flannel/setup_test.go
@@ -23,13 +23,16 @@ func Test_findNetMode(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    string
-		want    int
+		wantv4  bool
+		wantv6  bool
 		wantErr bool
 	}{
-		{"dual-stack", "10.42.0.0/16,2001:cafe:22::/56", ipv4 + ipv6, false},
-		{"ipv4 only", "10.42.0.0/16", ipv4, false},
-		{"ipv6 only", "2001:cafe:42:0::/56", ipv6, false},
-		{"wrong input", "wrong", 0, true},
+		{"dual-stack", "10.42.0.0/16,2001:cafe:22::/56", true, true, false},
+		{"dual-stack ipv6 first", "2001:cafe:22::/56,10.42.0.0/16", true, true, false},
+		{"ipv4 only", "10.42.0.0/16", true, false, false},
+		{"ipv6 only", "2001:cafe:42:0::/56", false, true, false},
+		{"empty", "", false, false, true},
+		{"wrong input", "wrong", false, false, true},
 	}
 	for _, tt := range tests {
 
@@ -37,11 +40,13 @@ func Test_findNetMode(t *testing.T) {
 			netCidrs := stringToCIDR(tt.args)
 			got, err := findNetMode(netCidrs)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("findNetMode() error = %v, wantErr %v", err, tt.wantErr)
-				return
+				t.Fatalf("got error %v, want %v", err, tt.wantErr)
 			}
-			if got != tt.want {
-				t.Errorf("findNetMode() = %v, want %v", got, tt.want)
+			if gotv4 := got.IPv4Enabled(); gotv4 != tt.wantv4 {
+				t.Errorf("got ipv4 %v, want %v", gotv4, tt.wantv4)
+			}
+			if gotv6 := got.IPv6Enabled(); gotv6 != tt.wantv6 {
+				t.Errorf("got ipv6 %v, want %v", gotv6, tt.wantv6)
 			}
 		})
 	}


### PR DESCRIPTION
#### Proposed Changes ####

Move the `ipv4` and `ipv6` constants to their own constant declaration.  This ensures that the `iota` expression for the `ipv4` constant evaluates to 0, not some arbitrary value.  (`iota` evaluates to N for the Nth constant in the constant declaration; see <https://go.dev/ref/spec#Iota>.)  This is also more idiomatic, which improves readability.

Also switch from incremental integers to bit flags, and use bitwise operators for checking.  This is more idiomatic (the integer is treated like a set of booleans), it avoids some code duplication, and it is necessary to avoid ambiguity.  Consider the following:

    const (
      ipv4 = iota
      ipv6
    )

In the above, `ipv4` would have the value 0 and `ipv6` would have the value 1.  This would make it impossible to distinguish an IPv6-only stack from a dual-stack configuration because `ipv6` would equal `ipv4 + ipv6`.  With bit flags this problem doesn't exist.

And put the integer holding the bit flags in a custom type with convenience methods to improve readability.

#### Types of Changes ####

Code readability improvements.

#### Verification ####

Unit tests.

#### Testing ####

Existing unit tests.

#### Linked Issues ####

* #12294

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
