### PR TITLE
[Main] Update busybox image version to 1.37.0

### DIFF
--- a/manifests/local-storage.yaml
+++ b/manifests/local-storage.yaml
@@ -129,5 +129,5 @@ data:
     spec:
       containers:
       - name: helper-pod
-        image: "%{SYSTEM_DEFAULT_REGISTRY}%rancher/mirrored-library-busybox:1.36.1"
+        image: "%{SYSTEM_DEFAULT_REGISTRY}%rancher/mirrored-library-busybox:1.37.0"
         imagePullPolicy: IfNotPresent

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -2,7 +2,7 @@ docker.io/rancher/klipper-helm:v0.9.10-build20251111
 docker.io/rancher/klipper-lb:v0.4.13
 docker.io/rancher/local-path-provisioner:v0.0.32
 docker.io/rancher/mirrored-coredns-coredns:1.13.1
-docker.io/rancher/mirrored-library-busybox:1.36.1
+docker.io/rancher/mirrored-library-busybox:1.37.0
 docker.io/rancher/mirrored-library-traefik:3.5.1
 docker.io/rancher/mirrored-metrics-server:v0.8.0
 docker.io/rancher/mirrored-pause:3.6

--- a/tests/e2e/startup/startup_test.go
+++ b/tests/e2e/startup/startup_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 		})
 
 		It("Runs an interactive command a pod", func() {
-			cmd := "kubectl run busybox --rm -it --restart=Never --image=rancher/mirrored-library-busybox:1.36.1 -- uname -a"
+			cmd := "kubectl run busybox --rm -it --restart=Never --image=rancher/mirrored-library-busybox:1.37.0 -- uname -a"
 			_, err := tc.Servers[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -325,7 +325,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 		})
 
 		It("Runs an interactive command a pod", func() {
-			cmd := "kubectl run busybox --rm -it --restart=Never --image=rancher/mirrored-library-busybox:1.36.1 -- uname -a"
+			cmd := "kubectl run busybox --rm -it --restart=Never --image=rancher/mirrored-library-busybox:1.37.0 -- uname -a"
 			_, err := tc.Servers[0].RunCmdOnNode(cmd)
 			Expect(err).NotTo(HaveOccurred())
 		})


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->
Signed-off-by: Xelus22 <xelus22@gmail.com>

#### Proposed Changes ####

Bump busybox to latest version 1.37.0.

Fixes:
- [CVE-2023-42366](https://nvd.nist.gov/vuln/detail/CVE-2023-42366)
- [CVE-2023-42365](https://nvd.nist.gov/vuln/detail/CVE-2023-42365)
- [CVE-2023-42364](https://nvd.nist.gov/vuln/detail/CVE-2023-42364)
- [CVE-2023-42363](https://nvd.nist.gov/vuln/detail/CVE-2023-42363)
- [CVE-2022-48174](https://nvd.nist.gov/vuln/detail/CVE-2022-48174)

Says 1.36.1 includes this issue.

#### Types of Changes ####

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####

#13236 

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
