### PR TITLE
Fix sqlite-etcd migration

### DIFF
--- a/tests/e2e/scripts/setup_rootless.sh
+++ b/tests/e2e/scripts/setup_rootless.sh
@@ -54,5 +54,3 @@ systemctl daemon-reload
 loginctl enable-linger vagrant
 # We need to run this as vagrant user, because rootless k3s will be run as vagrant user
 su -c 'XDG_RUNTIME_DIR="/run/user/$UID" DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus" systemctl --user daemon-reload' vagrant
-su -c 'XDG_RUNTIME_DIR="/run/user/$UID" DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus" systemctl --user enable --now k3s-rootless' vagrant
-


### PR DESCRIPTION
#### Proposed Changes ####

* Fix sqlite-etcd migration
  Forgot to add new config to temporary kine in #12293
* Fix rootless e2e flake
  Rootless test was restarting the service unnecessarily, which caused flakiness.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

Needs a test

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12478

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
