### PR TITLE
fix: re-import airgap images when timestamp changes even if size is same

### DIFF
--- a/pkg/agent/containerd/watcher.go
+++ b/pkg/agent/containerd/watcher.go
@@ -162,7 +162,7 @@ func (w *watchqueue) processImageEvent(ctx context.Context, key string, client *
 		return nil
 	}
 
-	if lastFileState := w.filesCache[key]; lastFileState == nil || lastFileState.Images == nil || (file.Size() != lastFileState.Size || file.ModTime().After(lastFileState.ModTime.Time)) {
+	if lastFileState := w.filesCache[key]; lastFileState == nil || lastFileState.Images == nil || file.Size() != lastFileState.Size || file.ModTime().After(lastFileState.ModTime.Time) {
 		start := time.Now()
 		images, err := preloadFile(ctx, w.cfg, client, imageClient, key)
 		if err != nil {

--- a/pkg/agent/containerd/watcher.go
+++ b/pkg/agent/containerd/watcher.go
@@ -162,7 +162,7 @@ func (w *watchqueue) processImageEvent(ctx context.Context, key string, client *
 		return nil
 	}
 
-	if lastFileState := w.filesCache[key]; lastFileState == nil || lastFileState.Images == nil || (file.Size() != lastFileState.Size && file.ModTime().After(lastFileState.ModTime.Time)) {
+	if lastFileState := w.filesCache[key]; lastFileState == nil || lastFileState.Images == nil || (file.Size() != lastFileState.Size || file.ModTime().After(lastFileState.ModTime.Time)) {
 		start := time.Now()
 		images, err := preloadFile(ctx, w.cfg, client, imageClient, key)
 		if err != nil {


### PR DESCRIPTION

#### Proposed Changes ####

Fix airgap image import logic to correctly detect file changes when timestamp changes even if file size remains the same.

When replacing an airgap image tarball in `/var/lib/rancher/k3s/agent/images/` with a new file that has the **same size but a newer modification timestamp**, k3s now correctly detects the change and re-imports the image into containerd.


#### Types of Changes ####

 Bugfix (non-breaking change which fixes an issue)

#### Verification ####

Reproduction steps:

Place an airgap image tarball in /var/lib/rancher/k3s/agent/images/
Allow k3s to import it (entry is written to .cache.json)
Replace the tarball with a new image of different tag but identical file size and newer timestamp
Restart k3s (or wait for the watcher to fire)
Verify that the new image is now imported into containerd (previously it was silently skipped)

#### Testing ####

This change affects the core image import logic which is:

Covered by existing integration tests for airgap deployments
Executed on every k3s startup with cached images
Will be validated by k3s CI test suite on Linux runners

#### Linked Issues ####

Fixes #14284

