### PR TITLE
[release-1.34] Fix arm airgap platforms

### DIFF
--- a/.github/workflows/airgap.yaml
+++ b/.github/workflows/airgap.yaml
@@ -1,0 +1,39 @@
+name: Airgap Test
+on:
+  pull_request:
+    paths:
+      - "scripts/package-airgap"
+      - "scripts/airgap/image-list.txt"
+      - ".github/workflows/airgap.yaml"
+  workflow_dispatch: {}
+
+jobs:
+  build-airgap:
+    name: Build Airgap Pkg (${{ matrix.arch }})
+    runs-on: ubuntu-latest # Runs on standard runner, docker pulls with --platform
+    strategy:
+      matrix:
+        arch: [amd64, arm64, arm]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        with:
+          version: type=image,tag=28
+          daemon-config: '{"features":{"containerd-snapshotter":true}}'
+ 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install Dependencies
+        run: sudo apt-get update -y && sudo apt-get install -y zstd pigz
+
+      - name: Create Airgap Package (${{ matrix.arch }})
+        run: |
+          mkdir -p ./dist/artifacts
+          sudo chgrp $(id -g) /run/containerd /run/containerd/containerd.sock
+          ./scripts/package-airgap ${{ matrix.arch }}
+

--- a/scripts/package-airgap
+++ b/scripts/package-airgap
@@ -14,7 +14,7 @@ OPT_ARCH=${1:-""}
 if [ -n "${OPT_ARCH}" ]; then
   ARCH=${OPT_ARCH}
   if [ "${ARCH}" = "arm" ]; then
-    OPT_PLATFORM="--platform=linux/arm/v7"
+    OPT_PLATFORM="--platform=linux/arm/v6 --platform=linux/arm/v7"
   else
     OPT_PLATFORM="--platform=linux/${ARCH}"
   fi
@@ -22,8 +22,8 @@ fi
 
 airgap_image_file='scripts/airgap/image-list.txt'
 images=$(cat "${airgap_image_file}")
-xargs -n1 docker pull ${OPT_PLATFORM} <<< "${images}"
-docker save ${images} ${OPT_PLATFORM} -o dist/artifacts/k3s-airgap-images-${ARCH}.tar
+xargs -tn1 ctr --debug -n moby images pull ${OPT_PLATFORM} <<< "${images}" || true
+ctr -n moby images export ${OPT_PLATFORM} dist/artifacts/k3s-airgap-images-${ARCH}.tar ${images}
 zstd --no-progress -T0 -16 -f --long=25 dist/artifacts/k3s-airgap-images-${ARCH}.tar -o dist/artifacts/k3s-airgap-images-${ARCH}.tar.zst
 pigz -v -c dist/artifacts/k3s-airgap-images-${ARCH}.tar > dist/artifacts/k3s-airgap-images-${ARCH}.tar.gz
 if [ ${ARCH} = amd64 ]; then


### PR DESCRIPTION
#### Proposed Changes ####

Fix arm airgap platforms

Most images are linux/arm/v7 but traefik is linux/arm/v6 and docker is fussy about platform matching when saving. You can however ask containerd to export platforms it doesn't have and it will just ignore them :shrug:

I also added a PR workflow that is triggered on changes to the airgap image list and package script, to enable testing this outside the release workflow.

#### Types of Changes ####

CI

#### Verification ####

Check CI

#### Testing ####

Added a temporary workflow

#### Linked Issues ####

#### User-Facing Change ####
```release-note
```

#### Further Comments ####