### PR TITLE
Fix etcd member promotion

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -476,12 +476,9 @@ steps:
   # Cleanup VMs that are older than 2h. Happens if a previous test panics or is canceled
   - tests/e2e/scripts/cleanup_vms.sh
   - tests/e2e/scripts/drone_registries.sh
-   # Stagger the launch of this test with the parallel splitserver test
-   # to prevent conflicts over libvirt network interfaces
   - |
     cd tests/e2e/validatecluster
     ../scripts/cleanup_vms.sh 'validatecluster_([0-9]+)_(server|agent)'
-    sleep 15
     go test -v -timeout=45m ./validatecluster_test.go -ci -local
     cp ./coverage.out /tmp/artifacts/validate-coverage.out
   volumes:
@@ -510,12 +507,37 @@ steps:
   - |
     cd tests/e2e/splitserver
     ../scripts/cleanup_vms.sh 'splitserver_([0-9]+)'
+    # Stagger the launch of this test with the validatecluster test
+    # to prevent conflicts over libvirt network interfaces
+    sleep 15
     go test -v -timeout=30m ./splitserver_test.go -ci -local
     cp ./coverage.out /tmp/artifacts/split-coverage.out
+  volumes:
+  - name: libvirt
+    path: /var/run/libvirt/
+  - name: docker
+    path: /var/run/docker.sock
+  - name: cache
+    path: /tmp/artifacts
+
+- name: test-e2e-upgradecluster
+  depends_on:
+    - build-e2e-image
+  image: test-e2e
+  pull: never
+  resources:
+    cpu: 6000
+    memory: 10Gi
+  environment:
+    E2E_REGISTRY: 'true'
+    E2E_GOCOVER: 'true'
+  commands:
+  - mkdir -p dist/artifacts
+  - cp /tmp/artifacts/* dist/artifacts/
+  - tests/e2e/scripts/drone_registries.sh
   - |
     if [ "$DRONE_BUILD_EVENT" = "pull_request" ]; then
-      cd ../upgradecluster
-      ../scripts/cleanup_vms.sh 'upgradecluster_([0-9]+)_(server|agent)'
+      cd tests/e2e/upgradecluster
       # Convert release-1.XX branch to v1.XX channel
       if [ "$DRONE_BRANCH" = "master" ]; then
         UPGRADE_CHANNEL="latest"
@@ -526,10 +548,13 @@ steps:
           UPGRADE_CHANNEL="latest"
         fi
       fi
+      ../scripts/cleanup_vms.sh 'upgradecluster_([0-9]+)_(server|agent)'
+      # Stagger the launch of this test with the splitserver test
+      # to prevent conflicts over libvirt network interfaces
+      sleep 30
       E2E_RELEASE_CHANNEL=$UPGRADE_CHANNEL go test -v -timeout=45m ./upgradecluster_test.go  -ci -local -ginkgo.v
       cp ./coverage.out /tmp/artifacts/upgrade-coverage.out
     fi
-  
   volumes:
   - name: libvirt
     path: /var/run/libvirt/
@@ -537,11 +562,11 @@ steps:
     path: /var/run/docker.sock
   - name: cache
     path: /tmp/artifacts
-
 - name: upload to codecov
   depends_on:
     - test-e2e-validatecluster
     - test-e2e-splitserver
+    - test-e2e-upgradecluster
   image: robertstettner/drone-codecov
   settings:
     token: 
@@ -555,7 +580,6 @@ steps:
   when:
     event:
     - push
-
   volumes:
   - name: cache
     path: /tmp/artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ __pycache__
 /tests/.tox/
 /tests/.vscode
 /tests/**/*log.txt
+/tests/**/vagrant.log
 /sonobuoy-output
 *.tmp
 config/local.tfvars

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -38,7 +38,8 @@ FROM vagrantlibvirt/vagrant-libvirt:sha-a94ce0d AS test-e2e
 RUN apt-get update && apt-get install -y docker.io wget
 
 ENV VAGRANT_DISABLE_STRICT_DEPENDENCY_ENFORCEMENT=1
