### PR TITLE
Use etcd-snapshot-retention as default for s3 if etcd-s3-retention is not set

### DIFF
--- a/pkg/cli/etcdsnapshot/etcd_snapshot.go
+++ b/pkg/cli/etcdsnapshot/etcd_snapshot.go
@@ -48,8 +48,12 @@ func commandSetup(app *cli.Context, cfg *cmds.Server) (*etcd.SnapshotRequest, *c
 	if app.IsSet("etcd-snapshot-retention") {
 		sr.Retention = &cfg.EtcdSnapshotRetention
 	}
-
 	if cfg.EtcdS3 {
+		// set default s3 retention from local snapshot retention
+		// preserves legacy behavior of local snapshot retention also affecting s3
+		if !app.IsSet("etcd-s3-retention") && app.IsSet("etcd-snapshot-retention") {
+			cfg.EtcdS3Retention = cfg.EtcdSnapshotRetention
+		}
 		sr.S3 = &config.EtcdS3{
 			AccessKey:     cfg.EtcdS3AccessKey,
 			Bucket:        cfg.EtcdS3BucketName,

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -213,6 +213,11 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 			if cfg.EtcdS3Timeout <= 0 {
 				return errors.New("etcd-s3-timeout must be greater than 0s")
 			}
+			// set default s3 retention from local snapshot retention
+			// preserves legacy behavior of local snapshot retention also affecting s3
+			if !app.IsSet("etcd-s3-retention") && app.IsSet("etcd-snapshot-retention") {
+				cfg.EtcdS3Retention = cfg.EtcdSnapshotRetention
+			}
 			serverConfig.ControlConfig.EtcdS3 = &config.EtcdS3{
 				AccessKey:     cfg.EtcdS3AccessKey,
 				Bucket:        cfg.EtcdS3BucketName,

--- a/pkg/etcd/s3/s3.go
+++ b/pkg/etcd/s3/s3.go
@@ -129,6 +129,8 @@ func (c *Controller) GetClient(ctx context.Context, etcdS3 *config.EtcdS3) (*Cli
 	// update ConfigSecret in defaults so that comparisons between current and default config
 	// ignore ConfigSecret when deciding if CLI configuration is present.
 	defaultEtcdS3.ConfigSecret = etcdS3.ConfigSecret
+	// also ignore retention, as it may have been defaulted from the etcd-snapshot-retention flag.
+	defaultEtcdS3.Retention = etcdS3.Retention
 
 	// If config is default, try to load config from secret, and fail if it cannot be retrieved or if the secret name is not set.
 	// If config is not default, and secret name is set, warn that the secret is being ignored


### PR DESCRIPTION
#### Proposed Changes ####
Use etcd-snapshot-retention as default for s3 if etcd-s3-retention is not set

#### Types of Changes ####
enhancement

#### Verification ####
See linked issue

#### Testing ####


#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/13769

#### User-Facing Change ####
```release-note

```

#### Further Comments ####
