### PR TITLE
Redact single-dash secret flags in the node args annotation

### DIFF
--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -30,7 +30,7 @@ const (
 func getNodeArgs() (string, error) {
 	nodeArgsList := []string{}
 	for _, arg := range configfilearg.MustParse(os.Args[1:]) {
-		if strings.HasPrefix(arg, "--") && strings.Contains(arg, "=") {
+		if strings.HasPrefix(arg, "-") && strings.Contains(arg, "=") {
 			parsedArg := strings.SplitN(arg, "=", 2)
 			nodeArgsList = append(nodeArgsList, parsedArg...)
 			continue


### PR DESCRIPTION
#### Proposed Changes ####

Only double-dash flags were split before secret redaction, so a token passed in the short form -t=<token> stayed joined, was not matched by isSecret, and was stored unredacted in the node-args annotation. Split single-dash flags as well so the value is redacted.

#### Types of Changes ####

Bugfix

#### Linked Issues
* https://github.com/k3s-io/k3s/issues/14347

#### Verification ####

Start an agent with -t=<token> 

#### User-Facing Change ####
```release-note
Redact the join token in the node args annotation when it is passed as -t=<token>.
```