### PR TITLE
Fix CVE-2025-54410: Update docker/docker to v25.0.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace (
 	github.com/containerd/imgcrypt => github.com/containerd/imgcrypt v1.1.11
 	github.com/containerd/stargz-snapshotter => github.com/k3s-io/stargz-snapshotter v0.17.0-k3s1
 	github.com/docker/distribution => github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker => github.com/docker/docker v25.0.8+incompatible
+	github.com/docker/docker => github.com/docker/docker v25.0.13+incompatible
 	github.com/emicklei/go-restful/v3 => github.com/emicklei/go-restful/v3 v3.12.2
 	github.com/golang/protobuf => github.com/golang/protobuf v1.5.4
 	github.com/google/cadvisor => github.com/k3s-io/cadvisor v0.52.1

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,8 @@ github.com/docker/cli v28.3.2+incompatible h1:mOt9fcLE7zaACbxW1GeS65RI67wIJrTnqS
 github.com/docker/cli v28.3.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v25.0.8+incompatible h1:FSKbeS2aCyKqNymmbPnq6qM8EQkxOpLK7gth1cpy4g4=
-github.com/docker/docker v25.0.8+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v25.0.13+incompatible h1:YeBrkUd3q0ZoRDNoEzuopwCLU+uD8GZahDHwBdsTnkU=
+github.com/docker/docker v25.0.13+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=


### PR DESCRIPTION
Upgrade docker/docker dependency from v25.0.8 to v25.0.13 to address CVE-2025-54410 which affects Moby/Docker versions before 25.0.13. This vulnerability could allow containers across different bridge networks to access each other's ports when firewalld is reloaded, breaking network isolation.


#### Proposed Changes ####

Upgrade docker/docker dependency from v25.0.8 to v25.0.13 to address CVE-2025-54410 which affects Moby/Docker versions before 25.0.13


#### Types of Changes ####

To address CVE-2025-54410 security vulnerability

#### Verification ####

N/A

#### Testing ####

N/A

#### Linked Issues ####

https://avd.aquasec.com/nvd/cve-2025-54410

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

N/A
