### PR TITLE
Reduce GRPC console spam

### DIFF
--- a/pkg/cli/cmds/log.go
+++ b/pkg/cli/cmds/log.go
@@ -2,11 +2,13 @@ package cmds
 
 import (
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	"google.golang.org/grpc/grpclog"
 )
 
 type Log struct {
@@ -72,6 +74,7 @@ func checkUnixTimestamp() error {
 }
 
 func setupLogging() {
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 	if Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}


### PR DESCRIPTION
#### Proposed Changes ####

Recent version bumps have changed how various imported components set up grpc logging; previously we (unintentionally) relied on these to reduce grpc logging output. See for example:
* https://github.com/etcd-io/etcd/blob/v3.6.12/server/embed/config_logging.go#L237
* https://github.com/containerd/containerd/blob/v2.3.1/cmd/containerd/command/main.go#L58-L59
* https://github.com/kubernetes/kubernetes/blob/v1.36.1/staging/src/k8s.io/apiserver/pkg/storage/etcd3/logger.go#L27


Without this occurring, we now get a bunch of spam from grpc when shutting down:

`W0609 02:43:12.412252      37 logging.go:55] [core] [Channel #129 SubChannel #130] grpc: addrConn.createTransport failed to connect to {Addr: "unix:kine.sock", ServerName: "kine.sock", }. Err: connection error: desc = "transport: Error while dialing: dial unix kine.sock: connect: no such file or directory"`

#### Types of Changes ####

Bugfix

#### Verification ####

Check logs when stopping k3s

#### Testing ####

#### Linked Issues ####

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
