### PR TITLE
fix: populate IfaceName in LookupExtInterface for VXLAN recreation

### DIFF
--- a/pkg/agent/flannel/flannel.go
+++ b/pkg/agent/flannel/flannel.go
@@ -175,6 +175,7 @@ func LookupExtInterface(iface *net.Interface, nm netMode) (*backend.ExternalInte
 
 	return &backend.ExternalInterface{
 		Iface:       iface,
+		IfaceName:   iface.Name,
 		IfaceAddr:   ifaceAddr[0],
 		IfaceV6Addr: ifacev6Addr[0],
 		ExtAddr:     ifaceAddr[0],


### PR DESCRIPTION
LookupExtInterface() constructs a backend.ExternalInterface but never sets the IfaceName field, leaving it as an empty string. When the VXLAN device (flannel.1) is deleted — e.g. because the parent interface specified via --flannel-iface transiently disappears — the recreation code in vxlan_network.go:165 calls net.InterfaceByName(""), which always fails. This puts flannel into an unrecoverable retry loop:

  external interface  not found, retrying in 30s

The fix adds IfaceName: iface.Name to the struct literal. The iface variable already holds the correct *net.Interface; its Name field just needs to be copied into the IfaceName string that the VXLAN recreation path reads.

This is a one-line change that enables the VXLAN device recreation logic added in flannel PR https://github.com/flannel-io/flannel/issues/2247 (v0.27.4+) to actually work when flannel is embedded in K3s.

Affects any deployment using --flannel-iface with an overlay network (Tailscale, Nebula, ZeroTier) where the parent interface can transiently restart.

Ref: https://github.com/k3s-io/k3s/issues/12436
Ref: https://github.com/flannel-io/flannel/issues/2247

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
