### PR TITLE
fix: pre-apply feature gates before embedded API server starts

### DIFF
--- a/pkg/executor/embed/embed.go
+++ b/pkg/executor/embed/embed.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	cloudprovider "k8s.io/cloud-provider"
 	ccmapp "k8s.io/cloud-provider/app"
 	cloudcontrollerconfig "k8s.io/cloud-provider/app/config"
@@ -240,6 +241,20 @@ func (*Embedded) APIServerHandlers(ctx context.Context) (authenticator.Request, 
 }
 
 func (e *Embedded) APIServer(ctx context.Context, args []string) error {
+	// Pre-apply feature gates to the global default before starting the API
+	// server goroutine. In the embedded executor all Kubernetes components
+	// share a single utilfeature.DefaultFeatureGate. The API server's REST
+	// storage registration reads the global gate during startup, but flag
+	// parsing (which normally sets the gate) only happens inside
+	// command.ExecuteContext. Without this early application, there is a
+	// race: REST storage may read the gate before flags are parsed, seeing
+	// alpha-default values instead of the user-configured ones.
+	if featureGates := util.ArgValue("feature-gates", args); featureGates != "" {
+		if err := utilfeature.DefaultMutableFeatureGate.Set(featureGates); err != nil {
+			logrus.Warnf("Failed to pre-apply feature gates: %v", err)
+		}
+	}
+
 	command := apiapp.NewAPIServerCommand(ctx.Done())
 	command.SetArgs(args)
 

--- a/pkg/executor/embed/embed.go
+++ b/pkg/executor/embed/embed.go
@@ -241,17 +241,10 @@ func (*Embedded) APIServerHandlers(ctx context.Context) (authenticator.Request, 
 }
 
 func (e *Embedded) APIServer(ctx context.Context, args []string) error {
-	// Pre-apply feature gates to the global default before starting the API
-	// server goroutine. In the embedded executor all Kubernetes components
-	// share a single utilfeature.DefaultFeatureGate. The API server's REST
-	// storage registration reads the global gate during startup, but flag
-	// parsing (which normally sets the gate) only happens inside
-	// command.ExecuteContext. Without this early application, there is a
-	// race: REST storage may read the gate before flags are parsed, seeing
-	// alpha-default values instead of the user-configured ones.
+	// set feature-gates now, to avoid race conditions between components started in parallel
 	if featureGates := util.ArgValue("feature-gates", args); featureGates != "" {
 		if err := utilfeature.DefaultMutableFeatureGate.Set(featureGates); err != nil {
-			logrus.Warnf("Failed to pre-apply feature gates: %v", err)
+			logrus.Warnf("Failed to set feature-gates %s: %v", featureGates, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Pre-apply feature gates to `utilfeature.DefaultMutableFeatureGate` before the embedded API server goroutine starts, fixing an intermittent race condition where alpha feature gates are ignored.

## Problem

In the embedded executor, all Kubernetes components share a single global `utilfeature.DefaultFeatureGate`. Feature gate flag parsing normally occurs inside `command.ExecuteContext()`, which runs in a goroutine. However, the API server's REST storage registration can read the global gate before flags are parsed, seeing alpha-default values (disabled) instead of user-configured ones.

This causes feature gates like `InPlacePodVerticalScaling` (alpha on K8s v1.32) to be intermittently ignored even when correctly configured via the k3s config file (`kube-apiserver-arg: ["feature-gates=InPlacePodVerticalScaling=true"]`). When the race triggers, the API server does not register the `pods/resize` subresource, and `kubectl get --raw /api/v1` shows an empty `resources` list for resize.

The race is intermittent because it depends on goroutine scheduling: whether REST storage init reads `DefaultFeatureGate` before or after `ExecuteContext` parses the `--feature-gates` flag. Factors like I/O contention during startup (e.g., flannel subnet.env loading) affect timing and can increase the probability.

## Fix

Extract the `--feature-gates` value from the API server args using the existing `util.ArgValue()` helper, then call `utilfeature.DefaultMutableFeatureGate.Set()` before creating the API server command and launching its goroutine. This ensures the global gate reflects user configuration before any component reads it.

The subsequent flag parsing in `ExecuteContext()` will set the same values again, which is idempotent.

## Testing

- Verified the change compiles successfully with `go build ./pkg/executor/embed/`
- Verified `goimports` formatting is clean
- The fix is minimal (1 new import, 1 guard block of ~10 lines)
- Full CI test suite will exercise this on Linux runners

## Related

Ref #14286

## AI Disclosure

This PR was developed with AI assistance.
