### PR TITLE
Add Percona and Solanica to k3s adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -16,3 +16,4 @@ A non-exhaustive list of k3s adopters is provided below.  To add your company to
  - SUSE's [Rancher Desktop](https://rancherdesktop.io/)
  - [Kairos](https://kairos.io)
  - [Getdeck Beiboot](https://github.com/Getdeck/beiboot)
+ - [Solanica](https://solanica.io/) and [Percona](https://www.percona.com/) (development and CI usage via k3d for the [OpenEverest](https://openeverest.io/) project)


### PR DESCRIPTION
Percona and Solanica use k3s via k3d for development and CI workflows in the OpenEverest project.
k3d is used as a lightweight wrapper around k3s to provision Kubernetes clusters for local development and CI purposes.
This PR adds Percona to the k3s adopters list with that context.