### PR TITLE
fix: default forward after override imports

### DIFF
--- a/manifests/coredns.yaml
+++ b/manifests/coredns.yaml
@@ -67,12 +67,12 @@ data:
           fallthrough
         }
         prometheus :9153
-        forward . /etc/resolv.conf
         cache 30
         loop
         reload
         loadbalance
         import /etc/coredns/custom/*.override
+        forward . /etc/resolv.conf
     }
     import /etc/coredns/custom/*.server
 ---


### PR DESCRIPTION
#### Proposed Changes ####
Default `forward . /etc/resolv.conf` after override imports to ensure we'll be able to partially and fully override the `forward` statement.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix #12979 

#### Verification ####

See #12979 

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->
NA

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
* #12979 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```