### PR TITLE
Plumb flannel ip-masq-fully-random-disable option

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -624,20 +624,21 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	}
 
 	nodeConfig := &config.Node{
-		Docker:                   envInfo.Docker,
-		SELinux:                  envInfo.EnableSELinux,
-		ContainerRuntimeEndpoint: envInfo.ContainerRuntimeEndpoint,
-		ImageServiceEndpoint:     envInfo.ImageServiceEndpoint,
-		EnablePProf:              envInfo.EnablePProf,
-		EmbeddedRegistry:         controlConfig.EmbeddedRegistry,
-		FlannelBackend:           controlConfig.FlannelBackend,
-		FlannelIPv6Masq:          controlConfig.FlannelIPv6Masq,
-		FlannelExternalIP:        controlConfig.FlannelExternalIP,
-		EgressSelectorMode:       controlConfig.EgressSelectorMode,
-		ServerHTTPSPort:          controlConfig.HTTPSPort,
-		SupervisorPort:           controlConfig.SupervisorPort,
-		SupervisorMetrics:        controlConfig.SupervisorMetrics,
-		Token:                    info.String(),
+		Docker:                          envInfo.Docker,
+		SELinux:                         envInfo.EnableSELinux,
+		ContainerRuntimeEndpoint:        envInfo.ContainerRuntimeEndpoint,
+		ImageServiceEndpoint:            envInfo.ImageServiceEndpoint,
+		EnablePProf:                     envInfo.EnablePProf,
+		EmbeddedRegistry:                controlConfig.EmbeddedRegistry,
+		FlannelBackend:                  controlConfig.FlannelBackend,
+		FlannelIPv6Masq:                 controlConfig.FlannelIPv6Masq,
+		FlannelIPMasqDisableRandomFully: controlConfig.FlannelIPMasqDisableRandomFully,
+		FlannelExternalIP:               controlConfig.FlannelExternalIP,
+		EgressSelectorMode:              controlConfig.EgressSelectorMode,
+		ServerHTTPSPort:                 controlConfig.HTTPSPort,
+		SupervisorPort:                  controlConfig.SupervisorPort,
+		SupervisorMetrics:               controlConfig.SupervisorMetrics,
+		Token:                           info.String(),
 	}
 	nodeConfig.FlannelIface = flannelIface
 	nodeConfig.Images = filepath.Join(envInfo.DataDir, "agent", "images")

--- a/pkg/agent/flannel/flannel.go
+++ b/pkg/agent/flannel/flannel.go
@@ -51,7 +51,7 @@ var (
 	FlannelExternalIPv6Annotation = FlannelBaseAnnotation + "/public-ipv6-overwrite"
 )
 
