### PR TITLE
Cleanup WriteSubnetFile error handling and add fsync(directory)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/go-test/deep v1.0.7
 	github.com/google/cadvisor v0.56.2
 	github.com/google/go-containerregistry v0.20.2
+	github.com/google/renameio v1.0.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/inetaf/tcpproxy v0.0.0-20240214030015-3ce58045626c

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/go-test/deep v1.0.7
 	github.com/google/cadvisor v0.56.2
 	github.com/google/go-containerregistry v0.20.2
-	github.com/google/renameio v1.0.1
+	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/inetaf/tcpproxy v0.0.0-20240214030015-3ce58045626c

--- a/go.sum
+++ b/go.sum
@@ -960,8 +960,8 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/vP9vJGqPwcdqsWjOt+V8J7+bTc=
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/renameio v1.0.1 h1:Lh/jXZmvZxb0BBeSY5VKEfidcbcbenKjZFzM/q0fSeU=
-github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWUAweKUpk=
+github.com/google/renameio/v2 v2.0.2 h1:qKZs+tfn+arruZZhQ7TKC/ergJunuJicWS6gLDt/dGw=
+github.com/google/renameio/v2 v2.0.2/go.mod h1:OX+G6WHHpHq3NVj7cAOleLOwJfcQ1s3uUJQCrr78SWo=
 github.com/google/s2a-go v0.1.0/go.mod h1:OJpEgntRZo8ugHpF9hkoLJbS5dSI20XZeXJ9JVywLlM=
 github.com/google/s2a-go v0.1.3/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=

--- a/go.sum
+++ b/go.sum
@@ -960,6 +960,8 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/vP9vJGqPwcdqsWjOt+V8J7+bTc=
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/renameio v1.0.1 h1:Lh/jXZmvZxb0BBeSY5VKEfidcbcbenKjZFzM/q0fSeU=
+github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWUAweKUpk=
 github.com/google/s2a-go v0.1.0/go.mod h1:OJpEgntRZo8ugHpF9hkoLJbS5dSI20XZeXJ9JVywLlM=
 github.com/google/s2a-go v0.1.3/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=

--- a/pkg/agent/flannel/flannel.go
+++ b/pkg/agent/flannel/flannel.go
@@ -20,7 +20,6 @@ import (
 	"math/big"
 	"net"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -28,7 +27,6 @@ import (
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/pkg/subnet/kube"
 	"github.com/flannel-io/flannel/pkg/trafficmngr/iptables"
-	"github.com/google/renameio/v2"
 	"github.com/joho/godotenv"
 	"github.com/k3s-io/k3s/pkg/util/errors"
 	"github.com/sirupsen/logrus"
@@ -182,74 +180,6 @@ func LookupExtInterface(iface *net.Interface, nm netMode) (*backend.ExternalInte
 		ExtAddr:     ifaceAddr[0],
 		ExtV6Addr:   ifacev6Addr[0],
 	}, nil
-}
-
-// WriteSubnetFile atomically writes the flannel subnet configuration file.
-// Uses google/renameio for safe atomic write semantics, which handles creating
-// a temporary file, syncing, closing, renaming, and directory fsync.
-func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn backend.Network, nm netMode) error {
-	dir, _ := filepath.Split(path)
-	if dir == "" {
-		dir = "."
-	}
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return errors.WithMessage(err, "mkdir subnet directory")
-	}
-
-	// Preserve original file permissions if the file already exists
-	perm := os.FileMode(0644)
-	if info, err := os.Stat(path); err == nil {
-		perm = info.Mode().Perm()
-	}
-
-	f, err := renameio.TempFile(dir, path)
-	if err != nil {
-		return errors.WithMessage(err, "create temp file")
-	}
-	defer f.Cleanup()
-
-	if err := f.Chmod(perm); err != nil {
-		return errors.WithMessage(err, "chmod temp file")
-	}
-
-	// We lease a subnet for the node from the cluster state (etcd)
-	sn := bn.Lease().Subnet
-	// Increment from network address to the first usable host address
-	sn.IP++
-	if nm.IPv4Enabled() {
-		// Save the CIDR assigned to flannel
-		if _, err := fmt.Fprintf(f, "FLANNEL_NETWORK=%s\n", nw); err != nil {
-			return errors.WithMessage(err, "failed to write FLANNEL_NETWORK")
-		}
-		// Save the first usable address in the node's subnet
-		if _, err := fmt.Fprintf(f, "FLANNEL_SUBNET=%s\n", sn); err != nil {
-			return errors.WithMessage(err, "failed to write FLANNEL_SUBNET")
-		}
-	}
-
-	if nwv6.String() != emptyIPv6Network {
-		// We lease a subnet for the node from the cluster state (etcd)
-		snv6 := bn.Lease().IPv6Subnet
-		// Increment from network address to the first usable host address
-		snv6.IncrementIP()
-		// Save the CIDR assigned to flannel
-		if _, err := fmt.Fprintf(f, "FLANNEL_IPV6_NETWORK=%s\n", nwv6); err != nil {
-			return errors.WithMessage(err, "failed to write FLANNEL_IPV6_NETWORK")
-		}
-		// Save the first usable address in the node's subnet
-		if _, err := fmt.Fprintf(f, "FLANNEL_IPV6_SUBNET=%s\n", snv6); err != nil {
-			return errors.WithMessage(err, "failed to write FLANNEL_IPV6_SUBNET")
-		}
-	}
-
-	if _, err := fmt.Fprintf(f, "FLANNEL_MTU=%d\n", bn.MTU()); err != nil {
-		return errors.WithMessage(err, "failed to write FLANNEL_MTU")
-	}
-	if _, err := fmt.Fprintf(f, "FLANNEL_IPMASQ=%v\n", ipMasq); err != nil {
-		return errors.WithMessage(err, "failed to write FLANNEL_IPMASQ")
-	}
-
-	return f.CloseAtomicallyReplace()
 }
 
 // ReadCIDRFromSubnetFile reads the flannel subnet file and extracts the value of IPv4 network key

