### PR TITLE
[release-1.35] Bump cni plugins to v1.9.1

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -55,7 +55,7 @@ if [ -z "$VERSION_CRI_DOCKERD" ]; then
   VERSION_CRI_DOCKERD="v0.0.0"
 fi
 
-VERSION_CNIPLUGINS="v1.9.0-k3s1"
+VERSION_CNIPLUGINS="v1.9.1-k3s1"
 VERSION_FLANNEL_PLUGIN="v1.9.0-flannel1"
 
 VERSION_KUBE_ROUTER=$(get-module-version github.com/cloudnativelabs/kube-router/v2)


### PR DESCRIPTION
#### Proposed Changes ####

Bump cni plugins to v1.9.1

* Backport: https://github.com/k3s-io/k3s/pull/13817

#### Types of Changes ####

version bump for bugfix

#### Verification ####

Check version
See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/13818

#### User-Facing Change ####
```release-note
```

#### Further Comments ####