### PR TITLE
feat: support custom kubeconfig name

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -302,6 +302,7 @@ var ServerFlags = []cli.Flag{
 		Usage:       "(client) Write kubeconfig with this name",
 		Destination: &ServerConfig.KubeConfigName,
 		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_NAME"},
+		Value:       "default",
 	},
 	&cli.StringFlag{
 		Name:        "helm-job-image",

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -46,6 +46,7 @@ type Server struct {
 	KubeConfigOutput         string
 	KubeConfigMode           string
 	KubeConfigGroup          string
+	KubeConfigName           string
 	HelmJobImage             string
 	TLSSan                   cli.StringSlice
 	TLSSanSecurity           bool
@@ -295,6 +296,12 @@ var ServerFlags = []cli.Flag{
 		Usage:       "(client) Write kubeconfig with this group",
 		Destination: &ServerConfig.KubeConfigGroup,
 		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_GROUP"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-name",
+		Usage:       "(client) Write kubeconfig with this name",
+		Destination: &ServerConfig.KubeConfigName,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_NAME"},
 	},
 	&cli.StringFlag{
 		Name:        "helm-job-image",

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -299,7 +299,7 @@ var ServerFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:        "write-kubeconfig-name",
-		Usage:       "(client) Write kubeconfig with this name",
+		Usage:       "(client) Write kubeconfig using this name for the generated cluster, user, and context",
 		Destination: &ServerConfig.KubeConfigName,
 		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_NAME"},
 		Value:       "default",

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -157,6 +157,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.KubeConfigOutput = cfg.KubeConfigOutput
 	serverConfig.ControlConfig.KubeConfigMode = cfg.KubeConfigMode
 	serverConfig.ControlConfig.KubeConfigGroup = cfg.KubeConfigGroup
+	serverConfig.ControlConfig.KubeConfigName = cfg.KubeConfigName
 	serverConfig.ControlConfig.HelmJobImage = cfg.HelmJobImage
 	serverConfig.ControlConfig.Rootless = cfg.Rootless
 	serverConfig.ControlConfig.ServiceLBNamespace = cfg.ServiceLBNamespace

--- a/pkg/clientaccess/kubeconfig.go
+++ b/pkg/clientaccess/kubeconfig.go
@@ -10,7 +10,7 @@ import (
 )
 
 // WriteClientKubeConfig generates a kubeconfig at destFile that can be used to connect to a server at url with the given certs and keys
-func WriteClientKubeConfig(destFile, url, serverCAFile, clientCertFile, clientKeyFile string) error {
+func WriteClientKubeConfig(destFile, name, url, serverCAFile, clientCertFile, clientKeyFile string) error {
 	serverCA, err := os.ReadFile(serverCAFile)
 	if err != nil {
 		return errors.WithMessagef(err, "failed to read %s", serverCAFile)
@@ -37,13 +37,13 @@ func WriteClientKubeConfig(destFile, url, serverCAFile, clientCertFile, clientKe
 	authInfo.ClientKeyData = clientKey
 
 	context := clientcmdapi.NewContext()
-	context.AuthInfo = "default"
-	context.Cluster = "default"
+	context.AuthInfo = name
+	context.Cluster = name
 
-	config.Clusters["default"] = cluster
-	config.AuthInfos["default"] = authInfo
-	config.Contexts["default"] = context
-	config.CurrentContext = "default"
+	config.Clusters[name] = cluster
+	config.AuthInfos[name] = authInfo
+	config.Contexts[name] = context
+	config.CurrentContext = name
 
 	return clientcmd.WriteToFile(*config, destFile)
 }

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -207,6 +207,7 @@ type Control struct {
 	KubeConfigOutput         string
 	KubeConfigMode           string
 	KubeConfigGroup          string
+	KubeConfigName           string
 	HelmJobImage             string
 	DataDir                  string
 	KineTLS                  bool

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -439,7 +439,12 @@ func writeKubeConfig(certs string, config *Config) error {
 		}
 	}
 
-	if err = clientaccess.WriteClientKubeConfig(kubeConfig, url, config.ControlConfig.Runtime.ServerCA, config.ControlConfig.Runtime.ClientAdminCert,
+	kubeConfigName := "default"
+	if config.ControlConfig.KubeConfigName != "" {
+		kubeConfigName = config.ControlConfig.KubeConfigName
+	}
+
+	if err = clientaccess.WriteClientKubeConfig(kubeConfig, kubeConfigName, url, config.ControlConfig.Runtime.ServerCA, config.ControlConfig.Runtime.ClientAdminCert,
 		config.ControlConfig.Runtime.ClientAdminKey); err == nil {
 		logrus.Infof("Wrote kubeconfig %s", kubeConfig)
 	} else {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -439,12 +439,7 @@ func writeKubeConfig(certs string, config *Config) error {
 		}
 	}
 
-	kubeConfigName := "default"
-	if config.ControlConfig.KubeConfigName != "" {
-		kubeConfigName = config.ControlConfig.KubeConfigName
-	}
-
-	if err = clientaccess.WriteClientKubeConfig(kubeConfig, kubeConfigName, url, config.ControlConfig.Runtime.ServerCA, config.ControlConfig.Runtime.ClientAdminCert,
+	if err = clientaccess.WriteClientKubeConfig(kubeConfig, config.ControlConfig.KubeConfigName, url, config.ControlConfig.Runtime.ServerCA, config.ControlConfig.Runtime.ClientAdminCert,
 		config.ControlConfig.Runtime.ClientAdminKey); err == nil {
 		logrus.Infof("Wrote kubeconfig %s", kubeConfig)
 	} else {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Add new `--write-kubeconfig-name` server flag.

This flag sets the name for cluster, user and context in generated kubeconfig.
If the flag is not set, the default name (`default`) is used.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

New Feature

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

1. Start K3s with `--write-kubeconfig-name=testing`
2. Verify that the cluster, user and context names are `testing`
3. Start K3s without the flag and verify that the names are `default`

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

- #14441

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added `--write-kubeconfig-name` server flag to set the name for cluster, user and context in generated kubeconfig.
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
