### PR TITLE
fix: upgrade Go to 1.25.7 to resolve CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k3s-io/k3s
 
-go 1.25.6
+go 1.25.7
 
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.13.0


### PR DESCRIPTION
## Summary
Upgrades Go version to 1.25.7 to fix a CRITICAL vulnerability in the Go standard library.

## CVE Fixed
CVE-2025-68121 (CRITICAL): crypto/tls session resumption vulnerability

## Vulnerability Findings

### Trivy Scan Command
```
trivy image --severity HIGH,CRITICAL rancher/k3s:latest
```

### Before Fix (rancher/k3s:latest)
```
bin/k3s (gobinary)
==================
Total: 10 (HIGH: 5, CRITICAL: 1)

| Library | Vulnerability  | Severity | Title |
|---------|----------------|----------|-------|
| stdlib  | CVE-2025-68121 | CRITICAL | crypto/tls: Unexpected session resumption |
| stdlib  | CVE-2025-58183 | HIGH     | archive/tar: Unbounded allocation |
| stdlib  | CVE-2025-61726 | HIGH     | net/url: Memory exhaustion |
| stdlib  | CVE-2025-61728 | HIGH     | archive/zip: CPU consumption |
| stdlib  | CVE-2025-61729 | HIGH     | crypto/x509: DoS |
| stdlib  | CVE-2025-61730 | HIGH     | TLS 1.3 handshake issue |
```

### After Fix
Go 1.25.7 contains patches for CVE-2025-68121 and related stdlib vulnerabilities.

This is a minimal patch-level version bump fix.