### PR TITLE
Drop calls to rand.Seed

### DIFF
--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"net"
 	"os"
 	"path/filepath"
@@ -35,7 +34,6 @@ import (
 )
 
 func Agent(ctx context.Context, nodeConfig *daemonconfig.Node, proxy proxy.Proxy) error {
-	rand.Seed(time.Now().UTC().UnixNano())
 	logsapi.ReapplyHandling = logsapi.ReapplyHandlingIgnoreUnchanged
 	logs.InitLogs()
 	defer logs.FlushLogs()

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -3,7 +3,6 @@ package control
 import (
 	"context"
 	"errors"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -42,8 +41,6 @@ import (
 // Prepare loads bootstrap data from the datastore and sets up the initial
 // tunnel server request handler and stub authenticator.
 func Prepare(ctx context.Context, wg *sync.WaitGroup, cfg *config.Control) error {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	logsapi.ReapplyHandling = logsapi.ReapplyHandlingIgnoreUnchanged
 	if err := prepare(ctx, wg, cfg); err != nil {
 		return pkgerrors.WithMessage(err, "preparing server")

--- a/pkg/kubectl/main.go
+++ b/pkg/kubectl/main.go
@@ -2,11 +2,9 @@ package kubectl
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/k3s-io/k3s/pkg/server"
 	"github.com/sirupsen/logrus"
@@ -44,8 +42,6 @@ func Main() {
 }
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
-
 	command := cmd.NewDefaultKubectlCommand()
 	if err := cli.RunNoErrOutput(command); err != nil {
 		util.CheckErr(err)


### PR DESCRIPTION
#### Proposed Changes ####

The rng has been automatically seeded since go1.20, and explicitly seeding it has been a no-op since go1.24.

Ref: https://go.dev/doc/godebug#go-120 and https://go.dev/doc/godebug#go-124

#### Types of Changes ####

tech debt

#### Verification ####

Note lack of rand.Seed calls in source code

#### Testing ####

none needed, this is dead code.

#### Linked Issues ####

* 

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
