### PR TITLE
Refac shell completion to a better command structure

### DIFF
--- a/cmd/completion/main.go
+++ b/cmd/completion/main.go
@@ -15,8 +15,8 @@ func main() {
 	app := cmds.NewApp()
 	app.Commands = []*cli.Command{
 		cmds.NewCompletionCommand(
-			completion.RunBash,
-			completion.RunZsh,
+			completion.Bash,
+			completion.Zsh,
 		),
 	}
 

--- a/cmd/completion/main.go
+++ b/cmd/completion/main.go
@@ -14,7 +14,10 @@ import (
 func main() {
 	app := cmds.NewApp()
 	app.Commands = []*cli.Command{
-		cmds.NewCompletionCommand(completion.Run),
+		cmds.NewCompletionCommand(
+			completion.RunBash,
+			completion.RunZsh,
+		),
 	}
 
 	if err := app.Run(os.Args); err != nil && !errors.Is(err, context.Canceled) {

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -87,7 +87,10 @@ func main() {
 			certCommand,
 			certCommand,
 		),
-		cmds.NewCompletionCommand(internalCLIAction(version.Program+"-completion", dataDir, os.Args)),
+		cmds.NewCompletionCommand(
+			internalCLIAction(version.Program+"-completion", dataDir, os.Args),
+			internalCLIAction(version.Program+"-completion", dataDir, os.Args),
+		),
 	}
 
 	if err := app.Run(os.Args); err != nil && !errors.Is(err, context.Canceled) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -77,7 +77,10 @@ func main() {
 			cert.Rotate,
 			cert.RotateCA,
 		),
-		cmds.NewCompletionCommand(completion.Run),
+		cmds.NewCompletionCommand(
+			completion.RunBash,
+			completion.RunZsh,
+		),
 	}
 
 	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil && !errors.Is(err, context.Canceled) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -78,8 +78,8 @@ func main() {
 			cert.RotateCA,
 		),
 		cmds.NewCompletionCommand(
-			completion.RunBash,
-			completion.RunZsh,
+			completion.Bash,
+			completion.Zsh,
 		),
 	}
 

--- a/main.go
+++ b/main.go
@@ -51,7 +51,10 @@ func main() {
 			cert.Rotate,
 			cert.RotateCA,
 		),
-		cmds.NewCompletionCommand(completion.Run),
+		cmds.NewCompletionCommand(
+			completion.RunBash,
+			completion.RunZsh,
+		),
 	}
 
 	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil && !errors.Is(err, context.Canceled) {

--- a/main.go
+++ b/main.go
@@ -52,8 +52,8 @@ func main() {
 			cert.RotateCA,
 		),
 		cmds.NewCompletionCommand(
-			completion.RunBash,
-			completion.RunZsh,
+			completion.Bash,
+			completion.Zsh,
 		),
 	}
 

