### PR TITLE
Do not create etcd name file if etcd is not in use

### DIFF
--- a/pkg/daemons/control/server_test.go
+++ b/pkg/daemons/control/server_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/k3s-io/k3s/pkg/cluster"
 	"github.com/k3s-io/k3s/pkg/cluster/managed"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
-	"github.com/k3s-io/k3s/pkg/daemons/control/deps"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
 	"github.com/k3s-io/k3s/pkg/etcd"
 	testutil "github.com/k3s-io/k3s/tests"
@@ -198,12 +197,8 @@ func mockControl(ctx context.Context, t *testing.T, clusterInit bool) (*config.C
 	testutil.GenerateRuntime(control)
 
 	control.Cluster = cluster.New(control)
-	if err := control.Cluster.Bootstrap(ctx, control.ClusterReset); err != nil {
-		return nil, pkgerrors.WithMessage(err, "failed to bootstrap cluster data")
-	}
-
-	if err := deps.GenServerDeps(control); err != nil {
-		return nil, pkgerrors.WithMessage(err, "failed to generate server dependencies")
+	if err := prepare(ctx, nil, control); err != nil {
+		return nil, pkgerrors.WithMessage(err, "failed to prepare cluster")
 	}
 
 	return control, nil

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -188,8 +188,7 @@ func (e *ETCD) SetControlConfig(config *config.Control) error {
 		return err
 	}
 	e.address = address
-
-	return e.setName(false)
+	return nil
 }
 
 // Test ensures that the local node is a voting member of the target cluster,


### PR DESCRIPTION

#### Proposed Changes ####

Do not create etcd name file if etcd is not in use

etcd.setName was being called during managed driver creation, even if the managed driver (etcd) is not in use. Let etcd.Register handle calling setName.

The two call paths are:
```
main.main(main.go:88)
github.com/urfave/cli/v2.(*App).Run(app.go:307)
github.com/urfave/cli/v2.(*App).RunContext(app.go:333)
github.com/urfave/cli/v2.(*Command).Run(command.go:269)
github.com/urfave/cli/v2.(*Command).Run(command.go:276)
github.com/k3s-io/k3s/pkg/cli/server.Run(server.go:48)
github.com/k3s-io/k3s/pkg/cli/server.run(server.go:533)
github.com/k3s-io/k3s/pkg/server.PrepareServer(server.go:61)
github.com/k3s-io/k3s/pkg/daemons/control.Prepare(server.go:44)
github.com/k3s-io/k3s/pkg/daemons/control.prepare(server.go:327)
github.com/k3s-io/k3s/pkg/cluster.(*Cluster).Bootstrap(bootstrap.go:39)
github.com/k3s-io/k3s/pkg/cluster.(*Cluster).assignManagedDriver(managed.go:87)
github.com/k3s-io/k3s/pkg/etcd.(*ETCD).SetControlConfig(etcd.go:192)
github.com/k3s-io/k3s/pkg/etcd.(*ETCD).setName(etcd.go:724)
```

and then again later, if etcd is actually enabled:
```
main.main(main.go:88)
github.com/urfave/cli/v2.(*App).Run(app.go:307)
github.com/urfave/cli/v2.(*App).RunContext(app.go:333)
github.com/urfave/cli/v2.(*Command).Run(command.go:269)
github.com/urfave/cli/v2.(*Command).Run(command.go:276)
github.com/k3s-io/k3s/pkg/cli/server.Run(server.go:48)
github.com/k3s-io/k3s/pkg/cli/server.run(server.go:533)
github.com/k3s-io/k3s/pkg/server.PrepareServer(server.go:61)
github.com/k3s-io/k3s/pkg/daemons/control.Prepare(server.go:44)
github.com/k3s-io/k3s/pkg/daemons/control.prepare(server.go:335)
github.com/k3s-io/k3s/pkg/cluster.(*Cluster).ListenAndServe(cluster.go:42)
github.com/k3s-io/k3s/pkg/cluster.(*Cluster).initClusterAndHTTPS(https.go:113)
github.com/k3s-io/k3s/pkg/cluster.(*Cluster).registerDBHandlers(managed.go:76)
github.com/k3s-io/k3s/pkg/etcd.(*ETCD).Register(etcd.go:712)
github.com/k3s-io/k3s/pkg/etcd.(*ETCD).setName(etcd.go:724)
```

#### Types of Changes ####

bugfix

#### Verification ####

See linked

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13728

#### User-Facing Change ####
```release-note
```

#### Further Comments ####