--- a/pkg/agent/flannel/flannel.go
+++ b/pkg/agent/flannel/flannel.go
@@ -28,7 +28,7 @@ import (
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/pkg/subnet/kube"
 	"github.com/flannel-io/flannel/pkg/trafficmngr/iptables"
-	"github.com/google/renameio"
+	"github.com/google/renameio/v2"
 	"github.com/joho/godotenv"
 	"github.com/k3s-io/k3s/pkg/util/errors"
 	"github.com/sirupsen/logrus"

--- a/pkg/agent/flannel/flannel.go
+++ b/pkg/agent/flannel/flannel.go
@@ -193,7 +193,7 @@ func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn 
 		dir = "."
 	}
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return err
+		return errors.WithMessage(err, "mkdir subnet directory")
 	}
 
 	// Preserve original file permissions if the file already exists
@@ -204,62 +204,86 @@ func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn 
 
 	f, err := os.CreateTemp(dir, "."+name+".")
 	if err != nil {
-		return err
+		return errors.WithMessage(err, "create temp file")
 	}
 	tempFile := f.Name()
-	cleanupNoClose := func(err error) error {
-		return errors.Join(err, os.Remove(tempFile))
-	}
-	cleanup := func(err error) error {
-		return errors.Join(err, f.Close(), os.Remove(tempFile))
-	}
+	// Remove the temp file on any early exit
+	// After a successful rename the file no longer exists so
+	// this is a harmless no-op
+	defer os.Remove(tempFile)
+	// Close the file descriptor on any early exit.
+	// On the success path the explicit Close below will run first,
+	// and double-closing a file is harmless.
+	defer f.Close()
+
 	if err := f.Chmod(perm); err != nil {
-		return cleanup(err)
+		return errors.WithMessage(err, "chmod temp file")
 	}
 
-	// Write out the first usable IP by incrementing
-	// sn.IP by one
+	// We lease a subnet for the node from the cluster state (etcd)
 	sn := bn.Lease().Subnet
