### PR TITLE
Fix spegel filter for wildcards

### DIFF
--- a/pkg/spegel/spegel.go
+++ b/pkg/spegel/spegel.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"time"
 
@@ -58,6 +59,8 @@ var (
 	P2pEnableLatestEnv   = version.ProgramUpper + "_P2P_ENABLE_LATEST"
 
 	resolveLatestTag = false
+
+	wildcardRegistries = []string{"_default", "*"}
 
 	// Agents request a list of peers when joining, and then again periodically afterwards.
 	// Limit the number of concurrent peer list requests that will be served simultaneously.
@@ -123,6 +126,9 @@ func (c *Config) Start(ctx context.Context, nodeConfig *config.Node, criReadyCha
 		}
 		if _, err := url.Parse("https://" + host); err != nil || docker.IsLocalhost(host) {
 			logrus.Errorf("Distributed registry mirror skipping invalid registry: %s", host)
+		} else if slices.Contains(wildcardRegistries, host) {
+			urls = append(urls, host)
+			registries = append(registries, host)
 		} else {
 			urls = append(urls, "https://"+host)
 			registries = append(registries, host)

--- a/pkg/spegel/store.go
+++ b/pkg/spegel/store.go
@@ -80,10 +80,12 @@ func (ds *deferredStore) Subscribe(ctx context.Context) (<-chan oci.OCIEvent, er
 
 // Close is not part of the Store interface, but probably should be. Containerd impliments it.
 func (ds *deferredStore) Close() error {
-	store := ds.store
-	ds.store = nil
-	if closer, ok := store.(io.Closer); ok {
-		return closer.Close()
+	if ds.store != nil {
+		store := ds.store
+		ds.store = nil
+		if closer, ok := store.(io.Closer); ok {
+			return closer.Close()
+		}
 	}
 	return nil
 }


### PR DESCRIPTION

#### Proposed Changes ####
Fix spegel filter for wildcards

Wildcard entry should be bare `*` or `_default`, not a URL

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13526

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
