### PR TITLE
Prevent caching on PR of golangci-lint entries

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -16,4 +16,5 @@ jobs:
         with:
           shellcheck: false
           pyflakes: false
+          cache: ${{ github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -64,12 +64,14 @@ jobs:
         with:
           version: v2.7
           args: "--new-from-merge-base ${{ github.event.pull_request.base.sha }}"
+          skip-save-cache: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Lint (windows)
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.7
           args: "--new-from-merge-base ${{ github.event.pull_request.base.sha }} ./pkg/... ./cmd/..."
+          skip-save-cache: ${{ github.ref != 'refs/heads/main' }}
         env:
           GOOS: "windows"
 


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Addendum to https://github.com/k3s-io/k3s/commit/358c8cc00fdb534da771c997e6030208683ac9cd, we also have unecessary cache entries for the actionlint and golangci-lint actions.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
CI Fix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Stop entries like:
<img width="898" height="688" alt="image" src="https://github.com/user-attachments/assets/324eb76e-fb66-4b48-b399-1bd5256f97cb" />

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/13488
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
