### PR TITLE
Add IPv6 loopback to kubelet-serving cert

### DIFF
--- a/pkg/server/handlers/handlers.go
+++ b/pkg/server/handlers/handlers.go
@@ -66,7 +66,7 @@ func ServingKubeletCert(control *config.Control, auth nodepassword.NodeAuthValid
 			return
 		}
 
-		ips := []net.IP{net.ParseIP("127.0.0.1")}
+		ips := []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
 		program := mux.Vars(req)["program"]
 		if nodeIP := req.Header.Get(program + "-Node-IP"); nodeIP != "" {
 			for _, v := range strings.Split(nodeIP, ",") {


### PR DESCRIPTION
#### Proposed Changes ####

Add IPv6 loopback to kubelet-serving cert

Fixes issue preventing containerd from accessing spegel on ipv6-primary agents. Only affects agents because only agents use the kubelet-serving cert for the supervisor listener.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue - requires ipv6-primary cluster with spegel and agent node.

#### Testing ####

We should probably reopen https://github.com/k3s-io/k3s/issues/12991 - we still don't have ipv6-primary tests that cover everything.

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13530

#### User-Facing Change ####
```release-note
```

#### Further Comments ####