### PR TITLE
Add image names to file cache

### DIFF
--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -161,49 +161,49 @@ func PreloadImages(ctx context.Context, cfg *config.Node) error {
 // preloadFile handles loading images from a single tarball or pre-pull image list.
 // This is in its own function so that we can ensure that the various readers are properly closed, as some
 // decompressing readers need to be explicitly closed and others do not.
-func preloadFile(ctx context.Context, cfg *config.Node, client *containerd.Client, imageClient runtimeapi.ImageServiceClient, filePath string) error {
+func preloadFile(ctx context.Context, cfg *config.Node, client *containerd.Client, imageClient runtimeapi.ImageServiceClient, filePath string) ([]images.Image, error) {
 	var images []images.Image
 	if util2.HasSuffixI(filePath, ".txt") {
 		file, err := os.Open(filePath)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		defer file.Close()
 		logrus.Infof("Pulling images from %s", filePath)
 		images, err = prePullImages(ctx, client, imageClient, file)
 		if err != nil {
-			return errors.WithMessage(err, "failed to pull images from "+filePath)
+			return nil, errors.WithMessage(err, "failed to pull images from "+filePath)
 		}
 	} else {
 		opener, err := tarfile.GetOpener(filePath)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		imageReader, err := opener()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		defer imageReader.Close()
 
 		logrus.Infof("Importing images from %s", filePath)
 		images, err = client.Import(ctx, imageReader, containerd.WithAllPlatforms(true), containerd.WithSkipMissing())
 		if err != nil {
-			return errors.WithMessage(err, "failed to import images from "+filePath)
+			return nil, errors.WithMessage(err, "failed to import images from "+filePath)
 		}
 	}
 
 	if err := labelImages(ctx, client, images, filepath.Base(filePath)); err != nil {
-		return errors.WithMessage(err, "failed to add pinned label to images")
+		return nil, errors.WithMessage(err, "failed to add pinned label to images")
 	}
 	if err := retagImages(ctx, client, images, cfg.AgentConfig.AirgapExtraRegistry); err != nil {
-		return errors.WithMessage(err, "failed to retag images")
+		return nil, errors.WithMessage(err, "failed to retag images")
 	}
 	if err := labelContent(ctx, client, images, cfg.AgentConfig.AirgapExtraRegistry); err != nil {
-		return errors.WithMessage(err, "failed to add source labels to layer content")
+		return nil, errors.WithMessage(err, "failed to add source labels to layer content")
 	}
 
-	return nil
+	return images, nil
 }
 
 // clearLeases deletes any leases left by previous versions of k3s.
@@ -240,6 +240,19 @@ func clearLabels(ctx context.Context, client *containerd.Client) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// labelImagesByName adds labels to the listed image names, indicating that they
+// are pinned by k3s and should not be pruned.
+func labelImagesByName(ctx context.Context, client *containerd.Client, names []string, fileName string) error {
+	imageService := client.ImageService()
+	images := []images.Image{}
+	for _, name := range names {
+		if image, err := imageService.Get(ctx, name); err == nil {
+			images = append(images, image)
+		}
+	}
+	return labelImages(ctx, client, images, fileName)
 }
 
 // labelImages adds labels to the listed images, indicating that they

--- a/pkg/agent/containerd/watcher.go
+++ b/pkg/agent/containerd/watcher.go
@@ -24,6 +24,7 @@ import (
 type fileInfo struct {
 	Size    int64       `json:"size"`
 	ModTime metav1.Time `json:"modTime"`
+	Images  []string    `json:"images"`
 	seen    bool        // field is not serialized, and can be used to track if a file has been seen since the last restart
 }
 
@@ -161,17 +162,31 @@ func (w *watchqueue) processImageEvent(ctx context.Context, key string, client *
 		return nil
 	}
 
-	if lastFileState := w.filesCache[key]; lastFileState == nil || (file.Size() != lastFileState.Size && file.ModTime().After(lastFileState.ModTime.Time)) {
+	if lastFileState := w.filesCache[key]; lastFileState == nil || lastFileState.Images == nil || (file.Size() != lastFileState.Size && file.ModTime().After(lastFileState.ModTime.Time)) {
 		start := time.Now()
-		if err := preloadFile(ctx, w.cfg, client, imageClient, key); err != nil {
+		images, err := preloadFile(ctx, w.cfg, client, imageClient, key)
+		if err != nil {
 			return errors.WithMessagef(err, "failed to import %s", key)
 		}
-		logrus.Infof("Imported images from %s in %s", key, time.Since(start))
-		w.filesCache[key] = &fileInfo{Size: file.Size(), ModTime: metav1.NewTime(file.ModTime()), seen: true}
+		logrus.Infof("Imported %d images from %s in %s", len(images), key, time.Since(start))
+		imageNames := make([]string, len(images))
+		for i, image := range images {
+			imageNames[i] = image.Name
+		}
+		w.filesCache[key] = &fileInfo{
+			Size:    file.Size(),
+			ModTime: metav1.NewTime(file.ModTime()),
+			Images:  imageNames,
+			seen:    true,
+		}
 		defer w.syncCache()
 	} else if lastFileState != nil && !lastFileState.seen {
+		// first time seeing this file this start, re-add pinned label since K3s clears all pins on startup
+		if err := labelImagesByName(ctx, client, lastFileState.Images, filepath.Base(key)); err != nil {
+			return errors.WithMessagef(err, "failed to add pinned label to cached images from %s", key)
+		}
 		lastFileState.seen = true
-		// no need to sync as the field is not serialized
+		// no need to sync as seen field is not serialized
 	}
 
 	return nil


### PR DESCRIPTION

#### Proposed Changes ####

Add image names to file cache

Image names are used to re-add the pinned label when importing is skipped due to the archive being present in the cache. This is done once on startup, same as pinned label clearing.

#### Types of Changes ####

bugfix

#### Verification ####

* Create cache file, and drop a tarball in the images dir
* Restart k3s
* Note that images imported from tarball retain the `io.cattle.k3s.pinned=pinned` label in ctr following the restart


```console
root@systemd-node-001:/# cat /var/lib/rancher/k3s/agent/images/busybox.txt
docker.io/library/busybox:latest
root@systemd-node-001:/# jq . /var/lib/rancher/k3s/agent/images/.cache.json
{
  "/var/lib/rancher/k3s/agent/images/busybox.txt": {
    "size": 33,
    "modTime": "2026-06-23T18:05:52Z",
    "images": [
      "docker.io/library/busybox:latest"
    ]
  }
}
root@systemd-node-001:/# ctr image ls name==docker.io/library/busybox:latest
REF                              TYPE                                    DIGEST                                                                  SIZE    PLATFORMS                                                                                                           LABELS
docker.io/library/busybox:latest application/vnd.oci.image.index.v1+json sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d 2.1 MiB linux/386,linux/amd64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/riscv64,linux/s390x io.cattle.k3s.pinned=pinned,io.cri-containerd.image=managed,io.cri-containerd.pinned=pinned
```

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/14265

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
