### PR TITLE
Emit events attached to node when snapshot retention fails

### DIFF
--- a/pkg/etcd/snapshot.go
+++ b/pkg/etcd/snapshot.go
@@ -36,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/pager"
 	"k8s.io/client-go/util/retry"
@@ -347,10 +348,10 @@ func (e *ETCD) snapshot(ctx context.Context) (_ *managed.SnapshotResult, rerr er
 
 		// Snapshot retention may prune some files before returning an error. Failing to prune is not fatal.
 		deleted, err := snapshotRetention(e.config.EtcdSnapshotRetention, e.config.EtcdSnapshotName, snapshotDir)
-		if err != nil {
-			logrus.Warnf("Failed to apply local snapshot retention policy: %v", err)
-		}
 		res.Deleted = append(res.Deleted, deleted...)
+		if err != nil {
+			e.warningEventf("ETDCSnapshotRetentionFailedLocal", "Failed to apply local snapshot retention policy: %v", err)
+		}
 
 		if e.config.EtcdS3 != nil {
 			s3Start := time.Now()
@@ -390,7 +391,7 @@ func (e *ETCD) snapshot(ctx context.Context) (_ *managed.SnapshotResult, rerr er
 				deleted, err := s3client.SnapshotRetention(ctx, e.config.EtcdSnapshotName)
 				res.Deleted = append(res.Deleted, deleted...)
 				if err != nil {
-					logrus.Warnf("Failed to apply s3 snapshot retention policy: %v", err)
+					e.warningEventf("ETCDSnapshotRetentionFailedS3", "Failed to apply S3 snapshot retention policy: %v", err)
 				}
 			}
 			// sf is either s3 snapshot metadata, or s3 init/upload failure record.
@@ -650,7 +651,7 @@ func (e *ETCD) addSnapshotData(sf snapshot.File) error {
 			created, err = snapshots.Create(esf)
 			if err == nil {
 				// Only emit an event for the snapshot when creating the resource
-				e.emitEvent(created)
+				e.snapshotEvent(created)
 			}
 		} else if !equality.Semantic.DeepEqual(existing, esf) {
 			_, err = snapshots.Update(esf)
@@ -669,7 +670,8 @@ func generateETCDSnapshotFileConfigMapKey(esf k3s.ETCDSnapshotFile) string {
 	return "local-" + name
 }
 
-func (e *ETCD) emitEvent(esf *k3s.ETCDSnapshotFile) {
+// snapshotEvent emits an Event attached to the EtcdSnapshotFile resource
+func (e *ETCD) snapshotEvent(esf *k3s.ETCDSnapshotFile) {
 	switch {
 	case e.config.Runtime.Event == nil:
 	case !esf.DeletionTimestamp.IsZero():
@@ -682,6 +684,23 @@ func (e *ETCD) emitEvent(esf *k3s.ETCDSnapshotFile) {
 		e.config.Runtime.Event.Event(esf, v1.EventTypeWarning, "ETCDSnapshotFailed", message)
 	default:
 		e.config.Runtime.Event.Eventf(esf, v1.EventTypeNormal, "ETCDSnapshotCreated", "Snapshot %s saved on %s", esf.Spec.SnapshotName, esf.Spec.NodeName)
+	}
+}
+
+// warningEventf emits a warning Event attached to the Node resource,
+// or directly logs a warning if the event recorder is not available.
+func (e *ETCD) warningEventf(reason, messageFmt string, args ...any) {
+	nodeName := os.Getenv("NODE_NAME")
+	if nodeName != "" && e.config.Runtime.Event != nil {
+		nodeRef := &v1.ObjectReference{
+			Kind:      "Node",
+			Name:      nodeName,
+			UID:       types.UID(nodeName),
+			Namespace: "",
+		}
+		e.config.Runtime.Event.Eventf(nodeRef, v1.EventTypeWarning, reason, messageFmt, args...)
+	} else {
+		logrus.Warnf(messageFmt, args...)
 	}
 }
 

--- a/pkg/etcd/snapshot_controller.go
+++ b/pkg/etcd/snapshot_controller.go
@@ -166,7 +166,7 @@ func (e *etcdSnapshotHandler) onRemove(key string, esf *k3s.ETCDSnapshotFile) (*
 			return nil, errors.WithMessage(err, "failed to remove snapshot from ConfigMap")
 		}
 	}
-	e.etcd.emitEvent(esf)
+	e.etcd.snapshotEvent(esf)
 	return nil, nil
 }
 

--- a/pkg/etcd/snapshot_handler.go
+++ b/pkg/etcd/snapshot_handler.go
@@ -150,6 +150,7 @@ func (e *ETCD) withRequest(sr *SnapshotRequest) *ETCD {
 			Runtime:               e.config.Runtime,
 			DataDir:               e.config.DataDir,
 			Datastore:             e.config.Datastore,
+			DisableAgent:          e.config.DisableAgent,
 			EtcdSnapshotCompress:  e.config.EtcdSnapshotCompress,
 			EtcdSnapshotName:      e.config.EtcdSnapshotName,
 			EtcdSnapshotRetention: e.config.EtcdSnapshotRetention,


### PR DESCRIPTION
#### Proposed Changes ####

* Emit events attached to node when snapshot retention fails
* Pass through config.DisableAgent in snapshot request handler

#### Types of Changes ####

enhancement

#### Verification ####

Check for events when retention fails (see linked issue for example)

#### Testing ####

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/14343
* https://github.com/rancher/rke2/issues/10687#issuecomment-4907048477

#### User-Facing Change ####

```release-note
```

#### Further Comments ####

Failure can be triggered manually by starting k3s with `'--etcd-snapshot-retention=1' '--etcd-snapshot-schedule-cron=* * * * *'`, waiting for a snapshot to be saved, and then running `chattr +i /var/lib/rancher/k3s/server/db/snapshots/*` to make the snapshot immutable, which will cause the prune to fail to delete them:

```
INFO[0126] Applying snapshot retention=1 to local snapshots with prefix etcd-snapshot in /var/lib/rancher/k3s/server/db/snapshots
INFO[0126] Event occurred                                apiVersion=k3s.cattle.io/v1 fieldPath= kind=ETCDSnapshotFile logger=k3s message="Snapshot etcd-snapshot-k3s-server-001.example.com-1783543141 saved on k3s-server-001.example.com" object=local-etcd-snapshot-k3s-server-001.example.com-1783543141-c777d8 reason=ETCDSnapshotCreated type=Normal
INFO[0126] Removing local snapshot /var/lib/rancher/k3s/server/db/snapshots/etcd-snapshot-k3s-server-001.example.com-1783543081
INFO[0126] Reconciling ETCDSnapshotFile resources
INFO[0126] Event occurred                                apiVersion= fieldPath= kind=Node logger=k3s message="Failed to apply local snapshot retention policy: remove /var/lib/rancher/k3s/server/db/snapshots/etcd-snapshot-k3s-server-001.example.com-1783543081: operation not permitted" object=k3s-server-001.example.com reason=ETDCSnapshotRetentionFailedLocal type=Warning
INFO[0126] Reconciliation of ETCDSnapshotFile resources complete
```

```console
root@k3s-server-001:~# kubectl get event | grep Retention
3m48s       Warning   ETDCSnapshotRetentionFailedLocal   node/k3s-server-001.example.com                                                     Failed to apply local snapshot retention policy: remove /var/lib/rancher/k3s/server/db/snapshots/etcd-snapshot-k3s-server-001.example.com-1783543025: operation not permitted
44s         Warning   ETDCSnapshotRetentionFailedLocal   node/k3s-server-001.example.com                                                     Failed to apply local snapshot retention policy: remove /var/lib/rancher/k3s/server/db/snapshots/etcd-snapshot-k3s-server-001.example.com-1783543081: operation not permitted
```

If managed by Rancher, these events should also appear in the UI when viewing the node.