### PR TITLE
test(kubeflags): add K3sCleanup between server restarts to fix flake

### DIFF
--- a/tests/integration/kubeflags/kubeflags_test.go
+++ b/tests/integration/kubeflags/kubeflags_test.go
@@ -114,6 +114,7 @@ var _ = Describe("create a new cluster with kube-* flags", Ordered, func() {
 		When("server is setup without kube-proxy or cloud-controller-manager ", func() {
 			It("kills previous server and clean logs", func() {
 				Expect(testutil.K3sKillServer(server)).To(Succeed())
+				Expect(testutil.K3sCleanup(-1, "")).To(Succeed())
 			})
 			It("start up with disabled kube-proxy and cloud controller", func() {
 				var err error
@@ -167,6 +168,7 @@ var _ = Describe("create a new cluster with kube-* flags", Ordered, func() {
 			})
 			It("kills previous server and clean logs", func() {
 				Expect(testutil.K3sKillServer(server)).To(Succeed())
+				Expect(testutil.K3sCleanup(-1, "")).To(Succeed())
 			})
 			It("start up with no problems and fully disabled cloud controller", func() {
 				var err error


### PR DESCRIPTION
#### Proposed Changes ####

The kubeflags integration test restarts k3s multiple times mid-suite with different arguments. Between each restart, K3sKillServer is called but the data directory is left on disk. If the server was killed before etcd had a chance to write bootstrap data, the next server start with --cluster-init finds the stale etcd snapshot dir, tries to reconcile against the datastore, and fatals:

```
level=fatal msg="Error: preparing server: failed to bootstrap cluster data: failed to reconcile with local datastore: no bootstrap data found in datastore"
```

Fix is to call K3sCleanup(-1, "") after each of the two intermediate K3sKillServer calls. This removes /var/lib/rancher/k3s before the next server starts. -1 is passed to skip releasing the test lock since that is held until AfterSuite.

#### Types of Changes ####

Bugfix (test only)

#### Verification ####

Failing CI job that shows the exact error: https://github.com/k3s-io/k3s/actions/runs/26903167063/job/79362389771?pr=14151#step:6:73

The startup integration test already does this correctly - every K3sKillServer call in that test is paired with K3sCleanup(-1, ""). Kubeflags was just missing it.

#### Testing ####

Covered by the kubeflags integration test itself. Once the cleanup is in place the stale etcd state can not carry over between server restarts.

#### Linked Issues ####

* #14153

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

The pattern K3sKillServer + K3sCleanup(-1, "") is already established in startup_int_test.go for every mid-test kill. This change brings kubeflags in line with that.