### PR TITLE
etcd: write compressed snapshots with mode 0600

### DIFF
--- a/pkg/etcd/snapshot.go
+++ b/pkg/etcd/snapshot.go
@@ -124,7 +124,9 @@ func (e *ETCD) compressSnapshot(snapshotDir, snapshotFilename string, mtime time
 		return "", err
 	}
 
-	of, err := os.Create(zipPath)
+	// Etcd writes uncompressed snapshots with mode 0600; use the same mode here so
+	// compressed snapshots do not leak through the default 0644 umask result of os.Create.
+	of, err := os.OpenFile(zipPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/etcd/snapshot_test.go
+++ b/pkg/etcd/snapshot_test.go
@@ -1,0 +1,76 @@
+package etcd
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/k3s-io/k3s/pkg/etcd/snapshot"
+)
+
+func Test_UnitETCD_compressSnapshot(t *testing.T) {
+	const (
+		snapshotName = "on-demand-test-node-1700000000"
+		payload      = "fake etcd snapshot contents"
+	)
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, snapshotName)
+	if err := os.WriteFile(src, []byte(payload), 0600); err != nil {
+		t.Fatalf("failed to seed source snapshot: %v", err)
+	}
+
+	e := &ETCD{}
+	zipPath, err := e.compressSnapshot(dir, snapshotName, time.Unix(1700000000, 0))
+	if err != nil {
+		t.Fatalf("compressSnapshot returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(zipPath) })
+
+	wantPath := src + snapshot.CompressedExtension
+	if zipPath != wantPath {
+		t.Errorf("zipPath = %q, want %q", zipPath, wantPath)
+	}
+
+	info, err := os.Stat(zipPath)
+	if err != nil {
+		t.Fatalf("stat compressed snapshot: %v", err)
+	}
+
+	// The compressed snapshot can contain the same etcd data as the
+	// uncompressed file, so its on-disk mode must be just as restrictive.
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Errorf("compressed snapshot mode = %#o, want 0600", got)
+	}
+
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Fatalf("opening zip: %v", err)
+	}
+	t.Cleanup(func() { _ = zr.Close() })
+
+	if len(zr.File) != 1 {
+		t.Fatalf("zip contains %d files, want 1", len(zr.File))
+	}
+	if zr.File[0].Name != snapshotName {
+		t.Errorf("zip entry name = %q, want %q", zr.File[0].Name, snapshotName)
+	}
+
+	rc, err := zr.File[0].Open()
+	if err != nil {
+		t.Fatalf("opening zip entry: %v", err)
+	}
+	defer rc.Close()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, rc); err != nil {
+		t.Fatalf("reading zip entry: %v", err)
+	}
+	if buf.String() != payload {
+		t.Errorf("zip entry contents = %q, want %q", buf.String(), payload)
+	}
+}


### PR DESCRIPTION
#### Proposed Changes ####

\`compressSnapshot\` creates the destination \`.zip\` with \`os.Create\`, which applies the process umask to the default 0666 mode. On the default umask of 022 the on-disk mode ends up as 0644 and the snapshot becomes readable to any local user. Uncompressed snapshots are written by etcd with 0600 (verified by the existing \`decompressSnapshot\` path and the bug report), so enabling \`etcd-snapshot-compress\` silently downgraded snapshot permissions.

Switch the compression path to \`os.OpenFile\` with explicit 0600 so the mode is independent of umask and matches the uncompressed file.

Also add a unit test that:
1. Seeds a fake source snapshot,
2. Calls \`compressSnapshot\`,
3. Asserts the resulting file mode is exactly \`0600\`,
4. Verifies the zip's single entry name and contents match the source.

The new test fails on \`main\` (\`compressed snapshot mode = 0664, want 0600\` on a typical umask) and passes with this fix.

#### Types of Changes ####

Bugfix.

#### Verification ####

\`\`\`
$ go test -run Test_UnitETCD_compressSnapshot ./pkg/etcd/ -v
=== RUN   Test_UnitETCD_compressSnapshot
time=... level=info msg="Compressing etcd snapshot file: on-demand-test-node-1700000000"
--- PASS: Test_UnitETCD_compressSnapshot (0.00s)
PASS
ok      github.com/k3s-io/k3s/pkg/etcd  0.030s
\`\`\`

Full \`./pkg/etcd/...\` unit test suite also passes:

\`\`\`
$ go test -run Unit ./pkg/etcd/... -count=1
ok      github.com/k3s-io/k3s/pkg/etcd  79.701s
\`\`\`

To reproduce manually on a running server:

\`\`\`
$ k3s etcd-snapshot save --etcd-snapshot-compress=true
$ k3s etcd-snapshot save --etcd-snapshot-compress=false
$ ls -l /var/lib/rancher/k3s/server/db/snapshots
\`\`\`

Before this fix the \`.zip\` snapshot has mode 0644 while the uncompressed one has 0600; after the fix both have 0600.

#### Testing ####

Yes, covered by the new \`Test_UnitETCD_compressSnapshot\` unit test in \`pkg/etcd/snapshot_test.go\`. The test exercises \`compressSnapshot\` directly and validates both the file mode and the zip contents, so it would have caught the original bug.

#### Linked Issues ####

Refs https://github.com/k3s-io/k3s/issues/13490

#### User-Facing Change ####
\`\`\`release-note
Compressed etcd snapshots are now written with mode 0600, matching the existing permissions of uncompressed snapshots.
\`\`\`

#### Further Comments ####

The companion path \`decompressSnapshot\` already uses \`os.OpenFile\` with 0600 (lines 193 of the original file), so this change is a small consistency fix on the compression side. No additional callers or paths needed adjustment.