### PR TITLE
Fix install script raspi cmdline message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1114,7 +1114,7 @@ has_working_xtables() {
 # --- startup systemd or openrc service ---
 service_enable_and_start() {
     if ! grep -qs memory /sys/fs/cgroup/cgroup.controllers && ! [ "$(grep -s memory /proc/cgroups | while read -r n n n enabled; do echo $enabled; done)" = "1" ]; then
-        info 'Failed to find memory cgroup, you may need to add "cgroup_memory=1 cgroup_enable=memory" to your linux cmdline (/boot/cmdline.txt on a Raspberry Pi)'
+        info 'Failed to find memory cgroup, you may need to add "cgroup_memory=1 cgroup_enable=memory" to your linux cmdline (/boot/firmware/cmdline.txt on a Raspberry Pi)'
     fi
 
     [ "${INSTALL_K3S_SKIP_ENABLE}" = true ] && return


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Updated the error message for memory cgroup detection to reflect the correct location of the `cmdline.txt` file on Raspberry Pi systems running Raspberry Pi OS Bookworm or later (released in 2023). The file path has changed from `/boot/cmdline.txt` to `/boot/firmware/cmdline.txt` due to the new firmware structure introduced in Raspberry Pi OS Bookworm.

#### Types of Changes ####
Docs

#### Verification ####
The change can be verified by:
1. Running k3s on a Raspberry Pi with Raspberry Pi OS Bookworm or later.
2. Triggering the memory cgroup detection error (e.g., by not having `cgroup_memory=1 cgroup_enable=memory` in the kernel command line).
3. Confirming that the error message now correctly references `/boot/firmware/cmdline.txt` instead of `/boot/cmdline.txt`.
4. Ensuring the updated path aligns with the Raspberry Pi documentation for the `/boot/firmware/` directory.

#### Testing ####
This change is a minor text update to an error message and does not affect the core functionality of k3s. Existing integration tests for cgroup detection should suffice, as the change only modifies the displayed file path. No new tests are required, but manual verification on a Raspberry Pi running Bookworm can confirm the updated message appears as expected.

#### Linked Issues ####
None

#### User-Facing Change ####
```release-note
Updated error message for memory cgroup detection to reference the correct `cmdline.txt` location (`/boot/firmware/cmdline.txt`) on Raspberry Pi systems running Raspberry Pi OS Bookworm or later.
```

#### Further Comments ####
This change corrects an outdated file path in the error message, addressing confusion for Raspberry Pi users on Bookworm or later, where boot configuration files moved to `/boot/firmware/`. The fix is straightforward, aligning the error message with the current Raspberry Pi OS filesystem. No alternative approaches were considered, as this directly resolves the issue.
