### PR TITLE
rootless ports: add support for udp

### DIFF
--- a/pkg/rootlessports/controller.go
+++ b/pkg/rootlessports/controller.go
@@ -5,6 +5,7 @@ package rootlessports
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/k3s-io/k3s/pkg/rootless"
@@ -77,9 +78,12 @@ func (h *handler) serviceChanged(key string, svc *v1.Service) (*v1.Service, erro
 		return svc, err
 	}
 
-	boundPorts := map[int]int{}
+	boundPorts := map[string]map[int]int{
+		"tcp": {},
+		"udp": {},
+	}
 	for _, port := range ports {
-		boundPorts[port.Spec.ParentPort] = port.ID
+		boundPorts[port.Spec.Proto][port.Spec.ParentPort] = port.ID
 	}
 
 	toBindPort, err := h.toBindPorts()
@@ -87,45 +91,50 @@ func (h *handler) serviceChanged(key string, svc *v1.Service) (*v1.Service, erro
 		return svc, err
 	}
 
-	for bindPort, childBindPort := range toBindPort {
-		if _, ok := boundPorts[bindPort]; ok {
-			logrus.Debugf("Parent port %d to child already bound", bindPort)
-			delete(boundPorts, bindPort)
-			continue
-		}
+	for proto, ports := range toBindPort {
+		for bindPort, childBindPort := range ports {
+			if _, ok := boundPorts[proto][bindPort]; ok {
+				logrus.Debugf("Parent port %d/%s to child already bound", bindPort, proto)
+				delete(boundPorts[proto], bindPort)
+				continue
+			}
 
-		status, err := h.rootlessClient.PortManager().AddPort(h.ctx, port.Spec{
-			Proto:      "tcp",
-			ParentPort: bindPort,
-			ChildPort:  childBindPort,
-		})
-		if err != nil {
-			return svc, err
-		}
+			status, err := h.rootlessClient.PortManager().AddPort(h.ctx, port.Spec{
+				Proto:      proto,
+				ParentPort: bindPort,
+				ChildPort:  childBindPort,
+			})
+			if err != nil {
+				return svc, err
+			}
 
-		logrus.Infof("Bound parent port %s:%d to child namespace port %d", status.Spec.ParentIP,
-			status.Spec.ParentPort, status.Spec.ChildPort)
+			logrus.Infof("Bound parent port %s:%d/%s to child namespace port %d", status.Spec.ParentIP,
+				status.Spec.ParentPort, proto, status.Spec.ChildPort)
+		}
 	}
 
-	for bindPort, id := range boundPorts {
-		if err := h.rootlessClient.PortManager().RemovePort(h.ctx, id); err != nil {
-			return svc, err
-		}
+	for proto, ports := range boundPorts {
+		for bindPort, id := range ports {
+			if err := h.rootlessClient.PortManager().RemovePort(h.ctx, id); err != nil {
+				return svc, err
+			}
 
-		logrus.Infof("Removed parent port %d to child namespace", bindPort)
+			logrus.Infof("Removed parent port %d/%s to child namespace", bindPort, proto)
+		}
 	}
 
 	return svc, nil
 }
 
-func (h *handler) toBindPorts() (map[int]int, error) {
+func (h *handler) toBindPorts() (map[string]map[int]int, error) {
 	svcs, err := h.serviceCache.List("", labels.Everything())
 	if err != nil {
 		return nil, err
 	}
 
-	toBindPorts := map[int]int{
-		h.httpsPort: h.httpsPort,
+	toBindPorts := map[string]map[int]int{
+		"tcp": {h.httpsPort: h.httpsPort},
+		"udp": {},
 	}
 
 	if !h.enabled {
@@ -139,7 +148,9 @@ func (h *handler) toBindPorts() (map[int]int, error) {
 			}
 
 			for _, port := range svc.Spec.Ports {
-				if port.Protocol != v1.ProtocolTCP {
+				proto := strings.ToLower(string(port.Protocol))
+				if _, ok := toBindPorts[proto]; !ok {
+					logrus.Debugf("Skipping bind for unsupported protocol: %d/%s", port.Port, proto)
 					continue
 				}
 
@@ -148,9 +159,9 @@ func (h *handler) toBindPorts() (map[int]int, error) {
 						continue
 					}
 					if toBindPort <= 1024 {
-						toBindPorts[10000+int(toBindPort)] = int(toBindPort)
+						toBindPorts[proto][10000+int(toBindPort)] = int(toBindPort)
 					} else {
-						toBindPorts[int(toBindPort)] = int(toBindPort)
+						toBindPorts[proto][int(toBindPort)] = int(toBindPort)
 					}
 				}
 			}


### PR DESCRIPTION
#### Proposed Changes ####
Add support for binding UDP ports when running rootless.

#### Types of Changes ####
New Feature

#### Verification ####
Deploy k3s rootless as described in https://docs.k3s.io/advanced#running-rootless-servers-experimental

Create a UDP service and observe that the ports are bound on the host

Example pod and service:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: rsyslog
  labels:
    app.kubernetes.io/name: rsyslog
spec:
  containers:
  - name: rsyslog
    image: rsyslog/syslog_appliance_alpine:8.36.0-3.7
    ports:
    - containerPort: 514
      protocol: UDP
    - containerPort: 514
      protocol: TCP
---
apiVersion: v1
kind: Service
metadata:
  name: rsyslog
spec:
  externalTrafficPolicy: Local
  internalTrafficPolicy: Local
  type: LoadBalancer
  selector:
    app.kubernetes.io/name: rsyslog
  ports:
    - name: udp
      protocol: UDP
      port: 514
      targetPort: 514
    - name: tcp
      protocol: TCP
      port: 1514
      targetPort: 514
```

Bound UDP ports:
```
$ k get services
NAME         TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)                        AGE
kubernetes   ClusterIP      10.43.0.1      <none>        443/TCP                        52m
rsyslog      LoadBalancer   10.43.112.97   127.0.0.1     514:31110/UDP,1514:31230/TCP   5m5s

$ ss -plunt | grep -E 'k3s-server|slirp4netns'
udp   UNCONN 0      0                          *:31110            *:*    users:(("k3s-server",pid=31952,fd=17))
udp   UNCONN 0      0                          *:10514            *:*    users:(("k3s-server",pid=31952,fd=16))
tcp   LISTEN 0      4096                       *:1514             *:*    users:(("k3s-server",pid=31952,fd=13))
tcp   LISTEN 0      4096                       *:6443             *:*    users:(("k3s-server",pid=31952,fd=11))
tcp   LISTEN 0      4096                       *:31230            *:*    users:(("k3s-server",pid=31952,fd=15))
```

#### Testing ####
(none)

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/3333

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####
