### PR TITLE
[Release 1.36] Use new Traefik v3.7.8

### DIFF
--- a/manifests/traefik.yaml
+++ b/manifests/traefik.yaml
@@ -28,7 +28,7 @@ spec:
     priorityClassName: "system-cluster-critical"
     image:
       repository: "rancher/mirrored-library-traefik"
-      tag: "3.7.7"
+      tag: "3.7.8"
     tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -3,6 +3,6 @@ docker.io/rancher/klipper-lb:v0.4.17
 docker.io/rancher/local-path-provisioner:v0.0.36
 docker.io/rancher/mirrored-coredns-coredns:1.14.6
 docker.io/rancher/mirrored-library-busybox:1.37.0
-docker.io/rancher/mirrored-library-traefik:3.7.7
+docker.io/rancher/mirrored-library-traefik:3.7.8
 docker.io/rancher/mirrored-metrics-server:v0.9.0
 docker.io/rancher/mirrored-pause:3.10.2


### PR DESCRIPTION
Backport: https://github.com/k3s-io/k3s/pull/14404
Issue: https://github.com/k3s-io/k3s/issues/14374