### PR TITLE
Fix --docker with --container-runtime-endpoint

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -731,14 +731,14 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		nodeConfig.AgentConfig.ImageServiceSocket = nodeConfig.ImageServiceEndpoint
 	}
 
-	if nodeConfig.ContainerRuntimeEndpoint != "" {
-		nodeConfig.AgentConfig.RuntimeSocket = nodeConfig.ContainerRuntimeEndpoint
-	} else if nodeConfig.Docker {
+	if nodeConfig.Docker {
 		if err := applyCRIDockerdOSSpecificConfig(nodeConfig); err != nil {
 			return nil, err
 		}
 		nodeConfig.AgentConfig.CNIPlugin = true
 		nodeConfig.AgentConfig.RuntimeSocket = nodeConfig.CRIDockerd.Address
+	} else if nodeConfig.ContainerRuntimeEndpoint != "" {
+		nodeConfig.AgentConfig.RuntimeSocket = nodeConfig.ContainerRuntimeEndpoint
 	} else {
 		if err := applyContainerdOSSpecificConfig(nodeConfig); err != nil {
 			return nil, err


### PR DESCRIPTION
#### Proposed Changes ####

Fix `--docker` with `--container-runtime-endpoint`

The container runtime endpoint value is passed into cri-dockerd as the docker socket address, so we need to check for --docker BEFORE checking for non-nil --container-runtime-endpoint.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

No.

`pkg/agent/config/get()` is an unholy 400 line behemoth that handles both retrieving config from the server, and merging it with cli flags. We should break it out into separate functions that can be tested.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12700

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
