### PR TITLE
[release-1.34] Bump helm-controller and klipper-helm for `--force-conflicts` support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/json-iterator/go v1.1.12
 	github.com/k3s-io/api v0.1.4
-	github.com/k3s-io/helm-controller v0.16.24
+	github.com/k3s-io/helm-controller v0.16.25
 	github.com/k3s-io/kine v0.16.3
 	github.com/klauspost/compress v1.18.6
 	github.com/libp2p/go-libp2p v0.48.0

--- a/go.sum
+++ b/go.sum
@@ -874,8 +874,8 @@ github.com/k3s-io/etcd/pkg/v3 v3.6.12-k3s1 h1:nsxkj7ZfkN6Lwgcc2hgzgtonlzACGid7tL
 github.com/k3s-io/etcd/pkg/v3 v3.6.12-k3s1/go.mod h1:qDFIetmpC8TTZfkZkDzpNrXtVqVsyYumRWNPFXFhcpQ=
 github.com/k3s-io/etcd/server/v3 v3.6.12-k3s1 h1:Vbyuel/bZd/RgDQkfCxuYZmdUNcwgp8RuER5w+GrsYU=
 github.com/k3s-io/etcd/server/v3 v3.6.12-k3s1/go.mod h1:iiREo2DGRVjtiAjQeA3LQyYCk6YDFo3uS30/vImHdtk=
-github.com/k3s-io/helm-controller v0.16.24 h1:4IyPzJHh5aDLby/Lj761iDp56a/o6JYxFmUn9AFJEO0=
-github.com/k3s-io/helm-controller v0.16.24/go.mod h1:1iRWHzW54LV5t3NdpRD8Eo3DWosPaDVrXBQ6hjac+8c=
+github.com/k3s-io/helm-controller v0.16.25 h1:z+3WDJMxZ9G7+tcodfY2X44CtnKGCp7WqIpHisTXnRQ=
+github.com/k3s-io/helm-controller v0.16.25/go.mod h1:1iRWHzW54LV5t3NdpRD8Eo3DWosPaDVrXBQ6hjac+8c=
 github.com/k3s-io/kine v0.16.3 h1:NstMQZ7AIRA9dC+uu+ZpK5eITwsANrSDX4Fe6yTSmpU=
 github.com/k3s-io/kine v0.16.3/go.mod h1:8cpZsCKacjwrka3BjQDY7sCQ2qI9iGtcCs2I/I5euec=
 github.com/k3s-io/klog/v2 v2.140.0-k3s1 h1:Z6S9oqaxcKtLaTcQNgWsaZNE5a+qJmCrTI+Lahor4X8=

--- a/manifests/traefik.yaml
+++ b/manifests/traefik.yaml
@@ -5,6 +5,8 @@ metadata:
   name: traefik-crd
   namespace: kube-system
 spec:
+  forceConflicts: true
+  failurePolicy: retry
   chart: https://%{KUBERNETES_API}%/static/charts/traefik-crd-40.1.4+up40.1.0.tgz
 ---
 apiVersion: helm.cattle.io/v1
@@ -13,6 +15,8 @@ metadata:
   name: traefik
   namespace: kube-system
 spec:
+  forceConflicts: true
+  failurePolicy: retry
   chart: https://%{KUBERNETES_API}%/static/charts/traefik-40.1.4+up40.1.0.tgz
   set:
     global.systemDefaultRegistry: "%{SYSTEM_DEFAULT_REGISTRY_RAW}%"

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,4 +1,4 @@
-docker.io/rancher/klipper-helm:v0.13.1-build20260715
+docker.io/rancher/klipper-helm:v0.13.2-build20260716
 docker.io/rancher/klipper-lb:v0.4.17
 docker.io/rancher/local-path-provisioner:v0.0.36
 docker.io/rancher/mirrored-coredns-coredns:1.14.6

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -82,7 +82,7 @@ case ${ARCH} in
     ;;
 esac
 
-VERSION_HELM_JOB="v0.13.1-build20260715"
+VERSION_HELM_JOB="v0.13.2-build20260716"
 
 if [[ -n "$GIT_TAG" ]]; then
     if [[ ! "$GIT_TAG" =~ ^"$VERSION_K8S"[+-] ]]; then


### PR DESCRIPTION
#### Proposed Changes ####

* Bump helm-controller for `--force-conflicts` support
* Enable force-conflicts and retry (instead of reinstall) for traefik charts

#### Types of Changes ####

bugfix/enhancement

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/helm-controller/issues/343

#### User-Facing Change ####
```release-note
```

#### Further Comments ####

