### PR TITLE
create policy hint only when all variables defined

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -612,17 +612,18 @@ setup_selinux() {
         package_installer=dnf
     fi
 
-    policy_hint="please install:
-    ${package_installer} install -y container-selinux
-    ${package_installer} install -y https://${rpm_site}/k3s/${rpm_channel}/common/${rpm_site_infix}/noarch/${available_version}
-"
-
     if [ "$INSTALL_K3S_SKIP_SELINUX_RPM" = true ] || can_skip_download_selinux || [ ! -d /usr/share/selinux ]; then
         info "Skipping installation of SELinux RPM"
         return
     fi
 
     get_k3s_selinux_version
+
+    policy_hint="please install:
+    ${package_installer} install -y container-selinux
+    ${package_installer} install -y https://${rpm_site}/k3s/${rpm_channel}/common/${rpm_site_infix}/noarch/${available_version}
+"
+
     install_selinux_rpm ${rpm_site} ${rpm_channel} ${rpm_target} ${rpm_site_infix}
 
     policy_error=fatal

--- a/install.sh.sha256sum
+++ b/install.sh.sha256sum
@@ -1,1 +1,1 @@
-08ffd92c47a886edd56ce97734f3d67e7f6115f07295dcdcdc6df7ea2c0bee1a  install.sh
+8598e002e61d658fed7b7542fc6d2c66d8da6eae69e088830105d2ee1ffb6d91  install.sh


### PR DESCRIPTION
#### Proposed Changes ####

Print a useful error message if latest k3-selinux version not discoverable.

If `setup_selinux()` fails to get a k3s-selinux version from online repo, it sets a default version  in `available_verfsion` instead.  This version is used in the string `policy_hint` to tell the user to manually install the policy rpm in a warning.  Because this string is initialized before calling `setup_selinux`, the rpm filename is not printed. 

This change moves the `policy_hint` initialization to after `setup_selinux()`.

#### Types of Changes ####

Bugfix

#### Verification ####


replace https://api.github.com/repos/k3s-io/k3s-selinux/releases/latest to http server that returns an empty document

#### Testing ####

Manual testing. I'm not aware of any existing installer test infrastructure in this project to extend.