-RUN vagrant plugin install vagrant-k3s vagrant-reload vagrant-scp
+RUN vagrant plugin install vagrant-k3s --plugin-version 0.4.0
+RUN vagrant plugin install vagrant-reload vagrant-scp
 
 # Workaround for older vagrant-libvirt image and new vagrant infra wesbites
 # See https://github.com/hashicorp/vagrant/issues/13571 and

--- a/pkg/util/condition.go
+++ b/pkg/util/condition.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/k3s-io/k3s/pkg/daemons/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// GetNodeCondition extracts the provided condition from the given status and returns that.
+// Returns nil and -1 if the condition is not present, and the index of the located condition.
+func GetNodeCondition(status *corev1.NodeStatus, conditionType corev1.NodeConditionType) (int, *corev1.NodeCondition) {
+	if status == nil {
+		return -1, nil
+	}
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == conditionType {
+			return i, &status.Conditions[i]
+		}
+	}
+	return -1, nil
+}
+
+// SetNodeCondition updates specific node condition with patch operation.
+func SetNodeCondition(core config.CoreFactory, nodeName string, condition corev1.NodeCondition) error {
+	if core == nil {
+		return ErrCoreNotReady
+	}
+	condition.LastHeartbeatTime = metav1.NewTime(time.Now())
+	patch, err := json.Marshal(map[string]interface{}{
+		"status": map[string]interface{}{
+			"conditions": []corev1.NodeCondition{condition},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	_, err = core.Core().V1().Node().Patch(nodeName, types.StrategicMergePatchType, patch, "status")
+	return err
+}

--- a/tests/docker/autoimport/autoimport_test.go
+++ b/tests/docker/autoimport/autoimport_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tc.ProvisionServers(1)).To(Succeed())
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, tc.KubeconfigFile)
+				return tests.CheckDefaultDeployments(tc.KubeconfigFile)
 			}, "120s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.NodesReady(tc.KubeconfigFile, tc.GetNodeNames())

--- a/tests/docker/basics/basics_test.go
+++ b/tests/docker/basics/basics_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Basic Tests", Ordered, func() {
 			Expect(config.ProvisionServers(1)).To(Succeed())
 			Expect(config.ProvisionAgents(1)).To(Succeed())
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDefaultDeployments(config.KubeconfigFile)
 			}, "180s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())

--- a/tests/docker/bootstraptoken/bootstraptoken_test.go
+++ b/tests/docker/bootstraptoken/bootstraptoken_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Boostrap Token Tests", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(config.ProvisionServers(1)).To(Succeed())
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDefaultDeployments(config.KubeconfigFile)
 			}, "120s", "5s").Should(Succeed())
 		})
 	})

--- a/tests/docker/cacerts/cacerts_test.go
+++ b/tests/docker/cacerts/cacerts_test.go
@@ -65,7 +65,7 @@ var _ = Describe("CA Certs Tests", Ordered, func() {
 			Expect(config.ProvisionServers(1)).To(Succeed())
 			Expect(config.ProvisionAgents(1)).To(Succeed())
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDefaultDeployments(config.KubeconfigFile)
 			}, "120s", "5s").Should(Succeed())
 		})
 	})

