### PR TITLE
Use xx for multiarch builds without emulation

### DIFF
--- a/.github/workflows/build-k3s.yaml
+++ b/.github/workflows/build-k3s.yaml
@@ -1,14 +1,11 @@
 on: 
   workflow_call:
     inputs:
-      arch:
+      platforms:
         type: string
-        description: 'Architecture to build (amd64, arm64, or arm)'
-        default: 'amd64'
-      os:
-        type: string
-        description: 'Target OS (linux or windows)'
-        default: 'linux'
+        description: 'Buildx platform list.'
+        required: false
+        default: 'linux/amd64'
       upload-image:
         type: boolean
         description: 'Build and upload k3s image (only works on arm64 or amd64)'
@@ -31,22 +28,13 @@ permissions:
 jobs:
   build:
     name: Build # DO NOT CHANGE THIS NAME, we rely on it for INSTALL_K3S_PR functionality
-    runs-on: ${{ contains(inputs.arch, 'arm') && (github.repository_owner == 'k3s-io' && 'cncf-ubuntu-16-64-arm' || 'ubuntu-24.04-arm') || (github.repository_owner == 'k3s-io' && inputs.arch == 'amd64' && 'cncf-ubuntu-16-64-x86' || 'ubuntu-24.04') }}
-    timeout-minutes: 20
-    env:
-      BIN_EXT: ${{ inputs.os == 'windows' && '.exe' || '' }}
-      ARCH_EXT: ${{ inputs.os == 'windows' && '-windows' || format('-{0}', inputs.arch) }}
-      GOOS: ${{ inputs.os }}
+    runs-on: ${{ (!contains(inputs.platforms, 'amd64') && !contains(inputs.platforms, 'windows/') && !contains(inputs.platforms, 'riscv64') && (github.repository_owner == 'k3s-io' && 'cncf-ubuntu-16-64-arm' || 'ubuntu-24.04-arm')) 
+      || (github.repository_owner == 'k3s-io' && 'cncf-ubuntu-16-64-x86' || 'ubuntu-24.04') }}
+    timeout-minutes: 30
     steps:
     - name: Checkout K3s
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     
-    - name: Set up QEMU
-      if: inputs.arch == 'arm'
-      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
-      with:
-        cache-image: false
-
     - name: Set up Docker
       uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 # v5
       with:
@@ -68,78 +56,83 @@ jobs:
           echo "dirty=${DIRTY}"
         } >> "$GITHUB_OUTPUT"
 
