### PR TITLE
Fix token delete argument handling

### DIFF
--- a/pkg/cli/token/token.go
+++ b/pkg/cli/token/token.go
@@ -113,15 +113,15 @@ func deleteToken(app *cli.Context, cfg *cmds.Token) error {
 
 	for _, token := range args.Slice() {
 		if !bootstraputil.IsValidBootstrapTokenID(token) {
-			bts, err := kubeadm.NewBootstrapTokenString(cfg.Token)
+			bts, err := kubeadm.NewBootstrapTokenString(token)
 			if err != nil {
-				return fmt.Errorf("given token didn't match pattern %q or %q", bootstrapapi.BootstrapTokenIDPattern, bootstrapapi.BootstrapTokenIDPattern)
+				return fmt.Errorf("given token didn't match pattern %q or %q", bootstrapapi.BootstrapTokenIDPattern, bootstrapapi.BootstrapTokenPattern)
 			}
 			token = bts.ID
 		}
 		secretName := bootstraputil.BootstrapTokenSecretName(token)
-		if err := client.CoreV1().Secrets(metav1.NamespaceSystem).Delete(context.TODO(), secretName, metav1.DeleteOptions{}); err != nil {
-			return errors.WithMessagef(err, "failed to delete bootstrap token %q", err)
+		if err := client.CoreV1().Secrets(metav1.NamespaceSystem).Delete(app.Context, secretName, metav1.DeleteOptions{}); err != nil {
+			return errors.WithMessagef(err, "failed to delete bootstrap token %q", token)
 		}
 
 		fmt.Printf("bootstrap token %q deleted\n", token)

--- a/tests/docker/token/token_test.go
+++ b/tests/docker/token/token_test.go
@@ -70,6 +70,21 @@ var _ = Describe("Use the token CLI to create and join agents", Ordered, func() 
 			}, "60s", "5s").Should(Succeed())
 		})
 	})
+	Context("Delete bootstrap token by full token:", func() {
+		It("Deletes a token using the full token value", func() {
+			token := "deltok.0123456789abcdef"
+			_, err := tc.Servers[0].RunCmdOnNode("k3s token create --ttl=0 " + token)
+			Expect(err).NotTo(HaveOccurred())
+
+			res, err := tc.Servers[0].RunCmdOnNode("k3s token delete " + token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(ContainSubstring(`bootstrap token "deltok" deleted`))
+
+			res, err = tc.Servers[0].RunCmdOnNode("k3s token list")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).NotTo(ContainSubstring("deltok"))
+		})
+	})
 	Context("Agent joins with temporary token:", func() {
 		It("Creates a 20s agent token", func() {
 			_, err := tc.Servers[0].RunCmdOnNode("k3s token create --ttl=20s 20sect.jxnpve6vg8dqm895")


### PR DESCRIPTION
#### Proposed Changes ####

Fix `k3s token delete` handling when the argument is a full bootstrap token instead of only a token ID.

Previously, when the provided argument was not already a bootstrap token ID, the delete path attempted to parse `cfg.Token` instead of the current CLI argument. This meant `k3s token delete <full-token>` could fail instead of normalizing the provided full bootstrap token to its token ID.

This change:
- Parses the token value passed to `k3s token delete`
- Normalizes full bootstrap tokens to their token ID before deleting the secret
- Reports the token ID, rather than the delete error value, when delete fails
- Adds Docker e2e coverage for deleting a bootstrap token by full token value

#### Types of Changes ####

Bugfix

#### Verification ####

The affected behavior is covered by the token Docker e2e suite. The new e2e context creates a bootstrap token, deletes it by passing the full token value to `k3s token delete`, and verifies that the token ID no longer appears in `k3s token list`.

#### Testing ####

```bash
go test ./pkg/cli/token
go test ./tests/docker/token -run Test_DockerToken --ginkgo.dry-run
make local-binary
go test -timeout=45m -v ./tests/docker/token -run Test_DockerToken
```

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/14118

#### User-Facing Change ####

```release-note
Fixed `k3s token delete` handling when deleting a bootstrap token by full token value.
```

#### Further Comments ####

This is intentionally scoped to the token delete path. The e2e coverage exercises the CLI behavior through a live Docker-backed k3s test cluster.