### PR TITLE
Save cluster state before reencyrpting secrets with newly created key

### DIFF
--- a/pkg/server/handlers/secrets-encrypt.go
+++ b/pkg/server/handlers/secrets-encrypt.go
@@ -378,6 +378,12 @@ func encryptionRotateKeys(ctx context.Context, control *config.Control) error {
 		return err
 	}
 
+	// Save the cluster files after the new key was added, so if something breaks during reencryption,
+	// the cluster can still be restarted with the old and new keys together.
+	if err := cluster.Save(ctx, control, true); err != nil {
+		return err
+	}
+
 	if err := secretsencrypt.WaitForEncryptionConfigReload(control.Runtime, reloadSuccesses, reloadTime); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Saves state of `encryption-config.json` after a new key has been added, but before reencryption and old key removal. This allows recover of cluster even if the cluster crashes when secrets reencryption is occuring.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bug fix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
See linked issue
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/13763
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####
The secrets reencryption v2 occurs so fast that we never had an incident where the server broke between edits of adding and then removing the old key. 
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
