### PR TITLE
nodepassword: handle wrapped AlreadyExists

### DIFF
--- a/pkg/nodepassword/nodepassword_test.go
+++ b/pkg/nodepassword/nodepassword_test.go
@@ -29,6 +29,13 @@ func Test_PasswordError(t *testing.T) {
 	assertNotEqual(t, errors.Unwrap(err), nil)
 }
 
+func TestIsAlreadyExists(t *testing.T) {
+	assertEqual(t, isAlreadyExists(errorAlreadyExists()), true)
+	assertEqual(t, isAlreadyExists(fmt.Errorf("wrapped: %w", errorAlreadyExists())), true)
+	assertEqual(t, isAlreadyExists(errorNotFound()), false)
+	assertEqual(t, isAlreadyExists(nil), false)
+}
+
 // --------------------------
 // utility functions
 


### PR DESCRIPTION
#### Proposed Changes ####
- Handle wrapped AlreadyExists errors when creating node-password secrets during deferred validation.
- Add a unit test for wrapped AlreadyExists detection.

#### Types of Changes ####
- Bugfix

#### Verification ####
- Prevents spurious "already exists" warnings when cache is stale and the create error is wrapped.

#### Testing ####
- Not run (macOS build fails in unrelated package due to linux build tags: "pkg/cli/cmds/agent.go:168:16: undefined: DefaultSnapshotter").

#### Linked Issues ####
- Refs #11354

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####
- Some client layers wrap API errors; unwrapping ensures AlreadyExists is handled consistently.