### PR TITLE
[Release-1.32] Refac shell completion to a better command structure

### DIFF
--- a/cmd/completion/main.go
+++ b/cmd/completion/main.go
@@ -14,7 +14,10 @@ import (
 func main() {
 	app := cmds.NewApp()
 	app.Commands = []*cli.Command{
-		cmds.NewCompletionCommand(completion.Run),
+		cmds.NewCompletionCommand(
+			completion.Bash,
+			completion.Zsh,
+		),
 	}
 
 	if err := app.Run(os.Args); err != nil && !errors.Is(err, context.Canceled) {

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -87,7 +87,10 @@ func main() {
 			certCommand,
 			certCommand,
 		),
-		cmds.NewCompletionCommand(internalCLIAction(version.Program+"-completion", dataDir, os.Args)),
+		cmds.NewCompletionCommand(
+			internalCLIAction(version.Program+"-completion", dataDir, os.Args),
+			internalCLIAction(version.Program+"-completion", dataDir, os.Args),
+		),
 	}
 
 	if err := app.Run(os.Args); err != nil && !errors.Is(err, context.Canceled) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -77,7 +77,10 @@ func main() {
 			cert.Rotate,
 			cert.RotateCA,
 		),
-		cmds.NewCompletionCommand(completion.Run),
+		cmds.NewCompletionCommand(
+			completion.Bash,
+			completion.Zsh,
+		),
 	}
 
 	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil && !errors.Is(err, context.Canceled) {

--- a/main.go
+++ b/main.go
@@ -51,7 +51,10 @@ func main() {
 			cert.Rotate,
 			cert.RotateCA,
 		),
-		cmds.NewCompletionCommand(completion.Run),
+		cmds.NewCompletionCommand(
+			completion.Bash,
+			completion.Zsh,
+		),
 	}
 
 	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil && !errors.Is(err, context.Canceled) {

--- a/pkg/cli/cmds/completion.go
+++ b/pkg/cli/cmds/completion.go
@@ -4,16 +4,34 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func NewCompletionCommand(action func(*cli.Context) error) *cli.Command {
+func NewCompletionCommand(bash, zsh func(*cli.Context) error) *cli.Command {
+	installFlag := cli.BoolFlag{
+		Name:  "i",
+		Usage: "Install source line to rc file",
+	}
+
 	return &cli.Command{
 		Name:      "completion",
 		Usage:     "Install shell completion script",
-		UsageText: appName + " completion [SHELL] (valid shells: bash, zsh)",
-		Action:    action,
-		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:  "i",
-				Usage: "Install source line to rc file",
+		UsageText: appName + " completion [COMMAND]",
+		Subcommands: []*cli.Command{
+			{
+				Name:      "bash",
+				Usage:     "Bash completion",
+				UsageText: appName + " completion bash [OPTIONS]",
+				Action:    bash,
+				Flags: []cli.Flag{
+					&installFlag,
+				},
+			},
+			{
+				Name:      "zsh",
+				Usage:     "Zsh completion",
+				Action:    zsh,
+				UsageText: appName + " completion zsh [OPTIONS]",
+				Flags: []cli.Flag{
+					&installFlag,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- better structure for shell completion command, this new structure for this command is to avoid unnecessary problems specially related to verify input from the user
```bash
k3s completion --help
```
```bash
k3s completion bash --help
```
```bash
k3s completion zsh --help
```

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

- Fix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

- you can see that the two of them are separated commands by
```bash
k3s completion --help
```

- the verification to test if it's working as expected is
```bash
k3s completion bash -i
```

- and then
```bash
source ~/.bashrc
```

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
k3s completion shell command will now be separate to specific subcommands for bash and zsh
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