+	// Increment from network address to the first usable host address
 	sn.IP++
 	if nm.IPv4Enabled() {
+		// Save the CIDR assigned to flannel
 		if _, err := fmt.Fprintf(f, "FLANNEL_NETWORK=%s\n", nw); err != nil {
-			return cleanup(err)
+			return errors.WithMessage(err, "failed to write FLANNEL_NETWORK")
 		}
+		// Save the first usable address in the node's subnet
 		if _, err := fmt.Fprintf(f, "FLANNEL_SUBNET=%s\n", sn); err != nil {
-			return cleanup(err)
+			return errors.WithMessage(err, "failed to write FLANNEL_SUBNET")
 		}
 	}
 
 	if nwv6.String() != emptyIPv6Network {
+		// We lease a subnet for the node from the cluster state (etcd)
 		snv6 := bn.Lease().IPv6Subnet
+		// Increment from network address to the first usable host address
 		snv6.IncrementIP()
+		// Save the CIDR assigned to flannel
 		if _, err := fmt.Fprintf(f, "FLANNEL_IPV6_NETWORK=%s\n", nwv6); err != nil {
-			return cleanup(err)
+			return errors.WithMessage(err, "failed to write FLANNEL_IPV6_NETWORK")
 		}
+		// Save the first usable address in the node's subnet
 		if _, err := fmt.Fprintf(f, "FLANNEL_IPV6_SUBNET=%s\n", snv6); err != nil {
-			return cleanup(err)
+			return errors.WithMessage(err, "failed to write FLANNEL_IPV6_SUBNET")
 		}
 	}
 
+	// 1. Write
 	if _, err := fmt.Fprintf(f, "FLANNEL_MTU=%d\n", bn.MTU()); err != nil {
-		return cleanup(err)
+		return errors.WithMessage(err, "failed to write FLANNEL_MTU")
 	}
 	if _, err := fmt.Fprintf(f, "FLANNEL_IPMASQ=%v\n", ipMasq); err != nil {
-		return cleanup(err)
-	}
-	if err := f.Sync(); err != nil {
-		return cleanup(err)
-	}
-	if err := f.Close(); err != nil {
-		return cleanupNoClose(err)
+		return errors.WithMessage(err, "failed to write FLANNEL_IPMASQ")
 	}
 
-	// rename(2) the temporary file to the desired location so that it becomes
+	// 2. Fsync(file)
+	if err := f.Sync(); err != nil {
+		return errors.WithMessage(err, "failed to sync subnet file")
+	}
+
+	// 3. Close
+	if err := f.Close(); err != nil {
+		return errors.WithMessage(err, "failed to close subnet file")
+	}
+
+	// 4. Rename the temporary file to the desired location so that it becomes
 	// atomically visible with the contents (same directory keeps it on the same FS)
 	if err := os.Rename(tempFile, path); err != nil {
-		_ = os.Remove(tempFile)
-		return err
+		return errors.WithMessage(err, "failed to rename subnet file")
 	}
+
+	// 5. Fsync(directory)
+	dirFile, err := os.Open(dir)
+	if err != nil {
+		return errors.WithMessage(err, "failed to open subnet directory")
+	}
+	defer dirFile.Close()
+	if err := dirFile.Sync(); err != nil {
+		return errors.WithMessage(err, "failed to sync subnet directory")
+	}
+
 	return nil
 }
 

--- a/pkg/agent/flannel/flannel.go
+++ b/pkg/agent/flannel/flannel.go
@@ -242,7 +242,6 @@ func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn 
 		}
 	}
 
-	// 1. write
 	if _, err := fmt.Fprintf(f, "FLANNEL_MTU=%d\n", bn.MTU()); err != nil {
 		return errors.WithMessage(err, "failed to write FLANNEL_MTU")
 	}
@@ -250,7 +249,6 @@ func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn 
 		return errors.WithMessage(err, "failed to write FLANNEL_IPMASQ")
 	}
 
-	// CloseAtomicallyReplace does steps 2-5: fsync, close, rename, dir fsync.
 	return f.CloseAtomicallyReplace()
 }
 

--- a/pkg/agent/flannel/flannel.go
+++ b/pkg/agent/flannel/flannel.go
@@ -28,6 +28,7 @@ import (
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/pkg/subnet/kube"
 	"github.com/flannel-io/flannel/pkg/trafficmngr/iptables"
+	"github.com/google/renameio"
 	"github.com/joho/godotenv"
 	"github.com/k3s-io/k3s/pkg/util/errors"
 	"github.com/sirupsen/logrus"
@@ -184,11 +185,10 @@ func LookupExtInterface(iface *net.Interface, nm netMode) (*backend.ExternalInte
 }
 
 // WriteSubnetFile atomically writes the flannel subnet configuration file.
-// Uses CreateTemp to avoid issues with pre-existing temp files (stale files
-// from crashes, unexpected permissions/ownership) and to ensure clean atomic
-// rename semantics with O_EXCL guarantees.
+// Uses google/renameio for safe atomic write semantics, which handles creating
+// a temporary file, syncing, closing, renaming, and directory fsync.
 func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn backend.Network, nm netMode) error {
-	dir, name := filepath.Split(path)
+	dir, _ := filepath.Split(path)
 	if dir == "" {
 		dir = "."
 	}
@@ -202,19 +202,11 @@ func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn 
 		perm = info.Mode().Perm()
 	}
 
