### PR TITLE
[release-1.34] Bump klipper-helm image for revision check fix

### DIFF
--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,4 +1,4 @@
-docker.io/rancher/klipper-helm:v0.9.15-build20260324
+docker.io/rancher/klipper-helm:v0.9.17-build20260422
 docker.io/rancher/klipper-lb:v0.4.15
 docker.io/rancher/local-path-provisioner:v0.0.35
 docker.io/rancher/mirrored-coredns-coredns:1.14.2

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -68,7 +68,7 @@ fi
 
 VERSION_ROOT="v0.15.0"
 
-VERSION_HELM_JOB="v0.9.15-build20260324"
+VERSION_HELM_JOB="v0.9.17-build20260422"
 
 GO_VERSION_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${BRANCH_K8S}/.go-version"
 VERSION_GOLANG="go"$(curl -sL "${GO_VERSION_URL}" | tr -d '[:space:]')


### PR DESCRIPTION
#### Proposed Changes ####

* Backport https://github.com/k3s-io/k3s/pull/13995

Bump klipper-helm image to avoid showing job as failed when chart has already been upgraded by another pod:
* https://github.com/k3s-io/klipper-helm/pull/126

Follow-up to:
* https://github.com/k3s-io/klipper-helm/pull/120
* https://github.com/k3s-io/helm-controller/pull/312

#### Types of Changes ####

bugfix

#### Verification ####

Note that helm job pods do not show as failed when the chart has already been upgraded by a previous iteration of the job, and the revision check correctly protects against rollback.

#### Testing ####

#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/13999

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
