### PR TITLE
Fix completion command in e2e

### DIFF
--- a/tests/e2e/secretsencryption/Vagrantfile
+++ b/tests/e2e/secretsencryption/Vagrantfile
@@ -44,7 +44,7 @@ def provision(vm, role, role_num, node_num)
   if vm.box.to_s.include?("microos")
     vm.provision 'k3s-reload', type: 'reload', run: 'once'
   end
-  vm.provision 'k3s-autocomplete', type: 'shell', inline: "k3s completion -i bash"
+  vm.provision 'k3s-autocomplete', type: 'shell', inline: "k3s completion bash -i"
 end
 
 Vagrant.configure("2") do |config|


### PR DESCRIPTION
#### Proposed Changes ####

Current syntax is incorrect, and while it doesn't break the test it is throwing an error in the logs:

```console
  ==> agent-0: Enabling K3s autocompletion ...
      agent-0: Incorrect Usage: flag provided but not defined: -i
      agent-0: 
      agent-0: NAME:
      agent-0:    k3s completion - Install shell completion script
      agent-0: 
      agent-0: USAGE:
      agent-0:    k3s completion [COMMAND]
      agent-0: 
      agent-0: COMMANDS:
      agent-0:    bash     Bash completion
      agent-0:    zsh      Zsh completion
      agent-0:    help, h  Shows a list of commands or help for one command
      agent-0: 
      agent-0: OPTIONS:
      agent-0:    --help, -h  show help
      agent-0: time="2025-07-31T22:21:55Z" level=fatal msg="Error: flag provided but not defined: -i"
      agent-0: time="2025-07-31T22:21:55Z" level=fatal msg="Error: flag provided but not defined: -i"
```

#### Types of Changes ####

test

#### Verification ####

check CI logs

#### Testing ####

yes

#### Linked Issues ####

n/a

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
