### PR TITLE
[release-1.35] Bump to coredns 1.14.0

### DIFF
--- a/manifests/coredns.yaml
+++ b/manifests/coredns.yaml
@@ -123,7 +123,7 @@ spec:
               k8s-app: kube-dns
       containers:
       - name: coredns
-        image: "%{SYSTEM_DEFAULT_REGISTRY}%rancher/mirrored-coredns-coredns:1.13.2"
+        image: "%{SYSTEM_DEFAULT_REGISTRY}%rancher/mirrored-coredns-coredns:1.14.0"
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,7 +1,7 @@
 docker.io/rancher/klipper-helm:v0.9.12-build20251215
 docker.io/rancher/klipper-lb:v0.4.13
 docker.io/rancher/local-path-provisioner:v0.0.34
-docker.io/rancher/mirrored-coredns-coredns:1.13.2
+docker.io/rancher/mirrored-coredns-coredns:1.14.0
 docker.io/rancher/mirrored-library-busybox:1.37.0
 docker.io/rancher/mirrored-library-traefik:3.6.6
 docker.io/rancher/mirrored-metrics-server:v0.8.0


### PR DESCRIPTION
Backport: https://github.com/k3s-io/k3s/pull/13449