### PR TITLE
Require token when bootstrap data already exists

### DIFF
--- a/pkg/cluster/storage_test.go
+++ b/pkg/cluster/storage_test.go
@@ -1,0 +1,50 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/k3s-io/kine/pkg/client"
+)
+
+func Test_UnitValidateBootstrapTokenRequirement(t *testing.T) {
+	tests := []struct {
+		name    string
+		values  []client.Value
+		wantErr bool
+	}{
+		{
+			name:    "no bootstrap data",
+			values:  nil,
+			wantErr: false,
+		},
+		{
+			name: "bootstrap lock exists",
+			values: []client.Value{
+				{
+					Key:  []byte("/bootstrap/test"),
+					Data: []byte{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bootstrap data exists",
+			values: []client.Value{
+				{
+					Key:  []byte("/bootstrap/test"),
+					Data: []byte("payload"),
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBootstrapTokenRequirement(tt.values)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateBootstrapTokenRequirement() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Proposed Changes ####
- Require a join token when bootstrap data already exists in the external datastore.
- Add a unit test to cover the token requirement behavior.

#### Types of Changes ####
- Bugfix

#### Verification ####
- Unable to run full unit suite on macOS due to linux build tags in several packages.

#### Testing ####
- Not run (requires linux build tags; local environment is macOS)

#### Linked Issues ####
- Refs #864

#### User-Facing Change ####
```release-note
When using an external datastore, servers now require a join token if bootstrap data already exists, preventing accidental bootstrap data divergence.
```

#### Further Comments ####
This prevents secondary servers from generating a new ServiceAccount signing key when joining an already-initialized datastore, which can lead to repeated "invalid bearer token" errors after controller removal.