### PR TITLE
[Release-1.32] - Bump metrics-server to v0.8.0

### DIFF
--- a/manifests/metrics-server/metrics-server-deployment.yaml
+++ b/manifests/metrics-server/metrics-server-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: "%{SYSTEM_DEFAULT_REGISTRY}%rancher/mirrored-metrics-server:v0.7.2"
+        image: "%{SYSTEM_DEFAULT_REGISTRY}%rancher/mirrored-metrics-server:v0.8.0"
         args:
         - --cert-dir=/tmp
         - --secure-port=10250

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -4,5 +4,5 @@ docker.io/rancher/local-path-provisioner:v0.0.31
 docker.io/rancher/mirrored-coredns-coredns:1.12.3
 docker.io/rancher/mirrored-library-busybox:1.36.1
 docker.io/rancher/mirrored-library-traefik:3.3.6
-docker.io/rancher/mirrored-metrics-server:v0.7.2
+docker.io/rancher/mirrored-metrics-server:v0.8.0
 docker.io/rancher/mirrored-pause:3.6


### PR DESCRIPTION
Backport: https://github.com/k3s-io/k3s/pull/12726
Issue: https://github.com/k3s-io/k3s/issues/12739