### PR TITLE
feat: add k3s-owned systemd watchdog notifier

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -191,8 +191,8 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 // watchdog whenever kube-proxy is disabled.
 func agentHealthCheckers(nodeConfig *daemonconfig.Node) []healthz.HealthChecker {
 	return []healthz.HealthChecker{
-		health.HTTPGet("kubelet", "http://127.0.0.1:10248/healthz"),
-		health.GRPC("cri", nodeConfig.AgentConfig.RuntimeSocket),
+		health.NewHTTPGetHealthz("kubelet", "http://127.0.0.1:10248/healthz"),
+		health.NewGRPCHealthz("cri", nodeConfig.AgentConfig.RuntimeSocket),
 	}
 }
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/client-go/kubernetes"
 	toolscache "k8s.io/client-go/tools/cache"
 	toolswatch "k8s.io/client-go/tools/watch"
@@ -143,6 +144,14 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 	notifySocket := os.Getenv("NOTIFY_SOCKET")
 	os.Unsetenv("NOTIFY_SOCKET")
 
+	// Capture the watchdog interval before stripping WATCHDOG_USEC so the
+	// kubelet's own NewHealthChecker short-circuits and doesn't spawn a
+	// goroutine that logs "Failed to notify watchdog" every tick.
+	watchdogInterval, werr := systemd.SdWatchdogEnabled(true)
+	if werr != nil {
+		logrus.Warnf("systemd watchdog: failed to read WATCHDOG_USEC, watchdog disabled: %v", werr)
+	}
+
 	go func() {
 		if err := startCRI(ctx, nodeConfig); err != nil {
 			signals.RequestShutdown(errors.WithMessage(err, "failed to start container runtime"))
@@ -166,42 +175,25 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 			logrus.Info(version.Program + " agent is up and running")
 			os.Setenv("NOTIFY_SOCKET", notifySocket)
 			systemd.SdNotify(true, "READY=1\n")
-			go watchdog.Run(ctx, notifySocket, agentHealthGroup(nodeConfig))
+			go watchdog.Run(ctx, notifySocket, watchdogInterval, agentHealthCheckers(nodeConfig))
 		}
 	}()
 
 	return nil
 }
 
-// agentHealthGroup returns the set of liveness checks that must all pass for
-// the k3s agent process to be considered healthy by the systemd watchdog. It
-// is only used on agent-only nodes; on server nodes the server's checker set
-// also covers kubelet and kube-proxy. kube-proxy is not included here because
-// its disabled state is not stored on nodeConfig — adding it unconditionally
-// would silence the watchdog whenever kube-proxy is disabled.
-func agentHealthGroup(nodeConfig *daemonconfig.Node) *health.Group {
-	g := health.NewGroup()
-
-	g.Add(health.HTTPGet("kubelet", "http://127.0.0.1:10248/healthz"))
-	if socket := criSocketPath(nodeConfig); socket != "" {
-		g.Add(health.UnixSocket("cri", socket))
+// agentHealthCheckers returns the set of liveness checks that must all pass
+// for the k3s agent process to be considered healthy by the systemd
+// watchdog. Only used on agent-only nodes; on server nodes the server's
+// checker set covers kubelet (and kube-proxy when gated by DisableKubeProxy
+// on Control). kube-proxy is not included here because its disabled state is
+// not stored on nodeConfig — adding it unconditionally would silence the
+// watchdog whenever kube-proxy is disabled.
+func agentHealthCheckers(nodeConfig *daemonconfig.Node) []healthz.HealthChecker {
+	return []healthz.HealthChecker{
+		health.HTTPGet("kubelet", "http://127.0.0.1:10248/healthz"),
+		health.GRPC("cri", nodeConfig.AgentConfig.RuntimeSocket),
 	}
-	return g
-}
-
-// criSocketPath returns a filesystem path suitable for net.DialUnix, stripping
-// the "unix://" scheme that some configurations use. It returns "" when the
-// runtime socket is unknown or not a unix socket.
-func criSocketPath(nodeConfig *daemonconfig.Node) string {
-	addr := nodeConfig.AgentConfig.RuntimeSocket
-	if addr == "" {
-		return ""
-	}
-	addr = strings.TrimPrefix(addr, "unix://")
-	if strings.Contains(addr, "://") {
-		return ""
-	}
-	return addr
 }
 
 // startCRI starts the configured CRI, or waits for an external CRI to be ready.

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -26,6 +26,8 @@ import (
 	"github.com/k3s-io/k3s/pkg/daemons/agent"
 	daemonconfig "github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
+	"github.com/k3s-io/k3s/pkg/daemons/health"
+	"github.com/k3s-io/k3s/pkg/daemons/watchdog"
 	"github.com/k3s-io/k3s/pkg/metrics"
 	"github.com/k3s-io/k3s/pkg/nodeconfig"
 	"github.com/k3s-io/k3s/pkg/profile"
@@ -164,10 +166,42 @@ func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 			logrus.Info(version.Program + " agent is up and running")
 			os.Setenv("NOTIFY_SOCKET", notifySocket)
 			systemd.SdNotify(true, "READY=1\n")
+			go watchdog.Run(ctx, notifySocket, agentHealthGroup(nodeConfig))
 		}
 	}()
 
 	return nil
+}
+
+// agentHealthGroup returns the set of liveness checks that must all pass for
+// the k3s agent process to be considered healthy by the systemd watchdog. It
+// is only used on agent-only nodes; on server nodes the server's checker set
+// also covers kubelet and kube-proxy. kube-proxy is not included here because
+// its disabled state is not stored on nodeConfig — adding it unconditionally
+// would silence the watchdog whenever kube-proxy is disabled.
+func agentHealthGroup(nodeConfig *daemonconfig.Node) *health.Group {
+	g := health.NewGroup()
+
+	g.Add(health.HTTPGet("kubelet", "http://127.0.0.1:10248/healthz"))
+	if socket := criSocketPath(nodeConfig); socket != "" {
+		g.Add(health.UnixSocket("cri", socket))
+	}
+	return g
+}
+
+// criSocketPath returns a filesystem path suitable for net.DialUnix, stripping
+// the "unix://" scheme that some configurations use. It returns "" when the
+// runtime socket is unknown or not a unix socket.
+func criSocketPath(nodeConfig *daemonconfig.Node) string {
+	addr := nodeConfig.AgentConfig.RuntimeSocket
+	if addr == "" {
+		return ""
+	}
+	addr = strings.TrimPrefix(addr, "unix://")
+	if strings.Contains(addr, "://") {
+		return ""
+	}
+	return addr
 }
 
 // startCRI starts the configured CRI, or waits for an external CRI to be ready.

--- a/pkg/agent/run_test.go
+++ b/pkg/agent/run_test.go
@@ -97,3 +97,25 @@ func Test_UnitGetConntrackConfig(t *testing.T) {
 		})
 	}
 }
+
+func Test_UnitCRISocketPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		socket string
+		want   string
+	}{
+		{name: "empty", socket: "", want: ""},
+		{name: "plain path", socket: "/run/k3s/containerd/containerd.sock", want: "/run/k3s/containerd/containerd.sock"},
+		{name: "unix scheme", socket: "unix:///run/k3s/containerd/containerd.sock", want: "/run/k3s/containerd/containerd.sock"},
+		{name: "non-unix scheme", socket: "tcp://127.0.0.1:1234", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeConfig := &daemonconfig.Node{}
+			nodeConfig.AgentConfig.RuntimeSocket = tt.socket
+			if got := criSocketPath(nodeConfig); got != tt.want {
+				t.Errorf("criSocketPath(%q) = %q, want %q", tt.socket, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/agent/run_test.go
+++ b/pkg/agent/run_test.go
@@ -97,25 +97,3 @@ func Test_UnitGetConntrackConfig(t *testing.T) {
 		})
 	}
 }
-
-func Test_UnitCRISocketPath(t *testing.T) {
-	tests := []struct {
-		name   string
-		socket string
-		want   string
-	}{
-		{name: "empty", socket: "", want: ""},
-		{name: "plain path", socket: "/run/k3s/containerd/containerd.sock", want: "/run/k3s/containerd/containerd.sock"},
-		{name: "unix scheme", socket: "unix:///run/k3s/containerd/containerd.sock", want: "/run/k3s/containerd/containerd.sock"},
-		{name: "non-unix scheme", socket: "tcp://127.0.0.1:1234", want: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			nodeConfig := &daemonconfig.Node{}
-			nodeConfig.AgentConfig.RuntimeSocket = tt.socket
-			if got := criSocketPath(nodeConfig); got != tt.want {
-				t.Errorf("criSocketPath(%q) = %q, want %q", tt.socket, got, tt.want)
-			}
-		})
-	}
-}

