### PR TITLE
Fix adding OwnerReferences to Nodes seen from initial list

### DIFF
--- a/pkg/nodepassword/controller.go
+++ b/pkg/nodepassword/controller.go
@@ -78,16 +78,17 @@ func (npc *nodePasswordController) onChangeNode(key string, node *corev1.Node) (
 		}
 		return nil, err
 	}
+	gvk := npc.nodes.GroupVersionKind()
 	for _, ref := range secret.OwnerReferences {
-		if ref.APIVersion == node.APIVersion && ref.Kind == node.Kind && ref.Name == node.Name && ref.UID == node.UID {
+		if ref.APIVersion == gvk.Version && ref.Kind == gvk.Kind && ref.Name == node.Name && ref.UID == node.UID {
 			return node, nil
 		}
 	}
 	logrus.Infof("Adding node OwnerReference to node-password secret %s", secret.Name)
 	secret = secret.DeepCopy()
 	secret.OwnerReferences = append(secret.OwnerReferences, metav1.OwnerReference{
-		APIVersion: node.APIVersion,
-		Kind:       node.Kind,
+		APIVersion: gvk.Version,
+		Kind:       gvk.Kind,
 		Name:       node.Name,
 		UID:        node.UID,
 	})


### PR DESCRIPTION
#### Proposed Changes ####

Apparently Kubernetes objects may not have TypeMeta (APIVersion and Kind) fields set if they come from a List response, or for other various reasons... so we can't count on the objects passed to the handler having these properly set.

Debug tracing shows that these are set when we see objects at time of creation, but not when listing during startup, or when they are later updated.

Refs:
* https://github.com/kubernetes/kubernetes/issues/3030
* https://github.com/kubernetes/kubernetes/issues/80609

#### Types of Changes ####

Bugfix

#### Verification ####

1. Install K3s
2. Restart K3s
3. Note lack of errors in logs:
  `handler node-password: Secret \"MYNODE.node-password.k3s\" is invalid: [metadata.ownerReferences.apiVersion: Invalid value: \"\": version must not be empty, metadata.ownerReferences.kind: Invalid value: \"\": must not be empty], requeuing`

#### Testing ####

Yes

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13163

#### User-Facing Change ####
```release-note
```

#### Further Comments ####