### PR TITLE
Wire cri-dockerd `--log-level=debug` up to k3s `--debug` flag

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -660,6 +660,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	nodeConfig.Containerd.Config = filepath.Join(envInfo.DataDir, "agent", "etc", "containerd", "config.toml")
 	nodeConfig.Containerd.Root = filepath.Join(envInfo.DataDir, "agent", "containerd")
 	nodeConfig.CRIDockerd.Root = filepath.Join(envInfo.DataDir, "agent", "cri-dockerd")
+	nodeConfig.CRIDockerd.Debug = envInfo.Debug
 	nodeConfig.Containerd.Opt = filepath.Join(envInfo.DataDir, "agent", "containerd")
 	nodeConfig.Containerd.Log = filepath.Join(envInfo.DataDir, "agent", "containerd", "containerd.log")
 	nodeConfig.Containerd.Registry = filepath.Join(envInfo.DataDir, "agent", "etc", "containerd", "certs.d")

--- a/pkg/agent/cridockerd/cridockerd.go
+++ b/pkg/agent/cridockerd/cridockerd.go
@@ -57,6 +57,10 @@ func getDockerCRIArgs(cfg *config.Node) []string {
 		"streaming-bind-addr":        "127.0.0.1:10010",
 	}
 
+	if cfg.CRIDockerd.Debug {
+		argsMap["log-level"] = "debug"
+	}
+
 	if dualNode, _ := utilsnet.IsDualStackIPs(cfg.AgentConfig.NodeIPs); dualNode {
 		argsMap["ipv6-dual-stack"] = "true"
 	}

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -101,6 +101,7 @@ type Containerd struct {
 type CRIDockerd struct {
 	Address string
 	Root    string
+	Debug   bool
 }
 
 type Agent struct {


### PR DESCRIPTION
#### Proposed Changes ####

Wire cri-dockerd `--log-level=debug` up to k3s `--debug` flag

Fixes issue caused by cri-dockerd reseting the logrus log-level during startup.

#### Types of Changes ####

Bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12749

#### User-Facing Change ####
```release-note
```

#### Further Comments ####