### PR TITLE
[release-1.34] Bump runc to v1.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ replace (
 	github.com/golang/protobuf => github.com/golang/protobuf v1.5.4
 	github.com/google/cadvisor => github.com/k3s-io/cadvisor v0.52.1
 	github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.12.0
-	github.com/opencontainers/runc => github.com/opencontainers/runc v1.4.0
+	github.com/opencontainers/runc => github.com/opencontainers/runc v1.4.1
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.13.0
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/common => github.com/prometheus/common v0.62.0


### PR DESCRIPTION
#### Proposed Changes ####

Bump runc to v1.4.1

* https://github.com/k3s-io/k3s/pull/13796

#### Types of Changes ####

version bump

#### Verification ####

check version

#### Testing ####


#### Linked Issues ####


#### User-Facing Change ####
```release-note
```

#### Further Comments ####