-	f, err := os.CreateTemp(dir, "."+name+".")
+	f, err := renameio.TempFile(dir, path)
 	if err != nil {
 		return errors.WithMessage(err, "create temp file")
 	}
-	tempFile := f.Name()
-	// Remove the temp file on any early exit
-	// After a successful rename the file no longer exists so
-	// this is a harmless no-op
-	defer os.Remove(tempFile)
-	// Close the file descriptor on any early exit.
-	// On the success path the explicit Close below will run first,
-	// and double-closing a file is harmless.
-	defer f.Close()
+	defer f.Cleanup()
 
 	if err := f.Chmod(perm); err != nil {
 		return errors.WithMessage(err, "chmod temp file")
@@ -250,7 +242,7 @@ func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn 
 		}
 	}
 
-	// 1. Write
+	// 1. write
 	if _, err := fmt.Fprintf(f, "FLANNEL_MTU=%d\n", bn.MTU()); err != nil {
 		return errors.WithMessage(err, "failed to write FLANNEL_MTU")
 	}
@@ -258,33 +250,8 @@ func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn 
 		return errors.WithMessage(err, "failed to write FLANNEL_IPMASQ")
 	}
 
-	// 2. Fsync(file)
-	if err := f.Sync(); err != nil {
-		return errors.WithMessage(err, "failed to sync subnet file")
-	}
-
-	// 3. Close
-	if err := f.Close(); err != nil {
-		return errors.WithMessage(err, "failed to close subnet file")
-	}
-
-	// 4. Rename the temporary file to the desired location so that it becomes
-	// atomically visible with the contents (same directory keeps it on the same FS)
-	if err := os.Rename(tempFile, path); err != nil {
-		return errors.WithMessage(err, "failed to rename subnet file")
-	}
-
-	// 5. Fsync(directory)
-	dirFile, err := os.Open(dir)
-	if err != nil {
-		return errors.WithMessage(err, "failed to open subnet directory")
-	}
-	defer dirFile.Close()
-	if err := dirFile.Sync(); err != nil {
-		return errors.WithMessage(err, "failed to sync subnet directory")
-	}
-
-	return nil
+	// CloseAtomicallyReplace does steps 2-5: fsync, close, rename, dir fsync.
+	return f.CloseAtomicallyReplace()
 }
 
 // ReadCIDRFromSubnetFile reads the flannel subnet file and extracts the value of IPv4 network key