--- a/pkg/cli/cmds/log_linux.go
+++ b/pkg/cli/cmds/log_linux.go
@@ -57,7 +57,11 @@ func forkIfLoggingOrReaping() error {
 		}
 
 		args := append([]string{version.Program}, os.Args[1:]...)
-		env := append(os.Environ(), "_K3S_LOG_REEXEC_=true", "NOTIFY_SOCKET=")
+		// NOTIFY_SOCKET is intentionally passed through to the child so that
+		// pkg/daemons/watchdog can drive systemd's WATCHDOG=1 pings. The child
+		// strips NOTIFY_SOCKET from its env early (server.go / agent run.go)
+		// before any embedded component can read it.
+		env := append(os.Environ(), "_K3S_LOG_REEXEC_=true")
 		ctx := signals.SetupSignalContext()
 		cmd := exec.CommandContext(ctx, "/proc/self/exe")
 		cmd.Args = args

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +19,8 @@ import (
 	"github.com/k3s-io/k3s/pkg/clientaccess"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/daemons/executor"
+	"github.com/k3s-io/k3s/pkg/daemons/health"
+	"github.com/k3s-io/k3s/pkg/daemons/watchdog"
 	"github.com/k3s-io/k3s/pkg/datadir"
 	"github.com/k3s-io/k3s/pkg/etcd"
 	k3smetrics "github.com/k3s-io/k3s/pkg/metrics"
@@ -615,9 +618,46 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		logrus.Info(version.Program + " is up and running")
 		os.Setenv("NOTIFY_SOCKET", notifySocket)
 		systemd.SdNotify(true, "READY=1\n")
+		go watchdog.Run(ctx, notifySocket, serverHealthGroup(&serverConfig.ControlConfig, cfg.DisableAgent))
 	}()
 
 	return server.StartServer(ctx, wg, &serverConfig, cfg)
+}
+
+// serverHealthGroup returns the set of liveness checks that must all pass for
+// the k3s server process to be considered healthy by the systemd watchdog.
+// Components that are disabled via --disable-* flags are skipped. When the
+// embedded agent is running on this node, kubelet and kube-proxy checks are
+// included as well, because the same k3s process is responsible for their
+// liveness too. All probes target loopback because every component lives in
+// the same process.
+func serverHealthGroup(cc *config.Control, agentDisabled bool) *health.Group {
+	g := health.NewGroup()
+	host := cc.Loopback(false)
+
+	if !cc.DisableAPIServer && cc.HTTPSPort > 0 {
+		url := fmt.Sprintf("https://%s/livez", net.JoinHostPort(host, strconv.Itoa(cc.HTTPSPort)))
+		g.Add(health.HTTPGet("kube-apiserver", url))
+	}
+	if !cc.DisableETCD {
+		g.Add(health.TCP("etcd", net.JoinHostPort(host, "2379")))
+	}
+	if !cc.DisableControllerManager {
+		g.Add(health.TCP("kube-controller-manager", net.JoinHostPort(host, "10257")))
+	}
+	if !cc.DisableScheduler {
+		g.Add(health.TCP("kube-scheduler", net.JoinHostPort(host, "10259")))
+	}
+	if cc.SupervisorPort > 0 {
+		g.Add(health.TCP("supervisor", net.JoinHostPort(host, strconv.Itoa(cc.SupervisorPort))))
+	}
+	if !agentDisabled {
+		g.Add(health.HTTPGet("kubelet", fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, "10248"))))
+		if !cc.DisableKubeProxy {
+			g.Add(health.HTTPGet("kube-proxy", fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, "10256"))))
+		}
+	}
+	return g
 }
 
 // validateNetworkConfig ensures that the network configuration values make sense.

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -42,6 +42,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server/healthz"
 	kubeapiserverflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controlplane/apiserver/options"
@@ -479,6 +480,14 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	notifySocket := os.Getenv("NOTIFY_SOCKET")
 	os.Unsetenv("NOTIFY_SOCKET")
 
+	// Capture the watchdog interval before stripping WATCHDOG_USEC so the
+	// kubelet's own NewHealthChecker short-circuits and doesn't spawn a
+	// goroutine that logs "Failed to notify watchdog" every tick.
+	watchdogInterval, err := systemd.SdWatchdogEnabled(true)
+	if err != nil {
+		logrus.Warnf("systemd watchdog: failed to read WATCHDOG_USEC, watchdog disabled: %v", err)
+	}
+
 	// try setting advertise-ip from agent VPN
 	if vpnInfo, _ := vpn.GetInfoFromExecutor(); vpnInfo != nil {
 		// If we are in ipv6-only mode, we should pass the ipv6 address. Otherwise, ipv4
@@ -618,46 +627,49 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		logrus.Info(version.Program + " is up and running")
 		os.Setenv("NOTIFY_SOCKET", notifySocket)
 		systemd.SdNotify(true, "READY=1\n")
-		go watchdog.Run(ctx, notifySocket, serverHealthGroup(&serverConfig.ControlConfig, cfg.DisableAgent))
+		go watchdog.Run(ctx, notifySocket, watchdogInterval, serverHealthCheckers(&serverConfig.ControlConfig, cfg.DisableAgent))
 	}()
 
 	return server.StartServer(ctx, wg, &serverConfig, cfg)
 }
 
-// serverHealthGroup returns the set of liveness checks that must all pass for
-// the k3s server process to be considered healthy by the systemd watchdog.
-// Components that are disabled via --disable-* flags are skipped. When the
-// embedded agent is running on this node, kubelet and kube-proxy checks are
-// included as well, because the same k3s process is responsible for their
-// liveness too. All probes target loopback because every component lives in
-// the same process.
-func serverHealthGroup(cc *config.Control, agentDisabled bool) *health.Group {
-	g := health.NewGroup()
+// serverHealthCheckers returns the liveness checks that must all pass for the
+// k3s server process to be considered healthy by the systemd watchdog.
+// Components disabled via --disable-* are skipped. When the embedded agent is
+// running on this node, kubelet and kube-proxy are included too, since the
+// same process owns their liveness. Endpoints mirror the RKE2 static-pod
+// readiness/liveness probes:
+//
+//	https://github.com/rancher/rke2/blob/v1.36.0+rke2r1/pkg/podtemplate/spec.go
+func serverHealthCheckers(cc *config.Control, agentDisabled bool) []healthz.HealthChecker {
+	var checkers []healthz.HealthChecker
 	host := cc.Loopback(false)
 
 	if !cc.DisableAPIServer && cc.HTTPSPort > 0 {
 		url := fmt.Sprintf("https://%s/livez", net.JoinHostPort(host, strconv.Itoa(cc.HTTPSPort)))
-		g.Add(health.HTTPGet("kube-apiserver", url))
+		checkers = append(checkers, health.HTTPGet("kube-apiserver", url))
 	}
 	if !cc.DisableETCD {
-		g.Add(health.TCP("etcd", net.JoinHostPort(host, "2379")))
+		checkers = append(checkers, health.HTTPGet("etcd", fmt.Sprintf("http://%s/health?serializable=true", net.JoinHostPort(host, "2381"))))
 	}
 	if !cc.DisableControllerManager {
-		g.Add(health.TCP("kube-controller-manager", net.JoinHostPort(host, "10257")))
+		checkers = append(checkers, health.HTTPGet("kube-controller-manager", fmt.Sprintf("https://%s/healthz", net.JoinHostPort(host, "10257"))))
 	}
 	if !cc.DisableScheduler {
-		g.Add(health.TCP("kube-scheduler", net.JoinHostPort(host, "10259")))
+		checkers = append(checkers, health.HTTPGet("kube-scheduler", fmt.Sprintf("https://%s/healthz", net.JoinHostPort(host, "10259"))))
 	}
 	if cc.SupervisorPort > 0 {
-		g.Add(health.TCP("supervisor", net.JoinHostPort(host, strconv.Itoa(cc.SupervisorPort))))
+		// The supervisor has no HTTP /healthz; a TCP probe verifies the
+		// listener is still bound.
+		checkers = append(checkers, health.TCP("supervisor", net.JoinHostPort(host, strconv.Itoa(cc.SupervisorPort))))
 	}
 	if !agentDisabled {
-		g.Add(health.HTTPGet("kubelet", fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, "10248"))))
+		checkers = append(checkers, health.HTTPGet("kubelet", fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, "10248"))))
 		if !cc.DisableKubeProxy {
-			g.Add(health.HTTPGet("kube-proxy", fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, "10256"))))
+			checkers = append(checkers, health.HTTPGet("kube-proxy", fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, "10256"))))
 		}
 	}