--- a/tests/docker/etcd/etcd_test.go
+++ b/tests/docker/etcd/etcd_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Etcd Tests", Ordered, func() {
 		It("should provision servers", func() {
 			Expect(config.ProvisionServers(3)).To(Succeed())
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDefaultDeployments(config.KubeconfigFile)
 			}, "120s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())
@@ -59,7 +59,7 @@ var _ = Describe("Etcd Tests", Ordered, func() {
 			Expect(config.ProvisionServers(5)).To(Succeed())
 			Expect(config.ProvisionAgents(1)).To(Succeed())
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDefaultDeployments(config.KubeconfigFile)
 			}, "90s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())

--- a/tests/docker/hardened/hardened_test.go
+++ b/tests/docker/hardened/hardened_test.go
@@ -68,7 +68,7 @@ kubelet-arg:
 			config.SkipStart = false
 			Expect(config.ProvisionAgents(1)).To(Succeed())
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDefaultDeployments(config.KubeconfigFile)
 			}, "120s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())

--- a/tests/docker/lazypull/lazypull_test.go
+++ b/tests/docker/lazypull/lazypull_test.go
@@ -33,7 +33,7 @@ var _ = Describe("LazyPull Tests", Ordered, func() {
 			config.ServerYaml = "snapshotter: stargz"
 			Expect(config.ProvisionServers(1)).To(Succeed())
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDefaultDeployments(config.KubeconfigFile)
 			}, "120s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())

--- a/tests/docker/skew/skew_test.go
+++ b/tests/docker/skew/skew_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Skew Tests", Ordered, func() {
 			config.K3sImage = "rancher/k3s:" + lastMinorVersion
 			Expect(config.ProvisionAgents(1)).To(Succeed())
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDefaultDeployments(config.KubeconfigFile)
 			}, "180s", "5s").Should(Succeed())
 		})
 		It("should match respective versions", func() {
@@ -101,7 +101,7 @@ var _ = Describe("Skew Tests", Ordered, func() {
 			config.K3sImage = *k3sImage
 			Expect(config.ProvisionServers(3)).To(Succeed())
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDefaultDeployments(config.KubeconfigFile)
 			}, "240s", "10s").Should(Succeed())
 			Eventually(func(g Gomega) {
 				g.Expect(tests.ParseNodes(config.KubeconfigFile)).To(HaveLen(3))

--- a/tests/docker/snapshotrestore/snapshotrestore_test.go
+++ b/tests/docker/snapshotrestore/snapshotrestore_test.go
@@ -140,16 +140,8 @@ var _ = Describe("Verify snapshots and cluster restores work", Ordered, func() {
 			}, "60s", "5s").Should(Succeed())
 
 			By("Fetching Pods status")
-			Eventually(func(g Gomega) {
-				pods, err := tests.ParsePods(config.KubeconfigFile)
-				g.Expect(err).NotTo(HaveOccurred())
-				for _, pod := range pods {
-					if strings.Contains(pod.Name, "helm-install") {
-						g.Expect(string(pod.Status.Phase)).Should(Equal("Succeeded"), pod.Name)
-					} else {
-						g.Expect(string(pod.Status.Phase)).Should(Equal("Running"), pod.Name)
-					}
-				}
+			Eventually(func() error {
+				return tests.AllPodsUp(config.KubeconfigFile, "kube-system")
 			}, "120s", "5s").Should(Succeed())
 		})
 

--- a/tests/docker/svcpoliciesandfirewall/svcpoliciesandfirewall_test.go
+++ b/tests/docker/svcpoliciesandfirewall/svcpoliciesandfirewall_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Verify Services Traffic policies and firewall config", Ordered
 			// Check where the server pod is running
 			var serverNodeName string
 			Eventually(func() (string, error) {
-				pods, err := tests.ParsePods(tc.KubeconfigFile)
+				pods, err := tests.ParsePods(tc.KubeconfigFile, "default")
 				Expect(err).NotTo(HaveOccurred(), "failed to parse pods")
 				for _, pod := range pods {
 					if strings.Contains(pod.Name, "test-loadbalancer-ext") {
@@ -134,7 +134,7 @@ var _ = Describe("Verify Services Traffic policies and firewall config", Ordered
 
 			// Check that client pods are running
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"client-deployment"}, tc.KubeconfigFile)
+				return tests.CheckDeployments(tc.KubeconfigFile, "default", "client-deployment")
 			}, "50s", "5s").Should(Succeed())
 		})
 
@@ -143,7 +143,7 @@ var _ = Describe("Verify Services Traffic policies and firewall config", Ordered
 		It("Verify connectivity in internal traffic policy=local", func() {
 			var clientPod1, clientPod1Node, clientPod1IP, clientPod2, clientPod2Node, clientPod2IP, serverNodeName string
 			Eventually(func(g Gomega) {
-				pods, err := tests.ParsePods(tc.KubeconfigFile)
+				pods, err := tests.ParsePods(tc.KubeconfigFile, "default")
 				Expect(err).NotTo(HaveOccurred(), "failed to parse pods")
 				for _, pod := range pods {
 					if strings.Contains(pod.Name, "test-loadbalancer-int") {

--- a/tests/docker/upgrade/upgrade_test.go
+++ b/tests/docker/upgrade/upgrade_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Upgrade Tests", Ordered, func() {
 			Expect(config.ProvisionServers(numServers)).To(Succeed())
 			Expect(config.ProvisionAgents(numAgents)).To(Succeed())
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDefaultDeployments(config.KubeconfigFile)
 			}, "120s", "5s").Should(Succeed())
 		})
 		It("should confirm latest version", func() {
@@ -114,7 +114,7 @@ var _ = Describe("Upgrade Tests", Ordered, func() {
 			Expect(config.ProvisionAgents(numAgents)).To(Succeed())
 
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server", "traefik"}, config.KubeconfigFile)
+				return tests.CheckDefaultDeployments(config.KubeconfigFile)
 			}, "120s", "5s").Should(Succeed())
 		})
 		It("should confirm commit version", func() {

--- a/tests/e2e/btrfs/btrfs_test.go
+++ b/tests/e2e/btrfs/btrfs_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Verify that btrfs based servers work", Ordered, func() {
 			e2e.DumpPods(tc.KubeconfigFile)
 
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 
 		It("Checks pod status", func() {
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})
@@ -94,7 +94,7 @@ var _ = Describe("Verify DualStack Configuration", Ordered, func() {
 				if strings.Contains(ip, "::") {
 					ip = "[" + ip + "]"
 				}
-				pods, err := tests.ParsePods(tc.KubeconfigFile)
+				pods, err := tests.ParsePods(tc.KubeconfigFile, "kube-system")
 				Expect(err).NotTo(HaveOccurred())
 				for _, pod := range pods {
 					if !strings.HasPrefix(pod.Name, "ds-clusterip-pod") {

--- a/tests/e2e/embeddedmirror/embeddedmirror_test.go
+++ b/tests/e2e/embeddedmirror/embeddedmirror_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			By("Fetching pod status")
 			Eventually(func() error {
 				e2e.DumpPods(tc.KubeconfigFile)
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "10s").Should(Succeed())
 		})
 		It("Should create and validate deployment with embedded registry mirror using image tag", func() {

--- a/tests/e2e/externalip/externalip_test.go
+++ b/tests/e2e/externalip/externalip_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Verify External-IP config", Ordered, func() {
 		It("Checks pod status", func() {
 			By("Fetching pod status")
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "10s").Should(Succeed())
 		})
 	})

--- a/tests/e2e/privateregistry/privateregistry_test.go
+++ b/tests/e2e/privateregistry/privateregistry_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			By("Fetching pod status")
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "10s").Should(Succeed())
 		})
 
@@ -109,7 +109,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			var pod corev1.Pod
 			Eventually(func(g Gomega) {
-				pods, err := tests.ParsePods(tc.KubeconfigFile)
+				pods, err := tests.ParsePods(tc.KubeconfigFile, "default")
 				for _, p := range pods {
 					if strings.Contains(p.Name, "my-webpage") {
 						pod = p

--- a/tests/e2e/rotateca/rotateca_test.go
+++ b/tests/e2e/rotateca/rotateca_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Verify Custom CA Rotation", Ordered, func() {
 			e2e.DumpNodes(tc.KubeconfigFile)
 
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})
@@ -93,7 +93,7 @@ var _ = Describe("Verify Custom CA Rotation", Ordered, func() {
 			}, "360s", "5s").Should(Succeed())
 
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "420s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})

--- a/tests/e2e/s3/s3_test.go
+++ b/tests/e2e/s3/s3_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			e2e.DumpNodes(tc.KubeconfigFile)
 
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})

--- a/tests/e2e/secretsencryption/secretsencryption_test.go
+++ b/tests/e2e/secretsencryption/secretsencryption_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 			e2e.DumpNodes(tc.KubeconfigFile)
 
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})

--- a/tests/e2e/secretsencryption_old/secretsencryption_test.go
+++ b/tests/e2e/secretsencryption_old/secretsencryption_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 			}, "620s", "5s").Should(Succeed())
 
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})
@@ -104,7 +104,7 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 			}, "360s", "5s").Should(Succeed())
 
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "360s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})

