### PR TITLE
Fix invalid replaced versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -158,20 +158,20 @@ require (
 	k8s.io/apimachinery v0.34.1
 	k8s.io/apiserver v0.34.1
 	k8s.io/cli-runtime v0.34.1
-	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
+	k8s.io/client-go v0.34.1
 	k8s.io/cloud-provider v0.34.1
-	k8s.io/cluster-bootstrap v0.0.0
+	k8s.io/cluster-bootstrap v0.34.1
 	k8s.io/component-base v0.34.1
 	k8s.io/component-helpers v0.34.1
 	k8s.io/cri-api v0.34.1
 	k8s.io/cri-client v0.34.1
 	k8s.io/klog/v2 v2.130.1
-	k8s.io/kube-proxy v0.0.0
+	k8s.io/kube-proxy v0.34.1
 	k8s.io/kubectl v0.34.1
 	k8s.io/kubelet v0.34.1
 	k8s.io/kubernetes v1.34.1
 	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d
-	sigs.k8s.io/cri-tools v0.0.0-00010101000000-000000000000
+	sigs.k8s.io/cri-tools v0.34.0
 	sigs.k8s.io/yaml v1.6.0
 )
 


### PR DESCRIPTION
#### Proposed Changes ####

Fix invalid replaced versions

These versions were replaced here in this project's go.mod, but they would break projects that import k3s-io/k3s without also replacing them


#### Types of Changes ####

tech debt

#### Verification ####

check go.mod

#### Testing ####

#### Linked Issues ####


#### User-Facing Change ####
```release-note
```

#### Further Comments ####

