### PR TITLE
[release-1.32] Fix authorization-config/authentication-config handling

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -211,10 +211,15 @@ func apiServer(ctx context.Context, cfg *config.Control) error {
 	argsMap["cert-dir"] = certDir
 	argsMap["allow-privileged"] = "true"
 	argsMap["enable-bootstrap-token-auth"] = "true"
-	if authConfigFile := util.ArgValue("authorization-config", cfg.ExtraAPIArgs); authConfigFile == "" {
-		logrus.Warn("Not setting kube-apiserver 'authorization-mode' and 'anonymous-auth' flags due to user-provided 'authorization-config' file.")
+	if util.ArgValue("authorization-config", cfg.ExtraAPIArgs) == "" {
 		argsMap["authorization-mode"] = strings.Join([]string{modes.ModeNode, modes.ModeRBAC}, ",")
+	} else {
+		logrus.Warn("Not setting kube-apiserver 'authorization-mode' flag due to user-provided 'authorization-config' file.")
+	}
+	if util.ArgValue("authentication-config", cfg.ExtraAPIArgs) == "" {
 		argsMap["anonymous-auth"] = "false"
+	} else {
+		logrus.Warn("Not setting kube-apiserver 'anonymous-auth' flag due to user-provided 'authentication-config' file.")
 	}
 	argsMap["service-account-signing-key-file"] = runtime.ServiceCurrentKey
 	argsMap["service-cluster-ip-range"] = util.JoinIPNets(cfg.ServiceIPRanges)

--- a/pkg/daemons/control/server_test.go
+++ b/pkg/daemons/control/server_test.go
@@ -103,7 +103,7 @@ func Test_UnitServer(t *testing.T) {
 			},
 		},
 		{
-			name: "ControlPlane+Kine with authorization-config",
+			name: "ControlPlane+Kine with auth config",
 			setup: func(ctx context.Context, t *testing.T) (*config.Control, error) {
 				control, err := mockControl(ctx, t, false)
 				if err != nil {
@@ -114,10 +114,11 @@ func Test_UnitServer(t *testing.T) {
 
 				executor := mock.NewExecutorWithEmbeddedETCD(t)
 
-				// authorization-mode and anonymous-auth should not be set when user sets --authorization-config
-				control.ExtraAPIArgs = []string{"authorization-config=/dev/null"}
+				// authorization-mode and anonymous-auth should not be set when user sets --authorization-config and --authentication-config
+				control.ExtraAPIArgs = []string{"authorization-config=/dev/null", "authentication-config=/dev/null"}
 				matchAuthArgs := mock.GM(And(
 					ContainElement(ContainSubstring("--authorization-config")),
+					ContainElement(ContainSubstring("--authentication-config")),
 					Not(ContainElement(ContainSubstring("--authorization-mode"))),
 					Not(ContainElement(ContainSubstring("--anonymous-auth"))),
 				))


### PR DESCRIPTION
#### Proposed Changes ####

* Fix authorization-config/authentication-config handling.
  Need to handle authn/authz config separately. Also, the warning was being printed under the wrong condition.

#### Types of Changes ####

Bugfix

#### Verification ####

See linked issue

#### Testing ####

Yes

#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/12277


#### User-Facing Change ####
```release-note
```

#### Further Comments ####

