### PR TITLE
Bump spegel to v0.7.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ replace (
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.13.1
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common => github.com/prometheus/common v0.67.5
-	github.com/spegel-org/spegel => github.com/k3s-io/spegel v0.7.1-k3s1
+	github.com/spegel-org/spegel => github.com/k3s-io/spegel v0.7.2-k3s1
 	go.etcd.io/etcd/api/v3 => github.com/k3s-io/etcd/api/v3 v3.6.12-k3s1
 	go.etcd.io/etcd/client/pkg/v3 => github.com/k3s-io/etcd/client/pkg/v3 v3.6.12-k3s1
 	go.etcd.io/etcd/client/v3 => github.com/k3s-io/etcd/client/v3 v3.6.12-k3s1
@@ -451,7 +451,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/quic-go/quic-go v0.60.0 // indirect
 	github.com/quic-go/webtransport-go v0.10.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1232,8 +1232,8 @@ github.com/k3s-io/kubernetes/staging/src/k8s.io/pod-security-admission v1.36.2-k
 github.com/k3s-io/kubernetes/staging/src/k8s.io/pod-security-admission v1.36.2-k3s1/go.mod h1:nyNS3ewNDj9jee9ewuHjznU+y7L7ghfUn4EwO2t6ky8=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/streaming v1.36.2-k3s1 h1:bfqh95gxRQ0HvBQMzXt3K/BFduwjOkr4UEyC607wJ1Y=
 github.com/k3s-io/kubernetes/staging/src/k8s.io/streaming v1.36.2-k3s1/go.mod h1:z6fV3D+NVkoeqRMtWwlUZK6U17SY/LqNzOxWL6GyR/s=
-github.com/k3s-io/spegel v0.7.1-k3s1 h1:yuZDh77+YQNLCAJS0uKwQtiUwm7LIN2co3dVdWVWDco=
-github.com/k3s-io/spegel v0.7.1-k3s1/go.mod h1:DLw832twvYHLyR1Aa+qIcO63ERZoNUDX5WJ4dZ1kCTg=
+github.com/k3s-io/spegel v0.7.2-k3s1 h1:KsYrhHgrCYdk5EN8KexgO5VzYkUXiWzm4ZgxDB5hOIY=
+github.com/k3s-io/spegel v0.7.2-k3s1/go.mod h1:K6K8/o/FJNtQ7Qm2oyO6oJGAQEsEp1EXfTg0D7ERYMY=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -1611,10 +1611,12 @@ github.com/prometheus/procfs v0.16.0/go.mod h1:8veyXUu3nGP7oaCxhX6yeaM5u4stL2FeM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/quic-go/go-ossfuzz-seeds v0.1.0 h1:APacT+iIaNF6fd8AGEiN3bT/Jtkd2jz4v4TzM7MFjy0=
+github.com/quic-go/go-ossfuzz-seeds v0.1.0/go.mod h1:3IOHRbJIc+L6YKMwfDtJAM9Vj9k0YY4muhuyUYk5tbk=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.60.0 h1:xcQioE8OM66UQLeUMHltK1CCcOu3JbVB4JAQdDQSB+0=
+github.com/quic-go/quic-go v0.60.0/go.mod h1:wpKpjmPpftl30sL6pFh7REVpjbcCVy4zt2vDyK1TuJk=
 github.com/quic-go/webtransport-go v0.10.0 h1:LqXXPOXuETY5Xe8ITdGisBzTYmUOy5eSj+9n4hLTjHI=
 github.com/quic-go/webtransport-go v0.10.0/go.mod h1:LeGIXr5BQKE3UsynwVBeQrU1TPrbh73MGoC6jd+V7ow=
 github.com/rancher/dynamiclistener v0.9.0-rc.2 h1:TZHW8KvNMOe/LGxkBn/ZPF1pI7WLAUlTzd5Sa6Q+JaU=


### PR DESCRIPTION
#### Proposed Changes ####

Bump spegel: https://github.com/spegel-org/spegel/releases/tag/v0.7.2

#### Types of Changes ####

version bump

#### Verification ####

Check version in go.mod

#### Testing ####

#### Linked Issues ####
* 

#### User-Facing Change ####
```release-note
```

#### Further Comments ####