### PR TITLE
Fix apiserver starting before remote etcd is up

### DIFF
--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -564,7 +564,7 @@ func (c *Cluster) reconcileEtcd(ctx context.Context) error {
 	}
 
 	for {
-		if err := e.Test(reconcileCtx); err != nil && !errors.Is(err, etcd.ErrNotMember) {
+		if err := e.Test(reconcileCtx, true); err != nil && !errors.Is(err, etcd.ErrNotMember) {
 			logrus.Infof("Failed to test temporary data store connection: %v", err)
 		} else {
 			logrus.Info(e.EndpointName() + " temporary data store connection OK")

--- a/pkg/cluster/managed/drivers.go
+++ b/pkg/cluster/managed/drivers.go
@@ -27,6 +27,7 @@ type Driver interface {
 	ReconcileSnapshotData(ctx context.Context) error
 	GetMembersClientURLs(ctx context.Context) ([]string, error)
 	RemoveSelf(ctx context.Context) error
+	Test(ctx context.Context, enableMaintenance bool) error
 }
 
 func RegisterDriver(d Driver) {

--- a/pkg/daemons/executor/etcd.go
+++ b/pkg/daemons/executor/etcd.go
@@ -30,7 +30,7 @@ func (e *Embedded) ETCD(ctx context.Context, wg *sync.WaitGroup, args *ETCDConfi
 	if e.etcdReady != nil {
 		go func() {
 			for {
-				if err := test(ctx); err != nil {
+				if err := test(ctx, true); err != nil {
 					logrus.Infof("Failed to test etcd connection: %v", err)
 				} else {
 					logrus.Info("Connection to etcd is ready")

--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -21,8 +21,9 @@ var (
 	executor Executor
 )
 
-// TestFunc is the signature of a function that returns nil error when the component is ready
-type TestFunc func(context.Context) error
+// TestFunc is the signature of a function that returns nil error when the component is ready.
+// The enableMaintenance flag enables attempts to perform corrective maintenance during the test process.
+type TestFunc func(ctx context.Context, enableMaintenance bool) error
 
 type Executor interface {
 	Bootstrap(ctx context.Context, nodeConfig *daemonconfig.Node, cfg cmds.Agent) error

--- a/pkg/etcd/etcd_linux_test.go
+++ b/pkg/etcd/etcd_linux_test.go
@@ -660,7 +660,7 @@ func Test_UnitETCD_Test(t *testing.T) {
 				return
 			}
 			start := time.Now()
-			err := e.Test(tt.fields.context.ctx)
+			err := e.Test(tt.fields.context.ctx, true)
 			duration := time.Now().Sub(start)
 			t.Logf("ETCD.Test() %q completed in %v with err=%v", tt.name, duration, err)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
#### Proposed Changes ####

Fixes issue where the apiserver on control-plane-only nodes does not actually wait for a connection to etcd to be available before starting.

Generally etcd is pretty quick to start, but on slow nodes or under high load, it may take a while before it is ready to serve requests. Here in K3s, this could cause the apiserver to panic and take the rest of the k3s process with it:

```
Nov 07 00:50:18 systemd-node-004 k3s[270]: time="2025-11-07T00:50:18Z" level=info msg="Running kube-apiserver --advertise-port=6443 --allow-privileged=true --anonymous-auth=false --api-audiences=https://kubernetes.default.svc.cluster.local,k3>
Nov 07 00:50:39 systemd-node-004 k3s[270]: time="2025-11-07T00:50:39Z" level=fatal msg="apiserver panic: F1107 00:50:39.946344     270 instance.go:232] Error creating leases: error creating storage factory: context deadline exceeded\n" stack=>
```

On control-plane-only nodes, we should wait for the etcd load-balancer to have at least one healthy server before marking etcd as ready.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue - may be difficult to reproduce outside dev/ci as it relies on particularly poor node performance to trigger.

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13167

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
