### PR TITLE
Fix removal of init node via annotation

### DIFF
--- a/pkg/etcd/etcd_linux_test.go
+++ b/pkg/etcd/etcd_linux_test.go
@@ -213,6 +213,7 @@ func Test_UnitETCD_Register(t *testing.T) {
 				testutil.CleanupDataDir(cnf)
 				return nil
 			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
#### Proposed Changes ####

Removing the initial node from the cluster would previously cause etcd to panic on startup. Fixes to etcd reconcile have stopped that from happening, but now the node will successfully come up and start a new cluster - which is not right either. Require either manual removal of DB files to create a new cluster, or setting server address to join an existing cluster.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####

* not yet

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13623

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
