### PR TITLE
Bump runc to v1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ replace (
 	github.com/google/cadvisor => github.com/k3s-io/cadvisor v0.52.1
 	github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.12.0
 	github.com/open-policy-agent/opa => github.com/open-policy-agent/opa v0.59.0 // github.com/Microsoft/hcsshim using bad version v0.42.2
-	github.com/opencontainers/runc => github.com/opencontainers/runc v1.3.3
+	github.com/opencontainers/runc => github.com/opencontainers/runc v1.4.0
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.13.0
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/common => github.com/prometheus/common v0.62.0


### PR DESCRIPTION
#### Proposed Changes ####

Bump runc to v1.4.0

#### Types of Changes ####

Version bump

#### Verification ####

Check runc version

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13293
  **NOTE FOR QA** - you are not expected to validate this issue - just that we are including the new version of runc

#### User-Facing Change ####
```release-note
```

#### Further Comments ####