### PR TITLE
Wire up kine metrics

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
 	"github.com/k3s-io/k3s/pkg/datadir"
 	"github.com/k3s-io/k3s/pkg/etcd"
+	"github.com/k3s-io/k3s/pkg/metrics"
 	k3smetrics "github.com/k3s-io/k3s/pkg/metrics"
 	"github.com/k3s-io/k3s/pkg/proctitle"
 	"github.com/k3s-io/k3s/pkg/profile"
@@ -136,6 +137,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.Datastore.BackendTLSConfig.CertFile = cfg.DatastoreCertFile
 	serverConfig.ControlConfig.Datastore.BackendTLSConfig.KeyFile = cfg.DatastoreKeyFile
 	serverConfig.ControlConfig.Datastore.Endpoint = cfg.DatastoreEndpoint
+	serverConfig.ControlConfig.Datastore.MetricsRegisterer = metrics.DefaultRegisterer
 	serverConfig.ControlConfig.DataDir = cfg.DataDir
 	serverConfig.ControlConfig.KubeConfigOutput = cfg.KubeConfigOutput
 	serverConfig.ControlConfig.KubeConfigMode = cfg.KubeConfigMode


### PR DESCRIPTION
#### Proposed Changes ####

Wire up kine metrics

Set metrics registrar in kine datastore config so that metrics are registered to the correct registry.

#### Types of Changes ####

enhancement

#### Verification ####

`kubectl get --raw /metrics | grep kine`

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12595


#### User-Facing Change ####
```release-note
```

#### Further Comments ####
