### PR TITLE
[Release 1.32] Bump traefik to 3.6.12

### DIFF
--- a/manifests/traefik.yaml
+++ b/manifests/traefik.yaml
@@ -5,7 +5,7 @@ metadata:
   name: traefik-crd
   namespace: kube-system
 spec:
-  chart: https://%{KUBERNETES_API}%/static/charts/traefik-crd-39.0.501+up39.0.5.tgz
+  chart: https://%{KUBERNETES_API}%/static/charts/traefik-crd-39.0.701+up39.0.7.tgz
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -13,7 +13,7 @@ metadata:
   name: traefik
   namespace: kube-system
 spec:
-  chart: https://%{KUBERNETES_API}%/static/charts/traefik-39.0.501+up39.0.5.tgz
+  chart: https://%{KUBERNETES_API}%/static/charts/traefik-39.0.701+up39.0.7.tgz
   set:
     global.systemDefaultRegistry: "%{SYSTEM_DEFAULT_REGISTRY_RAW}%"
   valuesContent: |-
@@ -28,7 +28,7 @@ spec:
     priorityClassName: "system-cluster-critical"
     image:
       repository: "rancher/mirrored-library-traefik"
-      tag: "3.6.10"
+      tag: "3.6.12"
     tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -3,6 +3,6 @@ docker.io/rancher/klipper-lb:v0.4.15
 docker.io/rancher/local-path-provisioner:v0.0.35
 docker.io/rancher/mirrored-coredns-coredns:1.14.2
 docker.io/rancher/mirrored-library-busybox:1.37.0
-docker.io/rancher/mirrored-library-traefik:3.6.10
+docker.io/rancher/mirrored-library-traefik:3.6.12
 docker.io/rancher/mirrored-metrics-server:v0.8.1
 docker.io/rancher/mirrored-pause:3.6


### PR DESCRIPTION
Backport: https://github.com/k3s-io/k3s/pull/13912
Issue: https://github.com/k3s-io/k3s/issues/13924