### PR TITLE
Add opencontainers/runc pin to v1.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ replace (
 	github.com/google/cadvisor => github.com/k3s-io/cadvisor v0.52.1
 	github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.12.0
 	github.com/open-policy-agent/opa => github.com/open-policy-agent/opa v0.59.0 // github.com/Microsoft/hcsshim using bad version v0.42.2
+	github.com/opencontainers/runc => github.com/opencontainers/runc v1.3.1
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.11.1
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/common => github.com/prometheus/common v0.62.0


### PR DESCRIPTION
#### Proposed Changes ####

Add opencontainers/runc pin

We no longer depend on this as a module any more, but need to keep it pinned for build-time version selection.

#### Types of Changes ####

version bump/pin

#### Verification ####

check runc version

#### Testing ####

#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/12865

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
