### PR TITLE
[release-1.34] Fix SANs added from comma-separated node-external-ip list

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -283,7 +283,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	}
 	serverConfig.ControlConfig.ServerNodeName = nodeName
 	serverConfig.ControlConfig.SANs = append(serverConfig.ControlConfig.SANs, "127.0.0.1", "::1", "localhost", nodeName)
-	serverConfig.ControlConfig.SANs = append(serverConfig.ControlConfig.SANs, cmds.AgentConfig.NodeExternalIP.Value()...)
+	serverConfig.ControlConfig.SANs = append(serverConfig.ControlConfig.SANs, util.SplitStringSlice(cmds.AgentConfig.NodeExternalIP.Value())...)
 	if shortName := strings.SplitN(nodeName, ".", 2)[0]; shortName != nodeName {
 		serverConfig.ControlConfig.SANs = append(serverConfig.ControlConfig.SANs, shortName)
 	}


### PR DESCRIPTION
#### Proposed Changes ####

Backport https://github.com/k3s-io/k3s/pull/13989

Fix SANs added from comma-separated node-external-ip list.

#### Types of Changes ####
Bugfix

#### Verification ####
See linked issue

#### Testing ####

#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/13988

#### User-Facing Change ####
```release-note
```