### PR TITLE
Explicitly close mvcc backend to fix high CPU on initial etcd server after restart

### DIFF
--- a/pkg/etcd/store/store.go
+++ b/pkg/etcd/store/store.go
@@ -195,6 +195,7 @@ var _ ReadCloser = &Store{}
 // the bbolt database.
 type Store struct {
 	kv mvcc.KV
+	be backend.Backend
 }
 
 func NewStore(dataDir string) (*Store, error) {
@@ -258,12 +259,20 @@ func NewStore(dataDir string) (*Store, error) {
 		}
 	}
 
-	return &Store{kv: mvcc.NewStore(cfg.Logger, be, &lease.FakeLessor{}, mvcc.StoreConfig{})}, nil
+	// nb: closing the kv store does not implicitly close its backend; the backend must be closed separately
+	return &Store{kv: mvcc.NewStore(cfg.Logger, be, &lease.FakeLessor{}, mvcc.StoreConfig{}), be: be}, nil
 }
 
 func (s *Store) Close() error {
 	logrus.Info("Closing etcd MVCC KV store")
-	return s.kv.Close()
+	errs := []error{}
+	if s.kv != nil {
+		errs = append(errs, s.kv.Close())
+	}
+	if s.be != nil {
+		errs = append(errs, s.be.Close())
+	}
+	return merr.NewErrors(errs...)
 }
 
 func (s *Store) List(ctx context.Context, key string, rev int64) ([]mvccpb.KeyValue, error) {


### PR DESCRIPTION
#### Proposed Changes ####

Explicitly close mvcc backend

Fixes issue that could cause excessive CPU usage on first server in embedded-etcd cluster after a restart.

Apparently closing the MVCC store does not also close the backend that was passed in when creating it; the backend needs to be closed separately and will busy-wait in the select loop chewing up CPU if it is not.

#### Types of Changes ####

bugfix

#### Verification ####

Check K3s CPU after restarting first etcd server - should not use excessive CPU

#### Testing ####

No, don't have any CPU tests :(

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13574

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
