### PR TITLE
Fix etcd join timeout handling

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -626,7 +626,7 @@ func (e *ETCD) join(ctx context.Context, clientAccessInfo *clientaccess.Info) er
 	if add {
 		logrus.Infof("Adding member %s=%s to etcd cluster %v", e.name, e.peerURL(), cluster)
 		if _, err = client.MemberAddAsLearner(clientCtx, []string{e.peerURL()}); err != nil {
-			if errors.Is(err, context.Canceled) {
+			if errors.Is(err, context.DeadlineExceeded) {
 				return ErrJoinTimeout
 			}
 			return err


### PR DESCRIPTION
#### Proposed Changes ####

Fix for incorrect error used in
* https://github.com/k3s-io/k3s/pull/12815

Error is deadline exceeded, not cancelled.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

Yes, error was seen in CI tests

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12794

#### User-Facing Change ####
```release-note
```

#### Further Comments ####