### PR TITLE
[release-1.35] Fix restart of control-plane-only nodes attempting to reconcile from local datastore

### DIFF
--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -287,7 +287,7 @@ func (c *Cluster) ReconcileBootstrapData(ctx context.Context, buf io.ReadSeeker,
 
 		storageClient, err := store.NewTemporaryStore(filepath.Join(c.config.DataDir, "db", "etcd"))
 		if err != nil {
-			return err
+			return pkgerrors.WithMessage(err, "failed to create temporary datastore client")
 		}
 		defer storageClient.Close()
 
@@ -465,7 +465,7 @@ func (c *Cluster) bootstrap(ctx context.Context) error {
 			logrus.Debugf("Failed to get bootstrap data from etcd proxy: %v", err)
 		} else {
 			if err := c.ReconcileBootstrapData(ctx, bytes.NewReader(data), &c.config.Runtime.ControlRuntimeBootstrap, false); err != nil {
-				logrus.Debugf("Failed to reconcile bootstrap data from etcd proxy: %v", err)
+				logrus.Debugf("Failed to reconcile with local datastore: %v", err)
 			} else {
 				return nil
 			}

--- a/pkg/etcd/store/store.go
+++ b/pkg/etcd/store/store.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/k3s-io/kine/pkg/endpoint"
 	"github.com/otiai10/copy"
+	pkgerrors "github.com/pkg/errors"
 	"github.com/rancher/wrangler/v3/pkg/merr"
 	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -61,7 +62,6 @@ func NewRemoteStore(config endpoint.ETCDConfig) (*RemoteStore, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	c, err := clientv3.New(clientv3.Config{
 		Endpoints:   config.Endpoints,
 		DialTimeout: 5 * time.Second,
@@ -205,11 +205,19 @@ func NewStore(dataDir string) (*Store, error) {
 	}
 
 	cfg := config.ServerConfig{Logger: logger, DataDir: dataDir}
-	logrus.Infof("Opening etcd MVCC KV store at %s", cfg.BackendPath())
+	path := cfg.BackendPath()
+
+	// need to check for backend path ourselves, as backend.New just logs a panic
+	// via zap if it doesn't exist, which isn't fatal.
+	if _, err := os.Stat(path); err != nil {
+		return nil, pkgerrors.WithMessage(err, "failed to stat MVCC KV store backend path")
+	}
+
+	logrus.Infof("Opening etcd MVCC KV store at %s", path)
 
 	// open backend database
 	bcfg := backend.DefaultBackendConfig(logger)
-	bcfg.Path = cfg.BackendPath()
+	bcfg.Path = path
 	bcfg.UnsafeNoFsync = true
 	bcfg.BatchInterval = 0
 	bcfg.BatchLimit = 0


### PR DESCRIPTION
#### Proposed Changes ####

Fix restart of control-plane-only nodes attempting to reconcile from local datastore

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

Need to add a test for simultaneous restart of split-role clusters

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13533

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