--- a/tests/e2e/splitserver/Vagrantfile
+++ b/tests/e2e/splitserver/Vagrantfile
@@ -46,6 +46,7 @@ def provision(vm, role, role_num, node_num)
       YAML
       k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
       k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      k3s.skip_start = true
     end
   elsif role.include?("server") && role.include?("etcd") && role_num != 0
     vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
@@ -62,6 +63,7 @@ def provision(vm, role, role_num, node_num)
       YAML
       k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
       k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      k3s.skip_start = true
     end
   elsif role.include?("server") && role.include?("cp")
     vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
@@ -75,6 +77,7 @@ def provision(vm, role, role_num, node_num)
       YAML
       k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
       k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      k3s.skip_start = true
     end
   elsif role.include?("server") && role.include?("all")
     vm.provision 'k3s-install', type: 'k3s', run: 'once' do |k3s|
@@ -85,6 +88,7 @@ def provision(vm, role, role_num, node_num)
       YAML
       k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
       k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      k3s.skip_start = true
     end
   end
   if role.include?("agent")
@@ -92,6 +96,7 @@ def provision(vm, role, role_num, node_num)
       k3s.args = %W[agent --server https://#{NETWORK_PREFIX}.101:6443 --flannel-iface=eth1]
       k3s.env = %W[K3S_KUBECONFIG_MODE=0644 K3S_TOKEN=vagrant #{install_type}]
       k3s.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
+      k3s.skip_start = true
     end
   end
   if vm.box.to_s.include?("microos")

--- a/tests/e2e/splitserver/splitserver_test.go
+++ b/tests/e2e/splitserver/splitserver_test.go
@@ -174,7 +174,7 @@ var _ = DescribeTableSubtree("Verify Create", Ordered, func(startFlags string) {
 
 			fmt.Printf("\nFetching Pods status\n")
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})

--- a/tests/e2e/startup/startup_test.go
+++ b/tests/e2e/startup/startup_test.go
@@ -101,10 +101,10 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.AllNodes()))
 			}, "360s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "360s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server"}, tc.KubeconfigFile)