--- a/pkg/agent/flannel/subnetfile_unix.go
+++ b/pkg/agent/flannel/subnetfile_unix.go
@@ -1,0 +1,82 @@
+//go:build !windows
+
+package flannel
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/flannel-io/flannel/pkg/backend"
+	"github.com/flannel-io/flannel/pkg/ip"
+	"github.com/google/renameio/v2"
+	"github.com/k3s-io/k3s/pkg/util/errors"
+)
+
+// WriteSubnetFile atomically writes the flannel subnet configuration file.
+// Uses google/renameio for safe atomic write semantics, which handles creating
+// a temporary file, syncing, closing, renaming, and directory fsync.
+func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn backend.Network, nm netMode) error {
+	dir, _ := filepath.Split(path)
+	if dir == "" {
+		dir = "."
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return errors.WithMessage(err, "mkdir subnet directory")
+	}
+
+	// Preserve original file permissions if the file already exists
+	perm := os.FileMode(0644)
+	if info, err := os.Stat(path); err == nil {
+		perm = info.Mode().Perm()
+	}
+
+	f, err := renameio.TempFile(dir, path)
+	if err != nil {
+		return errors.WithMessage(err, "create temp file")
+	}
+	defer f.Cleanup()
+
+	if err := f.Chmod(perm); err != nil {
+		return errors.WithMessage(err, "chmod temp file")
+	}
+
+	// We lease a subnet for the node from the cluster state (etcd)
+	sn := bn.Lease().Subnet
+	// Increment from network address to the first usable host address
+	sn.IP++
+	if nm.IPv4Enabled() {
+		// Save the CIDR assigned to flannel
+		if _, err := fmt.Fprintf(f, "FLANNEL_NETWORK=%s\n", nw); err != nil {
+			return errors.WithMessage(err, "failed to write FLANNEL_NETWORK")
+		}
+		// Save the first usable address in the node's subnet
+		if _, err := fmt.Fprintf(f, "FLANNEL_SUBNET=%s\n", sn); err != nil {
+			return errors.WithMessage(err, "failed to write FLANNEL_SUBNET")
+		}
+	}
+
+	if nwv6.String() != emptyIPv6Network {
+		// We lease a subnet for the node from the cluster state (etcd)
+		snv6 := bn.Lease().IPv6Subnet
+		// Increment from network address to the first usable host address
+		snv6.IncrementIP()
+		// Save the CIDR assigned to flannel
+		if _, err := fmt.Fprintf(f, "FLANNEL_IPV6_NETWORK=%s\n", nwv6); err != nil {
+			return errors.WithMessage(err, "failed to write FLANNEL_IPV6_NETWORK")
+		}
+		// Save the first usable address in the node's subnet
+		if _, err := fmt.Fprintf(f, "FLANNEL_IPV6_SUBNET=%s\n", snv6); err != nil {
+			return errors.WithMessage(err, "failed to write FLANNEL_IPV6_SUBNET")
+		}
+	}
+
+	if _, err := fmt.Fprintf(f, "FLANNEL_MTU=%d\n", bn.MTU()); err != nil {
+		return errors.WithMessage(err, "failed to write FLANNEL_MTU")
+	}
+	if _, err := fmt.Fprintf(f, "FLANNEL_IPMASQ=%v\n", ipMasq); err != nil {
+		return errors.WithMessage(err, "failed to write FLANNEL_IPMASQ")
+	}
+
+	return f.CloseAtomicallyReplace()
+}

--- a/pkg/agent/flannel/subnetfile_windows.go
+++ b/pkg/agent/flannel/subnetfile_windows.go
@@ -6,20 +6,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/flannel-io/flannel/pkg/backend"
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/k3s-io/k3s/pkg/util/errors"
-	"golang.org/x/sys/windows"
 )
 
-// WriteSubnetFile atomically writes the flannel subnet configuration file.
-// Windows does not provide a reliable atomic file replacement syscall, so this
-// is a best-effort approximation. The file is written to a temporary location
-// on the same directory, synced, then moved into place via MoveFileEx with
-// MOVEFILE_WRITE_THROUGH to flush metadata as much as the system allows.
+// WriteSubnetFile writes the flannel subnet configuration file.
+// renameio does not support Windows, and maintaining a full atomic write
+// implementation for a platform without reliable atomic rename is not
+// worth the complexity. Use a simple write instead.
 func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn backend.Network, nm netMode) error {
-	dir, name := filepath.Split(path)
+	dir, _ := filepath.Split(path)
 	if dir == "" {
 		dir = "."
 	}
@@ -33,34 +32,15 @@ func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn 
 		perm = info.Mode().Perm()
 	}
 