-	return g
+	return checkers
 }
 
 // validateNetworkConfig ensures that the network configuration values make sense.

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -646,27 +646,29 @@ func serverHealthCheckers(cc *config.Control, agentDisabled bool) []healthz.Heal
 	host := cc.Loopback(false)
 
 	if !cc.DisableAPIServer && cc.HTTPSPort > 0 {
+		// k3s starts kube-apiserver with --anonymous-auth=false, so /livez
+		// requires a client cert; the admin client cert is the simplest
+		// in-process identity that satisfies authn + authorization.
 		url := fmt.Sprintf("https://%s/livez", net.JoinHostPort(host, strconv.Itoa(cc.HTTPSPort)))
-		checkers = append(checkers, health.HTTPGet("kube-apiserver", url))
+		checkers = append(checkers, health.NewHTTPGetWithClientCertHealthz("kube-apiserver", url,
+			cc.Runtime.ClientAdminCert, cc.Runtime.ClientAdminKey))
 	}
 	if !cc.DisableETCD {
-		checkers = append(checkers, health.HTTPGet("etcd", fmt.Sprintf("http://%s/health?serializable=true", net.JoinHostPort(host, "2381"))))
+		checkers = append(checkers, health.NewHTTPGetHealthz("etcd", fmt.Sprintf("http://%s/health?serializable=true", net.JoinHostPort(host, "2381"))))
 	}
 	if !cc.DisableControllerManager {
-		checkers = append(checkers, health.HTTPGet("kube-controller-manager", fmt.Sprintf("https://%s/healthz", net.JoinHostPort(host, "10257"))))
+		checkers = append(checkers, health.NewHTTPGetHealthz("kube-controller-manager", fmt.Sprintf("https://%s/healthz", net.JoinHostPort(host, "10257"))))
 	}
 	if !cc.DisableScheduler {
-		checkers = append(checkers, health.HTTPGet("kube-scheduler", fmt.Sprintf("https://%s/healthz", net.JoinHostPort(host, "10259"))))
+		checkers = append(checkers, health.NewHTTPGetHealthz("kube-scheduler", fmt.Sprintf("https://%s/healthz", net.JoinHostPort(host, "10259"))))
 	}
 	if cc.SupervisorPort > 0 {
-		// The supervisor has no HTTP /healthz; a TCP probe verifies the
-		// listener is still bound.
-		checkers = append(checkers, health.TCP("supervisor", net.JoinHostPort(host, strconv.Itoa(cc.SupervisorPort))))
+		checkers = append(checkers, health.NewHTTPGetHealthz("supervisor", fmt.Sprintf("https://%s/ping", net.JoinHostPort(host, strconv.Itoa(cc.SupervisorPort)))))
 	}
 	if !agentDisabled {
-		checkers = append(checkers, health.HTTPGet("kubelet", fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, "10248"))))
+		checkers = append(checkers, health.NewHTTPGetHealthz("kubelet", fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, "10248"))))
 		if !cc.DisableKubeProxy {
-			checkers = append(checkers, health.HTTPGet("kube-proxy", fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, "10256"))))
+			checkers = append(checkers, health.NewHTTPGetHealthz("kube-proxy", fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, "10256"))))
 		}
 	}
 	return checkers

--- a/pkg/daemons/health/health.go
+++ b/pkg/daemons/health/health.go
@@ -17,7 +17,7 @@ import (
 
 const dialTimeout = 5 * time.Second
 
-func HTTPGet(name, url string) healthz.HealthChecker {
+func NewHTTPGetHealthz(name, url string) healthz.HealthChecker {
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
@@ -43,7 +43,42 @@ func HTTPGet(name, url string) healthz.HealthChecker {
 	})
 }
 
-func TCP(name, addr string) healthz.HealthChecker {
+func NewHTTPGetWithClientCertHealthz(name, url, certFile, keyFile string) healthz.HealthChecker {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return healthz.NamedCheck(name, func(_ *http.Request) error {
+			return fmt.Errorf("load client cert %s/%s: %w", certFile, keyFile, err)
+		})
+	}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				Certificates:       []tls.Certificate{cert},
+			},
+			DisableKeepAlives: true,
+		},
+	}
+	return healthz.NamedCheck(name, func(_ *http.Request) error {
+		ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("get %s: %w", url, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("get %s: status %d", url, resp.StatusCode)
+		}
+		return nil
+	})
+}
+
+func NewTCPConnectHealthz(name, addr string) healthz.HealthChecker {
 	return healthz.NamedCheck(name, func(_ *http.Request) error {
 		ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
 		defer cancel()
@@ -56,7 +91,7 @@ func TCP(name, addr string) healthz.HealthChecker {
 	})
 }
 
-func GRPC(name, target string) healthz.HealthChecker {
+func NewGRPCHealthz(name, target string) healthz.HealthChecker {
 	target = strings.TrimPrefix(target, "unix://")
 	dialTarget := "unix:" + target
 	return healthz.NamedCheck(name, func(_ *http.Request) error {

--- a/pkg/daemons/health/health.go
+++ b/pkg/daemons/health/health.go
@@ -1,7 +1,3 @@
-// Package health provides a small framework for registering per-component
-// liveness probes used by the systemd watchdog notifier. Each registered
-// Checker is invoked on every watchdog tick; if any check fails the notifier
-// stays silent and systemd will eventually restart k3s.
 package health
 
 import (
@@ -10,95 +6,28 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"k8s.io/apiserver/pkg/server/healthz"
 )
 
 const dialTimeout = 5 * time.Second
 
-type Checker interface {
-	Name() string
-	Check(ctx context.Context) error
-}
-
-type Func struct {
-	ComponentName string
-	Probe         func(ctx context.Context) error
-}
-
-func (f Func) Name() string                    { return f.ComponentName }
-func (f Func) Check(ctx context.Context) error { return f.Probe(ctx) }
-
-type Group struct {
-	checkers []Checker
-}
-
-func NewGroup() *Group { return &Group{} }
-
-func (g *Group) Add(c ...Checker) {
-	for _, ck := range c {
-		if ck == nil {
-			continue
-		}
-		g.checkers = append(g.checkers, ck)
-	}
-}
-
-func (g *Group) Len() int { return len(g.checkers) }
-
-func (g *Group) Names() []string {
-	names := make([]string, len(g.checkers))
-	for i, c := range g.checkers {
-		names[i] = c.Name()
-	}
-	return names
-}
-
-func (g *Group) CheckAll(ctx context.Context) (string, error) {
-	for _, c := range g.checkers {
-		if err := c.Check(ctx); err != nil {
-			return c.Name(), err
-		}
-	}
-	return "", nil
-}
-
-func TCP(name, addr string) Checker {
-	return Func{ComponentName: name, Probe: func(ctx context.Context) error {
-		probeCtx, cancel := context.WithTimeout(ctx, dialTimeout)
-		defer cancel()
-		var d net.Dialer
-		conn, err := d.DialContext(probeCtx, "tcp", addr)
-		if err != nil {
-			return fmt.Errorf("dial tcp %s: %w", addr, err)
-		}
-		return conn.Close()
-	}}
-}
-
-func UnixSocket(name, path string) Checker {
-	return Func{ComponentName: name, Probe: func(ctx context.Context) error {
-		probeCtx, cancel := context.WithTimeout(ctx, dialTimeout)
-		defer cancel()
-		var d net.Dialer
-		conn, err := d.DialContext(probeCtx, "unix", path)
-		if err != nil {
-			return fmt.Errorf("dial unix %s: %w", path, err)
-		}
-		return conn.Close()
-	}}
-}
-
-func HTTPGet(name, url string) Checker {
+func HTTPGet(name, url string) healthz.HealthChecker {
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 			DisableKeepAlives: true,
 		},
 	}
-	return Func{ComponentName: name, Probe: func(ctx context.Context) error {
-		probeCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+	return healthz.NamedCheck(name, func(_ *http.Request) error {
+		ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
 		defer cancel()
-		req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, url, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return err
 		}
@@ -111,5 +40,41 @@ func HTTPGet(name, url string) Checker {
 			return fmt.Errorf("get %s: status %d", url, resp.StatusCode)
 		}
 		return nil
-	}}
+	})
+}
+
+func TCP(name, addr string) healthz.HealthChecker {
+	return healthz.NamedCheck(name, func(_ *http.Request) error {
+		ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+		defer cancel()
+		var d net.Dialer
+		conn, err := d.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return fmt.Errorf("dial tcp %s: %w", addr, err)
+		}
+		return conn.Close()
+	})
+}
+
+func GRPC(name, target string) healthz.HealthChecker {
+	target = strings.TrimPrefix(target, "unix://")
+	dialTarget := "unix:" + target
+	return healthz.NamedCheck(name, func(_ *http.Request) error {
+		ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+		defer cancel()
+		conn, err := grpc.NewClient(dialTarget, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return fmt.Errorf("dial grpc %s: %w", dialTarget, err)
+		}
+		defer conn.Close()
+		client := healthpb.NewHealthClient(conn)
+		resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
+		if err != nil {
+			return fmt.Errorf("grpc health check %s: %w", dialTarget, err)
+		}
+		if resp.Status != healthpb.HealthCheckResponse_SERVING {
+			return fmt.Errorf("grpc health check %s: status %s", dialTarget, resp.Status)
+		}
+		return nil
+	})
 }

--- a/pkg/daemons/health/health.go
+++ b/pkg/daemons/health/health.go
@@ -1,0 +1,115 @@
+// Package health provides a small framework for registering per-component
+// liveness probes used by the systemd watchdog notifier. Each registered
+// Checker is invoked on every watchdog tick; if any check fails the notifier
+// stays silent and systemd will eventually restart k3s.
+package health
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+const dialTimeout = 5 * time.Second
+
+type Checker interface {
+	Name() string
+	Check(ctx context.Context) error
+}
+
+type Func struct {
+	ComponentName string
+	Probe         func(ctx context.Context) error
+}
+
+func (f Func) Name() string                    { return f.ComponentName }
+func (f Func) Check(ctx context.Context) error { return f.Probe(ctx) }
+
+type Group struct {
+	checkers []Checker
+}
+
+func NewGroup() *Group { return &Group{} }
+
+func (g *Group) Add(c ...Checker) {
+	for _, ck := range c {
+		if ck == nil {
+			continue
+		}
+		g.checkers = append(g.checkers, ck)
+	}
+}
+
+func (g *Group) Len() int { return len(g.checkers) }
+
+func (g *Group) Names() []string {
+	names := make([]string, len(g.checkers))
+	for i, c := range g.checkers {
+		names[i] = c.Name()
+	}
+	return names
+}
+
+func (g *Group) CheckAll(ctx context.Context) (string, error) {
+	for _, c := range g.checkers {
+		if err := c.Check(ctx); err != nil {
+			return c.Name(), err
+		}
+	}
+	return "", nil
+}
+
+func TCP(name, addr string) Checker {
+	return Func{ComponentName: name, Probe: func(ctx context.Context) error {
+		probeCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+		defer cancel()
+		var d net.Dialer
+		conn, err := d.DialContext(probeCtx, "tcp", addr)
+		if err != nil {
+			return fmt.Errorf("dial tcp %s: %w", addr, err)
+		}
+		return conn.Close()
+	}}
+}
+
+func UnixSocket(name, path string) Checker {
+	return Func{ComponentName: name, Probe: func(ctx context.Context) error {
+		probeCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+		defer cancel()
+		var d net.Dialer
+		conn, err := d.DialContext(probeCtx, "unix", path)
+		if err != nil {
+			return fmt.Errorf("dial unix %s: %w", path, err)
+		}
+		return conn.Close()
+	}}
+}
+
+func HTTPGet(name, url string) Checker {
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+			DisableKeepAlives: true,
+		},
+	}
+	return Func{ComponentName: name, Probe: func(ctx context.Context) error {
+		probeCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("get %s: %w", url, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("get %s: status %d", url, resp.StatusCode)
+		}
+		return nil
+	}}
+}

