### PR TITLE
Use 0600 permissions for compressed etcd snapshots

### DIFF
--- a/pkg/etcd/snapshot.go
+++ b/pkg/etcd/snapshot.go
@@ -124,7 +124,7 @@ func (e *ETCD) compressSnapshot(snapshotDir, snapshotFilename string, mtime time
 		return "", err
 	}
 
-	of, err := os.Create(zipPath)
+	of, err := os.OpenFile(zipPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return "", err
 	}

--- a/tests/integration/etcdsnapshot/etcdsnapshot_int_test.go
+++ b/tests/integration/etcdsnapshot/etcdsnapshot_int_test.go
@@ -2,6 +2,7 @@ package snapshot_test
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -145,6 +146,16 @@ var _ = Describe("etcd snapshots", Ordered, func() {
 				matches, err := filepath.Glob(filepath.Join(populatedTestSnapshotDir, fmt.Sprintf("%s%s%s", "*", etcdSnapshotFilePattern, "*.zip")))
 				return len(matches), err
 			}, "120s", "30s").Should(Equal(etcdSnapshotRetention))
+		})
+		It("writes the compressed snapshot with non-world-readable permissions", func() {
+			matches, err := filepath.Glob(filepath.Join(populatedTestSnapshotDir, fmt.Sprintf("%s%s%s", "*", etcdSnapshotFilePattern, "*.zip")))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(matches).ToNot(BeEmpty())
+			for _, match := range matches {
+				info, err := os.Stat(match)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(info.Mode().Perm()).To(Equal(os.FileMode(0600)))
+			}
 		})
 		It("kills previous server and start up with no problems and disabled snapshots", func() {
 


### PR DESCRIPTION
#### Proposed Changes ####

`compressSnapshot` created the compressed `.zip` snapshot file with `os.Create`, which
opens the file with mode `0666`, resulting in a world-readable `0644` file after the
default umask is applied. Uncompressed etcd snapshots are written with mode `0600`.

This change creates the compressed snapshot with `os.OpenFile(..., 0600)` instead, so
that compressed and uncompressed snapshots use the same restrictive permissions. This
also matches the existing `decompressSnapshot` logic, which already uses
`os.OpenFile(..., 0600)` for its output file.

#### Types of Changes ####

Bugfix — file permission consistency. No API or CLI changes.

#### Verification ####

Save a snapshot with and without compression and compare the resulting file modes:

```
k3s etcd-snapshot save --etcd-snapshot-compress=true
k3s etcd-snapshot save --etcd-snapshot-compress=false
ls -l /var/lib/rancher/k3s/server/db/snapshots
```

Before this change the compressed `.zip` snapshot is `0644`; after the change it is
`0600`, matching the uncompressed snapshot.

#### Testing ####

The existing `Test_IntegrationEtcdSnapshot` integration test already starts a server
with `--etcd-snapshot-compress` and produces a compressed snapshot. It is extended here
with an assertion that the compressed snapshot file is created with `0600` permissions,
so the fix is covered on the real code path without adding standalone scaffolding.

#### Linked Issues ####

Addresses issue #13490.

#### User-Facing Change ####
```release-note
Compressed etcd snapshots are now created with 0600 permissions, consistent with uncompressed snapshots.
```

#### Further Comments ####

AI assistance disclosure: I used Claude Code (an AI tool) to help locate the relevant
code path and draft this change and the test assertion. I have reviewed and understand
every line of the change, and verified it by execution — running the `pkg/etcd` package
test against `compressSnapshot` confirmed the compressed snapshot file mode changes from
`0644` to `0600` with this fix, and the integration test package builds and vets cleanly.