-func flannel(ctx context.Context, wg *sync.WaitGroup, flannelIface *net.Interface, flannelConf, kubeConfigFile string, flannelIPv6Masq bool, nm netMode) error {
+func flannel(ctx context.Context, wg *sync.WaitGroup, flannelIface *net.Interface, flannelConf, kubeConfigFile string, flannelIpMasqDisableRandomFully, flannelIPv6Masq bool, nm netMode) error {
 	extIface, err := LookupExtInterface(flannelIface, nm)
 	if err != nil {
 		return pkgerrors.WithMessage(err, "failed to find the interface")
@@ -101,10 +101,10 @@ func flannel(ctx context.Context, wg *sync.WaitGroup, flannelIface *net.Interfac
 	prevIPv6Network := ReadIP6CIDRFromSubnetFile(subnetFile, "FLANNEL_IPV6_NETWORK")
 	prevIPv6Subnet := ReadIP6CIDRFromSubnetFile(subnetFile, "FLANNEL_IPV6_SUBNET")
 	if flannelIPv6Masq {
-		err = trafficMngr.SetupAndEnsureMasqRules(ctx, config.Network, prevSubnet, prevNetwork, config.IPv6Network, prevIPv6Subnet, prevIPv6Network, bn.Lease(), 60, false)
+		err = trafficMngr.SetupAndEnsureMasqRules(ctx, config.Network, prevSubnet, prevNetwork, config.IPv6Network, prevIPv6Subnet, prevIPv6Network, bn.Lease(), 60, flannelIpMasqDisableRandomFully)
 	} else {
 		//set empty flannel ipv6 Network to prevent masquerading
-		err = trafficMngr.SetupAndEnsureMasqRules(ctx, config.Network, prevSubnet, prevNetwork, ip.IP6Net{}, prevIPv6Subnet, prevIPv6Network, bn.Lease(), 60, false)
+		err = trafficMngr.SetupAndEnsureMasqRules(ctx, config.Network, prevSubnet, prevNetwork, ip.IP6Net{}, prevIPv6Subnet, prevIPv6Network, bn.Lease(), 60, flannelIpMasqDisableRandomFully)
 	}
 	if err != nil {
 		return pkgerrors.WithMessage(err, "failed to setup masq rules")

--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -104,7 +104,7 @@ func Run(ctx context.Context, wg *sync.WaitGroup, nodeConfig *config.Node) error
 		return pkgerrors.WithMessage(err, "failed to check netMode for flannel")
 	}
 	go func() {
-		err := flannel(ctx, wg, nodeConfig.FlannelIface, nodeConfig.FlannelConfFile, kubeConfig, nodeConfig.FlannelIPv6Masq, nm)
+		err := flannel(ctx, wg, nodeConfig.FlannelIface, nodeConfig.FlannelConfFile, kubeConfig, nodeConfig.FlannelIPMasqDisableRandomFully, nodeConfig.FlannelIPv6Masq, nm)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			signals.RequestShutdown(pkgerrors.WithMessage(err, "flannel exited"))
 		}

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -39,81 +39,82 @@ type Server struct {
 	// The port which custom k3s API runs on
 	SupervisorPort int
 	// The port which kube-apiserver runs on
-	APIServerPort            int
-	APIServerBindAddress     string
-	DataDir                  string
-	DisableAgent             bool
-	KubeConfigOutput         string
-	KubeConfigMode           string
-	KubeConfigGroup          string
-	HelmJobImage             string
-	TLSSan                   cli.StringSlice
-	TLSSanSecurity           bool
-	ExtraAPIArgs             cli.StringSlice
-	ExtraEtcdArgs            cli.StringSlice
-	ExtraSchedulerArgs       cli.StringSlice
-	ExtraControllerArgs      cli.StringSlice
-	ExtraCloudControllerArgs cli.StringSlice
-	Rootless                 bool
-	DatastoreEndpoint        string
-	DatastoreCAFile          string
-	DatastoreCertFile        string
-	DatastoreKeyFile         string
-	KineTLS                  bool
-	AdvertiseIP              string
-	AdvertisePort            int
-	DisableScheduler         bool
-	ServerURL                string
-	FlannelBackend           string
-	FlannelIPv6Masq          bool
-	FlannelExternalIP        bool
-	EgressSelectorMode       string
-	DefaultLocalStoragePath  string
-	DisableCCM               bool
-	DisableNPC               bool
-	DisableHelmController    bool
-	DisableKubeProxy         bool
-	DisableAPIServer         bool
-	DisableControllerManager bool
-	DisableETCD              bool
-	EmbeddedRegistry         bool
-	ClusterInit              bool
-	ClusterReset             bool
-	ClusterResetRestorePath  string
-	EncryptSecrets           bool
-	EncryptForce             bool
-	EncryptOutput            string
-	EncryptSkip              bool
-	EncryptProvider          string
-	SystemDefaultRegistry    string
-	StartupHooks             []StartupHook
-	SupervisorMetrics        bool
-	EtcdSnapshotName         string
-	EtcdDisableSnapshots     bool
-	EtcdExposeMetrics        bool
-	EtcdSnapshotDir          string
-	EtcdSnapshotCron         string
-	EtcdSnapshotReconcile    time.Duration
-	EtcdSnapshotRetention    int
-	EtcdSnapshotCompress     bool
-	EtcdListFormat           string
-	EtcdS3                   bool
-	EtcdS3Endpoint           string
-	EtcdS3EndpointCA         string
-	EtcdS3SkipSSLVerify      bool
-	EtcdS3AccessKey          string
-	EtcdS3SecretKey          string
-	EtcdS3SessionToken       string
-	EtcdS3BucketName         string
-	EtcdS3Retention          int
-	EtcdS3BucketLookupType   string
-	EtcdS3Region             string
-	EtcdS3Folder             string
-	EtcdS3Proxy              string
-	EtcdS3ConfigSecret       string
-	EtcdS3Timeout            time.Duration
-	EtcdS3Insecure           bool
-	ServiceLBNamespace       string
+	APIServerPort                   int
+	APIServerBindAddress            string
+	DataDir                         string
+	DisableAgent                    bool
+	KubeConfigOutput                string
+	KubeConfigMode                  string
+	KubeConfigGroup                 string
+	HelmJobImage                    string
+	TLSSan                          cli.StringSlice
+	TLSSanSecurity                  bool
+	ExtraAPIArgs                    cli.StringSlice
+	ExtraEtcdArgs                   cli.StringSlice
+	ExtraSchedulerArgs              cli.StringSlice
+	ExtraControllerArgs             cli.StringSlice
+	ExtraCloudControllerArgs        cli.StringSlice
+	Rootless                        bool
+	DatastoreEndpoint               string
+	DatastoreCAFile                 string
+	DatastoreCertFile               string
+	DatastoreKeyFile                string
+	KineTLS                         bool
+	AdvertiseIP                     string
+	AdvertisePort                   int
+	DisableScheduler                bool
+	ServerURL                       string
+	FlannelBackend                  string
+	FlannelIPv6Masq                 bool
+	FlannelIPMasqDisableRandomFully bool
+	FlannelExternalIP               bool
+	EgressSelectorMode              string
+	DefaultLocalStoragePath         string
+	DisableCCM                      bool
+	DisableNPC                      bool
+	DisableHelmController           bool
+	DisableKubeProxy                bool
+	DisableAPIServer                bool
+	DisableControllerManager        bool
+	DisableETCD                     bool
+	EmbeddedRegistry                bool
+	ClusterInit                     bool
+	ClusterReset                    bool
+	ClusterResetRestorePath         string
+	EncryptSecrets                  bool
+	EncryptForce                    bool
+	EncryptOutput                   string
+	EncryptSkip                     bool
+	EncryptProvider                 string
+	SystemDefaultRegistry           string
+	StartupHooks                    []StartupHook
+	SupervisorMetrics               bool
+	EtcdSnapshotName                string
+	EtcdDisableSnapshots            bool
+	EtcdExposeMetrics               bool
+	EtcdSnapshotDir                 string
+	EtcdSnapshotCron                string
+	EtcdSnapshotReconcile           time.Duration
+	EtcdSnapshotRetention           int
+	EtcdSnapshotCompress            bool
+	EtcdListFormat                  string
+	EtcdS3                          bool
+	EtcdS3Endpoint                  string
+	EtcdS3EndpointCA                string
+	EtcdS3SkipSSLVerify             bool
+	EtcdS3AccessKey                 string
+	EtcdS3SecretKey                 string
+	EtcdS3SessionToken              string
+	EtcdS3BucketName                string
+	EtcdS3Retention                 int
+	EtcdS3BucketLookupType          string
+	EtcdS3Region                    string
+	EtcdS3Folder                    string
+	EtcdS3Proxy                     string
+	EtcdS3ConfigSecret              string
+	EtcdS3Timeout                   time.Duration
+	EtcdS3Insecure                  bool
+	ServiceLBNamespace              string
 }
 
 var (
@@ -253,6 +254,11 @@ var ServerFlags = []cli.Flag{
 		Name:        "flannel-ipv6-masq",
 		Usage:       "(networking) Enable IPv6 masquerading for pod",
 		Destination: &ServerConfig.FlannelIPv6Masq,
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-ip-masq-disable-random-fully",
+		Usage:       "(networking) Disable random fully-formed IP masquerading for Flannel",
+		Destination: &ServerConfig.FlannelIPMasqDisableRandomFully,
 	},
 	&cli.BoolFlag{
 		Name:        "flannel-external-ip",

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -177,6 +177,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.AdvertisePort = cfg.AdvertisePort
 	serverConfig.ControlConfig.FlannelBackend = cfg.FlannelBackend
 	serverConfig.ControlConfig.FlannelIPv6Masq = cfg.FlannelIPv6Masq
+	serverConfig.ControlConfig.FlannelIPMasqDisableRandomFully = cfg.FlannelIPMasqDisableRandomFully
 	serverConfig.ControlConfig.FlannelExternalIP = cfg.FlannelExternalIP
 	serverConfig.ControlConfig.EgressSelectorMode = cfg.EgressSelectorMode
 	serverConfig.ControlConfig.ExtraCloudControllerArgs = cfg.ExtraCloudControllerArgs.Value()

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -37,29 +37,30 @@ const (
 )
 
 type Node struct {
-	Docker                   bool
-	ContainerRuntimeEndpoint string
-	ImageServiceEndpoint     string
-	NoFlannel                bool
-	SELinux                  bool
-	EnablePProf              bool
-	SupervisorMetrics        bool
-	EmbeddedRegistry         bool
-	FlannelBackend           string
-	FlannelConfFile          string
-	FlannelConfOverride      bool
-	FlannelIface             *net.Interface
-	FlannelIPv6Masq          bool
-	FlannelExternalIP        bool
-	EgressSelectorMode       string
-	Containerd               Containerd
-	CRIDockerd               CRIDockerd
-	Images                   string
-	AgentConfig              Agent
-	Token                    string
-	ServerHTTPSPort          int
-	SupervisorPort           int
-	DefaultRuntime           string
+	Docker                          bool
+	ContainerRuntimeEndpoint        string
+	ImageServiceEndpoint            string
+	NoFlannel                       bool
+	SELinux                         bool
+	EnablePProf                     bool
+	SupervisorMetrics               bool
+	EmbeddedRegistry                bool
+	FlannelBackend                  string
+	FlannelConfFile                 string
+	FlannelConfOverride             bool
+	FlannelIface                    *net.Interface
+	FlannelIPv6Masq                 bool
+	FlannelIPMasqDisableRandomFully bool
+	FlannelExternalIP               bool
+	EgressSelectorMode              string
+	Containerd                      Containerd
+	CRIDockerd                      CRIDockerd
+	Images                          string
+	AgentConfig                     Agent
+	Token                           string
+	ServerHTTPSPort                 int
+	SupervisorPort                  int
+	DefaultRuntime                  string
 }
 
 type EtcdS3 struct {
@@ -171,25 +172,26 @@ type Agent struct {
 // CriticalControlArgs contains parameters that all control plane nodes in HA must share
 // The cli tag is used to provide better error information to the user on mismatch
 type CriticalControlArgs struct {
-	ClusterDNSs           []net.IP     `cli:"cluster-dns"`
-	ClusterIPRanges       []*net.IPNet `cli:"cluster-cidr"`
-	ClusterDNS            net.IP       `cli:"cluster-dns"`
-	ClusterDomain         string       `cli:"cluster-domain"`
-	ClusterIPRange        *net.IPNet   `cli:"cluster-cidr"`
-	DisableCCM            bool         `cli:"disable-cloud-controller"`
-	DisableHelmController bool         `cli:"disable-helm-controller"`
-	DisableNPC            bool         `cli:"disable-network-policy"`
-	DisableServiceLB      bool         `cli:"disable-service-lb"`
-	EncryptSecrets        bool         `cli:"secrets-encryption"`
-	EncryptProvider       string       `cli:"secrets-encryption-provider"`
-	EmbeddedRegistry      bool         `cli:"embedded-registry"`
-	FlannelBackend        string       `cli:"flannel-backend"`
-	FlannelIPv6Masq       bool         `cli:"flannel-ipv6-masq"`
-	FlannelExternalIP     bool         `cli:"flannel-external-ip"`
-	EgressSelectorMode    string       `cli:"egress-selector-mode"`
-	ServiceIPRange        *net.IPNet   `cli:"service-cidr"`
-	ServiceIPRanges       []*net.IPNet `cli:"service-cidr"`
-	SupervisorMetrics     bool         `cli:"supervisor-metrics"`
+	ClusterDNSs                     []net.IP     `cli:"cluster-dns"`
+	ClusterIPRanges                 []*net.IPNet `cli:"cluster-cidr"`
+	ClusterDNS                      net.IP       `cli:"cluster-dns"`
+	ClusterDomain                   string       `cli:"cluster-domain"`
+	ClusterIPRange                  *net.IPNet   `cli:"cluster-cidr"`
+	DisableCCM                      bool         `cli:"disable-cloud-controller"`
+	DisableHelmController           bool         `cli:"disable-helm-controller"`
+	DisableNPC                      bool         `cli:"disable-network-policy"`
+	DisableServiceLB                bool         `cli:"disable-service-lb"`
+	EncryptSecrets                  bool         `cli:"secrets-encryption"`
+	EncryptProvider                 string       `cli:"secrets-encryption-provider"`
+	EmbeddedRegistry                bool         `cli:"embedded-registry"`
+	FlannelBackend                  string       `cli:"flannel-backend"`
+	FlannelIPv6Masq                 bool         `cli:"flannel-ipv6-masq"`
+	FlannelIPMasqDisableRandomFully bool         `cli:"flannel-ip-masq-disable-random-fully"`
+	FlannelExternalIP               bool         `cli:"flannel-external-ip"`
+	EgressSelectorMode              string       `cli:"egress-selector-mode"`
+	ServiceIPRange                  *net.IPNet   `cli:"service-cidr"`
+	ServiceIPRanges                 []*net.IPNet `cli:"service-cidr"`
+	SupervisorMetrics               bool         `cli:"supervisor-metrics"`
 }
 
 type Control struct {


### PR DESCRIPTION
#### Proposed Changes ####

Plumb through the flannel option to disable fully-random mode for masquerade added in github.com/flannel-io/flannel/pull/2281.

fully-random mode does not play well with tailscale, causing the tailscale to be unable to establish direct connections to processes inside of pods. See https://github.com/tailscale/tailscale/issues/11427

To allow configuration, added a CLI arg, `flannel-ip-masq-disable-random-fully`.

#### Types of Changes ####

New Feature

#### Verification ####

Operation of the flag can be verified by checking the output of running:

```shell
iptables-save | grep random-fully
```

#### Testing ####

Don't think this is covered, does it need one?

#### Linked Issues ####

#13101 

#### User-Facing Change ####
```release-note
Adds the `--flannel-ip-masq-disable-random-fully` flag/option to disable random-fully in flannel.
```

#### Further Comments ####

Seemed straightforward to add the plumbing for the flag, though I'm not entirely sure about style and testing. Please let me know what I should do to clean this up if needed. Thanks!