### PR TITLE
[release-1.33] Bump kine to v0.14.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/k3s-io/api v0.1.4
 	github.com/k3s-io/helm-controller v0.16.17
-	github.com/k3s-io/kine v0.14.8
+	github.com/k3s-io/kine v0.14.9
 	github.com/klauspost/compress v1.18.2
 	github.com/libp2p/go-libp2p v0.43.0
 	github.com/minio/minio-go/v7 v7.0.91

--- a/go.sum
+++ b/go.sum
@@ -810,8 +810,8 @@ github.com/k3s-io/etcd/server/v3 v3.5.25-k3s1 h1:OPJFc6hoT7I+1mVmssTGRQNEHErlsq2
 github.com/k3s-io/etcd/server/v3 v3.5.25-k3s1/go.mod h1:FEA8m9ioIsPieWqKOvzDf6bD/GeiQA0flsN3Ho/Errw=
 github.com/k3s-io/helm-controller v0.16.17 h1:VXMmXQmmTB49x6bnN/PsJUTVKHb0r69b+SffIDUTMTM=
 github.com/k3s-io/helm-controller v0.16.17/go.mod h1:jmrgGttLQbh2yB1kcf9XFAigNW6U8oWCswCSuEjkxXU=
-github.com/k3s-io/kine v0.14.8 h1:dx/RGWXFM/xuxDaBPMUyeX4DFIBIu6ZHKbBY2OuaaQg=
-github.com/k3s-io/kine v0.14.8/go.mod h1:fa/AFMOBaNQuY4oRuxJdxwoQ3rESF/7tyCxP8jFWfaI=
+github.com/k3s-io/kine v0.14.9 h1:R4ZOeATGnDuwQ0fmY1bwQNVPDLowfpG15/pjh/hf1T8=
+github.com/k3s-io/kine v0.14.9/go.mod h1:G5pk9p9X852nn5etr62KqI7CW2vYR2g6kKAmXJhYaU4=
 github.com/k3s-io/klog/v2 v2.120.1-k3s1 h1:7twAHPFpZA21KdMnMNnj68STQMPldAxF2Zsaol57dxw=
 github.com/k3s-io/klog/v2 v2.120.1-k3s1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 github.com/k3s-io/kube-router/v2 v2.6.3-k3s1 h1:RZjUBIuitXCuYoCzm1aM6p5EgQFC5k3N72j4pBIc2j4=


### PR DESCRIPTION
#### Proposed Changes ####
Bump kine to v0.14.9

Fixes spurious watch progress response with revision=0

#### Types of Changes ####

version bump

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13316

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
