### PR TITLE
Add backoff to initial snapshot reconcile

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -90,7 +90,8 @@ func (c *Cluster) Start(ctx context.Context, wg *sync.WaitGroup) error {
 
 					if !c.config.EtcdDisableSnapshots {
 						// do an initial reconcile of snapshots with a fast retry until it succeeds
-						wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+						backoff := wait.Backoff{Duration: time.Second, Factor: 2, Steps: 5}
+						backoff.DelayFunc().Until(ctx, true, false, func(ctx context.Context) (bool, error) {
 							if err := c.managedDB.ReconcileSnapshotData(ctx); err != nil {
 								logrus.Errorf("Failed to record snapshots for cluster: %v", err)
 								return false, nil


### PR DESCRIPTION

#### Proposed Changes ####

Add backoff to initial snapshot reconcile

Backoff starts at 1s and doubles, up to max of 32 seconds

#### Types of Changes ####

enhancement

#### Verification ####

See linked issue

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/14321
* https://github.com/rancher/rke2/issues/10682

#### User-Facing Change ####

```release-note
```

#### Further Comments ####
