### PR TITLE
Remove download/generate from vulncheck

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -18,10 +18,6 @@ jobs:
         uses: actions/checkout@v6
       - name: Install Go
         uses: ./.github/actions/setup-go
-      - name: Go Generate
-        run: |
-          ./scripts/download
-          ./scripts/generate
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck


### PR DESCRIPTION
#### Proposed Changes ####

This has been broken since july when cb061687d451345c5e8de0afbc2bb71acb0898bc was merged

#### Types of Changes ####

CI

#### Verification ####

Check merge CI - for example https://github.com/k3s-io/k3s/actions/runs/20865959518/job/59957066957

#### Testing ####

#### Linked Issues ####

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
