### PR TITLE
Create dynamic-cert-regenerate file in CA cert rotation handler

### DIFF
--- a/pkg/server/handlers/cert.go
+++ b/pkg/server/handlers/cert.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -87,7 +88,16 @@ func caCertReplace(control *config.Control, buf io.ReadCloser, force bool) error
 		logrus.Warnf("Save of CA certificates and keys forced, ignoring validation errors: %v", err)
 	}
 
-	return cluster.Save(context.TODO(), tmpControl, true)
+	if err := cluster.Save(context.TODO(), tmpControl, true); err != nil {
+		return err
+	}
+
+	dynamicListenerRegenFilePath := filepath.Join(control.DataDir, "tls", "dynamic-cert-regenerate")
+	if err := os.WriteFile(dynamicListenerRegenFilePath, []byte{}, 0600); err != nil {
+		logrus.Warnf("Failed to create dynamic-cert-regenerate file: %v", err)
+	}
+
+	return nil
 }
 
 // defaultBootstrap provides default values from the existing bootstrap fields


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

This PR updates the CA certificate rotation handler to create a dynamic-cert-regenerate file in the control plane’s TLS directory.
The presence of this file signals K3s to regenerate certificates, ensuring that TLS updates are applied immediately after CA rotation. This improves cluster reliability during certificate rotation and avoids potential downtime caused by stale certificates.

#### Types of Changes ####

Bugfix
Minor enhancement in certificate rotation handling

#### Verification ####

Verified that dynamic-cert-regenerate file is created in the correct path after triggering CA rotation.
Confirmed that cluster operations continue without errors post rotation after cluster restart.

#### Testing ####

Manual testing

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13006