### PR TITLE
Bump stable to 1.34 and add 1.35

### DIFF
--- a/channel.yaml
+++ b/channel.yaml
@@ -1,7 +1,7 @@
 # Example channels config
 channels:
 - name: stable
-  latest: v1.33.6+k3s1
+  latest: v1.34.3+k3s1
 - name: latest
   latestRegexp: .*
   excludeRegexp: (^[^+]+-|v1\.25\.5\+k3s1|v1\.26\.0\+k3s1)
@@ -70,6 +70,9 @@ channels:
   excludeRegexp: ^[^+]+-
 - name: v1.34
   latestRegexp: v1\.34\..*
+  excludeRegexp: ^[^+]+-
+- name: v1.35
+  latestRegexp: v1\.35\..*
   excludeRegexp: ^[^+]+-
 github:
   owner: k3s-io


### PR DESCRIPTION
#### Proposed Changes ####

Bump stable to 1.34 and add 1.35

#### Types of Changes ####

Channel server

#### Verification ####

Check what version is used by install script by default

#### Testing ####

#### Linked Issues ####

#### User-Facing Change ####
```release-note
```

#### Further Comments ####