### PR TITLE
Fix image-endpoint assignment in run_linux.go

### DIFF
--- a/pkg/agent/run_linux.go
+++ b/pkg/agent/run_linux.go
@@ -43,7 +43,7 @@ func setupCriCtlConfig(cfg cmds.Agent, nodeConfig *config.Node) error {
 	crp := "runtime-endpoint: " + cre + "\n"
 	ise := nodeConfig.ImageServiceEndpoint
 	if ise != "" && ise != cre {
-		crp += "image-endpoint: " + cre + "\n"
+		crp += "image-endpoint: " + ise + "\n"
 	}
 	return os.WriteFile(agentConfDir+"/crictl.yaml", []byte(crp), 0600)
 }


### PR DESCRIPTION
#### Proposed Changes ####

Fix the generated `crictl.yaml` image endpoint value.

When `ImageServiceEndpoint` is configured and differs from `ContainerRuntimeEndpoint`, `setupCriCtlConfig` currently appears to write the container runtime endpoint for both `runtime-endpoint` and `image-endpoint`.

I am not sure if `cre` was used there on purpose, but it seems that the image service endpoint is the correct variable that should be used there.

#### Types of Changes ####

Bugfix

#### Verification ####

Configure an agent with separate container runtime and image service endpoints.

Expected generated `crictl.yaml`:

```yaml
runtime-endpoint: <container-runtime-endpoint>
image-endpoint: <image-service-endpoint>
```

The image endpoint should match the configured image service endpoint, not the runtime endpoint.
#### Testing ####
Manual verification by checking the generated crictl.yaml.
A unit test could be added for setupCriCtlConfig to verify that when ImageServiceEndpoint differs from ContainerRuntimeEndpoint, the generated image-endpoint value uses ImageServiceEndpoint.
#### Linked Issues ####
N/A
#### User-Facing Change ####
Fix generated crictl config to use the configured image service endpoint when it differs from the container runtime endpoint.
#### Further Comments ####
This appears to be a small variable mix-up in the generated crictl.yaml content.

