### PR TITLE
Use Get, not Head for channel page

### DIFF
--- a/tests/docker/upgrade/upgrade_test.go
+++ b/tests/docker/upgrade/upgrade_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Upgrade Tests", Ordered, func() {
 		var latestVersion string
 		It("should determine latest branch version", func() {
 			url := fmt.Sprintf("https://update.k3s.io/v1-release/channels/%s", *channel)
-			resp, err := http.Head(url)
+			resp, err := http.Get(url)
 			// Cover the case where the branch does not exist yet,
 			// such as a new unreleased minor version
 			if err != nil || resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
A forward port, found when backporting upgrade_test changes. We moved away from HEAD in E2E testing with https://github.com/k3s-io/k3s/pull/13130, but didn't change the docker test version of this. 
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
You can see on older release branches that its actually pulling the correct "release latest"
BEFORE:
```
derek@divobook:~/rancher/k3s/tests/docker/upgrade$ go test -v ./upgrade_test.go -channel v1.33 -ginkgo.v
=== RUN   Test_DockerUpgrade
Running Suite: Upgrade Docker Test Suite - /home/derek/rancher/k3s/tests/docker/upgrade
=======================================================================================
Random Seed: 1767038060

Will run 1 of 20 specs
------------------------------
Upgrade Tests Setup Cluster with Lastest Release should determine latest branch version
/home/derek/rancher/k3s/tests/docker/upgrade/upgrade_test.go:38
Using channel:  v1.33
&{405 Method Not Allowed 405 HTTP/2.0 2 0 map[Alt-Svc:[h3=":443"; ma=86400] Cf-Cache-Status:[DYNAMIC] Cf-Ray:
...
Using latest version:  v1.34.2-k3s1
```

NOW:
```
derek@divobook:~/rancher/k3s/tests/docker/upgrade$ go test -v ./upgrade_test.go -channel v1.33 -ginkgo.v
=== RUN   Test_DockerUpgrade
Running Suite: Upgrade Docker Test Suite - /home/derek/rancher/k3s/tests/docker/upgrade
=======================================================================================
Random Seed: 1767038107

Will run 1 of 20 specs
------------------------------
Upgrade Tests Setup Cluster with Lastest Release should determine latest branch version
/home/derek/rancher/k3s/tests/docker/upgrade/upgrade_test.go:38
Using channel:  v1.33
&{200 OK 200 HTTP/2.0 2 0 map[Accept-Ranges:[bytes] Cache-Control:[max-age=0, private, must-revalidate] Content-Security-Policy:[default-src 'none'; base-uri 'self'; child-src github.githubassets.com github.com/assets-cdn/worker/ github.com/assets/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-
...

Using latest version:  v1.33.6-k3s1
```

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
