### PR TITLE
fix: recover when dynamic-cert.json cache is corrupt

### DIFF
--- a/pkg/cluster/dynacert/storage.go
+++ b/pkg/cluster/dynacert/storage.go
@@ -1,0 +1,35 @@
+// Package dynacert provides dynamiclistener certificate cache helpers for k3s.
+package dynacert
+
+import (
+	"os"
+
+	"github.com/rancher/dynamiclistener"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// RecoveringStorage wraps a TLSStorage so a corrupt or unreadable cache entry is
+// removed and treated as empty (same as a missing file). This lets dynamiclistener
+// regenerate certificates instead of failing every handshake when
+// dynamic-cert.json is corrupt (k3s-io/k3s#14220).
+type RecoveringStorage struct {
+	Path  string
+	Inner dynamiclistener.TLSStorage
+}
+
+func (s *RecoveringStorage) Get() (*corev1.Secret, error) {
+	secret, err := s.Inner.Get()
+	if err != nil {
+		logrus.Warnf("Removing unreadable dynamic listener certificate cache %s: %v", s.Path, err)
+		if rmErr := os.Remove(s.Path); rmErr != nil && !os.IsNotExist(rmErr) {
+			logrus.Warnf("Failed to remove unreadable dynamic listener certificate cache %s: %v", s.Path, rmErr)
+		}
+		return nil, nil
+	}
+	return secret, nil
+}
+
+func (s *RecoveringStorage) Update(secret *corev1.Secret) error {
+	return s.Inner.Update(secret)
+}

--- a/pkg/cluster/dynacert/storage_test.go
+++ b/pkg/cluster/dynacert/storage_test.go
@@ -1,0 +1,69 @@
+package dynacert
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rancher/dynamiclistener/storage/file"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestRecoveringStorage_CorruptJSONReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dynamic-cert.json")
+	if err := os.WriteFile(path, []byte("-----BEGIN CERTIFICATE-----\n\x00\x00BADDATA"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &RecoveringStorage{Path: path, Inner: file.New(path)}
+	secret, err := s.Get()
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if secret != nil {
+		t.Fatalf("expected nil secret for corrupt cache, got %#v", secret)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected corrupt cache file to be removed, stat err=%v", err)
+	}
+}
+
+func TestRecoveringStorage_ValidJSONPreserved(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dynamic-cert.json")
+	want := &corev1.Secret{Data: map[string][]byte{"tls.crt": []byte("cert"), "tls.key": []byte("key")}}
+	raw, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &RecoveringStorage{Path: path, Inner: file.New(path)}
+	got, err := s.Get()
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if got == nil || string(got.Data["tls.crt"]) != "cert" {
+		t.Fatalf("unexpected secret: %#v", got)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("valid cache should remain: %v", err)
+	}
+}
+
+func TestRecoveringStorage_MissingFileOK(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dynamic-cert.json")
+	s := &RecoveringStorage{Path: path, Inner: file.New(path)}
+	secret, err := s.Get()
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if secret != nil {
+		t.Fatalf("expected nil secret for missing cache, got %#v", secret)
+	}
+}

--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/k3s-io/k3s/pkg/cluster/dynacert"
 	"github.com/k3s-io/k3s/pkg/daemons/config"
 	"github.com/k3s-io/k3s/pkg/util"
 	"github.com/k3s-io/k3s/pkg/version"
@@ -149,7 +150,11 @@ func (c *Cluster) initClusterAndHTTPS(ctx context.Context) error {
 // tlsStorage creates an in-memory cache for dynamiclistener's certificate, backed by a file on disk
 // and the Kubernetes datastore.
 func tlsStorage(ctx context.Context, dataDir string, runtime *config.ControlRuntime) dynamiclistener.TLSStorage {
-	fileStorage := file.New(filepath.Join(dataDir, "tls/dynamic-cert.json"))
+	certPath := filepath.Join(dataDir, "tls/dynamic-cert.json")
+	fileStorage := &dynacert.RecoveringStorage{
+		Path:  certPath,
+		Inner: file.New(certPath),
+	}
 	cache := memory.NewBacked(fileStorage)
 	coreGetter := func() *core.Factory {
 		if coreFactory, ok := runtime.Core.(*core.Factory); ok {


### PR DESCRIPTION
## Summary

If `server/tls/dynamic-cert.json` exists but is not valid JSON, dynamiclistener's file storage returns a decode error on every `Get()`. The supervisor TLS path then fails repeatedly (`failed to update cert with connection local address: invalid character...`) and does not self-heal without manual file removal.

## Fix

Introduce `pkg/cluster/dynacert.RecoveringStorage`, a thin wrapper around the file-backed cache used by `tlsStorage`:

- On `Get()` error (corrupt/unreadable file): log a warning, remove the cache file, return `(nil, nil)` — same as a missing file so dynamiclistener can regenerate.
- On successful `Get()` / `Update()`: unchanged behavior.

## Testing

```
go test ./pkg/cluster/dynacert/ -count=1 -v
```

Covers corrupt JSON (same failure class as the issue repro), valid JSON preserved, and missing file.

Red step (corrupt input): wrapper removes the file and returns empty instead of the decode error.

## AI assistance

This change was developed with AI coding assistance. I reviewed the code and tests.

## References

- Ref https://github.com/k3s-io/k3s/issues/14220