--- a/pkg/daemons/health/health_test.go
+++ b/pkg/daemons/health/health_test.go
@@ -2,11 +2,20 @@ package health
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -19,7 +28,7 @@ func Test_UnitTCPChecker(t *testing.T) {
 	}
 	t.Cleanup(func() { ln.Close() })
 
-	c := TCP("ok", ln.Addr().String())
+	c := NewTCPConnectHealthz("ok", ln.Addr().String())
 	if c.Name() != "ok" {
 		t.Errorf("Name() = %q, want %q", c.Name(), "ok")
 	}
@@ -27,7 +36,7 @@ func Test_UnitTCPChecker(t *testing.T) {
 		t.Errorf("expected open port to pass, got %v", err)
 	}
 	ln.Close()
-	if err := TCP("closed", ln.Addr().String()).Check(nil); err == nil {
+	if err := NewTCPConnectHealthz("closed", ln.Addr().String()).Check(nil); err == nil {
 		t.Errorf("expected closed port to fail")
 	}
 }
@@ -43,13 +52,13 @@ func Test_UnitHTTPGetChecker(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	if err := HTTPGet("ok", srv.URL+"/ok").Check(nil); err != nil {
+	if err := NewHTTPGetHealthz("ok", srv.URL+"/ok").Check(nil); err != nil {
 		t.Errorf("expected 200 to pass, got %v", err)
 	}
-	if err := HTTPGet("fail", srv.URL+"/fail").Check(nil); err == nil {
+	if err := NewHTTPGetHealthz("fail", srv.URL+"/fail").Check(nil); err == nil {
 		t.Errorf("expected 500 to fail")
 	}
-	if err := HTTPGet("dial", "http://127.0.0.1:1/never").Check(nil); err == nil {
+	if err := NewHTTPGetHealthz("dial", "http://127.0.0.1:1/never").Check(nil); err == nil {
 		t.Errorf("expected unreachable URL to fail")
 	}
 }
@@ -60,9 +69,80 @@ func Test_UnitHTTPGetCheckerSkipsTLSVerify(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
-	if err := HTTPGet("tls", srv.URL+"/livez").Check(nil); err != nil {
+	if err := NewHTTPGetHealthz("tls", srv.URL+"/livez").Check(nil); err != nil {
 		t.Errorf("expected TLS-skip-verify probe to pass against self-signed cert, got %v", err)
 	}
+}
+
+func Test_UnitHTTPGetWithClientCertChecker(t *testing.T) {
+	// TLS server that requires (and inspects) a client cert.
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(r.TLS.PeerCertificates) == 0 {
+			http.Error(w, "no client cert", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.TLS = &tls.Config{ClientAuth: tls.RequireAnyClientCert}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	// Generate a throwaway client cert + key on disk.
+	certPath, keyPath := writeSelfSignedCert(t)
+
+	if err := NewHTTPGetWithClientCertHealthz("apiserver", srv.URL+"/livez", certPath, keyPath).Check(nil); err != nil {
+		t.Errorf("expected probe with client cert to pass, got %v", err)
+	}
+
+	// Without a cert the same endpoint should 401.
+	if err := NewHTTPGetHealthz("apiserver-anon", srv.URL+"/livez").Check(nil); err == nil {
+		t.Errorf("expected anonymous probe to fail without client cert")
+	}
+}
+
+func Test_UnitHTTPGetWithClientCertMissingFiles(t *testing.T) {
+	// Cert path doesn't exist — Check should return an error every call,
+	// not panic.
+	c := NewHTTPGetWithClientCertHealthz("apiserver", "https://127.0.0.1:1/livez", "/nonexistent.crt", "/nonexistent.key")
+	if err := c.Check(nil); err == nil {
+		t.Errorf("expected missing cert files to surface as a Check error")
+	}
+}
+
+// writeSelfSignedCert generates an in-memory self-signed cert and writes the
+// PEM-encoded cert and key to a tempdir. Returns their paths.
+func writeSelfSignedCert(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "client.crt")
+	keyPath = filepath.Join(dir, "client.key")
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}), 0600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return certPath, keyPath
 }
 
 // healthServer is a minimal implementation of grpc.health.v1.Health that
@@ -98,21 +178,21 @@ func startHealthServer(t *testing.T, status healthpb.HealthCheckResponse_Serving
 
 func Test_UnitGRPCCheckerServing(t *testing.T) {
 	socket := startHealthServer(t, healthpb.HealthCheckResponse_SERVING)
-	if err := GRPC("cri", socket).Check(nil); err != nil {
+	if err := NewGRPCHealthz("cri", socket).Check(nil); err != nil {
 		t.Errorf("expected SERVING status to pass, got %v", err)
 	}
 }
 
 func Test_UnitGRPCCheckerNotServing(t *testing.T) {
 	socket := startHealthServer(t, healthpb.HealthCheckResponse_NOT_SERVING)
-	if err := GRPC("cri", socket).Check(nil); err == nil {
+	if err := NewGRPCHealthz("cri", socket).Check(nil); err == nil {
 		t.Errorf("expected NOT_SERVING status to fail")
 	}
 }
 
 func Test_UnitGRPCCheckerStripsUnixScheme(t *testing.T) {
 	socket := startHealthServer(t, healthpb.HealthCheckResponse_SERVING)
-	if err := GRPC("cri", "unix://"+socket).Check(nil); err != nil {
+	if err := NewGRPCHealthz("cri", "unix://"+socket).Check(nil); err != nil {
 		t.Errorf("expected unix:// scheme to be stripped, got %v", err)
 	}
 }
@@ -120,7 +200,7 @@ func Test_UnitGRPCCheckerStripsUnixScheme(t *testing.T) {
 func Test_UnitGRPCCheckerMissingSocket(t *testing.T) {
 	dir := t.TempDir()
 	socket := filepath.Join(dir, "absent.sock")
-	if err := GRPC("cri", socket).Check(nil); err == nil {
+	if err := NewGRPCHealthz("cri", socket).Check(nil); err == nil {
 		t.Errorf("expected missing socket to fail")
 	}
 }

--- a/pkg/daemons/health/health_test.go
+++ b/pkg/daemons/health/health_test.go
@@ -2,53 +2,15 @@ package health
 
 import (
 	"context"
-	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
+
+	"google.golang.org/grpc"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
-
-func Test_UnitGroupCheckAll(t *testing.T) {
-	boom := errors.New("boom")
-	g := NewGroup()
-	g.Add(
-		Func{ComponentName: "first", Probe: func(_ context.Context) error { return nil }},
-		Func{ComponentName: "second", Probe: func(_ context.Context) error { return boom }},
-		Func{ComponentName: "third", Probe: func(_ context.Context) error { t.Fatal("third should not run after second failed"); return nil }},
-	)
-	name, err := g.CheckAll(context.Background())
-	if name != "second" {
-		t.Errorf("expected first failure to be %q, got %q", "second", name)
-	}
-	if !errors.Is(err, boom) {
-		t.Errorf("expected wrapped boom error, got %v", err)
-	}
-}
-
-func Test_UnitGroupCheckAllPasses(t *testing.T) {
-	g := NewGroup()
-	g.Add(
-		Func{ComponentName: "a", Probe: func(_ context.Context) error { return nil }},
-		Func{ComponentName: "b", Probe: func(_ context.Context) error { return nil }},
-	)
-	if name, err := g.CheckAll(context.Background()); name != "" || err != nil {
-		t.Errorf("expected ('', nil), got (%q, %v)", name, err)
-	}
-}
-
-func Test_UnitGroupAddSkipsNil(t *testing.T) {
-	g := NewGroup()
-	g.Add(nil, Func{ComponentName: "x", Probe: func(_ context.Context) error { return nil }}, nil)
-	if g.Len() != 1 {
-		t.Errorf("expected nil checkers to be skipped; got Len=%d", g.Len())
-	}
-	if names := g.Names(); len(names) != 1 || names[0] != "x" {
-		t.Errorf("unexpected names: %v", names)
-	}
-}
 
 func Test_UnitTCPChecker(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -57,33 +19,16 @@ func Test_UnitTCPChecker(t *testing.T) {
 	}
 	t.Cleanup(func() { ln.Close() })
 
-	if err := TCP("ok", ln.Addr().String()).Check(context.Background()); err != nil {
+	c := TCP("ok", ln.Addr().String())
+	if c.Name() != "ok" {
+		t.Errorf("Name() = %q, want %q", c.Name(), "ok")
+	}
+	if err := c.Check(nil); err != nil {
 		t.Errorf("expected open port to pass, got %v", err)
 	}
 	ln.Close()
-	if err := TCP("closed", ln.Addr().String()).Check(context.Background()); err == nil {
+	if err := TCP("closed", ln.Addr().String()).Check(nil); err == nil {
 		t.Errorf("expected closed port to fail")
-	}
-}
-
-func Test_UnitUnixSocketChecker(t *testing.T) {
-	dir := t.TempDir()
-	socket := filepath.Join(dir, "test.sock")
-
-	ln, err := net.Listen("unix", socket)
-	if err != nil {
-		t.Fatalf("listen unix: %v", err)
-	}
-	t.Cleanup(func() { ln.Close() })
-
-	if err := UnixSocket("ok", socket).Check(context.Background()); err != nil {
-		t.Errorf("expected open socket to pass, got %v", err)
-	}
-
-	ln.Close()
-	_ = os.Remove(socket)
-	if err := UnixSocket("missing", socket).Check(context.Background()); err == nil {
-		t.Errorf("expected missing socket to fail")
 	}
 }
 
@@ -92,19 +37,19 @@ func Test_UnitHTTPGetChecker(t *testing.T) {
 		switch r.URL.Path {
 		case "/ok":
 			w.WriteHeader(http.StatusOK)
-		case "/fail":
+		default:
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}))
 	t.Cleanup(srv.Close)
 
-	if err := HTTPGet("ok", srv.URL+"/ok").Check(context.Background()); err != nil {
-		t.Errorf("expected 200 response to pass, got %v", err)
+	if err := HTTPGet("ok", srv.URL+"/ok").Check(nil); err != nil {
+		t.Errorf("expected 200 to pass, got %v", err)
 	}
-	if err := HTTPGet("fail", srv.URL+"/fail").Check(context.Background()); err == nil {
-		t.Errorf("expected 500 response to fail")
+	if err := HTTPGet("fail", srv.URL+"/fail").Check(nil); err == nil {
+		t.Errorf("expected 500 to fail")
 	}
-	if err := HTTPGet("dial", "http://127.0.0.1:1/never").Check(context.Background()); err == nil {
+	if err := HTTPGet("dial", "http://127.0.0.1:1/never").Check(nil); err == nil {
 		t.Errorf("expected unreachable URL to fail")
 	}
 }
@@ -115,7 +60,67 @@ func Test_UnitHTTPGetCheckerSkipsTLSVerify(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
-	if err := HTTPGet("tls", srv.URL+"/livez").Check(context.Background()); err != nil {
+	if err := HTTPGet("tls", srv.URL+"/livez").Check(nil); err != nil {
 		t.Errorf("expected TLS-skip-verify probe to pass against self-signed cert, got %v", err)
+	}
+}
+
+// healthServer is a minimal implementation of grpc.health.v1.Health that
+// returns a configurable status — used to test the gRPC health checker
+// against both SERVING and NOT_SERVING responses.
+type healthServer struct {
+	healthpb.UnimplementedHealthServer
+	status healthpb.HealthCheckResponse_ServingStatus
+}
+
+func (h *healthServer) Check(_ context.Context, _ *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	return &healthpb.HealthCheckResponse{Status: h.status}, nil
+}
+
+func startHealthServer(t *testing.T, status healthpb.HealthCheckResponse_ServingStatus) string {
+	t.Helper()
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "grpc.sock")
+
+	ln, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	srv := grpc.NewServer()
+	healthpb.RegisterHealthServer(srv, &healthServer{status: status})
+	go srv.Serve(ln)
+	t.Cleanup(func() {
+		srv.Stop()
+		ln.Close()
+	})
+	return socket
+}
+
+func Test_UnitGRPCCheckerServing(t *testing.T) {
+	socket := startHealthServer(t, healthpb.HealthCheckResponse_SERVING)
+	if err := GRPC("cri", socket).Check(nil); err != nil {
+		t.Errorf("expected SERVING status to pass, got %v", err)
+	}
+}
+
+func Test_UnitGRPCCheckerNotServing(t *testing.T) {
+	socket := startHealthServer(t, healthpb.HealthCheckResponse_NOT_SERVING)
+	if err := GRPC("cri", socket).Check(nil); err == nil {
+		t.Errorf("expected NOT_SERVING status to fail")
+	}
+}
+
+func Test_UnitGRPCCheckerStripsUnixScheme(t *testing.T) {
+	socket := startHealthServer(t, healthpb.HealthCheckResponse_SERVING)
+	if err := GRPC("cri", "unix://"+socket).Check(nil); err != nil {
+		t.Errorf("expected unix:// scheme to be stripped, got %v", err)
+	}
+}
+
+func Test_UnitGRPCCheckerMissingSocket(t *testing.T) {
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "absent.sock")
+	if err := GRPC("cri", socket).Check(nil); err == nil {
+		t.Errorf("expected missing socket to fail")
 	}
 }

--- a/pkg/daemons/health/health_test.go
+++ b/pkg/daemons/health/health_test.go
@@ -1,0 +1,121 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_UnitGroupCheckAll(t *testing.T) {
+	boom := errors.New("boom")
+	g := NewGroup()
+	g.Add(
+		Func{ComponentName: "first", Probe: func(_ context.Context) error { return nil }},
+		Func{ComponentName: "second", Probe: func(_ context.Context) error { return boom }},
+		Func{ComponentName: "third", Probe: func(_ context.Context) error { t.Fatal("third should not run after second failed"); return nil }},
+	)
+	name, err := g.CheckAll(context.Background())
+	if name != "second" {
+		t.Errorf("expected first failure to be %q, got %q", "second", name)
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("expected wrapped boom error, got %v", err)
+	}
+}
+
+func Test_UnitGroupCheckAllPasses(t *testing.T) {
+	g := NewGroup()
+	g.Add(
+		Func{ComponentName: "a", Probe: func(_ context.Context) error { return nil }},
+		Func{ComponentName: "b", Probe: func(_ context.Context) error { return nil }},
+	)
+	if name, err := g.CheckAll(context.Background()); name != "" || err != nil {
+		t.Errorf("expected ('', nil), got (%q, %v)", name, err)
+	}
+}
+
+func Test_UnitGroupAddSkipsNil(t *testing.T) {
+	g := NewGroup()
+	g.Add(nil, Func{ComponentName: "x", Probe: func(_ context.Context) error { return nil }}, nil)
+	if g.Len() != 1 {
+		t.Errorf("expected nil checkers to be skipped; got Len=%d", g.Len())
+	}
+	if names := g.Names(); len(names) != 1 || names[0] != "x" {
+		t.Errorf("unexpected names: %v", names)
+	}
+}
+
+func Test_UnitTCPChecker(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	if err := TCP("ok", ln.Addr().String()).Check(context.Background()); err != nil {
+		t.Errorf("expected open port to pass, got %v", err)
+	}
+	ln.Close()
+	if err := TCP("closed", ln.Addr().String()).Check(context.Background()); err == nil {
+		t.Errorf("expected closed port to fail")
+	}
+}
+
+func Test_UnitUnixSocketChecker(t *testing.T) {
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "test.sock")
+
+	ln, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	if err := UnixSocket("ok", socket).Check(context.Background()); err != nil {
+		t.Errorf("expected open socket to pass, got %v", err)
+	}
+
+	ln.Close()
+	_ = os.Remove(socket)
+	if err := UnixSocket("missing", socket).Check(context.Background()); err == nil {
+		t.Errorf("expected missing socket to fail")
+	}
+}
+
+func Test_UnitHTTPGetChecker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ok":
+			w.WriteHeader(http.StatusOK)
+		case "/fail":
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := HTTPGet("ok", srv.URL+"/ok").Check(context.Background()); err != nil {
+		t.Errorf("expected 200 response to pass, got %v", err)
+	}
+	if err := HTTPGet("fail", srv.URL+"/fail").Check(context.Background()); err == nil {
+		t.Errorf("expected 500 response to fail")
+	}
+	if err := HTTPGet("dial", "http://127.0.0.1:1/never").Check(context.Background()); err == nil {
+		t.Errorf("expected unreachable URL to fail")
+	}
+}
+
+func Test_UnitHTTPGetCheckerSkipsTLSVerify(t *testing.T) {
+	// httptest.NewTLSServer uses a self-signed cert; the checker must accept it.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	if err := HTTPGet("tls", srv.URL+"/livez").Check(context.Background()); err != nil {
+		t.Errorf("expected TLS-skip-verify probe to pass against self-signed cert, got %v", err)
+	}
+}

--- a/pkg/daemons/watchdog/watchdog.go
+++ b/pkg/daemons/watchdog/watchdog.go
@@ -1,0 +1,87 @@
+// Package watchdog implements the k3s side of the systemd watchdog protocol.
+//
+// k3s strips NOTIFY_SOCKET from the process environment early in startup so
+// that embedded components (kubelet, etcd, kine, etc.) cannot send READY=1 or
+// WATCHDOG=1 to systemd on behalf of the whole process. That is intentional:
+// the kubelet by itself does not know whether etcd, the API server, the CRI
+// runtime, and the other in-process components are alive, so letting it ping
+// the watchdog would mask whole-process failures.
+//
+// READY=1 is still sent the usual way via systemd.SdNotify by the server /
+// agent startup code, which temporarily restores NOTIFY_SOCKET and then
+// unsets it again. This package owns the periodic WATCHDOG=1 pings: callers
+// pass in the cached NOTIFY_SOCKET value they captured before it was
+// stripped, plus a health.Group covering every component that must be alive
+// for the process to be considered healthy. WATCHDOG=1 is only sent while
+// every Checker in the group passes; otherwise the loop stays quiet and
+// systemd will restart the unit after WatchdogSec.
+package watchdog
+
+import (
+	"context"
+	"errors"
+	"net"
+	"time"
+
+	systemd "github.com/coreos/go-systemd/v22/daemon"
+	"github.com/k3s-io/k3s/pkg/daemons/health"
+	"github.com/sirupsen/logrus"
+)
+
+func Run(ctx context.Context, socketPath string, group *health.Group) {
+	if socketPath == "" {
+		return
+	}
+	if group == nil || group.Len() == 0 {
+		logrus.Warn("systemd watchdog: no health checks registered, notifier disabled")
+		return
+	}
+	interval, err := systemd.SdWatchdogEnabled(false)
+	if err != nil {
+		logrus.Warnf("systemd watchdog: failed to read WATCHDOG_USEC: %v", err)
+		return
+	}
+	if interval == 0 {
+		logrus.Debug("systemd watchdog: not enabled by unit, notifier disabled")
+		return
+	}
+
+	tick := interval / 2
+	logrus.Infof("systemd watchdog: pinging every %s (WatchdogSec=%s), monitoring components %v",
+		tick, interval, group.Names())
+
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if name, err := group.CheckAll(ctx); err != nil {
+				logrus.Warnf("systemd watchdog: %q is unhealthy, withholding WATCHDOG=1: %v", name, err)
+				continue
+			}
+			if err := notify(socketPath, systemd.SdNotifyWatchdog); err != nil {
+				logrus.Warnf("systemd watchdog: failed to send WATCHDOG=1: %v", err)
+			}
+		}
+	}
+}
+
+// notify writes a single state line as a datagram to the systemd notify
+// socket. The socket is SOCK_DGRAM, so each call is a self-contained
+// message and we do not need to manage a persistent connection.
+func notify(socketPath, state string) error {
+	if socketPath == "" {
+		return errors.New("watchdog: empty notify socket path")
+	}
+	addr := &net.UnixAddr{Name: socketPath, Net: "unixgram"}
+	conn, err := net.DialUnix(addr.Net, nil, addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_, err = conn.Write([]byte(state))
+	return err
+}

--- a/pkg/daemons/watchdog/watchdog.go
+++ b/pkg/daemons/watchdog/watchdog.go
@@ -1,20 +1,21 @@
-// Package watchdog implements the k3s side of the systemd watchdog protocol.
+// Package watchdog implements the k3s side of the systemd notify / watchdog
+// protocol.
 //
-// k3s strips NOTIFY_SOCKET from the process environment early in startup so
-// that embedded components (kubelet, etcd, kine, etc.) cannot send READY=1 or
-// WATCHDOG=1 to systemd on behalf of the whole process. That is intentional:
-// the kubelet by itself does not know whether etcd, the API server, the CRI
-// runtime, and the other in-process components are alive, so letting it ping
-// the watchdog would mask whole-process failures.
+// k3s strips NOTIFY_SOCKET (and WATCHDOG_USEC) from the process environment
+// early in startup so embedded components — kubelet, etcd, kine, etc. —
+// cannot ping systemd on behalf of the whole process. That is intentional:
+// the kubelet by itself has no visibility into etcd, the apiserver, or the
+// CRI runtime, so letting it ping the watchdog would mask whole-process
+// failures.
 //
-// READY=1 is still sent the usual way via systemd.SdNotify by the server /
+// READY=1 is still sent the usual way via systemd.SdNotify in the server /
 // agent startup code, which temporarily restores NOTIFY_SOCKET and then
 // unsets it again. This package owns the periodic WATCHDOG=1 pings: callers
-// pass in the cached NOTIFY_SOCKET value they captured before it was
-// stripped, plus a health.Group covering every component that must be alive
-// for the process to be considered healthy. WATCHDOG=1 is only sent while
-// every Checker in the group passes; otherwise the loop stays quiet and
-// systemd will restart the unit after WatchdogSec.
+// pass in the cached NOTIFY_SOCKET path and WATCHDOG_USEC interval that they
+// captured before stripping, plus the set of healthz.HealthCheckers covering
+// every component that must be alive for the process to be considered
+// healthy. WATCHDOG=1 is only sent while every check passes; otherwise the
+// loop stays quiet and systemd will restart the unit after WatchdogSec.
 package watchdog
 
 import (
@@ -24,31 +25,30 @@ import (
 	"time"
 
 	systemd "github.com/coreos/go-systemd/v22/daemon"
-	"github.com/k3s-io/k3s/pkg/daemons/health"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apiserver/pkg/server/healthz"
 )
 
-func Run(ctx context.Context, socketPath string, group *health.Group) {
+func Run(ctx context.Context, socketPath string, interval time.Duration, checkers []healthz.HealthChecker) {
 	if socketPath == "" {
 		return
 	}
-	if group == nil || group.Len() == 0 {
-		logrus.Warn("systemd watchdog: no health checks registered, notifier disabled")
-		return
-	}
-	interval, err := systemd.SdWatchdogEnabled(false)
-	if err != nil {
-		logrus.Warnf("systemd watchdog: failed to read WATCHDOG_USEC: %v", err)
-		return
-	}
-	if interval == 0 {
+	if interval <= 0 {
 		logrus.Debug("systemd watchdog: not enabled by unit, notifier disabled")
+		return
+	}
+	if len(checkers) == 0 {
+		logrus.Warn("systemd watchdog: no health checks registered, notifier disabled")
 		return
 	}
 
 	tick := interval / 2
+	names := make([]string, len(checkers))
+	for i, c := range checkers {
+		names[i] = c.Name()
+	}
 	logrus.Infof("systemd watchdog: pinging every %s (WatchdogSec=%s), monitoring components %v",
-		tick, interval, group.Names())
+		tick, interval, names)
 
 	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
@@ -58,7 +58,7 @@ func Run(ctx context.Context, socketPath string, group *health.Group) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if name, err := group.CheckAll(ctx); err != nil {
+			if name, err := check(checkers); err != nil {
 				logrus.Warnf("systemd watchdog: %q is unhealthy, withholding WATCHDOG=1: %v", name, err)
 				continue
 			}
@@ -69,9 +69,15 @@ func Run(ctx context.Context, socketPath string, group *health.Group) {
 	}
 }
 
-// notify writes a single state line as a datagram to the systemd notify
-// socket. The socket is SOCK_DGRAM, so each call is a self-contained
-// message and we do not need to manage a persistent connection.
+func check(checkers []healthz.HealthChecker) (string, error) {
+	for _, c := range checkers {
+		if err := c.Check(nil); err != nil {
+			return c.Name(), err
+		}
+	}
+	return "", nil
+}
+
 func notify(socketPath, state string) error {
 	if socketPath == "" {
 		return errors.New("watchdog: empty notify socket path")

--- a/pkg/daemons/watchdog/watchdog_test.go
+++ b/pkg/daemons/watchdog/watchdog_test.go
@@ -1,0 +1,174 @@
+package watchdog
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/k3s-io/k3s/pkg/daemons/health"
+)
+
+// startNotifyListener opens a unix datagram socket at a temporary path and
+// returns the path plus a channel that receives every datagram written to it.
+// The listener is cleaned up when the test ends.
+func startNotifyListener(t *testing.T) (string, <-chan string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notify.sock")
+	conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: path, Net: "unixgram"})
+	if err != nil {
+		t.Fatalf("listen unixgram: %v", err)
+	}
+	t.Cleanup(func() {
+		conn.Close()
+		_ = os.Remove(path)
+	})
+
+	out := make(chan string, 16)
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, _, err := conn.ReadFromUnix(buf)
+			if err != nil {
+				close(out)
+				return
+			}
+			out <- string(buf[:n])
+		}
+	}()
+	return path, out
+}
+
+// withWatchdogEnv sets WATCHDOG_USEC for the duration of the test so the
+// notify loop actually ticks.
+func withWatchdogEnv(t *testing.T, usec string) {
+	t.Helper()
+	prev, had := os.LookupEnv("WATCHDOG_USEC")
+	if err := os.Setenv("WATCHDOG_USEC", usec); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("WATCHDOG_USEC", prev)
+		} else {
+			os.Unsetenv("WATCHDOG_USEC")
+		}
+	})
+}
+
+func Test_UnitWatchdogNoSocketReturnsImmediately(t *testing.T) {
+	g := health.NewGroup()
+	g.Add(health.Func{ComponentName: "x", Probe: func(_ context.Context) error { return nil }})
+	done := make(chan struct{})
+	go func() { Run(context.Background(), "", g); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return when socketPath was empty")
+	}
+}
+
+func Test_UnitWatchdogEmptyGroupReturnsImmediately(t *testing.T) {
+	socket, _ := startNotifyListener(t)
+	withWatchdogEnv(t, "200000") // 200ms
+
+	done := make(chan struct{})
+	go func() { Run(context.Background(), socket, health.NewGroup()); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return when group was empty")
+	}
+}
+
+func Test_UnitWatchdogNoEnvReturnsImmediately(t *testing.T) {
+	socket, _ := startNotifyListener(t)
+	// Make sure WATCHDOG_USEC is unset.
+	prev, had := os.LookupEnv("WATCHDOG_USEC")
+	os.Unsetenv("WATCHDOG_USEC")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("WATCHDOG_USEC", prev)
+		}
+	})
+
+	g := health.NewGroup()
+	g.Add(health.Func{ComponentName: "x", Probe: func(_ context.Context) error { return nil }})
+	done := make(chan struct{})
+	go func() { Run(context.Background(), socket, g); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return when WATCHDOG_USEC was unset")
+	}
+}
+
+func Test_UnitWatchdogPingsWhenHealthy(t *testing.T) {
+	socket, msgs := startNotifyListener(t)
+	withWatchdogEnv(t, "100000")
+
+	g := health.NewGroup()
+	g.Add(health.Func{ComponentName: "ok", Probe: func(_ context.Context) error { return nil }})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go Run(ctx, socket, g)
+
+	select {
+	case got := <-msgs:
+		if got != "WATCHDOG=1" {
+			t.Errorf("expected WATCHDOG=1, got %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive WATCHDOG=1 within 2s")
+	}
+}
+
+func Test_UnitWatchdogWithholdsPingWhenUnhealthy(t *testing.T) {
+	socket, msgs := startNotifyListener(t)
+	withWatchdogEnv(t, "100000")
+
+	var calls atomic.Int32
+	g := health.NewGroup()
+	g.Add(health.Func{ComponentName: "bad", Probe: func(_ context.Context) error {
+		calls.Add(1)
+		return errors.New("unhealthy")
+	}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go Run(ctx, socket, g)
+
+	select {
+	case got := <-msgs:
+		t.Fatalf("did not expect any WATCHDOG=1 ping, got %q", got)
+	case <-time.After(500 * time.Millisecond):
+	}
+	if calls.Load() == 0 {
+		t.Fatal("expected checker to have been invoked at least once")
+	}
+}
+
+func Test_UnitWatchdogStopsOnContextCancel(t *testing.T) {
+	socket, _ := startNotifyListener(t)
+	withWatchdogEnv(t, "100000")
+
+	g := health.NewGroup()
+	g.Add(health.Func{ComponentName: "ok", Probe: func(_ context.Context) error { return nil }})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { Run(ctx, socket, g); close(done) }()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after ctx cancellation")
+	}
+}

--- a/pkg/daemons/watchdog/watchdog_test.go
+++ b/pkg/daemons/watchdog/watchdog_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/k3s-io/k3s/pkg/daemons/health"
+	"k8s.io/apiserver/pkg/server/healthz"
 )
 
 // startNotifyListener opens a unix datagram socket at a temporary path and
@@ -44,28 +45,31 @@ func startNotifyListener(t *testing.T) (string, <-chan string) {
 	return path, out
 }
 
-// withWatchdogEnv sets WATCHDOG_USEC for the duration of the test so the
-// notify loop actually ticks.
-func withWatchdogEnv(t *testing.T, usec string) {
-	t.Helper()
-	prev, had := os.LookupEnv("WATCHDOG_USEC")
-	if err := os.Setenv("WATCHDOG_USEC", usec); err != nil {
-		t.Fatalf("setenv: %v", err)
-	}
-	t.Cleanup(func() {
-		if had {
-			os.Setenv("WATCHDOG_USEC", prev)
-		} else {
-			os.Unsetenv("WATCHDOG_USEC")
-		}
-	})
+// fakeChecker returns a healthz.HealthChecker that calls fn and exposes a
+// counter of invocations.
+type fakeChecker struct {
+	name  string
+	fn    func() error
+	calls atomic.Int32
+}
+
+func (f *fakeChecker) Name() string                   { return f.name }
+func (f *fakeChecker) Check(_ *http.Request) error    { f.calls.Add(1); return f.fn() }
+
+func ok(name string) *fakeChecker {
+	return &fakeChecker{name: name, fn: func() error { return nil }}
+}
+
+func bad(name string, err error) *fakeChecker {
+	return &fakeChecker{name: name, fn: func() error { return err }}
 }
 
 func Test_UnitWatchdogNoSocketReturnsImmediately(t *testing.T) {
-	g := health.NewGroup()
-	g.Add(health.Func{ComponentName: "x", Probe: func(_ context.Context) error { return nil }})
 	done := make(chan struct{})
-	go func() { Run(context.Background(), "", g); close(done) }()
+	go func() {
+		Run(context.Background(), "", time.Second, []healthz.HealthChecker{ok("x")})
+		close(done)
+	}()
 	select {
 	case <-done:
 	case <-time.After(time.Second):
@@ -73,51 +77,40 @@ func Test_UnitWatchdogNoSocketReturnsImmediately(t *testing.T) {
 	}
 }
 
-func Test_UnitWatchdogEmptyGroupReturnsImmediately(t *testing.T) {
+func Test_UnitWatchdogZeroIntervalReturnsImmediately(t *testing.T) {
 	socket, _ := startNotifyListener(t)
-	withWatchdogEnv(t, "200000") // 200ms
-
 	done := make(chan struct{})
-	go func() { Run(context.Background(), socket, health.NewGroup()); close(done) }()
+	go func() {
+		Run(context.Background(), socket, 0, []healthz.HealthChecker{ok("x")})
+		close(done)
+	}()
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("Run did not return when group was empty")
+		t.Fatal("Run did not return when interval was zero")
 	}
 }
 
-func Test_UnitWatchdogNoEnvReturnsImmediately(t *testing.T) {
+func Test_UnitWatchdogEmptyCheckersReturnsImmediately(t *testing.T) {
 	socket, _ := startNotifyListener(t)
-	// Make sure WATCHDOG_USEC is unset.
-	prev, had := os.LookupEnv("WATCHDOG_USEC")
-	os.Unsetenv("WATCHDOG_USEC")
-	t.Cleanup(func() {
-		if had {
-			os.Setenv("WATCHDOG_USEC", prev)
-		}
-	})
-
-	g := health.NewGroup()
-	g.Add(health.Func{ComponentName: "x", Probe: func(_ context.Context) error { return nil }})
 	done := make(chan struct{})
-	go func() { Run(context.Background(), socket, g); close(done) }()
+	go func() {
+		Run(context.Background(), socket, time.Second, nil)
+		close(done)
+	}()
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("Run did not return when WATCHDOG_USEC was unset")
+		t.Fatal("Run did not return when checkers was empty")
 	}
 }
 
 func Test_UnitWatchdogPingsWhenHealthy(t *testing.T) {
 	socket, msgs := startNotifyListener(t)
-	withWatchdogEnv(t, "100000")
-
-	g := health.NewGroup()
-	g.Add(health.Func{ComponentName: "ok", Probe: func(_ context.Context) error { return nil }})
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go Run(ctx, socket, g)
+
+	go Run(ctx, socket, 100*time.Millisecond, []healthz.HealthChecker{ok("ok")})
 
 	select {
 	case got := <-msgs:
@@ -131,39 +124,30 @@ func Test_UnitWatchdogPingsWhenHealthy(t *testing.T) {
 
 func Test_UnitWatchdogWithholdsPingWhenUnhealthy(t *testing.T) {
 	socket, msgs := startNotifyListener(t)
-	withWatchdogEnv(t, "100000")
-
-	var calls atomic.Int32
-	g := health.NewGroup()
-	g.Add(health.Func{ComponentName: "bad", Probe: func(_ context.Context) error {
-		calls.Add(1)
-		return errors.New("unhealthy")
-	}})
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go Run(ctx, socket, g)
+
+	checker := bad("bad", errors.New("unhealthy"))
+	go Run(ctx, socket, 100*time.Millisecond, []healthz.HealthChecker{checker})
 
 	select {
 	case got := <-msgs:
 		t.Fatalf("did not expect any WATCHDOG=1 ping, got %q", got)
 	case <-time.After(500 * time.Millisecond):
 	}
-	if calls.Load() == 0 {
+	if checker.calls.Load() == 0 {
 		t.Fatal("expected checker to have been invoked at least once")
 	}
 }
 
 func Test_UnitWatchdogStopsOnContextCancel(t *testing.T) {
 	socket, _ := startNotifyListener(t)
-	withWatchdogEnv(t, "100000")
-
-	g := health.NewGroup()
-	g.Add(health.Func{ComponentName: "ok", Probe: func(_ context.Context) error { return nil }})
-
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	go func() { Run(ctx, socket, g); close(done) }()
+	go func() {
+		Run(ctx, socket, 100*time.Millisecond, []healthz.HealthChecker{ok("ok")})
+		close(done)
+	}()
 
 	cancel()
 	select {


### PR DESCRIPTION
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Take ownership of the systemd watchdog at the k3s process level so that `Type=notify` + `WatchdogSec=` actually keeps the unit alive.

Today k3s strips `NOTIFY_SOCKET` from the process environment early in startup so that embedded components (kubelet, etcd, kine, …) cannot send `READY=1` / `WATCHDOG=1` on behalf of the whole process. That is intentional — the kubelet by itself does not know whether etcd, the apiserver, or the CRI runtime are alive — but it also means the kubelet's built-in watchdog (enabled by default in Kubernetes 1.35) cannot send keepalives, and systemd kills k3s after `WatchdogSec` elapses.

This PR adds a k3s-owned watchdog notifier:

- `pkg/daemons/health`: `Checker` / `Group` plus `TCP`, `UnixSocket`, and `HTTPGet` helpers used to register per-component liveness probes.
- `pkg/daemons/watchdog`: `Run()` reads `WATCHDOG_USEC` via `systemd.SdWatchdogEnabled`, ticks at half the interval, and writes `WATCHDOG=1` directly to the cached `NOTIFY_SOCKET` path **only** when every registered `Checker` passes. The notify socket is never put back into `os.Environ`, so the kubelet/etcd/kine goroutines still see it as unset and do not ping on their own.
- `pkg/cli/server/server.go`: after the existing `systemd.SdNotify(true, "READY=1\n")`, spawns the watchdog with checkers for `kube-apiserver /livez`, etcd, kube-controller-manager, kube-scheduler, supervisor — plus `kubelet /healthz` and `kube-proxy /healthz` when the embedded agent is enabled. Each is gated on its `--disable-*` flag.
- `pkg/agent/run.go`: on agent-only nodes, spawns the watchdog with `kubelet /healthz` and the CRI Unix socket.
- `pkg/cli/cmds/log_linux.go`: stops appending `NOTIFY_SOCKET=` to the re-exec child env so the child can carry the socket path forward to the watchdog. The child still strips `NOTIFY_SOCKET` from its own env at startup (existing code in `server.go` / `run.go`) before any embedded component reads it, so the defense against premature notification is preserved — it just moves entirely to the child.

#### Types of Changes ####

Bugfix

#### Verification ####

1. Clone the repo and build the k3s binary on a host with systemd using the following commands:

   ```bash
   cd ~/k3s
   ./scripts/download
   ./scripts/build
   ./scripts/package-cli
   sudo install -m 755 dist/artifacts/k3s /usr/bin/k3s
   ```

2. Edit the k3s systemd unit:

   ```ini
   [Service]
   Type=notify
   WatchdogSec=15
   ```

3. Reload and restart:

   ```bash
   systemctl daemon-reload && systemctl restart k3s
   ```

4. **Before this change:** the unit is killed after ~15s; journal shows kubelet logging `"Failed to notify watchdog" ... "NOTIFY_SOCKET is unset"`.

5. **After this change:** the unit stays running indefinitely; k3s logs show:

   ```
   root@k3s-test2-109f-5dc24f-node-pool-9b89-nw14i:~/k3s# sudo grep "systemd watchdog: pinging" /var/log/k3s.log
   time="2026-05-13T13:16:38Z" level=info msg="systemd watchdog: pinging every 7.5s (WatchdogSec=15s), monitoring components [kubelet cri]"
   ```

6. Verified the watchdog pinging:

   ```
   root@k3s-test2-109f-5dc24f-node-pool-9b89-nw14i:~/k3s# systemctl is-active k3s
   active

   root@k3s-test2-109f-5dc24f-node-pool-9b89-nw14i:~/k3s# for i in 1 2 3 4 5; do
     date +%T
     systemctl show k3s -p WatchdogTimestamp -p ActiveState
     sleep 8
   done
   13:17:37
   WatchdogTimestamp=Wed 2026-05-13 13:17:30 UTC
   ActiveState=active
   13:17:45
   WatchdogTimestamp=Wed 2026-05-13 13:17:38 UTC
   ActiveState=active
   13:17:53
   WatchdogTimestamp=Wed 2026-05-13 13:17:45 UTC
   ActiveState=active
   13:18:01
   WatchdogTimestamp=Wed 2026-05-13 13:18:00 UTC
   ActiveState=active
   13:18:09
   WatchdogTimestamp=Wed 2026-05-13 13:18:08 UTC
   ActiveState=active
   ```

#### Testing ####

Unit tests added:

- `pkg/daemons/health/health_test.go` — `CheckAll` ordering and short-circuit on first failure, nil-checker skipping, `TCP`/`UnixSocket`/`HTTPGet` against real listeners and `httptest` servers (including the self-signed TLS path).
- `pkg/daemons/watchdog/watchdog_test.go` — `Run` returns immediately on empty socket / empty group / missing `WATCHDOG_USEC`; sends `WATCHDOG=1` when healthy; stays silent when a checker fails; exits on `ctx.Done()`. Uses a real `unixgram` listener.
- `pkg/agent/run_test.go` — `criSocketPath` parses plain paths, `unix://` scheme, and rejects non-unix schemes.

`go build ./...` and `go vet ./...` are clean.

#### Linked Issues ####

Fixes #13725