### PR TITLE
Add anonymous-auth to flags gated on empty authorization-config value

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -208,7 +208,9 @@ func apiServer(ctx context.Context, cfg *config.Control) error {
 	argsMap["allow-privileged"] = "true"
 	argsMap["enable-bootstrap-token-auth"] = "true"
 	if authConfigFile := util.ArgValue("authorization-config", cfg.ExtraAPIArgs); authConfigFile == "" {
+		logrus.Warn("Not setting kube-apiserver 'authorization-mode' and 'anonymous-auth' flags due to user-provided 'authorization-config' file.")
 		argsMap["authorization-mode"] = strings.Join([]string{modes.ModeNode, modes.ModeRBAC}, ",")
+		argsMap["anonymous-auth"] = "false"
 	}
 	argsMap["service-account-signing-key-file"] = runtime.ServiceCurrentKey
 	argsMap["service-cluster-ip-range"] = util.JoinIPNets(cfg.ServiceIPRanges)
@@ -249,7 +251,6 @@ func apiServer(ctx context.Context, cfg *config.Control) error {
 	argsMap["requestheader-username-headers"] = "X-Remote-User"
 	argsMap["client-ca-file"] = runtime.ClientCA
 	argsMap["enable-admission-plugins"] = "NodeRestriction"
-	argsMap["anonymous-auth"] = "false"
 	argsMap["profiling"] = "false"
 	if cfg.EncryptSecrets {
 		argsMap["encryption-provider-config"] = runtime.EncryptionConfig

--- a/pkg/daemons/control/server_test.go
+++ b/pkg/daemons/control/server_test.go
@@ -112,11 +112,12 @@ func Test_UnitServer(t *testing.T) {
 
 				executor := mock.NewExecutorWithEmbeddedETCD(t)
 
-				// authorization-mode should not be set when user sets --authorization-config
+				// authorization-mode and anonymous-auth should not be set when user sets --authorization-config
 				control.ExtraAPIArgs = []string{"authorization-config=/dev/null"}
 				matchAuthArgs := mock.GM(And(
 					ContainElement(ContainSubstring("--authorization-config")),
 					Not(ContainElement(ContainSubstring("--authorization-mode"))),
+					Not(ContainElement(ContainSubstring("--anonymous-auth"))),
 				))
 
 				// leader-elect should be disabled when using kine+sqlite


### PR DESCRIPTION
#### Proposed Changes ####
Add anonymous-auth to flags gated on empty authorization-config value

Also warn if default flags are not set due to user provided config

#### Types of Changes ####

bugfix

#### Verification ####

See issue

#### Testing ####

yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12245

#### User-Facing Change ####

```release-note
```

#### Further Comments ####

