### PR TITLE
Fix ability to rotate server token to an invalid format

### DIFF
--- a/pkg/server/handlers/token.go
+++ b/pkg/server/handlers/token.go
@@ -82,6 +82,10 @@ func tokenRotate(ctx context.Context, control *config.Control, newToken string) 
 		}
 	}
 
+	if newToken, err = util.NormalizeToken(newToken); err != nil {
+		return err
+	}
+
 	if err := passwd.EnsureUser("server", version.Program+":server", newToken); err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Proposed Changes ####

Fix ability to rotate server token to an invalid format

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/12982

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

We should probably also tweak the docs to better note that server token rotation cannot use agent bootstrap tokens...