### PR TITLE
[release-1.36] Bump klipper-helm image tag

### DIFF
--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,4 +1,4 @@
-docker.io/rancher/klipper-helm:v0.9.17-build20260422
+docker.io/rancher/klipper-helm:v0.10.0-build20260513
 docker.io/rancher/klipper-lb:v0.4.17
 docker.io/rancher/local-path-provisioner:v0.0.36
 docker.io/rancher/mirrored-coredns-coredns:1.14.3

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -83,7 +83,7 @@ case ${ARCH} in
     ;;
 esac
 
-VERSION_HELM_JOB="v0.9.17-build20260422"
+VERSION_HELM_JOB="v0.10.0-build20260513"
 
 GO_VERSION_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${VERSION_K8S}/.go-version"
 VERSION_GOLANG="go"$(curl -sL "${GO_VERSION_URL}" | tr -d '[:space:]')


### PR DESCRIPTION
#### Proposed Changes ####

Bump klipper-helm image tag for CVE reasons.

We're not bumping the actual helm version, but we have rebuilt helm with a newer golang release than upstream.

#### Types of Changes ####

Version bump

#### Verification ####

Check image scan results

#### Testing ####


#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/14081

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
