### PR TITLE
Preserve logical paths for symlinked manifests

### DIFF
--- a/pkg/deploy/controller.go
+++ b/pkg/deploy/controller.go
@@ -82,6 +82,11 @@ type watcher struct {
 	discovery  discovery.DiscoveryInterface
 }
 
+type watchedFile struct {
+	os.FileInfo
+	removeOnDisable bool
+}
+
 // start calls listFiles at regular intervals to trigger application of manifests that have changed on disk.
 func (w *watcher) start(ctx context.Context, client kubernetes.Interface) {
 	w.recorder = pkgutil.BuildControllerEventRecorder(logger.NewContext(ctx, ControllerName), client, ControllerName, metav1.NamespaceSystem)
@@ -114,34 +119,8 @@ func (w *watcher) listFiles(force bool) error {
 // listFilesIn recursively processes all files within a path, and checks them against the disable and skip lists. Files found that
 // are not on either list are loaded as Addons and applied to the cluster.
 func (w *watcher) listFilesIn(base string, force bool) error {
-	files := map[string]os.FileInfo{}
-	if err := filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		// Descend into symlinked directories, however, only top-level links are followed
-		if info.Mode()&os.ModeSymlink != 0 {
-			linkInfo, err := os.Stat(path)
-			if err != nil {
-				return err
-			}
-			if linkInfo.IsDir() {
-				evalPath, err := filepath.EvalSymlinks(path)
-				if err != nil {
-					return err
-				}
-				filepath.Walk(evalPath, func(path string, info os.FileInfo, err error) error {
-					if err != nil {
-						return err
-					}
-					files[path] = info
-					return nil
-				})
-			}
-		}
-		files[path] = info
-		return nil
-	}); err != nil {
+	files, err := walkFiles(base)
+	if err != nil {
 		return err
 	}
 
@@ -162,9 +141,12 @@ func (w *watcher) listFilesIn(base string, force bool) error {
 
 	var errs []error
 	for _, path := range keys {
+		if files[path].IsDir() {
+			continue
+		}
 		// Disabled files are not just skipped, but actively deleted from the filesystem
 		if shouldDisableFile(base, path, w.disables) {
-			if err := w.delete(path); err != nil {
+			if err := w.delete(path, files[path].removeOnDisable); err != nil {
 				errs = append(errs, errors.WithMessagef(err, "failed to delete %s", path))
 			}
 			continue
@@ -185,6 +167,46 @@ func (w *watcher) listFilesIn(base string, force bool) error {
 	}
 
 	return errors.Join(errs...)
+}
+
+func walkFiles(base string) (map[string]watchedFile, error) {
+	files := map[string]watchedFile{}
+	if err := filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		// Descend into symlinked directories, however, only top-level links are followed.
+		// Keep the logical path for disable matching, but avoid unlinking backing files
+		// that are only reachable via a followed symlinked directory.
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkInfo, err := os.Stat(path)
+			if err != nil {
+				return err
+			}
+			if linkInfo.IsDir() {
+				evalPath, err := filepath.EvalSymlinks(path)
+				if err != nil {
+					return err
+				}
+				return filepath.Walk(evalPath, func(linkPath string, linkInfo os.FileInfo, err error) error {
+					if err != nil {
+						return err
+					}
+					rel, err := filepath.Rel(evalPath, linkPath)
+					if err != nil {
+						return err
+					}
+					files[filepath.Join(path, rel)] = watchedFile{FileInfo: linkInfo, removeOnDisable: false}
+					return nil
+				})
+			}
+		}
+		files[path] = watchedFile{FileInfo: info, removeOnDisable: true}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return files, nil
 }
 
 // deploy loads yaml from a manifest on disk, creates an AddOn resource to track its application, and then applies
@@ -268,8 +290,8 @@ func (w *watcher) deploy(path string, compareChecksum bool) error {
 }
 
 // delete completely removes both a manifest, and any resources that it did or would have created. The manifest is
-// parsed, and any resources it specified are deleted. Finally, the file itself is removed from disk.
-func (w *watcher) delete(path string) error {
+// parsed, and any resources it specified are deleted. If requested, the file itself is then removed from disk.
+func (w *watcher) delete(path string, removeFile bool) error {
 	name := basename(path)
 	addon, err := w.getOrCreateAddon(name)
 	if err != nil {
@@ -309,8 +331,10 @@ func (w *watcher) delete(path string) error {
 	}
 
 	// Remove the addon file
-	if err := os.Remove(path); err != nil {
-		return err
+	if removeFile {
+		if err := os.Remove(path); err != nil {
+			return err
+		}
 	}
 
 	// Delete the addon

--- a/pkg/deploy/controller_test.go
+++ b/pkg/deploy/controller_test.go
@@ -1,0 +1,72 @@
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_UnitWalkFilesSymlinkedDirectoryUsesLogicalPaths(t *testing.T) {
+	base := t.TempDir()
+	target := t.TempDir()
+
+	manifest := filepath.Join(target, "nested", "manifest.yaml")
+	if err := os.MkdirAll(filepath.Dir(manifest), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifest, []byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(base, "linked")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := walkFiles(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logicalPath := filepath.Join(link, "nested", "manifest.yaml")
+	entry, ok := files[logicalPath]
+	if !ok {
+		t.Fatalf("expected symlinked manifest to use logical path %q; got %v", logicalPath, fileKeys(files))
+	}
+	if _, ok := files[manifest]; ok {
+		t.Fatalf("expected resolved target path %q to be hidden by logical symlink path", manifest)
+	}
+	if entry.removeOnDisable {
+		t.Fatalf("expected symlinked manifest %q to avoid on-disk removal when disabled", logicalPath)
+	}
+	if !shouldDisableFile(base, logicalPath, map[string]bool{"linked": true}) {
+		t.Fatalf("expected logical path %q to match disabled symlink directory", logicalPath)
+	}
+	if !shouldDisableFile(base, logicalPath, map[string]bool{"manifest": true}) {
+		t.Fatalf("expected logical path %q to match disabled basename", logicalPath)
+	}
+}
+
+func Test_UnitWalkFilesRegularManifestRemainsRemovable(t *testing.T) {
+	base := t.TempDir()
+	manifest := filepath.Join(base, "regular.yaml")
+	if err := os.WriteFile(manifest, []byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: regular\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := walkFiles(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !files[manifest].removeOnDisable {
+		t.Fatalf("expected regular manifest %q to remain removable when disabled", manifest)
+	}
+}
+
+func fileKeys(files map[string]watchedFile) []string {
+	keys := make([]string, 0, len(files))
+	for key := range files {
+		keys = append(keys, key)
+	}
+	return keys
+}


### PR DESCRIPTION
#### Proposed Changes ####

Keep symlinked manifest dirs on their logical path when the deploy watcher walks them.

Before this, a top-level symlink got followed, but files were tracked by the resolved target path. So `--disable=linked` could miss `server/manifests/linked/...`. Tiny footgun, but real.

#### Types of Changes ####

Bugfix.

#### Verification ####

Repro:

1. Put a manifest under a real dir, ex: `/tmp/addons/nested/test.yaml`.
2. Symlink it into the manifests dir, ex: `server/manifests/linked -> /tmp/addons`.
3. Start with `--disable=linked`.
4. The old watcher records `/tmp/addons/nested/test.yaml`, so the disable check never sees `linked` in the path. oof.

This keeps the watched file as `server/manifests/linked/nested/test.yaml`, so the existing disable logic matches it.

#### Testing ####

Added a unit test with a real symlinked directory.

```bash
go test ./pkg/deploy -count=1
go test ./pkg/util ./pkg/configfilearg ./pkg/agent/util -count=1
git diff --check HEAD~1 HEAD
```

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/14233

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

No cloud/API quota angle here. This is just local filesystem behavior, and the watcher already supports top-level symlinked dirs.
