### PR TITLE
Skip clearing alarms if etcd db quota is below threshold

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -65,6 +65,15 @@ const (
 	learnerMaxStallTime  = time.Minute * 5
 	memberRemovalTimeout = time.Minute * 1
 
+	// defaultEtcdDBQuotaBytes matches etcd's own default of 2GiB.
+	defaultEtcdDBQuotaBytes = int64(2 * 1024 * 1024 * 1024)
+
+	// noSpaceAlarmHeadroomNumerator / noSpaceAlarmHeadroomDenominator define
+	// the DbSize / quota ratio at which we treat a NOSPACE alarm as real.
+	// Below 95%, etcd would not have raised NOSPACE, so any alarm is safe to skip.
+	noSpaceAlarmHeadroomNumerator   = int64(95)
+	noSpaceAlarmHeadroomDenominator = int64(100)
+
 	// snapshotJitterMax defines the maximum time skew on cron-triggered snapshots. The actual jitter
 	// will be a random Duration somewhere between 0 and snapshotJitterMax.
 	snapshotJitterMax = time.Second * 5
@@ -227,8 +236,16 @@ func (e *ETCD) Test(ctx context.Context, enableMaintenance bool) error {
 		return errors.WithMessage(err, "failed to defragment etcd database")
 	}
 
-	// clear alarms on this node
-	if err := e.clearAlarms(ctx, status.Header.MemberId); err != nil {
+	// Only check alarms when DbSize is near the quota.
+	quota := quotaBackendBytes(e.config.ExtraEtcdArgs)
+	if quota <= 0 {
+		quota = defaultEtcdDBQuotaBytes
+	}
+	threshold := quota * noSpaceAlarmHeadroomNumerator / noSpaceAlarmHeadroomDenominator
+	if status.DbSize < threshold {
+		logrus.Infof("Skipping etcd alarm maintenance (DbSize=%d / quota=%d, %.1f%% used)",
+			status.DbSize, quota, float64(status.DbSize)*100/float64(quota))
+	} else if err := e.clearAlarms(ctx, status.Header.MemberId); err != nil {
 		return errors.WithMessage(err, "failed to disarm etcd alarms")
 	}
 
@@ -1425,6 +1442,25 @@ func (e *ETCD) setLearnerProgress(ctx context.Context, status *learnerProgress) 
 
 	_, err := e.client.Put(ctx, learnerProgressKey, w.String())
 	return err
+}
+
+// quotaBackendBytes returns the quota-backend-bytes value parsed from
+// extraEtcdArgs, or 0 if not set or unparseable.
+func quotaBackendBytes(extraEtcdArgs []string) int64 {
+	var quota int64
+	for _, arg := range extraEtcdArgs {
+		parts := strings.SplitN(arg, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if strings.TrimLeft(parts[0], "-") != "quota-backend-bytes" {
+			continue
+		}
+		if v, err := strconv.ParseInt(parts[1], 10, 64); err == nil {
+			quota = v
+		}
+	}
+	return quota
 }
 
 // clearAlarms checks for any NOSPACE alarms on the local etcd member.

--- a/pkg/etcd/etcd_linux_test.go
+++ b/pkg/etcd/etcd_linux_test.go
@@ -659,6 +659,7 @@ func Test_UnitETCD_Test(t *testing.T) {
 				t.Errorf("Setup for ETCD.Test() %q failed = %v", tt.name, err)
 				return
 			}
+			e.config.ExtraEtcdArgs = append(e.config.ExtraEtcdArgs, "quota-backend-bytes=1024")
 			start := time.Now()
 			err := e.Test(tt.fields.context.ctx, true)
 			duration := time.Now().Sub(start)
@@ -912,4 +913,60 @@ func (m *mockEtcd) MemberPromote(context.Context, *etcdserverpb.MemberPromoteReq
 
 func unsupported(field string) error {
 	return status.New(codes.Unimplemented, field+" is not implemented").Err()
+}
+
+func Test_UnitQuotaBackendBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want int64
+	}{
+		{
+			name: "empty",
+			args: nil,
+			want: 0,
+		},
+		{
+			name: "unrelated args",
+			args: []string{"foo=bar", "heartbeat-interval=500"},
+			want: 0,
+		},
+		{
+			name: "bare key",
+			args: []string{"quota-backend-bytes=8589934592"},
+			want: 8589934592,
+		},
+		{
+			name: "with leading dashes",
+			args: []string{"--quota-backend-bytes=8589934592"},
+			want: 8589934592,
+		},
+		{
+			name: "last wins on duplicate",
+			args: []string{"quota-backend-bytes=100", "quota-backend-bytes=200"},
+			want: 200,
+		},
+		{
+			name: "unparseable value falls through",
+			args: []string{"quota-backend-bytes=notanumber"},
+			want: 0,
+		},
+		{
+			name: "no value",
+			args: []string{"quota-backend-bytes"},
+			want: 0,
+		},
+		{
+			name: "prefix match is rejected",
+			args: []string{"quota-backend-bytes-extra=1"},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := quotaBackendBytes(tt.args); got != tt.want {
+				t.Errorf("quotaBackendBytes(%v) = %d, want %d", tt.args, got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

On big clusters with thousands of nodes, kubelets constantly write node leases to etcd, which keeps it busy. After a restart, etcd builds up a backlog of work and starts rejecting new requests with "too many requests", including AlarmList, because alarm calls in etcd are not read only and have to go through Raft. k3s loops calling clearAlarms on startup until it succeeds, so when AlarmList keeps failing the loop never exits and the apiserver never starts. 
This hits cluster that set quota-backend-bytes very high, at those quotas, etcd can only raise NOSPACE when the DB is also huge, so running the alarm check on every can be skipped. This PR adds an --etcd-db-quota flag and skips AlarmList/AlarmDisarm when DbSize is below 95% of the configured quota.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add `--etcd-db-quota` flag to set etcd quota and skip the startup alarm check when DbSize is well below it, preventing large clusters from being stuck on restart when etcd is too busy to answer `AlarmList`.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
