### PR TITLE
chore: fix duplicated "the" in etcd/s3 and permissions doc comments

### DIFF
--- a/pkg/etcd/s3/s3.go
+++ b/pkg/etcd/s3/s3.go
@@ -75,7 +75,7 @@ type Client struct {
 }
 
 // Start initializes the cache and sets the cluster id and token hash,
-// returning a reference to the the initialized controller. Initialization is
+// returning a reference to the initialized controller. Initialization is
 // locked by a sync.Once to prevent races, and multiple calls to start will
 // return the same controller or error.
 func Start(ctx context.Context, config *config.Control) (*Controller, error) {

--- a/pkg/util/permissions/permissions_windows.go
+++ b/pkg/util/permissions/permissions_windows.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// IsPrivileged returns an error if the the process is not running as a member of the BUILTIN\Administrators group.
+// IsPrivileged returns an error if the process is not running as a member of the BUILTIN\Administrators group.
 // Ref: https://github.com/kubernetes/kubernetes/pull/96616
 func IsPrivileged() error {
 	var sid *windows.SID


### PR DESCRIPTION
Two small comment-only typos: doubled `the the` in `pkg/etcd/s3/s3.go` and `pkg/util/permissions/permissions_windows.go`. No functional change.