### PR TITLE
Fix VPN node IP not being applied to kubelet

### DIFF
--- a/pkg/executor/embed/embed.go
+++ b/pkg/executor/embed/embed.go
@@ -136,6 +136,8 @@ func (e *Embedded) Bootstrap(ctx context.Context, nodeConfig *daemonconfig.Node,
 					logrus.Warn("VPN provider overrides node-external-ip parameter")
 				}
 				nodeIPs = vpnIPs
+				nodeConfig.AgentConfig.NodeIPs = vpnIPs
+				nodeConfig.AgentConfig.NodeIP = vpnIPs[0].String()
 				nodeConfig.Flannel.Iface, err = net.InterfaceByName(vpnInfo.Interface)
 				if err != nil {
 					return pkgerrors.WithMessagef(err, "unable to find vpn interface: %s", vpnInfo.Interface)


### PR DESCRIPTION
#### Proposed Changes ####
Sync VPN IPs to `nodeConfig.AgentConfig` in Bootstrap() to fix kubelet using wrong node IP.
#### Types of Changes ####
Bugfix - Regression introduced in b9f1cc2174
#### Verification ####
1. Configure k3s with `--vpn-auth="name=tailscale,joinKey=..."`
2. Check kubelet `--node-ip` matches Tailscale IP (100.x.x.x)
#### Linked Issues ####
Regression from b9f1cc2174 - VPN setup moved to embed.go but forgot to sync nodeIPs back to nodeConfig.