### PR TITLE
Simplify WriteSubnetFile cleanup and make atomic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/go-test/deep v1.0.7
 	github.com/google/cadvisor v0.56.2
 	github.com/google/go-containerregistry v0.20.2
+	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/inetaf/tcpproxy v0.0.0-20240214030015-3ce58045626c

--- a/go.sum
+++ b/go.sum
@@ -960,6 +960,8 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/vP9vJGqPwcdqsWjOt+V8J7+bTc=
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/renameio/v2 v2.0.2 h1:qKZs+tfn+arruZZhQ7TKC/ergJunuJicWS6gLDt/dGw=
+github.com/google/renameio/v2 v2.0.2/go.mod h1:OX+G6WHHpHq3NVj7cAOleLOwJfcQ1s3uUJQCrr78SWo=
 github.com/google/s2a-go v0.1.0/go.mod h1:OJpEgntRZo8ugHpF9hkoLJbS5dSI20XZeXJ9JVywLlM=
 github.com/google/s2a-go v0.1.3/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=

--- a/pkg/agent/flannel/flannel.go
+++ b/pkg/agent/flannel/flannel.go
@@ -119,14 +119,13 @@ func flannel(ctx context.Context, wg *sync.WaitGroup, flannelIface *net.Interfac
 	trafficMngr.SetupAndEnsureForwardRules(ctx, config.Network, config.IPv6Network, 50)
 
 	if err := WriteSubnetFile(subnetFile, config.Network, config.IPv6Network, true, bn, nm); err != nil {
-		// Continue, even though it failed.
-		logrus.Warningf("Failed to write flannel subnet file: %s", err)
+		return errors.WithMessage(err, "failed to write flannel subnet file")
 	} else {
 		logrus.Infof("Wrote flannel subnet file to %s", subnetFile)
 	}
 
 	// Start "Running" the backend network. This will block until the context is done so run in another goroutine.
-	logrus.Info("Running flannel backend.")
+	logrus.Info("Running flannel backend")
 	bn.Run(ctx)
 	return nil
 }
@@ -188,7 +187,7 @@ func LookupExtInterface(iface *net.Interface, nm netMode) (*backend.ExternalInte
 // from crashes, unexpected permissions/ownership) and to ensure clean atomic
 // rename semantics with O_EXCL guarantees.
 func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn backend.Network, nm netMode) error {
-	dir, name := filepath.Split(path)
+	dir := filepath.Dir(path)
 	if dir == "" {
 		dir = "."
 	}
@@ -201,66 +200,27 @@ func WriteSubnetFile(path string, nw ip.IP4Net, nwv6 ip.IP6Net, ipMasq bool, bn 
 	if info, err := os.Stat(path); err == nil {
 		perm = info.Mode().Perm()
 	}
-
-	f, err := os.CreateTemp(dir, "."+name+".")
-	if err != nil {
-		return err
-	}
-	tempFile := f.Name()
-	cleanupNoClose := func(err error) error {
-		return errors.Join(err, os.Remove(tempFile))
-	}
-	cleanup := func(err error) error {
-		return errors.Join(err, f.Close(), os.Remove(tempFile))
-	}
-	if err := f.Chmod(perm); err != nil {
-		return cleanup(err)
-	}
+	b := []byte{}
 
 	// Write out the first usable IP by incrementing
 	// sn.IP by one
-	sn := bn.Lease().Subnet
-	sn.IP++
 	if nm.IPv4Enabled() {
-		if _, err := fmt.Fprintf(f, "FLANNEL_NETWORK=%s\n", nw); err != nil {
-			return cleanup(err)
-		}
-		if _, err := fmt.Fprintf(f, "FLANNEL_SUBNET=%s\n", sn); err != nil {
-			return cleanup(err)
-		}
+		// Write out the first usable IP by incrementing sn.IP by one
+		sn := bn.Lease().Subnet
+		sn.IncrementIP()
+		b = fmt.Appendf(b, "FLANNEL_NETWORK=%s\nFLANNEL_SUBNET=%s\n", nw, sn)
 	}
 
 	if nwv6.String() != emptyIPv6Network {
+		// Write out the first usable IP by incrementing ip6Sn.IP by one
 		snv6 := bn.Lease().IPv6Subnet
 		snv6.IncrementIP()
-		if _, err := fmt.Fprintf(f, "FLANNEL_IPV6_NETWORK=%s\n", nwv6); err != nil {
-			return cleanup(err)
-		}
-		if _, err := fmt.Fprintf(f, "FLANNEL_IPV6_SUBNET=%s\n", snv6); err != nil {
-			return cleanup(err)
-		}
+		b = fmt.Appendf(b, "FLANNEL_IPV6_NETWORK=%s\nFLANNEL_IPV6_SUBNET=%s\n", nwv6, snv6)
 	}
 
-	if _, err := fmt.Fprintf(f, "FLANNEL_MTU=%d\n", bn.MTU()); err != nil {
-		return cleanup(err)
-	}
-	if _, err := fmt.Fprintf(f, "FLANNEL_IPMASQ=%v\n", ipMasq); err != nil {
-		return cleanup(err)
-	}
-	if err := f.Sync(); err != nil {
-		return cleanup(err)
-	}
-	if err := f.Close(); err != nil {
-		return cleanupNoClose(err)
-	}
+	b = fmt.Appendf(b, "FLANNEL_MTU=%d\nFLANNEL_IPMASQ=%t\n", bn.MTU(), ipMasq)
 
-	// rename(2) the temporary file to the desired location so that it becomes
-	// atomically visible with the contents (same directory keeps it on the same FS)
-	if err := os.Rename(tempFile, path); err != nil {
-		_ = os.Remove(tempFile)
-		return err
-	}
-	return nil
+	return writeFile(path, b, perm)
 }
 
 // ReadCIDRFromSubnetFile reads the flannel subnet file and extracts the value of IPv4 network key

--- a/pkg/agent/flannel/writefile_other.go
+++ b/pkg/agent/flannel/writefile_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package flannel
+
+import (
+	"os"
+
+	"github.com/google/renameio/v2"
+)
+
+func writeFile(name string, data []byte, perm os.FileMode) error {
+	return renameio.WriteFile(name, data, perm, renameio.IgnoreUmask())
+}

--- a/pkg/agent/flannel/writefile_windows.go
+++ b/pkg/agent/flannel/writefile_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package flannel
+
+import "os"
+
+// no atomic writes on windows, fall back to os.WriteFile
+// ref: https://github.com/google/renameio/blob/v2.0.2/README.md#windows-support
+var writeFile = os.WriteFile


### PR DESCRIPTION

#### Proposed Changes ####

Simpler version of https://github.com/k3s-io/k3s/pull/14342
Proposed upstream: https://github.com/flannel-io/flannel/pull/2497

Theres no point in writing the file piecewise and then faffing about with a bunch of different cleanup functions; just write the contents to a buffer and then atomically write+rename it into place all at once.

#### Types of Changes ####

enhancement

#### Verification ####

no reported issue for this, just general code cleanup

#### Testing ####

yes, covered by tests

#### Linked Issues ####

*

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
