### PR TITLE
[release-1.34] Bump runc to v1.3.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ replace (
 	github.com/google/cadvisor => github.com/k3s-io/cadvisor v0.52.1
 	github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.12.0
 	github.com/open-policy-agent/opa => github.com/open-policy-agent/opa v0.59.0 // github.com/Microsoft/hcsshim using bad version v0.42.2
-	github.com/opencontainers/runc => github.com/opencontainers/runc v1.3.1
+	github.com/opencontainers/runc => github.com/opencontainers/runc v1.3.3
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.11.1
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/common => github.com/prometheus/common v0.62.0


### PR DESCRIPTION
#### Proposed Changes ####

Bump runc to v1.3.3 for https://github.com/advisories/GHSA-cgrx-mc8f-2prm

#### Types of Changes ####

version bump

#### Verification ####

check version

#### Testing ####


#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/13168


#### User-Facing Change ####
```release-note
```

#### Further Comments ####
