### PR TITLE
Match --disable for files under symlinked manifest directories

### DIFF
--- a/pkg/deploy/controller.go
+++ b/pkg/deploy/controller.go
@@ -111,10 +111,25 @@ func (w *watcher) listFiles(force bool) error {
 	return errors.Join(errs...)
 }
 
-// listFilesIn recursively processes all files within a path, and checks them against the disable and skip lists. Files found that
-// are not on either list are loaded as Addons and applied to the cluster.
-func (w *watcher) listFilesIn(base string, force bool) error {
-	files := map[string]os.FileInfo{}
+// fileEntry holds the information needed to process a manifest discovered by
+// scanManifests. The entry's map key is the file's logical path under the
+// watched manifests directory; realPath is the actual on-disk path, which
+// differs from the key only when the file was found by descending into a
+// top-level symlinked directory.
+type fileEntry struct {
+	info     os.FileInfo
+	realPath string
+}
+
+// scanManifests walks base and returns a map of logical path -> fileEntry for
+// every file found. Top-level symlinked directories are descended into, but
+// the files within are recorded under their logical path
+// (base/<symlinkName>/<relative-to-target>) rather than the resolved target
+// path. This ensures that --disable=<symlinkName> matches files under that
+// directory, and that subsequent file operations stay scoped to the watched
+// base instead of mutating files in the symlink target.
+func scanManifests(base string) (map[string]fileEntry, error) {
+	files := map[string]fileEntry{}
 	if err := filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -130,18 +145,36 @@ func (w *watcher) listFilesIn(base string, force bool) error {
 				if err != nil {
 					return err
 				}
-				filepath.Walk(evalPath, func(path string, info os.FileInfo, err error) error {
+				filepath.Walk(evalPath, func(walkPath string, walkInfo os.FileInfo, err error) error {
 					if err != nil {
 						return err
 					}
-					files[path] = info
+					rel, err := filepath.Rel(evalPath, walkPath)
+					if err != nil {
+						return err
+					}
+					logical := filepath.Join(path, rel)
+					files[logical] = fileEntry{info: walkInfo, realPath: walkPath}
 					return nil
 				})
 			}
 		}
-		files[path] = info
+		// Record the entry under its own path. For a symlinked directory this
+		// intentionally overwrites the rel="." entry written by the inner Walk,
+		// so the symlink itself is still managed as a normal local file.
+		files[path] = fileEntry{info: info, realPath: path}
 		return nil
 	}); err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+// listFilesIn recursively processes all files within a path, and checks them against the disable and skip lists. Files found that
+// are not on either list are loaded as Addons and applied to the cluster.
+func (w *watcher) listFilesIn(base string, force bool) error {
+	files, err := scanManifests(base)
+	if err != nil {
 		return err
 	}
 
@@ -149,35 +182,34 @@ func (w *watcher) listFilesIn(base string, force bool) error {
 	// For example, 'addon.yaml.skip' will cause 'addon.yaml' to be ignored completely - unless it is also
 	// disabled, since disable processing happens first.
 	skips := map[string]bool{}
-	keys := make([]string, len(files))
-	keyIndex := 0
-	for path, file := range files {
-		if strings.HasSuffix(file.Name(), ".skip") {
-			skips[strings.TrimSuffix(file.Name(), ".skip")] = true
+	keys := make([]string, 0, len(files))
+	for path, entry := range files {
+		if strings.HasSuffix(entry.info.Name(), ".skip") {
+			skips[strings.TrimSuffix(entry.info.Name(), ".skip")] = true
 		}
-		keys[keyIndex] = path
-		keyIndex++
+		keys = append(keys, path)
 	}
 	sort.Strings(keys)
 
 	var errs []error
 	for _, path := range keys {
+		entry := files[path]
 		// Disabled files are not just skipped, but actively deleted from the filesystem
 		if shouldDisableFile(base, path, w.disables) {
-			if err := w.delete(path); err != nil {
+			if err := w.delete(path, entry.realPath); err != nil {
 				errs = append(errs, errors.WithMessagef(err, "failed to delete %s", path))
 			}
 			continue
 		}
 		// Skipped files are just ignored
-		if shouldSkipFile(files[path].Name(), skips) {
+		if shouldSkipFile(entry.info.Name(), skips) {
 			continue
 		}
-		modTime := files[path].ModTime()
+		modTime := entry.info.ModTime()
 		if !force && modTime.Equal(w.modTime[path]) {
 			continue
 		}
-		if err := w.deploy(path, !force); err != nil {
+		if err := w.deploy(path, entry.realPath, !force); err != nil {
 			errs = append(errs, errors.WithMessagef(err, "failed to process %s", path))
 		} else {
 			w.modTime[path] = modTime
@@ -188,8 +220,10 @@ func (w *watcher) listFilesIn(base string, force bool) error {
 }
 
 // deploy loads yaml from a manifest on disk, creates an AddOn resource to track its application, and then applies
-// all resources contained within to the cluster.
-func (w *watcher) deploy(path string, compareChecksum bool) error {
+// all resources contained within to the cluster. path is the file's logical path under the watched manifests
+// directory (used for the addon's Source field and user-facing events); realPath is the actual on-disk path
+// read from, which differs from path only for files discovered through a top-level symlinked directory.
+func (w *watcher) deploy(path, realPath string, compareChecksum bool) error {
 	name := basename(path)
 	addon, err := w.getOrCreateAddon(name)
 	if err != nil {
@@ -208,7 +242,7 @@ func (w *watcher) deploy(path string, compareChecksum bool) error {
 		addon = *newAddon
 	}
 
-	content, err := os.ReadFile(path)
+	content, err := os.ReadFile(realPath)
 	if err != nil {
 		w.recorder.Eventf(&addon, corev1.EventTypeWarning, "ReadManifestFailed", "Read manifest at %q failed: %v", path, err)
 		return err
@@ -268,8 +302,11 @@ func (w *watcher) deploy(path string, compareChecksum bool) error {
 }
 
 // delete completely removes both a manifest, and any resources that it did or would have created. The manifest is
-// parsed, and any resources it specified are deleted. Finally, the file itself is removed from disk.
-func (w *watcher) delete(path string) error {
+// parsed, and any resources it specified are deleted. Finally, the file itself is removed from disk - except when
+// it was found by descending into a top-level symlinked directory, in which case the file lives outside the
+// watched base and is left in place so the administrator's external manifests directory is not modified.
+// path is the file's logical path under the watched manifests directory; realPath is the actual on-disk path.
+func (w *watcher) delete(path, realPath string) error {
 	name := basename(path)
 	addon, err := w.getOrCreateAddon(name)
 	if err != nil {
@@ -283,7 +320,7 @@ func (w *watcher) delete(path string) error {
 		}
 	}
 
-	content, err := os.ReadFile(path)
+	content, err := os.ReadFile(realPath)
 	if err != nil {
 		w.recorder.Eventf(&addon, corev1.EventTypeWarning, "ReadManifestFailed", "Read manifest at %q failed: %v", path, err)
 	} else {
@@ -308,9 +345,13 @@ func (w *watcher) delete(path string) error {
 		return err
 	}
 
-	// Remove the addon file
-	if err := os.Remove(path); err != nil {
-		return err
+	// Remove the addon file, but only when it lives inside the watched base
+	// directory. Files reached via a top-level symlinked directory belong to
+	// an external location and must be left alone.
+	if path == realPath {
+		if err := os.Remove(realPath); err != nil {
+			return err
+		}
 	}
 
 	// Delete the addon

--- a/pkg/deploy/controller_linux_test.go
+++ b/pkg/deploy/controller_linux_test.go
@@ -1,0 +1,112 @@
+//go:build linux
+
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// Test_UnitScanManifests covers the path-rewriting behavior that makes
+// --disable=<symlinkName> match files under a top-level symlinked manifests
+// directory. Each entry's map key is the file's logical path under base; the
+// realPath records the on-disk location, which differs only for entries
+// reached through a top-level symlink.
+func Test_UnitScanManifests(t *testing.T) {
+	base := t.TempDir()
+	external := t.TempDir()
+
+	// Plain file directly under base.
+	directPath := filepath.Join(base, "direct.yaml")
+	if err := os.WriteFile(directPath, []byte("---\n"), 0600); err != nil {
+		t.Fatalf("write direct: %v", err)
+	}
+
+	// Regular subdirectory under base with a file inside.
+	subDir := filepath.Join(base, "sub")
+	if err := os.Mkdir(subDir, 0700); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	subPath := filepath.Join(subDir, "child.yaml")
+	if err := os.WriteFile(subPath, []byte("---\n"), 0600); err != nil {
+		t.Fatalf("write sub child: %v", err)
+	}
+
+	// Top-level symlink under base pointing at an external directory with a
+	// nested manifest inside.
+	extNestedDir := filepath.Join(external, "nested")
+	if err := os.Mkdir(extNestedDir, 0700); err != nil {
+		t.Fatalf("mkdir external/nested: %v", err)
+	}
+	extFile := filepath.Join(extNestedDir, "test.yaml")
+	if err := os.WriteFile(extFile, []byte("---\n"), 0600); err != nil {
+		t.Fatalf("write external file: %v", err)
+	}
+	linkPath := filepath.Join(base, "linked")
+	if err := os.Symlink(external, linkPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	files, err := scanManifests(base)
+	if err != nil {
+		t.Fatalf("scanManifests: %v", err)
+	}
+
+	want := map[string]string{
+		base:                              base,
+		directPath:                        directPath,
+		subDir:                            subDir,
+		subPath:                           subPath,
+		linkPath:                          linkPath, // the symlink itself stays local
+		filepath.Join(linkPath, "nested"): extNestedDir,
+		filepath.Join(linkPath, "nested", "test.yaml"): extFile,
+	}
+
+	if len(files) != len(want) {
+		gotKeys := make([]string, 0, len(files))
+		for k := range files {
+			gotKeys = append(gotKeys, k)
+		}
+		sort.Strings(gotKeys)
+		t.Fatalf("scanManifests returned %d entries, want %d. got: %v", len(files), len(want), gotKeys)
+	}
+	for logical, wantReal := range want {
+		entry, ok := files[logical]
+		if !ok {
+			t.Errorf("missing entry for logical path %q", logical)
+			continue
+		}
+		if entry.realPath != wantReal {
+			t.Errorf("entry %q: realPath = %q, want %q", logical, entry.realPath, wantReal)
+		}
+	}
+}
+
+// Test_UnitShouldDisableFile_Symlinked covers the disable-matching fix: with
+// the logical paths produced by scanManifests, --disable=<symlinkName> must
+// match files under that symlinked directory.
+func Test_UnitShouldDisableFile_Symlinked(t *testing.T) {
+	base := "/var/lib/rancher/k3s/server/manifests/"
+	disables := map[string]bool{"linked": true}
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "file under symlinked dir", path: base + "linked/test.yaml", want: true},
+		{name: "nested file under symlinked dir", path: base + "linked/nested/test.yaml", want: true},
+		{name: "unrelated file", path: base + "other.yaml", want: false},
+		{name: "file in non-disabled subdir", path: base + "other/test.yaml", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldDisableFile(base, tt.path, disables); got != tt.want {
+				t.Errorf("shouldDisableFile(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Proposed Changes ####

When the deploy watcher descended into a top-level symlinked manifest
directory, files under that directory were recorded under their *resolved*
on-disk path (e.g. `/tmp/addons/nested/test.yaml`) instead of their logical
path under the watched base (`server/manifests/linked/nested/test.yaml`).

That broke two things:

1. `shouldDisableFile` derives a relative path with
   `strings.TrimPrefix(fileName, base)`. With the resolved path, the prefix
   never matched, so `--disable=<symlinkName>` silently failed for every
   file under that symlinked directory.
2. The disable path eventually calls `os.Remove(path)` on every "disabled"
   file. If matching ever did fire, it would remove files from the external
   target directory the user had symlinked in — outside the watched
   manifests dir.

This change extracts file discovery into a new `scanManifests` helper that
records each file under its *logical* path (the path under base) along with
its real on-disk path, then threads both through `deploy`/`delete`:
- `shouldDisableFile` now sees logical paths and `--disable=<symlinkName>`
  matches them as expected.
- `delete` only calls `os.Remove(realPath)` when the file lives inside the
  watched base (`path == realPath`); files reached through a top-level
  symlink have their cluster resources cleaned up but are left on disk.

Cluster-resource cleanup, skip handling, and the behavior for the symlink
entry itself are unchanged.

#### Types of Changes ####

Bugfix.

#### Verification ####

```
# Setup
mkdir -p /tmp/addons/nested
cat > /tmp/addons/nested/test.yaml <<EOF
apiVersion: v1
kind: ConfigMap
metadata: { name: from-symlink, namespace: default }
data: { ok: "yes" }
EOF
ln -s /tmp/addons /var/lib/rancher/k3s/server/manifests/linked

# Start k3s with --disable=linked
# Before: the ConfigMap is created (disable misses).
# After:  the ConfigMap is not created (disable matches files under `linked/`),
#         and /tmp/addons/nested/test.yaml is left untouched on disk.
```

#### Testing ####

Added `pkg/deploy/controller_linux_test.go` with two focused unit tests:

- `Test_UnitScanManifests` builds a real tmp manifests directory containing a
  direct file, a regular subdirectory, and a top-level symlink to an external
  directory with a nested manifest. It asserts that the returned map keys are
  the logical paths and that each entry's `realPath` is the correct on-disk
  location.
- `Test_UnitShouldDisableFile_Symlinked` is a table test confirming that
  `shouldDisableFile` matches the logical paths produced by `scanManifests`
  for `--disable=<symlinkName>`, while not matching unrelated entries.

`Test_UnitScanManifests` is the test that fails before this change is
applied; I verified the failure mode by reverting the path-rewriting locally
and observing the expected mismatch (8 entries with resolved paths instead
of 7 with logical paths), then restoring the fix.

#### Linked Issues ####

Addresses issue #14233.

#### User-Facing Change ####
```release-note
The deploy watcher now correctly matches `--disable=<directoryName>` for
files reached through a top-level symlinked manifest directory, and no
longer removes files from the symlink target when a symlinked directory is
disabled.
```

#### Further Comments ####

AI assistance disclosure: I used Claude Code (an AI tool) to help locate the
relevant code, draft this change, and write the tests. I reviewed every line
and verified the fix by execution — both unit tests pass on Linux, and a
deliberate revert of the path-rewriting confirmed that `Test_UnitScanManifests`
fails on the unfixed code.
