### PR TITLE
 Retry CRD creation in case of conflict

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -107,7 +107,7 @@ func startOnAPIServerReady(ctx context.Context, config *Config) {
 func runControllers(ctx context.Context, config *Config) error {
 	controlConfig := &config.ControlConfig
 
-	sc, err := NewContext(ctx, config, true)
+	sc, err := NewContext(ctx, config)
 	if err != nil {
 		return pkgerrors.WithMessage(err, "failed to create new server context")
 	}
@@ -220,7 +220,7 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 		helmchart.DefaultJobImage = config.ControlConfig.SystemDefaultRegistry + "/" + helmchart.DefaultJobImage
 	}
 
-	if !config.ControlConfig.DisableHelmController {
+	if sc.Helm != nil {
 		restConfig, err := util.GetRESTConfig(config.ControlConfig.Runtime.KubeConfigSupervisor)
 		if err != nil {
 			return err


### PR DESCRIPTION
#### Proposed Changes ####

 Retry CRD creation in case of conflict

Also cleans up some of the `server.Context` factory creation stuff to eliminate unused code paths and avoid registering the Helm controller when helm is disabled.

As of fe465cc83253fbc9139418f8a2a6254d24af1888 we no longer call `NewContext` outside `pkg/server`, so the `isServer` bool flag to use the supervisor kubeconfig and create an event recorder is unnecessary.

#### Types of Changes ####

bugfix
tech debt

#### Verification ####

See linked issue - this is difficult to reproduce due to tight timing; multiple control-plane nodes need to be at the exact same spot in the startup sequence at the exact same time.

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12813

#### User-Facing Change ####
```release-note
```

#### Further Comments ####