### PR TITLE
Add generation for kube-scheduler and kube-controller-manager certs

### DIFF
--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -333,16 +333,20 @@ type ControlRuntime struct {
 	KubeConfigAPIServer       string
 	KubeConfigCloudController string
 
-	ServingKubeAPICert string
-	ServingKubeAPIKey  string
-	ServingKubeletKey  string
-	ServerToken        string
-	AgentToken         string
-	APIServer          http.Handler
-	Handler            http.Handler
-	HTTPBootstrap      http.Handler
-	Tunnel             http.Handler
-	Authenticator      authenticator.Request
+	ServingKubeAPICert        string
+	ServingKubeAPIKey         string
+	ServingKubeSchedulerCert  string
+	ServingKubeSchedulerKey   string
+	ServingKubeControllerCert string
+	ServingKubeControllerKey  string
+	ServingKubeletKey         string
+	ServerToken               string
+	AgentToken                string
+	APIServer                 http.Handler
+	Handler                   http.Handler
+	HTTPBootstrap             http.Handler
+	Tunnel                    http.Handler
+	Authenticator             authenticator.Request
 
 	EgressSelectorConfig  string
 	CloudControllerConfig string

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -143,6 +143,12 @@ func CreateRuntimeCertFiles(config *config.Control) {
 	runtime.ServingKubeAPICert = filepath.Join(config.DataDir, "tls", "serving-kube-apiserver.crt")
 	runtime.ServingKubeAPIKey = filepath.Join(config.DataDir, "tls", "serving-kube-apiserver.key")
 
+	runtime.ServingKubeSchedulerCert = filepath.Join(config.DataDir, "tls", "kube-scheduler", "kube-scheduler.crt")
+	runtime.ServingKubeSchedulerKey = filepath.Join(config.DataDir, "tls", "kube-scheduler", "kube-scheduler.key")
+
+	runtime.ServingKubeControllerCert = filepath.Join(config.DataDir, "tls", "kube-controller-manager", "kube-controller-manager.crt")
+	runtime.ServingKubeControllerKey = filepath.Join(config.DataDir, "tls", "kube-controller-manager", "kube-controller-manager.key")
+
 	runtime.ClientKubeletKey = filepath.Join(config.DataDir, "tls", "client-kubelet.key")
 	runtime.ServingKubeletKey = filepath.Join(config.DataDir, "tls", "serving-kubelet.key")
 
@@ -437,6 +443,20 @@ func genServerCerts(config *config.Control) error {
 	}
 
 	if _, _, err := certutil.LoadOrGenerateKeyFile(runtime.ServingKubeletKey, regen); err != nil {
+		return err
+	}
+
+	if _, err := createClientCertKey(regen, "kube-scheduler", nil,
+		altNames, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		runtime.ServerCA, runtime.ServerCAKey,
+		runtime.ServingKubeSchedulerCert, runtime.ServingKubeSchedulerKey); err != nil {
+		return err
+	}
+
+	if _, err := createClientCertKey(regen, "kube-controller-manager", nil,
+		altNames, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		runtime.ServerCA, runtime.ServerCAKey,
+		runtime.ServingKubeControllerCert, runtime.ServingKubeControllerKey); err != nil {
 		return err
 	}
 

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -446,10 +446,8 @@ func genServerCerts(config *config.Control) error {
 		return err
 	}
 
-	altNames = &certutil.AltNames{
-		DNSNames: []string{"localhost"},
-	}
-	addSANs(altNames, []string{"127.0.0.1", "::1"})
+	altNames = &certutil.AltNames{}
+	addSANs(altNames, []string{"localhost" ,"127.0.0.1", "::1"})
 
 	if _, err := createClientCertKey(regen, "kube-scheduler", nil,
 		altNames, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},

--- a/pkg/daemons/control/deps/deps.go
+++ b/pkg/daemons/control/deps/deps.go
@@ -446,6 +446,11 @@ func genServerCerts(config *config.Control) error {
 		return err
 	}
 
+	altNames = &certutil.AltNames{
+		DNSNames: []string{"localhost"},
+	}
+	addSANs(altNames, []string{"127.0.0.1", "::1"})
+
 	if _, err := createClientCertKey(regen, "kube-scheduler", nil,
 		altNames, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		runtime.ServerCA, runtime.ServerCAKey,

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -105,6 +105,8 @@ func Server(ctx context.Context, cfg *config.Control) error {
 
 func controllerManager(ctx context.Context, cfg *config.Control) error {
 	runtime := cfg.Runtime
+	certDir := filepath.Join(cfg.DataDir, "tls", "kube-controller-manager")
+
 	argsMap := map[string]string{
 		"controllers":                      "*,tokencleaner",
 		"kubeconfig":                       runtime.KubeConfigController,
@@ -116,6 +118,7 @@ func controllerManager(ctx context.Context, cfg *config.Control) error {
 		"cluster-cidr":                     util.JoinIPNets(cfg.ClusterIPRanges),
 		"root-ca-file":                     runtime.ServerCA,
 		"profiling":                        "false",
+		"cert-dir":                         certDir,
 		"bind-address":                     cfg.Loopback(false),
 		"secure-port":                      "10257",
 		"use-service-account-credentials":  "true",
@@ -151,12 +154,15 @@ func controllerManager(ctx context.Context, cfg *config.Control) error {
 
 func scheduler(ctx context.Context, cfg *config.Control) error {
 	runtime := cfg.Runtime
+	certDir := filepath.Join(cfg.DataDir, "tls", "kube-scheduler")
+
 	argsMap := map[string]string{
 		"kubeconfig":                runtime.KubeConfigScheduler,
 		"authorization-kubeconfig":  runtime.KubeConfigScheduler,
 		"authentication-kubeconfig": runtime.KubeConfigScheduler,
 		"bind-address":              cfg.Loopback(false),
 		"secure-port":               "10259",
+		"cert-dir":                  certDir,
 		"profiling":                 "false",
 	}
 	if cfg.NoLeaderElect {

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -105,8 +105,6 @@ func Server(ctx context.Context, cfg *config.Control) error {
 
 func controllerManager(ctx context.Context, cfg *config.Control) error {
 	runtime := cfg.Runtime
-	certDir := filepath.Join(cfg.DataDir, "tls", "kube-controller-manager")
-
 	argsMap := map[string]string{
 		"controllers":                      "*,tokencleaner",
 		"kubeconfig":                       runtime.KubeConfigController,
@@ -118,7 +116,8 @@ func controllerManager(ctx context.Context, cfg *config.Control) error {
 		"cluster-cidr":                     util.JoinIPNets(cfg.ClusterIPRanges),
 		"root-ca-file":                     runtime.ServerCA,
 		"profiling":                        "false",
-		"cert-dir":                         certDir,
+		"tls-cert-file":                    runtime.ServingKubeControllerCert,
+		"tls-private-key-file":             runtime.ServingKubeControllerKey,
 		"bind-address":                     cfg.Loopback(false),
 		"secure-port":                      "10257",
 		"use-service-account-credentials":  "true",
@@ -154,15 +153,14 @@ func controllerManager(ctx context.Context, cfg *config.Control) error {
 
 func scheduler(ctx context.Context, cfg *config.Control) error {
 	runtime := cfg.Runtime
-	certDir := filepath.Join(cfg.DataDir, "tls", "kube-scheduler")
-
 	argsMap := map[string]string{
 		"kubeconfig":                runtime.KubeConfigScheduler,
 		"authorization-kubeconfig":  runtime.KubeConfigScheduler,
 		"authentication-kubeconfig": runtime.KubeConfigScheduler,
 		"bind-address":              cfg.Loopback(false),
 		"secure-port":               "10259",
-		"cert-dir":                  certDir,
+		"tls-cert-file":             runtime.ServingKubeSchedulerCert,
+		"tls-private-key-file":      runtime.ServingKubeSchedulerKey,
 		"profiling":                 "false",
 	}
 	if cfg.NoLeaderElect {

--- a/pkg/util/services/services.go
+++ b/pkg/util/services/services.go
@@ -71,11 +71,15 @@ func FilesForServices(controlConfig config.Control, services []string) (map[stri
 			fileMap[service] = []string{
 				controlConfig.Runtime.ClientControllerCert,
 				controlConfig.Runtime.ClientControllerKey,
+				controlConfig.Runtime.ServingKubeControllerCert,
+				controlConfig.Runtime.ServingKubeControllerKey,
 			}
 		case Scheduler:
 			fileMap[service] = []string{
 				controlConfig.Runtime.ClientSchedulerCert,
 				controlConfig.Runtime.ClientSchedulerKey,
+				controlConfig.Runtime.ServingKubeSchedulerCert,
+				controlConfig.Runtime.ServingKubeSchedulerKey,
 			}
 		case ETCD:
 			fileMap[service] = []string{

--- a/pkg/util/services/services_test.go
+++ b/pkg/util/services/services_test.go
@@ -38,29 +38,31 @@ func Test_UnitFilesForServices(t *testing.T) {
 				return nil
 			},
 			want: map[string][]string{
-				"admin": []string{
+				"admin": {
 					filepath.Join(serverDir, "tls", "client-admin.crt"),
 					filepath.Join(serverDir, "tls", "client-admin.key"),
 				},
-				"api-server": []string{
+				"api-server": {
 					filepath.Join(serverDir, "tls", "client-kube-apiserver.crt"),
 					filepath.Join(serverDir, "tls", "client-kube-apiserver.key"),
 					filepath.Join(serverDir, "tls", "serving-kube-apiserver.crt"),
 					filepath.Join(serverDir, "tls", "serving-kube-apiserver.key"),
 				},
-				"auth-proxy": []string{
+				"auth-proxy": {
 					filepath.Join(serverDir, "tls", "client-auth-proxy.crt"),
 					filepath.Join(serverDir, "tls", "client-auth-proxy.key"),
 				},
-				"cloud-controller": []string{
+				"cloud-controller": {
 					filepath.Join(serverDir, "tls", "client-k3s-cloud-controller.crt"),
 					filepath.Join(serverDir, "tls", "client-k3s-cloud-controller.key"),
 				},
-				"controller-manager": []string{
+				"controller-manager": {
 					filepath.Join(serverDir, "tls", "client-controller.crt"),
 					filepath.Join(serverDir, "tls", "client-controller.key"),
+					filepath.Join(serverDir, "tls", "kube-controller-manager", "kube-controller-manager.crt"),
+					filepath.Join(serverDir, "tls", "kube-controller-manager", "kube-controller-manager.key"),
 				},
-				"etcd": []string{
+				"etcd": {
 					filepath.Join(serverDir, "tls", "etcd", "client.crt"),
 					filepath.Join(serverDir, "tls", "etcd", "client.key"),
 					filepath.Join(serverDir, "tls", "etcd", "server-client.crt"),
@@ -68,19 +70,19 @@ func Test_UnitFilesForServices(t *testing.T) {
 					filepath.Join(serverDir, "tls", "etcd", "peer-server-client.crt"),
 					filepath.Join(serverDir, "tls", "etcd", "peer-server-client.key"),
 				},
-				"k3s-controller": []string{
+				"k3s-controller": {
 					filepath.Join(serverDir, "tls", "client-k3s-controller.crt"),
 					filepath.Join(serverDir, "tls", "client-k3s-controller.key"),
 					filepath.Join(agentDir, "client-k3s-controller.crt"),
 					filepath.Join(agentDir, "client-k3s-controller.key"),
 				},
-				"kube-proxy": []string{
+				"kube-proxy": {
 					filepath.Join(serverDir, "tls", "client-kube-proxy.crt"),
 					filepath.Join(serverDir, "tls", "client-kube-proxy.key"),
 					filepath.Join(agentDir, "client-kube-proxy.crt"),
 					filepath.Join(agentDir, "client-kube-proxy.key"),
 				},
-				"kubelet": []string{
+				"kubelet": {
 					filepath.Join(serverDir, "tls", "client-kubelet.key"),
 					filepath.Join(serverDir, "tls", "serving-kubelet.key"),
 					filepath.Join(agentDir, "client-kubelet.crt"),
@@ -88,11 +90,13 @@ func Test_UnitFilesForServices(t *testing.T) {
 					filepath.Join(agentDir, "serving-kubelet.crt"),
 					filepath.Join(agentDir, "serving-kubelet.key"),
 				},
-				"scheduler": []string{
+				"scheduler": {
 					filepath.Join(serverDir, "tls", "client-scheduler.crt"),
 					filepath.Join(serverDir, "tls", "client-scheduler.key"),
+					filepath.Join(serverDir, "tls", "kube-scheduler", "kube-scheduler.crt"),
+					filepath.Join(serverDir, "tls", "kube-scheduler", "kube-scheduler.key"),
 				},
-				"supervisor": []string{
+				"supervisor": {
 					filepath.Join(serverDir, "tls", "client-supervisor.crt"),
 					filepath.Join(serverDir, "tls", "client-supervisor.key"),
 				},
@@ -112,29 +116,31 @@ func Test_UnitFilesForServices(t *testing.T) {
 				return nil
 			},
 			want: map[string][]string{
-				"admin": []string{
+				"admin": {
 					filepath.Join(serverDir, "tls", "client-admin.crt"),
 					filepath.Join(serverDir, "tls", "client-admin.key"),
 				},
-				"api-server": []string{
+				"api-server": {
 					filepath.Join(serverDir, "tls", "client-kube-apiserver.crt"),
 					filepath.Join(serverDir, "tls", "client-kube-apiserver.key"),
 					filepath.Join(serverDir, "tls", "serving-kube-apiserver.crt"),
 					filepath.Join(serverDir, "tls", "serving-kube-apiserver.key"),
 				},
-				"auth-proxy": []string{
+				"auth-proxy": {
 					filepath.Join(serverDir, "tls", "client-auth-proxy.crt"),
 					filepath.Join(serverDir, "tls", "client-auth-proxy.key"),
 				},
-				"cloud-controller": []string{
+				"cloud-controller": {
 					filepath.Join(serverDir, "tls", "client-k3s-cloud-controller.crt"),
 					filepath.Join(serverDir, "tls", "client-k3s-cloud-controller.key"),
 				},
-				"controller-manager": []string{
+				"controller-manager": {
 					filepath.Join(serverDir, "tls", "client-controller.crt"),
 					filepath.Join(serverDir, "tls", "client-controller.key"),
+					filepath.Join(serverDir, "tls", "kube-controller-manager", "kube-controller-manager.crt"),
+					filepath.Join(serverDir, "tls", "kube-controller-manager", "kube-controller-manager.key"),
 				},
-				"etcd": []string{
+				"etcd": {
 					filepath.Join(serverDir, "tls", "etcd", "client.crt"),
 					filepath.Join(serverDir, "tls", "etcd", "client.key"),
 					filepath.Join(serverDir, "tls", "etcd", "server-client.crt"),
@@ -142,11 +148,13 @@ func Test_UnitFilesForServices(t *testing.T) {
 					filepath.Join(serverDir, "tls", "etcd", "peer-server-client.crt"),
 					filepath.Join(serverDir, "tls", "etcd", "peer-server-client.key"),
 				},
-				"scheduler": []string{
+				"scheduler": {
 					filepath.Join(serverDir, "tls", "client-scheduler.crt"),
 					filepath.Join(serverDir, "tls", "client-scheduler.key"),
+					filepath.Join(serverDir, "tls", "kube-scheduler", "kube-scheduler.crt"),
+					filepath.Join(serverDir, "tls", "kube-scheduler", "kube-scheduler.key"),
 				},
-				"supervisor": []string{
+				"supervisor": {
 					filepath.Join(serverDir, "tls", "client-supervisor.crt"),
 					filepath.Join(serverDir, "tls", "client-supervisor.key"),
 				},
@@ -166,19 +174,19 @@ func Test_UnitFilesForServices(t *testing.T) {
 				return nil
 			},
 			want: map[string][]string{
-				"k3s-controller": []string{
+				"k3s-controller": {
 					filepath.Join(serverDir, "tls", "client-k3s-controller.crt"),
 					filepath.Join(serverDir, "tls", "client-k3s-controller.key"),
 					filepath.Join(agentDir, "client-k3s-controller.crt"),
 					filepath.Join(agentDir, "client-k3s-controller.key"),
 				},
-				"kube-proxy": []string{
+				"kube-proxy": {
 					filepath.Join(serverDir, "tls", "client-kube-proxy.crt"),
 					filepath.Join(serverDir, "tls", "client-kube-proxy.key"),
 					filepath.Join(agentDir, "client-kube-proxy.crt"),
 					filepath.Join(agentDir, "client-kube-proxy.key"),
 				},
-				"kubelet": []string{
+				"kubelet": {
 					filepath.Join(serverDir, "tls", "client-kubelet.key"),
 					filepath.Join(serverDir, "tls", "serving-kubelet.key"),
 					filepath.Join(agentDir, "client-kubelet.crt"),
@@ -202,7 +210,7 @@ func Test_UnitFilesForServices(t *testing.T) {
 				return nil
 			},
 			want: map[string][]string{
-				"certificate-authority": []string{
+				"certificate-authority": {
 					filepath.Join(serverDir, "tls", "server-ca.crt"),
 					filepath.Join(serverDir, "tls", "server-ca.key"),
 					filepath.Join(serverDir, "tls", "client-ca.crt"),


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- Generate Serving Certs for kube-scheduler and kube-controller-manager

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

- New Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- Run k3s

- Go in the tls folder
```bash
cd /var/lib/rancher/k3s/server/tls
```

- Verify if the cert are signed by CA
```bash
root@test:/var/lib/rancher/k3s/server/tls# openssl verify -CAfile server-ca.crt $PWD/kube-controller-manager/kube-controller-manager.crt
/var/lib/rancher/k3s/server/tls/kube-controller-manager/kube-controller-manager.crt: OK

root@test:/var/lib/rancher/k3s/server/tls# openssl verify -CAfile server-ca.crt $PWD/kube-scheduler/kube-scheduler.crt
/var/lib/rancher/k3s/server/tls/kube-scheduler/kube-scheduler.crt: OK
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- https://github.com/k3s-io/k3s/issues/12172

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