-	// Uses a dotted-prefix pattern (".subnet.env.") that matches
-	// what renameio generates internally on Unix.
-	f, err := os.CreateTemp(dir, "."+name+".")
-	if err != nil {
-		return errors.WithMessage(err, "create temp file")
-	}
-	// On early exit (before the move), remove the temp file.
-	// After a successful MoveFileEx the source path no longer exists,
-	// so this becomes a harmless no-op.
-	defer os.Remove(f.Name())
-
-	if err := f.Chmod(perm); err != nil {
-		return errors.WithMessage(err, "chmod temp file")
-	}
+	var buf strings.Builder
 
 	// We lease a subnet for the node from the cluster state (etcd)
 	sn := bn.Lease().Subnet
 	// Increment from network address to the first usable host address
 	sn.IP++
 	if nm.IPv4Enabled() {
-		// Save the CIDR assigned to flannel
-		if _, err := fmt.Fprintf(f, "FLANNEL_NETWORK=%s\n", nw); err != nil {
-			return errors.WithMessage(err, "failed to write FLANNEL_NETWORK")
-		}
-		// Save the first usable address in the node's subnet
-		if _, err := fmt.Fprintf(f, "FLANNEL_SUBNET=%s\n", sn); err != nil {
-			return errors.WithMessage(err, "failed to write FLANNEL_SUBNET")
-		}
+		fmt.Fprintf(&buf, "FLANNEL_NETWORK=%s\n", nw)
+		fmt.Fprintf(&buf, "FLANNEL_SUBNET=%s\n", sn)
 	}
 
 	if nwv6.String() != emptyIPv6Network {
@@ -68,53 +48,12 @@ func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn 
 		snv6 := bn.Lease().IPv6Subnet
 		// Increment from network address to the first usable host address
 		snv6.IncrementIP()
-		// Save the CIDR assigned to flannel
-		if _, err := fmt.Fprintf(f, "FLANNEL_IPV6_NETWORK=%s\n", nwv6); err != nil {
-			return errors.WithMessage(err, "failed to write FLANNEL_IPV6_NETWORK")
-		}
-		// Save the first usable address in the node's subnet
-		if _, err := fmt.Fprintf(f, "FLANNEL_IPV6_SUBNET=%s\n", snv6); err != nil {
-			return errors.WithMessage(err, "failed to write FLANNEL_IPV6_SUBNET")
-		}
+		fmt.Fprintf(&buf, "FLANNEL_IPV6_NETWORK=%s\n", nwv6)
+		fmt.Fprintf(&buf, "FLANNEL_IPV6_SUBNET=%s\n", snv6)
 	}
 
-	// 1. Write
-	if _, err := fmt.Fprintf(f, "FLANNEL_MTU=%d\n", bn.MTU()); err != nil {
-		return errors.WithMessage(err, "failed to write FLANNEL_MTU")
-	}
-	if _, err := fmt.Fprintf(f, "FLANNEL_IPMASQ=%v\n", ipMasq); err != nil {
-		return errors.WithMessage(err, "failed to write FLANNEL_IPMASQ")
-	}
+	fmt.Fprintf(&buf, "FLANNEL_MTU=%d\n", bn.MTU())
+	fmt.Fprintf(&buf, "FLANNEL_IPMASQ=%v\n", ipMasq)
 
-	// 2. Flush file contents
-	if err := f.Sync(); err != nil {
-		f.Close()
-		return errors.WithMessage(err, "flush sync has failed")
-	}
-
-	// 3. Close the file
-	if err := f.Close(); err != nil {
-		return errors.WithMessage(err, "file close has failed")
-	}
-
-	src, err := windows.UTF16PtrFromString(f.Name())
-	if err != nil {
-		return errors.WithMessage(err, "UTF16 encoding has failed")
-	}
-
-	dst, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		return errors.WithMessage(err, "UTF16 encoding has failed")
-	}
-
-	// 4. Atomically swap the temp file into place.
-	// MOVEFILE_REPLACE_EXISTING overwrites the destination if present.
-	// MOVEFILE_WRITE_THROUGH requests the move and its metadata be flushed
-	// to persistent storage before returning, as close to fsync(dir) as
-	// Windows supports for this operation.
-	return windows.MoveFileEx(
-		src,
-		dst,
-		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
-	)
+	return errors.WithMessage(os.WriteFile(path, []byte(buf.String()), perm), "write subnet file")
 }

