### PR TITLE
Add .clomonitor.yml file so we can exclude the Artifact Hub check

### DIFF
--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -4,4 +4,4 @@
 # Checks exemptions
 exemptions:
   - check: artifacthub_badge # Check identifier (see https://github.com/cncf/clomonitor/blob/main/docs/checks.md#exemptions)
-    reason: "K3s is bundled Kubernetes distribution and it's installed via the k3s binary or script or shiped as part of OS and therefore, it does not appear on Artifact Hub independently."
+    reason: "K3s is bundled Kubernetes distribution and it's installed via the k3s binary or script or shipped as part of OS and therefore, it does not appear on Artifact Hub independently."

--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -1,0 +1,7 @@
+# CLOMonitor metadata file
+# This file must be located at the root of the repository
+
+# Checks exemptions
+exemptions:
+  - check: artifacthub_badge # Check identifier (see https://github.com/cncf/clomonitor/blob/main/docs/checks.md#exemptions)
+    reason: "K3s is bundled Kubernetes distribution and it's installed via the k3s binary or script or shiped as part of OS and therefore, it does not appear on Artifact Hub independently."


### PR DESCRIPTION
Add .clomonitor.yml file so we can exclude the Artifact Hub check and others in the future
https://clomonitor.io/projects/cncf/k3s

https://clomonitor.io/docs/topics/checks/#artifact-hub-badge
https://clomonitor.io/docs/topics/checks/#exemptions

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/12090

