### PR TITLE
check-config: accept nftables backend when legacy iptables is disabled

### DIFF
--- a/contrib/util/check-config.sh
+++ b/contrib/util/check-config.sh
@@ -463,12 +463,26 @@ flags="
   CGROUPS CGROUP_PIDS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG
   SECCOMP KEYS
   VETH BRIDGE BRIDGE_NETFILTER
-  IP_NF_FILTER IP_NF_TARGET_MASQUERADE IP_NF_TARGET_REJECT
   NETFILTER_XT_MATCH_ADDRTYPE NETFILTER_XT_MATCH_CONNTRACK NETFILTER_XT_MATCH_IPVS NETFILTER_XT_MATCH_COMMENT NETFILTER_XT_MATCH_MULTIPORT NETFILTER_XT_MATCH_STATISTIC
-  IP_NF_NAT NF_NAT
+  NF_NAT
   POSIX_MQUEUE
 "
 isError=1 check_flags $flags && isError=0
+
+# K3s ships both xtables-legacy-multi and xtables-nft-multi and falls back to whichever
+# the kernel supports, so either the legacy IPv4 iptables backend (CONFIG_IP_NF_IPTABLES
+# and its child symbols) or the nftables backend (CONFIG_NF_TABLES with the compatibility
+# shim) is sufficient. Kernels built without CONFIG_IP_NF_IPTABLES (increasingly common
+# on nftables-only distributions) automatically hide IP_NF_FILTER / IP_NF_TARGET_MASQUERADE
+# / IP_NF_NAT, so check the available backend rather than fail on symbols the kernel never
+# exposed.
+if is_set IP_NF_IPTABLES; then
+  isError=1 check_flags IP_NF_FILTER IP_NF_TARGET_MASQUERADE IP_NF_TARGET_REJECT IP_NF_NAT && isError=0
+elif is_set NF_TABLES; then
+  isError=1 check_flags NF_TABLES_IPV4 NFT_NAT NFT_MASQ NFT_COMPAT && isError=0
+else
+  wrap_bad "- CONFIG_IP_NF_IPTABLES or CONFIG_NF_TABLES" 'neither enabled; pod and service networking will not function'
+fi
 
 if [ "$kernelMajor" -lt 4 ] || ( [ "$kernelMajor" -eq 4 ] && [ "$kernelMinor" -lt 8 ] ); then
   check_flags DEVPTS_MULTIPLE_INSTANCES


### PR DESCRIPTION
#### Proposed Changes ####

\`contrib/util/check-config.sh\` treats \`CONFIG_IP_NF_FILTER\`, \`CONFIG_IP_NF_TARGET_MASQUERADE\`, \`CONFIG_IP_NF_TARGET_REJECT\` and \`CONFIG_IP_NF_NAT\` as unconditional requirements. In \`net/ipv4/netfilter/Kconfig\`, all four of those symbols sit inside the \`if IP_NF_IPTABLES\` block, so any kernel built without \`CONFIG_IP_NF_IPTABLES\` (the legacy iptables framework) automatically hides them. Distributions that ship nftables-only kernels — NixOS 6.18 in the linked report, but increasingly common elsewhere — see three hard \`(fail)\` lines on a kernel that K3s actually runs on fine via the bundled \`xtables-nft-multi\` shim.

This change makes the check honest about K3s's two supported netfilter backends:

- If \`CONFIG_IP_NF_IPTABLES\` is enabled, validate the existing legacy iptables symbols (\`IP_NF_FILTER\`, \`IP_NF_TARGET_MASQUERADE\`, \`IP_NF_TARGET_REJECT\`, \`IP_NF_NAT\`) — unchanged behaviour for any kernel that already passed.
- Else if \`CONFIG_NF_TABLES\` is enabled, validate the nftables-side equivalents (\`NF_TABLES_IPV4\`, \`NFT_NAT\`, \`NFT_MASQ\`, \`NFT_COMPAT\`) so the script can recognise an nftables-only kernel as a valid host.
- Otherwise, emit a single targeted failure (\`CONFIG_IP_NF_IPTABLES or CONFIG_NF_TABLES … neither enabled; pod and service networking will not function\`) — actionable instead of three confusing symbol-level failures.

The shared symbols (\`NF_NAT\`, \`BRIDGE_NETFILTER\`, the \`NETFILTER_XT_MATCH_*\` set, \`POSIX_MQUEUE\`, etc.) are still required regardless of backend, so they stay in the unconditional list.

#### Types of Changes ####

Bugfix.

#### Verification ####

Reproduces the original failure on a synthetic config that simulates the reporter's nftables-only kernel, then confirms all three branches behave correctly. The legacy path is unchanged.

Synthetic nftables-only kernel (the broken case in the issue):

\`\`\`
\$ /tmp/test/check-config.sh /tmp/test/.config-nft-only | grep -E 'CONFIG_(IP_NF|NF_TABLES|NFT_)'
- CONFIG_NF_TABLES_IPV4: enabled
- CONFIG_NFT_NAT: enabled (as module)
- CONFIG_NFT_MASQ: enabled (as module)
- CONFIG_NFT_COMPAT: enabled (as module)
\`\`\`

Synthetic legacy-iptables-only kernel (the original happy path):

\`\`\`
- CONFIG_IP_NF_FILTER: enabled (as module)
- CONFIG_IP_NF_TARGET_MASQUERADE: enabled (as module)
- CONFIG_IP_NF_TARGET_REJECT: enabled (as module)
- CONFIG_IP_NF_NAT: enabled (as module)
\`\`\`

Kernel with neither backend (worst case, should still fail loudly):

\`\`\`
- CONFIG_IP_NF_IPTABLES or CONFIG_NF_TABLES: neither enabled; pod and service networking will not function (fail)
\`\`\`

Running the script against the host's real kernel config (\`/boot/config-\$(uname -r)\`) continues to report the legacy symbols as \"enabled (as module)\". \`sh -n contrib/util/check-config.sh\` is clean.

#### Testing ####

Manual; \`check-config.sh\` does not have an automated test harness in the repo. Validated via the three synthetic kernel configs shown above plus the host kernel.

#### Linked Issues ####

Refs https://github.com/k3s-io/k3s/issues/13658

#### User-Facing Change ####
\`\`\`release-note
\`k3s check-config\` now recognises nftables-only kernels (CONFIG_IP_NF_IPTABLES disabled) and validates the equivalent CONFIG_NF_TABLES / CONFIG_NFT_* symbols instead of producing false negatives.
\`\`\`

#### Further Comments ####

The \`Optional Features\` block further down also references \`IP_NF_TARGET_REDIRECT\`; that one is already reported with the lower-severity warning style (not \`(fail)\`) and behaves correctly on both backends today, so it is intentionally left untouched.