+				return tests.CheckDeployments(tc.KubeconfigFile, "kube-system", "coredns", "local-path-provisioner", "metrics-server")
 			}, "300s", "10s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})
@@ -157,7 +157,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.AllNodes()))
 			}, "600s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "600s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.CheckDefaultDeployments(tc.KubeconfigFile)
@@ -196,7 +196,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.AllNodes()))
 			}, "600s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "600s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.CheckDefaultDeployments(tc.KubeconfigFile)
@@ -243,7 +243,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.AllNodes()))
 			}, "360s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "360s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.CheckDefaultDeployments(tc.KubeconfigFile)
@@ -282,7 +282,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.AllNodes()))
 			}, "360s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "360s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.CheckDefaultDeployments(tc.KubeconfigFile)
@@ -313,7 +313,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.Agents))
 			}, "360s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "360s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.CheckDefaultDeployments(tc.KubeconfigFile)
@@ -434,7 +434,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.AllNodes()))
 			}, "360s", "5s").Should(Succeed())
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "360s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.CheckDefaultDeployments(tc.KubeconfigFile)

--- a/tests/e2e/testutils.go
+++ b/tests/e2e/testutils.go
@@ -323,8 +323,8 @@ func KillK3sCluster(nodes []VagrantNode) error {
 }
 
 func DestroyCluster() error {
-	if _, err := RunCommand("vagrant destroy -f"); err != nil {
-		return err
+	if out, err := RunCommand("vagrant destroy -f"); err != nil {
+		return fmt.Errorf("%v - command output:\n%s", err, out)
 	}
 	return os.Remove("vagrant.log")
 }

--- a/tests/e2e/upgradecluster/upgradecluster_test.go
+++ b/tests/e2e/upgradecluster/upgradecluster_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 			}, "620s", "5s").Should(Succeed())
 
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})
@@ -240,7 +240,7 @@ var _ = Describe("Verify Upgrade", Ordered, func() {
 			e2e.DumpNodes(tc.KubeconfigFile)
 
 			By("Fetching Pod status")
-			tests.AllPodsUp(tc.KubeconfigFile)
+			tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			e2e.DumpPods(tc.KubeconfigFile)
 		})
 

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 
 			fmt.Printf("\nFetching Pods status\n")
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "5s").Should(Succeed())
 			e2e.DumpPods(tc.KubeconfigFile)
 		})
@@ -303,7 +303,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 			}, "620s", "5s").Should(Succeed())
 
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "5s").Should(Succeed())
 		})
 

