### PR TITLE
Fix lines to satisfy lint and fix CI

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -98,7 +98,7 @@ jobs:
         ## If no one connects after 5 minutes, shut down server.
         wait-timeout-minutes: 5
     - name: Generate coverage report
-      run: go tool covdata textfmt -i $GOCOVERDIR -o ${{ matrix.itest }}.out
+      run: sudo -E env "PATH=$PATH" go tool covdata textfmt -i $GOCOVERDIR -o ${{ matrix.itest }}.out
     - name: Upload Results To Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/pkg/server/handlers/secrets-encrypt.go
+++ b/pkg/server/handlers/secrets-encrypt.go
@@ -88,9 +88,8 @@ func encryptionStatus(control *config.Control) (EncryptionState, error) {
 	}
 	if providers[len(providers)-1].Identity != nil && (providers[0].AESCBC != nil || providers[0].Secretbox != nil) {
 		state.Enable = ptr.To(true)
-	} else if control.EncryptSecrets && providers[0].Identity != nil && len(providers) == 1 {
-		state.Enable = ptr.To(false)
-	} else if !control.EncryptSecrets || providers[0].Identity != nil && (providers[1].AESCBC != nil || providers[1].Secretbox != nil) {
+	} else if (control.EncryptSecrets && providers[0].Identity != nil && len(providers) == 1) ||
+		(!control.EncryptSecrets || providers[0].Identity != nil && (providers[1].AESCBC != nil || providers[1].Secretbox != nil)) {
 		state.Enable = ptr.To(false)
 	}
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
When building K3s locally, I get the error:
```
Running: golangci-lint
pkg/server/handlers/secrets-encrypt.go:91:1: File is not properly formatted (gofmt)
	} else if (control.EncryptSecrets && providers[0].Identity != nil && len(providers) == 1) || 
^
1 issues:
* gofmt: 1
FATA[0035] exit status 1   
```
This PR satisfies golangci-lint and fixes the error.

Moreover, add "sudo" to the generation of the coverage report because otherwise it can't find the coverage files, as they were created in the previous step with sudo

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Lint error fix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->
Build K3s locally by running "make"

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/13476

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
