### PR TITLE
fix: typo in etcd membership error message

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -136,7 +136,7 @@ type membershipError struct {
 }
 
 func (e *membershipError) Error() string {
-	return fmt.Sprintf("this server is a not a member of the etcd cluster. Found %v, expect: %s", e.members, e.self)
+	return fmt.Sprintf("this server is not a member of the etcd cluster. Found %v, expect: %s", e.members, e.self)
 }
 
 func (e *membershipError) Is(target error) bool {


### PR DESCRIPTION
Found a typo while working, quick fix.
It should display "This server is not a member of the etcd cluster" instead of "this server is a not a member of the etcd cluster" Kind regards,

#### Proposed Changes ####

Deletion of "A" character and one space character in an error message

#### Types of Changes ####

It's a typo fix so I guess a bugfix

#### Verification ####

It's a typo correction, instead of "this server is a not a member [...]" it's now "this server is not a member [...]"

#### Testing ####

I don't think it requires testing, feel free to correct me if I though wrong

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
Error message is now correct, doesn't solve the current issue the user is facing though but it's correctly written.
#### Further Comments ####

Wishing you a great day,

Signed-off-by: Damote <damotegit@gmail.com>