### PR TITLE
Synchronize egress map and CIDR trie reads in tunnel dialBackend

### DIFF
--- a/pkg/daemons/control/tunnel.go
+++ b/pkg/daemons/control/tunnel.go
@@ -211,10 +211,10 @@ func (t *TunnelServer) dialBackend(ctx context.Context, addr string) (net.Conn, 
 
 	var nodeName string
 	var toKubelet, useTunnel bool
-	t.RLock()
 	if ip := net.ParseIP(host); ip != nil {
 		// Destination is an IP address, which could be either a pod, or node by IP.
 		// We can only use the tunnel for egress to pods if the agent supports it.
+		t.RLock()
 		if nets, err := t.cidrs.ContainingNetworks(ip); err == nil && len(nets) > 0 {
 			if n, ok := nets[0].(*tunnelEntry); ok {
 				nodeName = n.nodeName
@@ -228,13 +228,13 @@ func (t *TunnelServer) dialBackend(ctx context.Context, addr string) (net.Conn, 
 				logrus.Debugf("Tunnel server egress proxy CIDR lookup returned unknown type for address %s", ip)
 			}
 		}
+		t.RUnlock()
 	} else {
 		// Destination is a node by name, it is safe to use the tunnel.
 		nodeName = host
 		toKubelet = true
 		useTunnel = true
 	}
-	t.RUnlock()
 
 	// If connecting to something hosted by the local node, don't tunnel
 	if nodeName == t.config.ServerNodeName {

--- a/pkg/daemons/control/tunnel.go
+++ b/pkg/daemons/control/tunnel.go
@@ -60,7 +60,7 @@ func authorizer(req *http.Request) (clientKey string, authed bool, err error) {
 var _ http.Handler = &TunnelServer{}
 
 type TunnelServer struct {
-	sync.Mutex
+	sync.RWMutex
 	cidrs  cidranger.Ranger
 	client kubernetes.Interface
 	config *config.Control
@@ -211,6 +211,7 @@ func (t *TunnelServer) dialBackend(ctx context.Context, addr string) (net.Conn, 
 
 	var nodeName string
 	var toKubelet, useTunnel bool
+	t.RLock()
 	if ip := net.ParseIP(host); ip != nil {
 		// Destination is an IP address, which could be either a pod, or node by IP.
 		// We can only use the tunnel for egress to pods if the agent supports it.
@@ -233,6 +234,7 @@ func (t *TunnelServer) dialBackend(ctx context.Context, addr string) (net.Conn, 
 		toKubelet = true
 		useTunnel = true
 	}
+	t.RUnlock()
 
 	// If connecting to something hosted by the local node, don't tunnel
 	if nodeName == t.config.ServerNodeName {


### PR DESCRIPTION
#### Proposed Changes ####

dialBackend read the egress map and the CIDR ranger without holding the lock that onChangeNode and onChangePod take when writing them. Under the default egress-selector mode these run on separate goroutines, so a concurrent map read and write can crash the server. Changed the mutex to a sync.RWMutex and take a read lock around the lookups in dialBackend, scoped so the lock is not held across the dial.

#### Types of Changes ####

Bugfix

#### Issue ####

#14346 

#### Verification ####

Run the tunnel server under -race while node and pod updates and egress CONNECT requests happen concurrently

#### User-Facing Change ####
```release-note
Fix a possible data race between tunnel server egress lookups and node or pod updates.
```