--- a/pkg/cli/cmds/completion.go
+++ b/pkg/cli/cmds/completion.go
@@ -18,7 +18,7 @@ func NewCompletionCommand(bash, zsh func(*cli.Context) error) *cli.Command {
 			{
 				Name:      "bash",
 				Usage:     "Bash completion",
-				UsageText: appName + " completion bash [FLAGS]",
+				UsageText: appName + " completion bash [OPTIONS]",
 				Action:    bash,
 				Flags: []cli.Flag{
 					&installFlag,
@@ -28,7 +28,7 @@ func NewCompletionCommand(bash, zsh func(*cli.Context) error) *cli.Command {
 				Name:      "zsh",
 				Usage:     "Zsh completion",
 				Action:    zsh,
-				UsageText: appName + " completion zsh [FLAGS]",
+				UsageText: appName + " completion zsh [OPTIONS]",
 				Flags: []cli.Flag{
 					&installFlag,
 				},

--- a/pkg/cli/cmds/completion.go
+++ b/pkg/cli/cmds/completion.go
@@ -4,16 +4,34 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func NewCompletionCommand(action func(*cli.Context) error) *cli.Command {
+func NewCompletionCommand(bash, zsh func(*cli.Context) error) *cli.Command {
+	installFlag := cli.BoolFlag{
+		Name:  "i",
+		Usage: "Install source line to rc file",
+	}
+
 	return &cli.Command{
 		Name:      "completion",
 		Usage:     "Install shell completion script",
-		UsageText: appName + " completion [SHELL] (valid shells: bash, zsh)",
-		Action:    action,
-		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:  "i",
-				Usage: "Install source line to rc file",
+		UsageText: appName + " completion [COMMAND]",
+		Subcommands: []*cli.Command{
+			{
+				Name:      "bash",
+				Usage:     "Bash completion",
+				UsageText: appName + " completion bash [FLAGS]",
+				Action:    bash,
+				Flags: []cli.Flag{
+					&installFlag,
+				},
+			},
+			{
+				Name:      "zsh",
+				Usage:     "Zsh completion",
+				Action:    zsh,
+				UsageText: appName + " completion zsh [FLAGS]",
+				Flags: []cli.Flag{
+					&installFlag,
+				},
 			},
 		},
 	}

--- a/pkg/cli/completion/completion.go
+++ b/pkg/cli/completion/completion.go
@@ -53,7 +53,7 @@ _cli_zsh_autocomplete() {
 compdef _cli_zsh_autocomplete %[1]s`
 )
 
-func RunBash(ctx *cli.Context) error {
+func Bash(ctx *cli.Context) error {
 	completetionScript, err := genCompletionScript(bashScript)
 	if err != nil {
 		return err
@@ -65,7 +65,7 @@ func RunBash(ctx *cli.Context) error {
 	return nil
 }
 
-func RunZsh(ctx *cli.Context) error {
+func Zsh(ctx *cli.Context) error {
 	completetionScript, err := genCompletionScript(zshScript)
 	if err != nil {
 		return err

--- a/pkg/cli/completion/completion.go
+++ b/pkg/cli/completion/completion.go
@@ -9,26 +9,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func Run(ctx *cli.Context) error {
-	if ctx.NArg() < 1 {
-		return fmt.Errorf("must provide a valid SHELL argument")
-	}
-	shell := ctx.Args().Get(0)
-	completetionScript, err := genCompletionScript(shell)
-	if err != nil {
-		return err
-	}
-	if ctx.Bool("i") {
-		return writeToRC(shell)
-	}
-	fmt.Println(completetionScript)
-	return nil
-}
-
-func genCompletionScript(shell string) (string, error) {
-	var completionScript string
-	if shell == "bash" {
-		completionScript = fmt.Sprintf(`#!/usr/bin/env bash
+var (
+	bashScript = `#!/usr/bin/env bash
 _cli_bash_autocomplete() {
 if [[ "${COMP_WORDS[0]}" != "source" ]]; then
 	local cur opts base
@@ -45,9 +27,9 @@ fi
 }
 
 complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete %s
-`, version.Program)
-	} else if shell == "zsh" {
-		completionScript = fmt.Sprintf(`#compdef %[1]s
+`
+
+	zshScript = `#compdef %[1]s
 _cli_zsh_autocomplete() {
 
 	local -a opts
@@ -68,36 +50,56 @@ _cli_zsh_autocomplete() {
 	return
 }
 
-compdef _cli_zsh_autocomplete %[1]s`, version.Program)
-	} else {
-		return "", fmt.Errorf("unknown shell: %s", shell)
-	}
+compdef _cli_zsh_autocomplete %[1]s`
+)
 
+func RunBash(ctx *cli.Context) error {
+	completetionScript, err := genCompletionScript(bashScript)
+	if err != nil {
+		return err
+	}
+	if ctx.Bool("i") {
+		return writeToRC("bash", "/.bashrc")
+	}
+	fmt.Println(completetionScript)
+	return nil
+}
+
+func RunZsh(ctx *cli.Context) error {
+	completetionScript, err := genCompletionScript(zshScript)
+	if err != nil {
+		return err
+	}
+	if ctx.Bool("i") {
+		return writeToRC("zsh", "/.zshrc")
+	}
+	fmt.Println(completetionScript)
+	return nil
+}
+
+func genCompletionScript(script string) (string, error) {
+	completionScript := fmt.Sprintf(script, version.Program)
 	return completionScript, nil
 }
 
-func writeToRC(shell string) error {
-	rcFileName := ""
-	if shell == "bash" {
-		rcFileName = "/.bashrc"
-	} else if shell == "zsh" {
-		rcFileName = "/.zshrc"
-	}
-
+func writeToRC(shell, envFileName string) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil
 	}
-	rcFileName = home + rcFileName
-	f, err := os.OpenFile(rcFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+
+	envFileName = home + envFileName
+	f, err := os.OpenFile(envFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
+
 	defer f.Close()
-	bashEntry := fmt.Sprintf("# >> %[1]s command completion (start)\n. <(%[1]s completion %s)\n# >> %[1]s command completion (end)", version.Program, shell)
-	if _, err := f.WriteString(bashEntry); err != nil {
+	shellEntry := fmt.Sprintf("# >> %[1]s command completion (start)\n. <(%[1]s completion %s)\n# >> %[1]s command completion (end)", version.Program, shell)
+	if _, err := f.WriteString(shellEntry); err != nil {
 		return err
 	}
-	fmt.Printf("Autocomplete for %s added to: %s\n", shell, rcFileName)
+
+	fmt.Printf("Autocomplete for %s added to: %s\n", shell, envFileName)
 	return nil
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- better structure for shell completion command, this new structure for this command is to avoid unnecessary problems specially related to verify input from the user
```bash
k3s completion --help
```
```bash
k3s completion bash --help
```
```bash
k3s completion zsh --help
```

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

- Fix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- you can see that the two of them are separated commands by
```bash
k3s completion --help
```

- the verification to test if it's working as expected is
```bash
k3s completion bash -i
```

- and then
```bash
source ~/.bashrc
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- the issue that came to that was from rke2, since rke2 uses the same structure for shell completion as k3s
https://github.com/rancher/rke2/issues/8495

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
k3s completion shell command will now be separate to specific subcommands for bash and zsh
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
