### PR TITLE
Fix netpol fatal error when changing node IP

### DIFF
--- a/pkg/agent/netpol/netpol.go
+++ b/pkg/agent/netpol/netpol.go
@@ -29,6 +29,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/util"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	v1core "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -68,13 +69,24 @@ func Run(ctx context.Context, nodeConfig *config.Node) error {
 	}
 
 	// kube-router netpol requires addresses to be available in the node object.
-	// Wait until the uninitialized taint has been removed, at which point the addresses should be set.
-	// TODO: Replace with non-deprecated PollUntilContextTimeout when our and Kubernetes code migrate to it
-	if err := wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+	// Wait until the ready condition is updated and the uninitialized taint has
+	// been removed, at which point the addresses should be synced.
+	startTime := time.Now().Truncate(time.Second)
+	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, util.DefaultAPIServerReadyTimeout, true, func(ctx context.Context) (bool, error) {
+		var readyTime metav1.Time
 		// Get the node object
 		node, err := client.CoreV1().Nodes().Get(ctx, nodeConfig.AgentConfig.NodeName, metav1.GetOptions{})
 		if err != nil {
 			logrus.Infof("Network policy controller waiting to get Node %s: %v", nodeConfig.AgentConfig.NodeName, err)
+			return false, nil
+		}
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == v1.NodeReady && cond.Status == v1.ConditionTrue {
+				readyTime = cond.LastHeartbeatTime
+			}
+		}
+		if readyTime.Time.Before(startTime) {
+			logrus.Debugf("Waiting for Ready condition to be updated for network policy controller")
 			return false, nil
 		}
 		// Check for the taint that should be removed by cloud-provider when the node has been initialized.


### PR DESCRIPTION
#### Proposed Changes ####

Fix netpol fatal error when changing node IP

Wait for updated ready condition before starting netpol controller, to ensure that node IPs have been updated following a restart. The current checks only ensure that the taint is removed, which works for the initial join - but does not handle changing node IPs on restarts.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12844

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
