### PR TITLE
Update github actions in a single grouped PR every month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,12 @@ updates:
     reviewers:
       - "k3s-io/k3s-dev"
     schedule:
-      interval: "weekly"
+      interval: "cron"
+      cronjob: "0 0 12 * *" # Every 12th of the month, generally before releases
+    groups:
+      action-deps:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
#### Proposed Changes ####
- Every 12th of the month, update all github actions in a single PR. Should greatly reduce number of dependabot PRs opened weekly.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
