### PR TITLE
Convert all nightly conformance to golang test framework

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -67,14 +67,10 @@ fi
 # ---
 
 if [ "$DRONE_BUILD_EVENT" = 'cron' ]; then
-  run-go-test ./tests/docker/conformance/conformance_test.go -k3sImage="$K3S_IMAGE" -db sqlite -serial -ginkgo.v -ci
-  echo "Did go conformance sqlite serial $?"
-  run-go-test ./tests/docker/conformance/conformance_test.go -k3sImage="$K3S_IMAGE" -db etcd -serial -ginkgo.v -ci
-  echo "Did go conformance etcd serial $?"
-  test-run-sonobuoy mysql serial
-  echo "Did test-run-sonobuoy-mysqk serial $?"
-  test-run-sonobuoy postgres serial
-  echo "Did test-run-sonobuoy-postgres serial $?"
+  LABEL="SERIAL SQLITE" run-go-test ./tests/docker/conformance/conformance_test.go -k3sImage="$K3S_IMAGE" -db sqlite -serial -ginkgo.v -ci
+  LABEL="SERIAL ETCD" run-go-test ./tests/docker/conformance/conformance_test.go -k3sImage="$K3S_IMAGE" -db etcd -serial -ginkgo.v -ci
+  LABEL="SERIAL MYSQL" run-go-test ./tests/docker/conformance/conformance_test.go -k3sImage="$K3S_IMAGE" -db mysql -serial -ginkgo.v -ci
+  LABEL="SERIAL POSTGRES" run-go-test ./tests/docker/conformance/conformance_test.go -k3sImage="$K3S_IMAGE" -db postgres -serial -ginkgo.v -ci
 
   # Wait until all serial tests have finished
   delay=15
@@ -85,16 +81,10 @@ if [ "$DRONE_BUILD_EVENT" = 'cron' ]; then
   done
   )
 
-  E2E_OUTPUT=$artifacts test-run-sonobuoy parallel
-  echo "Did test-run-sonobuoy parallel $?"
-  run-go-test ./tests/docker/conformance/conformance_test.go -k3sImage="$K3S_IMAGE" -db sqlite -ginkgo.v -ci
-  echo "Did go conformance sqlite parallel $?"
-  run-go-test ./tests/docker/conformance/conformance_test.go -k3sImage="$K3S_IMAGE" -db etcd -ginkgo.v -ci
-  echo "Did go test conformance etcd parallel $?"
-  test-run-sonobuoy mysql parallel
-  echo "Did test-run-sonobuoy-mysql parallel $?"
-  test-run-sonobuoy postgres parallel
-  echo "Did test-run-sonobuoy-postgres parallel $?"
+  LABEL="PARALLEL SQLITE" run-go-test ./tests/docker/conformance/conformance_test.go -k3sImage="$K3S_IMAGE" -db sqlite -ginkgo.v -ci
+  LABEL="PARALLEL ETCD" run-go-test ./tests/docker/conformance/conformance_test.go -k3sImage="$K3S_IMAGE" -db etcd -ginkgo.v -ci
+  LABEL="PARALLEL MYSQL" run-go-test ./tests/docker/conformance/conformance_test.go -k3sImage="$K3S_IMAGE" -db mysql -ginkgo.v -ci
+  LABEL="PARALLEL POSTGRES" run-go-test ./tests/docker/conformance/conformance_test.go -k3sImage="$K3S_IMAGE" -db postgres -ginkgo.v -ci
 fi
 
 # Wait until all tests have finished

--- a/tests/docker/test-helpers
+++ b/tests/docker/test-helpers
@@ -528,12 +528,22 @@ run-go-test() {
     local delay=15
     (
       set +x
-      while [ $(count-running-tests) -ge ${MAX_CONCURRENT_TESTS:-3} ]; do
+      while [ $(count-running-tests) -ge ${MAX_CONCURRENT_TESTS:-4} ]; do
           sleep $delay
       done
     )
+    
+    if [ "$LABEL" ]; then
+        exec > >(awk "{ printf \"[\033[36m${LABEL}\033[m] %s\n\", \$0; fflush() }") \
+            2> >(awk "{ printf \"[\033[35m${LABEL}\033[m] %s\n\", \$0; fflush() }" >&2)
+    fi
 
     go test -timeout=45m -v "$@" &
+
+    # Reset LABEL
+    unset "LABEL"
+    exec >/dev/tty 2>/dev/tty
+
     pids+=($!)
 }
 export -f run-go-test


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- Convert remaining NIGHTLY (not tag) sonobuoy conformance tests to golang test framework
- Implement similar `[LABEL]` prefix to test output to match existing sonobuoy tests
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Tested manually, will need to wait for nightly cron in Drone CI
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/11714
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####
Future PR will convert the tag conformance testing found [here](https://github.com/k3s-io/k3s/blob/master/scripts/test#L60-L66) to the new golang framework, once nightly conformance has proven to be stable. 
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
