### PR TITLE
Define DefaultHelmJobImage in K3s, overriding what helm-controller defaults to.

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,6 +40,8 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
+var DefaultHelmJobImage = "rancher/klipper-helm:v0.9.10-build20251111"
+
 func ResolveDataDir(dataDir string) (string, error) {
 	dataDir, err := datadir.Resolve(dataDir)
 	return filepath.Join(dataDir, "server"), err
@@ -217,11 +219,12 @@ func coreControllers(ctx context.Context, sc *Context, config *Config) error {
 		return err
 	}
 
-	// apply SystemDefaultRegistry setting to Helm before starting controllers
+	// Apply SystemDefaultRegistry setting to Helm before starting controllers.
+	// Additionally, set the helm job image to the immutable default image, internally helm-controller default to latest.
 	if config.ControlConfig.HelmJobImage != "" {
 		helmchart.DefaultJobImage = config.ControlConfig.HelmJobImage
 	} else if config.ControlConfig.SystemDefaultRegistry != "" {
-		helmchart.DefaultJobImage = config.ControlConfig.SystemDefaultRegistry + "/" + helmchart.DefaultJobImage
+		helmchart.DefaultJobImage = config.ControlConfig.SystemDefaultRegistry + "/" + DefaultHelmJobImage
 	}
 
 	if sc.Helm != nil {


### PR DESCRIPTION
#### Proposed Changes ####
- Define the immutable klipper-helm image version inside K3s instead of helm-controller. This should reduce the number of steps it takes when maintaining klipper-helm and allow helm-controller bumps to be focused exclusivily on funtionality of that repo, not just one line image bumps. 
- https://github.com/k3s-io/helm-controller/pull/294 is the assocaited helm-controller PR. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
