### PR TITLE
Replace PreparingExecutor with explicit embedded executor init

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 
@@ -20,13 +19,14 @@ import (
 	"github.com/k3s-io/k3s/pkg/configfilearg"
 	"github.com/k3s-io/k3s/pkg/containerd"
 	ctr2 "github.com/k3s-io/k3s/pkg/ctr"
+	"github.com/k3s-io/k3s/pkg/daemons/executor"
+	"github.com/k3s-io/k3s/pkg/executor/embed"
 	kubectl2 "github.com/k3s-io/k3s/pkg/kubectl"
+	"github.com/k3s-io/k3s/pkg/util/errors"
 	"github.com/moby/sys/reexec"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	crictl2 "sigs.k8s.io/cri-tools/cmd/crictl"
-
-	_ "github.com/k3s-io/k3s/pkg/executor/embed"
 )
 
 func init() {
@@ -34,6 +34,17 @@ func init() {
 	reexec.Register("kubectl", kubectl2.Main)
 	reexec.Register("crictl", crictl2.Main)
 	reexec.Register("ctr", ctr2.Main)
+}
+
+func initExecutor(af cli.ActionFunc) cli.ActionFunc {
+	return func(app *cli.Context) error {
+		ex, err := embed.New(app.Context, &cmds.AgentConfig)
+		if err != nil {
+			return errors.WithMessage(err, "failed to initialize executor")
+		}
+		executor.Set(ex)
+		return af(app)
+	}
 }
 
 func main() {
@@ -47,8 +58,8 @@ func main() {
 	app := cmds.NewApp()
 	app.DisableSliceFlagSeparator = true
 	app.Commands = []*cli.Command{
-		cmds.NewServerCommand(server.Run),
-		cmds.NewAgentCommand(agent.Run),
+		cmds.NewServerCommand(initExecutor(server.Run)),
+		cmds.NewAgentCommand(initExecutor(agent.Run)),
 		cmds.NewKubectlCommand(kubectl.Run),
 		cmds.NewCRICTL(crictl.Run),
 		cmds.NewCtrCommand(ctr.Run),

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"os"
 
 	"github.com/k3s-io/k3s/pkg/cli/agent"
@@ -15,18 +14,30 @@ import (
 	"github.com/k3s-io/k3s/pkg/cli/secretsencrypt"
 	"github.com/k3s-io/k3s/pkg/cli/server"
 	"github.com/k3s-io/k3s/pkg/configfilearg"
+	"github.com/k3s-io/k3s/pkg/daemons/executor"
+	"github.com/k3s-io/k3s/pkg/executor/embed"
+	"github.com/k3s-io/k3s/pkg/util/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
-
-	_ "github.com/k3s-io/k3s/pkg/executor/embed"
 )
+
+func initExecutor(af cli.ActionFunc) cli.ActionFunc {
+	return func(app *cli.Context) error {
+		ex, err := embed.New(app.Context, &cmds.AgentConfig)
+		if err != nil {
+			return errors.WithMessage(err, "failed to initialize executor")
+		}
+		executor.Set(ex)
+		return af(app)
+	}
+}
 
 func main() {
 	app := cmds.NewApp()
 	app.DisableSliceFlagSeparator = true
 	app.Commands = []*cli.Command{
-		cmds.NewServerCommand(server.Run),
-		cmds.NewAgentCommand(agent.Run),
+		cmds.NewServerCommand(initExecutor(server.Run)),
+		cmds.NewAgentCommand(initExecutor(agent.Run)),
 		cmds.NewKubectlCommand(kubectl.Run),
 		cmds.NewCRICTL(crictl.Run),
 		cmds.NewEtcdSnapshotCommands(

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -27,8 +27,6 @@ import (
 	"github.com/k3s-io/k3s/pkg/clientaccess"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/control/deps"
-	"github.com/k3s-io/k3s/pkg/daemons/executor"
-	"github.com/k3s-io/k3s/pkg/signals"
 	"github.com/k3s-io/k3s/pkg/spegel"
 	"github.com/k3s-io/k3s/pkg/util"
 	"github.com/k3s-io/k3s/pkg/util/errors"
@@ -727,13 +725,6 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 	}
 
 	if err := validateNetworkConfig(nodeConfig); err != nil {
-		return nil, err
-	}
-
-	// allow executor to do additional configuration; this is the last chance to modify nodeConfig before certs are signed
-	if err := executor.Prepare(ctx, nodeConfig, *envInfo); err != nil {
-		err = errors.WithMessage(err, "failed to prepare configuration")
-		signals.RequestShutdown(err)
 		return nil, err
 	}
 

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -476,6 +476,44 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	notifySocket := os.Getenv("NOTIFY_SOCKET")
 	os.Unsetenv("NOTIFY_SOCKET")
 
+	// try setting advertise-ip from agent VPN
+	if vpnInfo, _ := vpn.GetInfoFromExecutor(); vpnInfo != nil {
+		// If we are in ipv6-only mode, we should pass the ipv6 address. Otherwise, ipv4
+		if utilsnet.IsIPv6(nodeIPs[0]) {
+			if vpnInfo.IPv6Address != nil {
+				logrus.Infof("Changed advertise-address to %v due to VPN", vpnInfo.IPv6Address)
+				if serverConfig.ControlConfig.AdvertiseIP != "" {
+					logrus.Warn("Conflict in the config detected. VPN integration overwrites advertise-address but the config is setting the advertise-address parameter")
+				}
+				serverConfig.ControlConfig.AdvertiseIP = vpnInfo.IPv6Address.String()
+			} else {
+				return errors.New("tailscale does not provide an ipv6 address")
+			}
+		} else {
+			// We are in dual-stack or ipv4-only mode
+			if vpnInfo.IPv4Address != nil {
+				logrus.Infof("Changed advertise-address to %v due to VPN", vpnInfo.IPv4Address)
+				if serverConfig.ControlConfig.AdvertiseIP != "" {
+					logrus.Warn("Conflict in the config detected. VPN integration overwrites advertise-address but the config is setting the advertise-address parameter")
+				}
+				serverConfig.ControlConfig.AdvertiseIP = vpnInfo.IPv4Address.String()
+			} else {
+				return errors.New("tailscale does not provide an ipv4 address")
+			}
+		}
+		logrus.Warn("Etcd IP (PrivateIP) remains the local IP. Running etcd traffic over VPN is not recommended due to performance issues")
+	} else {
+		// if not set, try setting advertise-ip from agent node-external-ip
+		if serverConfig.ControlConfig.AdvertiseIP == "" && len(cmds.AgentConfig.NodeExternalIP.Value()) != 0 {
+			serverConfig.ControlConfig.AdvertiseIP = util.GetFirstValidIPString(cmds.AgentConfig.NodeExternalIP.Value())
+		}
+
+		// if not set, try setting advertise-ip from agent node-ip
+		if serverConfig.ControlConfig.AdvertiseIP == "" && len(cmds.AgentConfig.NodeIP.Value()) != 0 {
+			serverConfig.ControlConfig.AdvertiseIP = util.GetFirstValidIPString(cmds.AgentConfig.NodeIP.Value())
+		}
+	}
+
 	if err := server.PrepareServer(ctx, wg, &serverConfig, cfg); err != nil {
 		return err
 	}
@@ -549,44 +587,6 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	} else {
 		if err := agent.Run(ctx, wg, agentConfig); err != nil {
 			return err
-		}
-	}
-
-	// try setting advertise-ip from agent VPN
-	if vpnInfo, _ := vpn.GetInfoFromExecutor(); vpnInfo != nil {
-		// If we are in ipv6-only mode, we should pass the ipv6 address. Otherwise, ipv4
-		if utilsnet.IsIPv6(nodeIPs[0]) {
-			if vpnInfo.IPv6Address != nil {
-				logrus.Infof("Changed advertise-address to %v due to VPN", vpnInfo.IPv6Address)
-				if serverConfig.ControlConfig.AdvertiseIP != "" {
-					logrus.Warn("Conflict in the config detected. VPN integration overwrites advertise-address but the config is setting the advertise-address parameter")
-				}
-				serverConfig.ControlConfig.AdvertiseIP = vpnInfo.IPv6Address.String()
-			} else {
-				return errors.New("tailscale does not provide an ipv6 address")
-			}
-		} else {
-			// We are in dual-stack or ipv4-only mode
-			if vpnInfo.IPv4Address != nil {
-				logrus.Infof("Changed advertise-address to %v due to VPN", vpnInfo.IPv4Address)
-				if serverConfig.ControlConfig.AdvertiseIP != "" {
-					logrus.Warn("Conflict in the config detected. VPN integration overwrites advertise-address but the config is setting the advertise-address parameter")
-				}
-				serverConfig.ControlConfig.AdvertiseIP = vpnInfo.IPv4Address.String()
-			} else {
-				return errors.New("tailscale does not provide an ipv4 address")
-			}
-		}
-		logrus.Warn("Etcd IP (PrivateIP) remains the local IP. Running etcd traffic over VPN is not recommended due to performance issues")
-	} else {
-		// if not set, try setting advertise-ip from agent node-external-ip
-		if serverConfig.ControlConfig.AdvertiseIP == "" && len(cmds.AgentConfig.NodeExternalIP.Value()) != 0 {
-			serverConfig.ControlConfig.AdvertiseIP = util.GetFirstValidIPString(cmds.AgentConfig.NodeExternalIP.Value())
-		}
-
-		// if not set, try setting advertise-ip from agent node-ip
-		if serverConfig.ControlConfig.AdvertiseIP == "" && len(cmds.AgentConfig.NodeIP.Value()) != 0 {
-			serverConfig.ControlConfig.AdvertiseIP = util.GetFirstValidIPString(cmds.AgentConfig.NodeIP.Value())
 		}
 	}
 

--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -50,12 +50,6 @@ type Executor interface {
 	IsSelfHosted() bool
 }
 
-// PreparingExecutor is an optional interface that Executors may implement to modify node configuration
-// and CLI flags before config is retrieved from the server.
-type PreparingExecutor interface {
-	Prepare(ctx context.Context, nodeConfig *daemonconfig.Node, cfg cmds.Agent) error
-}
-
 type ETCDSocketOpts struct {
 	ReuseAddress bool `json:"reuse-address,omitempty"`
 	ReusePort    bool `json:"reuse-port,omitempty"`
@@ -287,13 +281,6 @@ func IsSelfHosted() bool {
 		return false
 	}
 	return executor.IsSelfHosted()
-}
-
-func Prepare(ctx context.Context, nodeConfig *daemonconfig.Node, cfg cmds.Agent) error {
-	if ex, ok := executor.(PreparingExecutor); ok {
-		return ex.Prepare(ctx, nodeConfig, cfg)
-	}
-	return nil
 }
 
 func CloseIfNilErr(err error, ch chan struct{}) error {

--- a/pkg/executor/embed/embed.go
+++ b/pkg/executor/embed/embed.go
@@ -30,6 +30,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/version"
 	"github.com/k3s-io/k3s/pkg/vpn"
 	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	cloudprovider "k8s.io/cloud-provider"
 	ccmapp "k8s.io/cloud-provider/app"
@@ -51,13 +52,8 @@ import (
 
 var once sync.Once
 
-func init() {
-	executor.Set(&Embedded{})
-}
-
 // explicit type check
 var _ executor.Executor = &Embedded{}
-var _ executor.PreparingExecutor = &Embedded{}
 var _ vpn.InfoProvider = &Embedded{}
 
 type Embedded struct {
@@ -68,44 +64,50 @@ type Embedded struct {
 	vpnInfo        *vpn.Info
 }
 
-// Prepare modifies the node config prior to downloading client and server certificates from the server.
-// If node IPs or names need to be modified, it should be done here so that the kubelet client and serving certs are valid.
-func (e *Embedded) Prepare(ctx context.Context, nodeConfig *daemonconfig.Node, cfg cmds.Agent) error {
+// New creates a new embeded executor from the provided agent CLI config.
+// Optional components like VPN may modify settings provided by the CLI.
+func New(ctx context.Context, cfg *cmds.Agent) (*Embedded, error) {
 	// If there is a VPN, we must start it early to overwrite NodeIP and flannel interface
+	var vpnInfo *vpn.Info
 	var err error
+
 	if cfg.VPNAuthFile != "" {
 		cfg.VPNAuth, err = util.ReadFile(ctx, cfg.VPNAuthFile)
 		if err != nil {
-			return errors.WithMessage(err, "failed to read vpn-auth-file")
+			return nil, errors.WithMessage(err, "failed to read vpn-auth-file")
 		}
 	}
 
 	if cfg.VPNAuth != "" {
 		err = vpn.StartVPN(cfg.VPNAuth)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		e.vpnInfo, err = vpn.GetInfo(cfg.VPNAuth)
+		vpnInfo, err = vpn.GetInfo(cfg.VPNAuth)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// Pass ipv4, ipv6 or both depending on nodeIPs mode
-		nodeIPs := nodeConfig.AgentConfig.NodeIPs
+		_, nodeIPs, err := util.GetHostnameAndIPs(cfg.NodeName, util.SplitStringSlice(cfg.NodeIP.Value()))
+		if err != nil {
+			return nil, err
+		}
+
 		var vpnIPs []net.IP
-		if utilsnet.IsIPv4(nodeIPs[0]) && e.vpnInfo.IPv4Address != nil {
-			vpnIPs = append(vpnIPs, e.vpnInfo.IPv4Address)
-			if e.vpnInfo.IPv6Address != nil {
-				vpnIPs = append(vpnIPs, e.vpnInfo.IPv6Address)
+		if utilsnet.IsIPv4(nodeIPs[0]) && vpnInfo.IPv4Address != nil {
+			vpnIPs = append(vpnIPs, vpnInfo.IPv4Address)
+			if vpnInfo.IPv6Address != nil {
+				vpnIPs = append(vpnIPs, vpnInfo.IPv6Address)
 			}
-		} else if utilsnet.IsIPv6(nodeIPs[0]) && e.vpnInfo.IPv6Address != nil {
-			vpnIPs = append(vpnIPs, e.vpnInfo.IPv6Address)
-			if e.vpnInfo.IPv4Address != nil {
-				vpnIPs = append(vpnIPs, e.vpnInfo.IPv4Address)
+		} else if utilsnet.IsIPv6(nodeIPs[0]) && vpnInfo.IPv6Address != nil {
+			vpnIPs = append(vpnIPs, vpnInfo.IPv6Address)
+			if vpnInfo.IPv4Address != nil {
+				vpnIPs = append(vpnIPs, vpnInfo.IPv4Address)
 			}
 		} else {
-			return fmt.Errorf("address family mismatch when assigning VPN addresses to node: node=%v, VPN ipv4=%v ipv6=%v", nodeIPs, e.vpnInfo.IPv4Address, e.vpnInfo.IPv6Address)
+			return nil, fmt.Errorf("address family mismatch when assigning VPN addresses to node: node=%v, VPN ipv4=%v ipv6=%v", nodeIPs, vpnInfo.IPv4Address, vpnInfo.IPv6Address)
 		}
 
 		// Overwrite nodeip and flannel interface and throw a warning if user explicitly set those parameters
@@ -117,16 +119,18 @@ func (e *Embedded) Prepare(ctx context.Context, nodeConfig *daemonconfig.Node, c
 			if len(cfg.NodeExternalIP.Value()) != 0 {
 				logrus.Warn("VPN provider overrides node-external-ip parameter")
 			}
-			nodeIPs = vpnIPs
-			nodeConfig.AgentConfig.NodeIPs = vpnIPs
-			nodeConfig.AgentConfig.NodeIP = vpnIPs[0].String()
-			nodeConfig.Flannel.Iface, err = net.InterfaceByName(e.vpnInfo.Interface)
-			if err != nil {
-				return errors.WithMessagef(err, "unable to find vpn interface: %s", e.vpnInfo.Interface)
+
+			// There is no way to clear the backing slice for the StringSlice
+			// so we have to recreate it and rebind it to the flag.
+			cfg.NodeIP = cli.StringSlice{}
+			cmds.NodeIPFlag.Destination = &cfg.NodeIP
+			for _, ip := range vpnIPs {
+				cfg.NodeIP.Set(ip.String())
 			}
+			cfg.FlannelIface = vpnInfo.Interface
 		}
 	}
-	return err
+	return &Embedded{vpnInfo: vpnInfo}, nil
 }
 
 func (e *Embedded) Bootstrap(ctx context.Context, nodeConfig *daemonconfig.Node, cfg cmds.Agent) error {


### PR DESCRIPTION
#### Proposed Changes ####
Drop the short-lived PreparingExecutor interface, which was ineffective at consistently modifying the node config as it ran too late in startup to change everything it needed to change.

Replace it with explicit executor setup, which gets a chance to modify config before anything else is running. This is similar to how other executors in downstream projects (ie RKE2) handle validating executor-specific config.

This also makes embedded executor setup and registration explicit, instead of having it hidden in an `init()` function in the embed module.

#### Types of Changes ####

enhancement

#### Verification ####

Note that tailscale IPs is included in the SAN list of the apiserver cert at /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt:

```console
root@systemd-node-001:/# tailscale status
100.124.31.55  systemd-node-001  username@  linux  -

root@systemd-node-001:/# openssl x509 -noout -text -in /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt | grep Address:
                DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster.local, DNS:localhost, DNS:systemd-node-001.example.com, DNS:systemd-node-001, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1, IP Address:100.124.31.55, IP Address:FD7A:115C:A1E0:0:0:0:1833:1F38, IP Address:10.43.0.1
```

#### Testing ####

* 

#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/13987

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
