### PR TITLE
[release-1.34] Bump klipper-helm image tag

### DIFF
--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,4 +1,4 @@
-docker.io/rancher/klipper-helm:v0.9.17-build20260422
+docker.io/rancher/klipper-helm:v0.10.0-build20260513
 docker.io/rancher/klipper-lb:v0.4.17
 docker.io/rancher/local-path-provisioner:v0.0.36
 docker.io/rancher/mirrored-coredns-coredns:1.14.3

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -68,7 +68,7 @@ fi
 
 VERSION_ROOT="v0.15.0"
 
-VERSION_HELM_JOB="v0.9.17-build20260422"
+VERSION_HELM_JOB="v0.10.0-build20260513"
 
 GO_VERSION_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${BRANCH_K8S}/.go-version"
 VERSION_GOLANG="go"$(curl -sL "${GO_VERSION_URL}" | tr -d '[:space:]')

--- a/tests/docker/dualstack/dualstack_test.go
+++ b/tests/docker/dualstack/dualstack_test.go
@@ -50,6 +50,12 @@ var _ = DescribeTableSubtree("DualStack Tests", Ordered, func(ipConfig string) {
 	})
 
 	Context("Validate dualstack components", func() {
+		It("Checks Node Status", func() {
+			Eventually(func() error {
+				return tests.NodesReady(tc.KubeconfigFile, tc.GetNodeNames())
+			}, "620s", "5s").Should(Succeed())
+		})
+
 		It("Verifies that each node has IPv4 and IPv6", func() {
 			for _, node := range append(tc.Servers, tc.Agents...) {
 				ips, err := tests.GetNodeIPs(node.Name, tc.KubeconfigFile)
@@ -57,6 +63,13 @@ var _ = DescribeTableSubtree("DualStack Tests", Ordered, func(ipConfig string) {
 				Expect(ips).To(ContainElements(ContainSubstring("172.18.0"), ContainSubstring("fd11:decf:c0ff")))
 			}
 		})
+
+		It("Checks pod status", func() {
+			Eventually(func() error {
+				return tests.AllPodsUp(tc.KubeconfigFile, "kube-system")
+			}, "620s", "5s").Should(Succeed())
+		})
+
 		It("Verifies that each pod has IPv4 and IPv6", func() {
 			pods, err := tests.ParsePods(tc.KubeconfigFile, "kube-system")
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
#### Proposed Changes ####

Bump klipper-helm image tag for CVE reasons.

We're not bumping the actual helm version, but we have rebuilt helm with a newer golang release than upstream.

#### Types of Changes ####

Version bump

#### Verification ####

Check image scan results

#### Testing ####


#### Linked Issues ####
* https://github.com/k3s-io/k3s/issues/14083

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
