### PR TITLE
Fix codecov reports for E2E and Integration tests

### DIFF
--- a/.github/workflows/build-k3s.yaml
+++ b/.github/workflows/build-k3s.yaml
@@ -19,6 +19,11 @@ on:
         description: 'Upload contents of build/out, used to build the k3s image externally'
         required: false
         default: false
+      test-coverage:
+        type: boolean
+        description: 'Whether to build K3s with -cover for test coverage collection'
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -79,6 +84,7 @@ jobs:
           TREE_STATE=${{ steps.git_vars.outputs.tree_state }}
           COMMIT=${{ steps.git_vars.outputs.commit }}
           DIRTY=${{ steps.git_vars.outputs.dirty }}
+          GOCOVER=${{ inputs.test-coverage && '1' || '0' }}
           GOOS=${{ inputs.os }}
         push: false
         provenance: mode=min

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,6 +36,7 @@ jobs:
     uses: ./.github/workflows/build-k3s.yaml
     with:
       upload-image: true
+      test-coverage: true
   build-arm64:
     uses: ./.github/workflows/build-k3s.yaml
     permissions:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -140,6 +140,7 @@ jobs:
           E2E_GOCOVER: "true"
         run: | 
           chmod +x ./dist/artifacts/k3s
+          mkdir -p /tmp/k3scov
           cd tests/e2e/${{ matrix.etest }}
           go test -timeout=45m ./${{ matrix.etest }}_test.go -test.v -ginkgo.v -ci -local
       - name: On Failure, Upload Journald Logs

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -34,10 +34,12 @@ jobs:
     uses: ./.github/workflows/build-k3s.yaml
     with:
       os: linux
+      test-coverage: true
   build-windows:
     uses: ./.github/workflows/build-k3s.yaml
     with:
       os: windows
+      test-coverage: true
   itest:
     needs: build
     name: Integration Tests

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         # Ordered longest-first from CI timings to reduce matrix tail latency.
         itest: [startup, etcdsnapshot, kubeflags, cacertrotation, longhorn, secretsencryption, certrotation, etcdrestore, localstorage, flannelnone, custometcdargs]
-      max-parallel: 3
+      max-parallel: 5
     steps:
     - name: Remove Unnecessary Tools
       working-directory: /

--- a/tests/client.go
+++ b/tests/client.go
@@ -26,6 +26,9 @@ func RunCommand(cmd string) (string, error) {
 	if kc, ok := os.LookupEnv("DOCKER_KUBECONFIG"); ok {
 		c.Env = append(os.Environ(), "KUBECONFIG="+kc)
 	}
+	if _, ok := os.LookupEnv("E2E_GOCOVER"); ok && strings.HasPrefix(cmd, "kubectl") {
+		c.Env = append(c.Env, "GOCOVERDIR=/tmp/k3scov")
+	}
 	out, err := c.CombinedOutput()
 	if err != nil {
 		return string(out), fmt.Errorf("failed to run command: %s, %v", cmd, err)

--- a/tests/docker/etcd/etcd_test.go
+++ b/tests/docker/etcd/etcd_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Etcd Tests", Ordered, func() {
 			Expect(config.ProvisionAgents(1)).To(Succeed())
 			Eventually(func() error {
 				return tests.CheckDefaultDeployments(config.KubeconfigFile)
-			}, "90s", "5s").Should(Succeed())
+			}, "240s", "5s").Should(Succeed())
 			Eventually(func() error {
 				return tests.NodesReady(config.KubeconfigFile, config.GetNodeNames())
 			}, "90s", "5s").Should(Succeed())


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
- [For over a year](https://github.com/k3s-io/k3s/commit/3ce4a6352db151e0ac374485d41d99b29fb42ba2) we have not been building the k3s binary with `-cover` when running E2E and Integration tests. This has resulted in only our unit tests being visible in coverage on codecov.
- Fix the k3s build so it include coverage info that can be passed to codecov
- Bump parallel runs of integration tests to 5, we have the runners for it and it saves about 5min in aggregate.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
<img width="700" height="165" alt="image" src="https://github.com/user-attachments/assets/3b17635c-9e32-4d89-ac11-c4e3db310b40" />

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####
N/A
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
