### PR TITLE
fix: typo 'seperate' -> 'separate' in comments

### DIFF
--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -63,7 +63,7 @@ func GetUserAgent(controllerName string) string {
 }
 
 // SplitStringSlice is a helper function to handle StringSliceFlag containing multiple values
-// By default, StringSliceFlag supports repeated values, and multiple values, seperated by a comma
+// By default, StringSliceFlag supports repeated values, and multiple values, separated by a comma
 // e.g. --foo="bar,car" --foo=baz will result in []string{"bar", "car". "baz"}
 // However, we disable this with urfave/cli/v2, as controls are not granular enough. You can either have all flags
 // support comma separated values, or no flags. We can't have all flags support comma separated values

--- a/tests/docker/test-helpers.go
+++ b/tests/docker/test-helpers.go
@@ -103,7 +103,7 @@ func (config *TestConfig) ProvisionServers(numOfServers int) error {
 	for i := 0; i < numOfServers; i++ {
 
 		// If a server i already exists, skip. This is useful for scenarios where
-		// the first server is started seperate from the rest of the servers
+		// the first server is started separate from the rest of the servers
 		if config.Servers != nil && i < len(config.Servers) {
 			continue
 		}


### PR DESCRIPTION
Two comment-only typo fixes:

- `pkg/util/client.go` — "seperated by a comma" → "separated by a comma"
- `tests/docker/test-helpers.go` — "seperate from the rest" → "separate from the rest"

No behavior change.

#### Proposed Changes

Correct misspellings of "separate".

#### Types of Changes

Comment-only change.

#### Verification

N/A — comment fix.

#### Testing

N/A.

#### Linked Issues

None.