--- a/pkg/agent/flannel/subnetfile_windows.go
+++ b/pkg/agent/flannel/subnetfile_windows.go
@@ -1,0 +1,120 @@
+//go:build windows
+
+package flannel
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/flannel-io/flannel/pkg/backend"
+	"github.com/flannel-io/flannel/pkg/ip"
+	"github.com/k3s-io/k3s/pkg/util/errors"
+	"golang.org/x/sys/windows"
+)
+
+// WriteSubnetFile atomically writes the flannel subnet configuration file.
+// Windows does not provide a reliable atomic file replacement syscall, so this
+// is a best-effort approximation. The file is written to a temporary location
+// on the same directory, synced, then moved into place via MoveFileEx with
+// MOVEFILE_WRITE_THROUGH to flush metadata as much as the system allows.
+func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn backend.Network, nm netMode) error {
+	dir, name := filepath.Split(path)
+	if dir == "" {
+		dir = "."
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return errors.WithMessage(err, "mkdir subnet directory")
+	}
+
+	// Preserve original file permissions if the file already exists
+	perm := os.FileMode(0644)
+	if info, err := os.Stat(path); err == nil {
+		perm = info.Mode().Perm()
+	}
+
+	// Uses a dotted-prefix pattern (".subnet.env.") that matches
+	// what renameio generates internally on Unix.
+	f, err := os.CreateTemp(dir, "."+name+".")
+	if err != nil {
+		return errors.WithMessage(err, "create temp file")
+	}
+	// On early exit (before the move), remove the temp file.
+	// After a successful MoveFileEx the source path no longer exists,
+	// so this becomes a harmless no-op.
+	defer os.Remove(f.Name())
+
+	if err := f.Chmod(perm); err != nil {
+		return errors.WithMessage(err, "chmod temp file")
+	}
+
+	// We lease a subnet for the node from the cluster state (etcd)
+	sn := bn.Lease().Subnet
+	// Increment from network address to the first usable host address
+	sn.IP++
+	if nm.IPv4Enabled() {
+		// Save the CIDR assigned to flannel
+		if _, err := fmt.Fprintf(f, "FLANNEL_NETWORK=%s\n", nw); err != nil {
+			return errors.WithMessage(err, "failed to write FLANNEL_NETWORK")
+		}
+		// Save the first usable address in the node's subnet
+		if _, err := fmt.Fprintf(f, "FLANNEL_SUBNET=%s\n", sn); err != nil {
+			return errors.WithMessage(err, "failed to write FLANNEL_SUBNET")
+		}
+	}
+
+	if nwv6.String() != emptyIPv6Network {
+		// We lease a subnet for the node from the cluster state (etcd)
+		snv6 := bn.Lease().IPv6Subnet
+		// Increment from network address to the first usable host address
+		snv6.IncrementIP()
+		// Save the CIDR assigned to flannel
+		if _, err := fmt.Fprintf(f, "FLANNEL_IPV6_NETWORK=%s\n", nwv6); err != nil {
+			return errors.WithMessage(err, "failed to write FLANNEL_IPV6_NETWORK")
+		}
+		// Save the first usable address in the node's subnet
+		if _, err := fmt.Fprintf(f, "FLANNEL_IPV6_SUBNET=%s\n", snv6); err != nil {
+			return errors.WithMessage(err, "failed to write FLANNEL_IPV6_SUBNET")
+		}
+	}
+
+	// 1. Write
+	if _, err := fmt.Fprintf(f, "FLANNEL_MTU=%d\n", bn.MTU()); err != nil {
+		return errors.WithMessage(err, "failed to write FLANNEL_MTU")
+	}
+	if _, err := fmt.Fprintf(f, "FLANNEL_IPMASQ=%v\n", ipMasq); err != nil {
+		return errors.WithMessage(err, "failed to write FLANNEL_IPMASQ")
+	}
+
+	// 2. Flush file contents
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return errors.WithMessage(err, "flush sync has failed")
+	}
+
+	// 3. Close the file
+	if err := f.Close(); err != nil {
+		return errors.WithMessage(err, "file close has failed")
+	}
+
+	src, err := windows.UTF16PtrFromString(f.Name())
+	if err != nil {
+		return errors.WithMessage(err, "UTF16 encoding has failed")
+	}
+
+	dst, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return errors.WithMessage(err, "UTF16 encoding has failed")
+	}
+
+	// 4. Atomically swap the temp file into place.
+	// MOVEFILE_REPLACE_EXISTING overwrites the destination if present.
+	// MOVEFILE_WRITE_THROUGH requests the move and its metadata be flushed
+	// to persistent storage before returning, as close to fsync(dir) as
+	// Windows supports for this operation.
+	return windows.MoveFileEx(
+		src,
+		dst,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
+	)
+}


### PR DESCRIPTION
#### Proposed Changes ####

Fix a crash-safety bug in `WriteSubnetFile`: the directory entry was not fsynced after rename, so the atomic swap could be lost on power loss. 

I also simplified the error handling by replacing inline cleanup closures with defers and wrapped errors.

#### Types of Changes ####

Bugfix

#### Verification ####

Existing unit tests in `setup_test.go` cover `WriteSubnetFile`.

#### Testing ####

Covered by `Test_UnitWriteSubnetFile`.

#### Linked Issues ####

N/A

#### User-Facing Change ####
```release-note
NONE
```