-    - name: Build K3s Binary Native
-      if: inputs.arch == 'arm64' || inputs.arch == 'amd64'
+    - name: Determine build platforms
+      id: platforms
+      run: |
+        platforms='${{ inputs.platforms }}'
+        case "${platforms}" in
+          linux/amd64) artifact_name='k3s-amd64' ;;
+          linux/arm64) artifact_name='k3s-arm64' ;;
+          linux/arm/v7) artifact_name='k3s-arm' ;;
+          windows/amd64) artifact_name='k3s-windows' ;;
+          *) artifact_name='k3s-all' ;;
+        esac
+        contains_linux=false
+        image_allowed=false
+        if [[ ",${platforms}," == *,linux/* ]]; then
+          contains_linux=true
+        fi
+        if [ "${platforms}" = 'linux/amd64' ] || [ "${platforms}" = 'linux/arm64' ]; then
+          image_allowed=true
+        fi
+        {
+          echo "platforms=${platforms}"
+          echo "artifact_name=${artifact_name}"
+          echo "contains_linux=${contains_linux}"
+          echo "image_allowed=${image_allowed}"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Build K3s binaries
       env:
-          DOCKER_BUILD_SUMMARY: false
+        DOCKER_BUILD_SUMMARY: false
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
       with:
         context: .
         file: ./Dockerfile
-        target: result
-        # Defined actions like this don't ingest GITHUB_ENV, so use outputs
-        # and manual set the build arguments
+        target: multiarch-result
         build-args: |
           GIT_TAG=${{ steps.git_vars.outputs.git_tag }}
           TREE_STATE=${{ steps.git_vars.outputs.tree_state }}
           COMMIT=${{ steps.git_vars.outputs.commit }}
           DIRTY=${{ steps.git_vars.outputs.dirty }}
           GOCOVER=${{ inputs.test-coverage && '1' || '0' }}
-          GOOS=${{ inputs.os }}
         push: false
         provenance: mode=min
-        outputs: type=local,dest=.
-
-    - name: Build K3s Binary Emulated
-      if: inputs.arch != 'arm64' && inputs.arch != 'amd64'
-      env:
-        PLATFORM: ${{ inputs.arch == 'arm' && 'linux/arm/v7' || format('linux/{0}', inputs.arch) }}
-        DOCKER_BUILD_SUMMARY: false
-      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-      with:
-        context: .
-        file: ./Dockerfile
-        target: result
-        build-args: |
-          GIT_TAG=${{ steps.git_vars.outputs.git_tag }}
-          TREE_STATE=${{ steps.git_vars.outputs.tree_state }}
-          COMMIT=${{ steps.git_vars.outputs.commit }}
-          DIRTY=${{ steps.git_vars.outputs.dirty }}
-        push: false
-        provenance: mode=min
-        platforms: ${{ env.PLATFORM }}
-        outputs: type=local,dest=.
+        platforms: ${{ steps.platforms.outputs.platforms }}
+        outputs: type=local,dest=.,platform-split=false
 
     - name: Caculate binary checksum
       run: |
-        if [ ${{ inputs.arch }} == 'amd64' ]; then
-          sha256sum dist/artifacts/k3s${{ env.BIN_EXT }} | sed 's|dist/artifacts/||' > dist/artifacts/k3s${{ env.BIN_EXT }}.sha256sum
-        elif [ ${{ inputs.arch }} == "arm" ]; then
-          sha256sum dist/artifacts/k3s-armhf | sed 's|dist/artifacts/||' > dist/artifacts/k3s${{ env.ARCH_EXT }}.sha256sum
-        else
-          sha256sum dist/artifacts/k3s${{ env.ARCH_EXT }}${{ env.BIN_EXT }} | sed 's|dist/artifacts/||' > dist/artifacts/k3s${{ env.ARCH_EXT }}${{ env.BIN_EXT }}.sha256sum
-        fi
+        for binary in dist/artifacts/k3s dist/artifacts/k3s-* dist/artifacts/k3s.exe; do
+          [ -f "${binary}" ] || continue
+          name=$(basename "${binary}")
+          case "${name}" in
+            k3s-armhf) checksum=k3s-arm.sha256sum ;;
+            *) checksum=${name}.sha256sum ;;
+          esac
+          sha256sum "${binary}" | sed 's|dist/artifacts/||' > "dist/artifacts/${checksum}"
+        done
     
-    - name: Build K3s image
-      if: inputs.upload-image == true && inputs.os == 'linux' && (inputs.arch == 'amd64' || inputs.arch == 'arm64')
-      run: ./scripts/package-image
-      
-    - name: "Save K3s image"
-      if: inputs.upload-image == true && inputs.os == 'linux'
-      run: docker image save rancher/k3s -o ./dist/artifacts/k3s-image.tar
-
-    - name: "Save K3s build"
-      if: inputs.upload-build == true  && inputs.os == 'linux'
+    - name: Build and save K3s image
+      if: inputs.upload-image == true && steps.platforms.outputs.image_allowed == 'true'
       run: |
-        mv ./build/out/data-linux.tar.zst ./dist/artifacts/data-linux${{ env.ARCH_EXT }}.tar.zst
+        ./scripts/package-image
+        docker image save rancher/k3s -o ./dist/artifacts/k3s-image.tar
+      
+    - name: "Save K3s build"
+      if: inputs.upload-build == true
+      run: |
+        cp ./build/out/data-*.tar.zst ./dist/artifacts/
 
-    # We use this version of the k3s binary to symlink to kubectl (and any other smylinks we need)
+    # We use this version of the k3s binary to symlink to kubectl (and any other symlinks we need)
     - name: "Save bin k3s binary"
-      if: inputs.os == 'linux'
-      run: install -m 0755 ./bin/k3s ./dist/artifacts/bin-k3s
+      if: contains(steps.platforms.outputs.platforms, 'linux/amd64')
+      run: |
+        tar --zstd -xf ./build/out/data-linux-amd64.tar.zst ./bin/k3s
+        install -m 0755 ./bin/k3s ./dist/artifacts/bin-k3s
 
     - name: "Upload K3s Artifacts"
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: k3s${{ env.ARCH_EXT }}
+        name: ${{ steps.platforms.outputs.artifact_name }}
         path: dist/artifacts/

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -43,7 +43,7 @@ jobs:
       contents: read
       packages: write
     with:
-      arch: arm64
+      platforms: linux/arm64
       upload-image: true
   e2e:
     name: "E2E Tests"

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -33,12 +33,12 @@ jobs:
   build:
     uses: ./.github/workflows/build-k3s.yaml
     with:
-      os: linux
+      platforms: linux/amd64
       test-coverage: true
   build-windows:
     uses: ./.github/workflows/build-k3s.yaml
     with:
-      os: windows
+      platforms: windows/amd64
       test-coverage: true
   itest:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,20 +15,14 @@ jobs:
     name: Build Binary (amd64)
     uses: ./.github/workflows/build-k3s.yaml
     with:
-      upload-build: true
-
-  build-arm64:
-    name: Build Binary (arm64)
-    uses: ./.github/workflows/build-k3s.yaml
-    with:
-      arch: arm64
+      platforms: linux/amd64
       upload-build: true
 
   build-arm:
-    name: Build Binary (arm)
+    name: Build Binary (arm64)
     uses: ./.github/workflows/build-k3s.yaml
     with:
-      arch: arm
+      platforms: linux/arm64,linux/arm/v7
       upload-build: true
 
   push-release-image:
@@ -37,7 +31,7 @@ jobs:
     permissions: 
       packages: write # Needed to push images to GHCR
       id-token: write
-    needs: [build-amd64, build-arm64, build-arm]
+    needs: [build-amd64, build-arm]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -188,7 +182,7 @@ jobs:
       contents: write # Needed to update release with assets
       id-token: write
     runs-on: ubuntu-latest
-    needs: [build-amd64, build-arm64, build-arm, build-airgap]
+    needs: [build-amd64, build-arm, build-airgap]
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -17,7 +17,13 @@ Before getting started, bear in mind that this repository includes all of Kubern
 git clone --depth 1 https://github.com/k3s-io/k3s.git
 ```
 
-To build the full release binary, you may now run `make`, which will create `./dist/artifacts/k3s`.
+To build the full release binary for your local platform, you may now run `make binary`, which will create `./dist/artifacts/k3s`.
+
+To build the full release platform set with Docker Buildx, run:
+
+```bash
+make multiarch-binary
+```
 
 To build the binaries using `make` without running linting (i.e.: if you have uncommitted changes):
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,29 @@
 ARG GOLANG=golang:1.26.4-alpine3.22
-FROM ${GOLANG} AS infra
+ARG XX=tonistiigi/xx:1.6.1
 
-RUN apk -U --no-cache add bash git gcc musl-dev docker vim less file curl wget ca-certificates jq linux-headers \
-    zlib-dev tar zip squashfs-tools npm coreutils openssl-dev libffi-dev libseccomp libseccomp-dev \
-    libseccomp-static make libuv-static sqlite-dev sqlite-static libselinux libselinux-dev zlib-dev zlib-static \
-    zstd pigz alpine-sdk btrfs-progs-dev btrfs-progs-static gawk yq pipx \
+FROM --platform=$BUILDPLATFORM ${XX} AS xx
+
+FROM --platform=$BUILDPLATFORM ${GOLANG} AS infra
+COPY --from=xx / /
+ARG TARGETOS
+ARG TARGETARCH
+ENV TARGETOS=$TARGETOS
+ENV TARGETARCH=$TARGETARCH
+
+RUN apk -U --no-cache add bash git docker vim less file curl wget ca-certificates jq \
+    tar zip squashfs-tools coreutils openssl-dev libffi-dev make libuv-static \
+    zstd pigz alpine-sdk yq clang lld \
     && \
-    if [ "$(go env GOARCH)" = "arm64" ]; then \
+    if [ "${TARGETARCH}" = "arm64" ]; then \
     apk -U --no-cache add binutils-gold; \
     fi \
     && \
-    if [ "$(go env GOARCH)" = "amd64" ]; then \
+    if [ "${TARGETOS}" = "windows" ] && [ "${TARGETARCH}" = "amd64" ]; then \
     apk -U --no-cache add mingw-w64-gcc; \
+    fi
+
+RUN if [ "${TARGETOS}" = "linux" ]; then \
+      xx-apk add --no-cache gcc musl-dev linux-headers zlib-dev zlib-static libseccomp libseccomp-dev libseccomp-static sqlite-dev sqlite-static libselinux libselinux-dev btrfs-progs-dev btrfs-progs-static; \
     fi
 
 # Install goimports
@@ -31,7 +43,10 @@ ARG TREE_STATE
 ARG COMMIT
 ARG DIRTY
 ARG GOOS
-ENV NO_DAPPER=true
+ARG TARGETOS
+ARG TARGETARCH
+ENV TARGETOS=$TARGETOS
+ENV TARGETARCH=$TARGETARCH
 # Used by both build and validate stages, better caching if we do this in a separate stage
 COPY ./scripts/ ./scripts
 COPY ./go.mod ./go.sum ./main.go ./
@@ -57,16 +72,15 @@ COPY ./cmd ./cmd
 COPY ./tests ./tests
 COPY ./pkg ./pkg
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
-    --mount=type=cache,id=gobuild,target=/root/.cache/go-build \
-    ./scripts/build
+    --mount=type=cache,id=gobuild-${TARGETOS}-${TARGETARCH},target=/root/.cache/go-build \
+    if [ "${TARGETOS}" = "linux" ]; then GO=xx-go ./scripts/build; else ./scripts/build; fi
 
 COPY ./contrib ./contrib
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
-    --mount=type=cache,id=gobuild,target=/root/.cache/go-build \
-    ./scripts/package-cli
+    --mount=type=cache,id=gobuild-${TARGETOS}-${TARGETARCH},target=/root/.cache/go-build \
+    if [ "${TARGETOS}" = "linux" ]; then GO=xx-go ./scripts/package-cli; else ./scripts/package-cli; fi
 
 RUN ./scripts/binary_size_check.sh
-
 
 FROM scratch AS result
 ENV SRC_DIR=/go/src/github.com/k3s-io/k3s
@@ -76,3 +90,9 @@ COPY --from=build ${SRC_DIR}/build/out /build/out
 COPY --from=build ${SRC_DIR}/build/static /build/static
 COPY --from=build ${SRC_DIR}/pkg/static /pkg/static
 COPY --from=build ${SRC_DIR}/pkg/deploy /pkg/deploy
+
+# For publishing artifacts, we only need mutlicall binaries and data tarballs.
+FROM scratch AS multiarch-result
+ENV SRC_DIR=/go/src/github.com/k3s-io/k3s
+COPY --from=build ${SRC_DIR}/dist /dist
+COPY --from=build ${SRC_DIR}/build/out /build/out

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,20 @@ binary:
 		--build-arg="DEBUG=$(DEBUG)" \
 		-f Dockerfile --target=result --output=. .
 
+.PHONY: multiarch-binary
+multiarch-binary:
+	@echo "INFO: Building K3s binaries and assets for all release platforms..."
+	. ./scripts/git_version.sh && \
+	DOCKER_BUILDKIT=1 docker buildx build \
+		--platform linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64,windows/amd64 \
+		--build-arg "GIT_TAG=$$GIT_TAG" \
+		--build-arg "TREE_STATE=$$TREE_STATE" \
+		--build-arg "COMMIT=$$COMMIT" \
+		--build-arg "DIRTY=$$DIRTY" \
+		--build-arg="GOCOVER=$(GOCOVER)" \
+		--build-arg="DEBUG=$(DEBUG)" \
+		-f Dockerfile --target=multiarch-result --output type=local,dest=.,platform-split=false .
+
 .PHONY: image
 image: binary
 	@echo "INFO: Building K3s image..."

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -3,9 +3,9 @@ RUN apk add -U ca-certificates zstd tzdata
 ARG TARGETARCH
 COPY build/out/data-linux*.tar.zst /
 RUN SOURCE_TAR_ZST="/data-linux-${TARGETARCH}.tar.zst" && \
-    # If the arch-specific file doesn't exist, try the default one (used with Dapper or single-arch)
     if [ ! -f "${SOURCE_TAR_ZST}" ]; then \
-       SOURCE_TAR_ZST="/data-linux.tar.zst" ; \
+         echo "Missing ${SOURCE_TAR_ZST}" >&2; \
+         exit 1; \
     fi && \
     \
     mkdir -p /image/etc/ssl/certs /image/run /image/var/run /image/tmp /image/lib/modules /image/lib/firmware /image/var/lib/rancher/k3s/data/cni && \

--- a/scripts/binary_size_check.sh
+++ b/scripts/binary_size_check.sh
@@ -5,7 +5,7 @@ set -e
 . ./scripts/version.sh
 
 GO=${GO-go}
-ARCH=${ARCH:-$("${GO}" env GOARCH)}
+. ./scripts/platform.sh
 
 if [ "${DEBUG}" = 1 ]; then
     set -x
@@ -15,15 +15,6 @@ fi
 # "64M ought to be enough for anybody"
 MAX_BINARY_MB=80
 MAX_BINARY_SIZE=$((MAX_BINARY_MB * 1024 * 1024))
-BIN_SUFFIX="-${ARCH}"
-if [ ${ARCH} = amd64 ]; then
-    BIN_SUFFIX=""
-elif [ ${ARCH} = arm ]; then
-    BIN_SUFFIX="-armhf"
-elif [ ${ARCH} = s390x ]; then
-    BIN_SUFFIX="-s390x"
-fi
-
 CMD_NAME="dist/artifacts/k3s${BIN_SUFFIX}${BINARY_POSTFIX}"
 SIZE=$(stat -c '%s' ${CMD_NAME})
 

--- a/scripts/build
+++ b/scripts/build
@@ -106,13 +106,10 @@ fi
 
 mkdir -p bin
 
-if [ ${ARCH} = armv7l ] || [ ${ARCH} = arm ]; then
-    export GOARCH="arm"
-    export GOARM="7"
-fi
-
-if [ ${ARCH} = s390x ]; then
-    export GOARCH="s390x"
+export GOOS=${GOOS:-${OS}}
+export GOARCH=${GOARCH:-${ARCH}}
+if [ ${ARCH} = arm ]; then
+  export GOARM=${GOARM:-7}
 fi
 
 k3s_binaries=(

--- a/scripts/build
+++ b/scripts/build
@@ -81,6 +81,12 @@ case ${OS} in
       TAGS="$TAGS selinux"
       RUNC_TAGS="$RUNC_TAGS selinux"
     fi
+
+    # runc's vendored libseccomp-golang can fail on riscv64 with duplicate
+    # C_ARCH_* switch cases when the seccomp build tag is enabled.
+    if [ "${ARCH}" = "riscv64" ]; then
+      RUNC_TAGS="${RUNC_TAGS/seccomp/}"
+    fi
     ;;
   windows)
     TAGS="$TAGS no_cri_dockerd"
@@ -194,11 +200,16 @@ case ${OS} in
     echo Building runc
     pushd ./build/src/github.com/opencontainers/runc
     rm -f runc
-    make EXTRA_FLAGS="-gcflags=\"all=${GCFLAGS}\"" EXTRA_LDFLAGS="$LDFLAGS" BUILDTAGS="$RUNC_TAGS" $RUNC_STATIC
+    make GO="${GO}" EXTRA_FLAGS="-gcflags=\"all=${GCFLAGS}\"" EXTRA_LDFLAGS="$LDFLAGS" BUILDTAGS="$RUNC_TAGS" $RUNC_STATIC
     popd
     cp -vf ./build/src/github.com/opencontainers/runc/runc ./bin/
     ;;
   windows)
+    if [ "${ARCH}" != "amd64" ]; then
+      echo "[ERROR] unsupported windows architecture: ${ARCH}"
+      exit 1
+    fi
+
     echo Building containerd-shim-runhcs-v1
     pushd ./build/src/github.com/microsoft/hcsshim
     TAGS="${TAGS/netcgo/netgo}"

--- a/scripts/git_version.sh
+++ b/scripts/git_version.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-GIT_TAG=$TAG
-TREE_STATE=clean
-COMMIT=$GITHUB_SHA
+GIT_TAG=${GIT_TAG:-$TAG}
+TREE_STATE=${TREE_STATE:-clean}
+COMMIT=${COMMIT:-$GITHUB_SHA}
+DIRTY=${DIRTY:-}
 
 if [ -d .git ]; then
     if [ -z "$GIT_TAG" ]; then

--- a/scripts/package-cli
+++ b/scripts/package-cli
@@ -61,15 +61,6 @@ HASH=$(sha256sum ./build/out/data-${OS}.tar.zst | awk '{print $1}')
 
 cp ./build/out/data-${OS}.tar.zst ./build/data/${HASH}.tar.zst
 
-BIN_SUFFIX="-${ARCH}"
-if [ ${ARCH} = amd64 ]; then
-    BIN_SUFFIX=""
-elif [ ${ARCH} = arm ]; then
-    BIN_SUFFIX="-armhf"
-elif [ ${ARCH} = s390x ]; then
-    BIN_SUFFIX="-s390x"
-fi
-
 CMD_NAME=dist/artifacts/k3s${BIN_SUFFIX}${BINARY_POSTFIX}
 
 LDFLAGS="

--- a/scripts/package-cli
+++ b/scripts/package-cli
@@ -55,11 +55,12 @@ mkdir -p ./etc
 )
 
 # Ensure the embedded tarball is reproducible: sort file order and clamp timestamps
+DATA_TAR_ZST=./build/out/data-${OS}-${ARCH}.tar.zst
 tar --sort=name --mtime=@0 -cvf ./build/out/data-${OS}.tar ./bin ./etc
-zstd --no-progress -T0 -16 -f --long=25 --rm ./build/out/data-${OS}.tar -o ./build/out/data-${OS}.tar.zst
-HASH=$(sha256sum ./build/out/data-${OS}.tar.zst | awk '{print $1}')
+zstd --no-progress -T0 -16 -f --long=25 --rm ./build/out/data-${OS}.tar -o ${DATA_TAR_ZST}
+HASH=$(sha256sum ${DATA_TAR_ZST} | awk '{print $1}')
 
-cp ./build/out/data-${OS}.tar.zst ./build/data/${HASH}.tar.zst
+cp ${DATA_TAR_ZST} ./build/data/${HASH}.tar.zst
 
 CMD_NAME=dist/artifacts/k3s${BIN_SUFFIX}${BINARY_POSTFIX}
 

--- a/scripts/package-image
+++ b/scripts/package-image
@@ -12,8 +12,9 @@ fi
 TAG=${TAG:-${VERSION_TAG}${SUFFIX}}
 REPO=${REPO:-rancher}
 IMAGE_NAME=${IMAGE_NAME:-k3s}
+PLATFORM=${PLATFORM:-${OS}/${ARCH}}
 
 IMAGE=${REPO}/${IMAGE_NAME}:${TAG}
-docker build --build-arg TAG=${VERSION_TAG} -t ${IMAGE} -f package/Dockerfile .
+docker build --build-arg TAG=${VERSION_TAG} -t ${IMAGE} --platform ${PLATFORM} -f package/Dockerfile .
 ./scripts/image_scan.sh ${IMAGE}
 echo Built ${IMAGE}

--- a/scripts/platform.sh
+++ b/scripts/platform.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+GO=${GO-go}
+
+target_os=${TARGETOS:-${GOOS:-}}
+target_arch=${TARGETARCH:-${GOARCH:-}}
+
+# Fallback on local execution
+OS=${OS:-${target_os:-$("${GO}" env GOOS)}}
+ARCH=${ARCH:-${target_arch:-$("${GO}" env GOARCH)}}
+
+case "${ARCH}" in
+  armv7l|arm/v7)
+    ARCH=arm
+    export GOARM=7
+    ;;
+esac
+
+export OS ARCH
+export GOOS=${GOOS:-${OS}}
+export GOARCH=${GOARCH:-${ARCH}}
+
+if [ "${ARCH}" = arm ]; then
+  export GOARM=${GOARM:-7}
+fi
+
+SUFFIX="-${ARCH}"
+BIN_SUFFIX="-${ARCH}"
+case "${ARCH}" in
+  amd64)
+    BIN_SUFFIX=""
+    ;;
+  arm)
+    BIN_SUFFIX="-armhf"
+    ;;
+esac
+
+BINARY_POSTFIX=
+if [ "${OS}" = windows ]; then
+  BINARY_POSTFIX=.exe
+fi
+
+export SUFFIX BIN_SUFFIX BINARY_POSTFIX

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 GO=${GO-go}
-ARCH=${ARCH:-$("${GO}" env GOARCH)}
-OS=${OS:-$("${GO}" env GOOS)}
-SUFFIX="-${ARCH}"
+. ./scripts/platform.sh
 
 if [ -z "$NO_DAPPER" ]; then
     . ./scripts/git_version.sh
@@ -95,8 +93,3 @@ else
     VERSION="$VERSION_K8S+k3s-${COMMIT:0:8}$DIRTY"
 fi
 VERSION_TAG="$(sed -e 's/+/-/g' <<< "$VERSION")"
-
-BINARY_POSTFIX=
-if [ ${OS} = windows ]; then
-    BINARY_POSTFIX=.exe
-fi

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -3,9 +3,7 @@
 GO=${GO-go}
 . ./scripts/platform.sh
 
-if [ -z "$NO_DAPPER" ]; then
-    . ./scripts/git_version.sh
-fi
+. ./scripts/git_version.sh
 
 get-module-version(){
   go list -mod=readonly -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' $1


### PR DESCRIPTION
#### Proposed Changes ####

* Updated `Dockerfile` with `tonistiigi/xx` to allow efficent `buildx --plaftorm` cross-compilation, and introduced a new `multiarch-binary` target to the `Makefile` that compiles all release binaries for all platforms.
* Transitioned from separate `arch` and `os` inputs to a single, standardized `platforms` input for  GHA workflows (`build-k3s`, `release`, `integration`, `e2e`). Runner selection is "smart", will use arm64 if arm64/arm32 platforms are the only ones. Selects larger amd64 runners otherwise. 
* Consolidated arch/os suffix handling into a `platforms.sh` script
* Cleanup around `package/Dockerfile` to strictly require architecture-specific tarballs.
* Cleanup of old Dapper / Drone lingering stubs

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Build System
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
- CI still green

- `make multi-arch binary`

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
None, but all the testing requires a binary, so the build system is constantly tested.
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####
https://github.com/k3s-io/k3s/issues/7151
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####
There are some hints in this PR around riscv64, but a future PR will enable release artifacts. 
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