--- a/tests/e2e/validatecluster/validatecluster_test.go
+++ b/tests/e2e/validatecluster/validatecluster_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Verify Create", Ordered, func() {
 		})
 
 		It("Checks node and pod status", func() {
-			fmt.Printf("\nFetching node status\n")
+			fmt.Printf("\nFetching Nodes status\n")
 			Eventually(func() error {
 				return tests.NodesReady(tc.KubeconfigFile, e2e.VagrantSlice(tc.AllNodes()))
 			}, "620s", "5s").Should(Succeed())

--- a/tests/e2e/wasm/wasm_test.go
+++ b/tests/e2e/wasm/wasm_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Verify K3s can run Wasm workloads", Ordered, func() {
 
 			By("Fetching pod status")
 			Eventually(func() error {
-				return tests.AllPodsUp(tc.KubeconfigFile)
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
 			}, "620s", "10s").Should(Succeed())
 			Eventually(func() error {
 				return tests.CheckDefaultDeployments(tc.KubeconfigFile)

--- a/tests/integration/flannelnone/flannelnone_int_test.go
+++ b/tests/integration/flannelnone/flannelnone_int_test.go
@@ -42,11 +42,11 @@ var _ = Describe("flannel-backend=none", Ordered, func() {
 		It("checks pods status", func() {
 			// Wait for pods to come up before running the real test
 			Eventually(func() int {
-				pods, _ := testutil.ParsePodsInNS("kube-system")
+				pods, _ := testutil.ParsePods("kube-system")
 				return len(pods)
 			}, "180s", "5s").Should(BeNumerically(">", 0))
 
-			pods, err := testutil.ParsePodsInNS("kube-system")
+			pods, err := testutil.ParsePods("kube-system")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Pods should remain in Pending state because there is no network plugin

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -373,7 +373,7 @@ func unmountFolder(folder string) error {
 	return nil
 }
 
-func ParsePodsInNS(namespace string) ([]corev1.Pod, error) {
+func ParsePods(namespace string) ([]corev1.Pod, error) {
 	clientSet, err := tests.K8sClient(DefaultConfig)
 	if err != nil {
 		return nil, err

--- a/tests/integration/longhorn/longhorn_int_test.go
+++ b/tests/integration/longhorn/longhorn_int_test.go
@@ -57,7 +57,7 @@ var _ = Describe("longhorn", Ordered, func() {
 		})
 		It("starts the longhorn pods with no problems", func() {
 			Eventually(func() error {
-				pods, err := testutil.ParsePodsInNS("longhorn-system")
+				pods, err := testutil.ParsePods("longhorn-system")
 				if err != nil {
 					return err
 				}

--- a/tests/integration/startup/startup_int_test.go
+++ b/tests/integration/startup/startup_int_test.go
@@ -125,7 +125,7 @@ var _ = Describe("startup tests", Ordered, func() {
 		})
 		It("has the default pods without traefik deployed", func() {
 			Eventually(func() error {
-				return tests.CheckDeployments([]string{"coredns", "local-path-provisioner", "metrics-server"}, testutil.DefaultConfig)
+				return tests.CheckDeployments(testutil.DefaultConfig, "kube-system", "coredns", "local-path-provisioner", "metrics-server")
 			}, "90s", "10s").Should(Succeed())
 			nodes, err := tests.ParseNodes(testutil.DefaultConfig)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
#### Proposed Changes ####

* Fix etcd member promotion, regressed in [#12913](https://github.com/k3s-io/k3s/pull/12913).
  The `continue` was incorrectly changed to `return` when converting the loop to an inline function in 4974fc7c2406d1175e5c7f1c519fcb595459a705.
  CI didn't catch this, as our split-role tests just start all the nodes at once - which works around this issue.
* Fix unnecessary creation of a new kubernetes client every time the promotion check runs.
* Fix test helpers to properly check that pods exist. Previously, readiness checks could pass if the check was made before any pods were created.

#### Types of Changes ####

bugfix

#### Verification ####

Create one etcd-only node, then join another etcd-only node. Note that the second node is never promoted from learner.

#### Testing ####

Yes, added a test for this

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12908
* https://github.com/k3s-io/k3s/issues/11647

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
