### PR TITLE
Don't retag images for a registry they are already hosted by

### DIFF
--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -49,10 +49,6 @@ const (
 	criPinnedImageLabelKey    = criContainerdPrefix + ".pinned"
 	criPinnedImageLabelValue  = "pinned"
 	criK8sContainerdNamespace = "k8s.io"
-
-	// forceCreateTagAttempts is the number of times to attempt tagging an image, in case
-	// another writer is concurrently creating or deleting a record with the same name.
-	forceCreateTagAttempts = 3
 )
 
 // Run configures and starts containerd as a child process. Once it is up, images are preloaded
@@ -302,8 +298,6 @@ func retagImages(ctx context.Context, client *containerd.Client, images []images
 		for _, name := range newNames {
 			if err := forceCreateTag(ctx, imageService, image, name); err != nil {
 				errs = append(errs, err)
-			} else {
-				logrus.Infof("Tagged %s", name)
 			}
 		}
 	}
@@ -345,28 +339,28 @@ func isHostedBy(name docker.Named, registry string) bool {
 }
 
 // forceCreateTag retags an image with the provided reference, replacing any image that
-// currently holds that name. Create and Update are each atomic, but another writer such as the
-// CRI plugin may add or remove the record between our calls, so retry a bounded number of times.
+// currently holds that name. If something else takes the name first, the tag is skipped.
 func forceCreateTag(ctx context.Context, imageService images.Store, image images.Image, targetRef string) error {
 	image.Name = targetRef
-	var err error
-	for range forceCreateTagAttempts {
-		if _, err = imageService.Create(ctx, image); err == nil {
-			return nil
-		}
+	if _, err := imageService.Create(ctx, image); err != nil {
 		if !errdefs.IsAlreadyExists(err) {
 			return errors.WithMessage(err, "failed to tag image "+image.Name)
 		}
-		// Update replaces the record within a single transaction; deleting and recreating
-		// it would leave a window for another writer to take the name first.
-		if _, err = imageService.Update(ctx, image); err == nil {
-			return nil
+		if err := imageService.Delete(ctx, image.Name); err != nil {
+			return errors.WithMessage(err, "failed to delete existing image "+image.Name)
 		}
-		if !errdefs.IsNotFound(err) {
-			return errors.WithMessage(err, "failed to tag image "+image.Name)
+		if _, err := imageService.Create(ctx, image); err != nil {
+			if errdefs.IsAlreadyExists(err) {
+				// Something else took the name after we deleted it; don't fail the
+				// import over a tag that we no longer own.
+				logrus.Warnf("Failed to tag after deleting existing image %s: %v", image.Name, err)
+				return nil
+			}
+			return errors.WithMessage(err, "failed to tag after deleting existing image "+image.Name)
 		}
 	}
-	return errors.WithMessagef(err, "failed to tag image %s after %d attempts", image.Name, forceCreateTagAttempts)
+	logrus.Infof("Tagged %s", image.Name)
+	return nil
 }
 
 // labelContent adds distribution source labels to layer content.

--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -49,6 +49,10 @@ const (
 	criPinnedImageLabelKey    = criContainerdPrefix + ".pinned"
 	criPinnedImageLabelValue  = "pinned"
 	criK8sContainerdNamespace = "k8s.io"
+
+	// forceCreateTagAttempts is the number of times to attempt tagging an image, in case
+	// another writer is concurrently creating or deleting a record with the same name.
+	forceCreateTagAttempts = 3
 )
 
 // Run configures and starts containerd as a child process. Once it is up, images are preloaded
@@ -289,23 +293,13 @@ func retagImages(ctx context.Context, client *containerd.Client, images []images
 	var errs []error
 	imageService := client.ImageService()
 	for _, image := range images {
-		name, err := parseNamedTagged(image.Name)
+		newNames, err := imageTagNames(image, registries)
 		if err != nil {
 			errs = append(errs, errors.WithMessage(err, "failed to parse tag for image "+image.Name))
 			continue
 		}
 		logrus.Infof("Imported %s", image.Name)
-		newNames := []string{fmt.Sprintf("%s@%s", name.Name(), image.Target.Digest)}
-		for _, registry := range registries {
-			newNames = append(newNames,
-				fmt.Sprintf("%s/%s:%s", registry, docker.Path(name), name.Tag()),
-				fmt.Sprintf("%s/%s@%s", registry, docker.Path(name), image.Target.Digest),
-			)
-		}
 		for _, name := range newNames {
-			if name == image.Name {
-				continue
-			}
 			if err := forceCreateTag(ctx, imageService, image, name); err != nil {
 				errs = append(errs, err)
 			} else {
@@ -316,22 +310,63 @@ func retagImages(ctx context.Context, client *containerd.Client, images []images
 	return errors.Join(errs...)
 }
 
-// forceCreateTag retags an image with the provided reference.
+// imageTagNames returns the additional names that an image should be tagged with, given the
+// list of registries that it may be pulled from. Registries that the image is already hosted
+// by are skipped, so the returned list never includes the image's current name.
+func imageTagNames(image images.Image, registries []string) ([]string, error) {
+	name, err := parseNamedTagged(image.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	newNames := make([]string, 0, 1+2*len(registries))
+	newNames = append(newNames, fmt.Sprintf("%s@%s", name.Name(), image.Target.Digest))
+
+	seen := make(map[string]bool, len(registries))
+	for _, registry := range registries {
+		registry = strings.TrimSuffix(registry, "/")
+		if seen[registry] || isHostedBy(name, registry) {
+			continue
+		}
+		seen[registry] = true
+		newNames = append(newNames,
+			fmt.Sprintf("%s/%s:%s", registry, docker.Path(name), name.Tag()),
+			fmt.Sprintf("%s/%s@%s", registry, docker.Path(name), image.Target.Digest),
+		)
+	}
+	return newNames, nil
+}
+
+// isHostedBy reports whether an image is already hosted by the given registry, which must not
+// have a trailing slash. Registries may include a path component; because docker.Path returns
+// everything after the domain, retagging for one would repeat that component on every import.
+func isHostedBy(name docker.Named, registry string) bool {
+	return strings.HasPrefix(name.Name(), registry+"/")
+}
+
+// forceCreateTag retags an image with the provided reference, replacing any image that
+// currently holds that name. Create and Update are each atomic, but another writer such as the
+// CRI plugin may add or remove the record between our calls, so retry a bounded number of times.
 func forceCreateTag(ctx context.Context, imageService images.Store, image images.Image, targetRef string) error {
 	image.Name = targetRef
-	if _, err := imageService.Create(ctx, image); err != nil {
-		if errdefs.IsAlreadyExists(err) {
-			if err = imageService.Delete(ctx, image.Name); err != nil {
-				return errors.WithMessage(err, "failed to delete existing image "+image.Name)
-			}
-			if _, err = imageService.Create(ctx, image); err != nil {
-				return errors.WithMessage(err, "failed to tag after deleting existing image "+image.Name)
-			}
-		} else {
+	var err error
+	for range forceCreateTagAttempts {
+		if _, err = imageService.Create(ctx, image); err == nil {
+			return nil
+		}
+		if !errdefs.IsAlreadyExists(err) {
+			return errors.WithMessage(err, "failed to tag image "+image.Name)
+		}
+		// Update replaces the record within a single transaction; deleting and recreating
+		// it would leave a window for another writer to take the name first.
+		if _, err = imageService.Update(ctx, image); err == nil {
+			return nil
+		}
+		if !errdefs.IsNotFound(err) {
 			return errors.WithMessage(err, "failed to tag image "+image.Name)
 		}
 	}
-	return nil
+	return errors.WithMessagef(err, "failed to tag image %s after %d attempts", image.Name, forceCreateTagAttempts)
 }
 
 // labelContent adds distribution source labels to layer content.

--- a/pkg/agent/containerd/containerd_test.go
+++ b/pkg/agent/containerd/containerd_test.go
@@ -1,0 +1,282 @@
+package containerd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/errdefs"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testDigest = "sha256:72fe734697c5d327a7549e65930898da999a5938f194a3e50340768b7de10604"
+
+func Test_UnitImageTagNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		imageName  string
+		registries []string
+		want       []string
+		wantErr    bool
+	}{
+		{
+			name:      "no registries",
+			imageName: "docker.io/library/nginx:1.29.4",
+			want: []string{
+				"docker.io/library/nginx@" + testDigest,
+			},
+		},
+		{
+			name:       "distinct registry",
+			imageName:  "docker.io/library/nginx:1.29.4",
+			registries: []string{"registry.example.com"},
+			want: []string{
+				"docker.io/library/nginx@" + testDigest,
+				"registry.example.com/library/nginx:1.29.4",
+				"registry.example.com/library/nginx@" + testDigest,
+			},
+		},
+		{
+			// Not hosted by the registry yet, so the path is prepended exactly once.
+			name:       "registry with path component",
+			imageName:  "docker.io/library/nginx:1.29.4",
+			registries: []string{"registry.example.com/mirror"},
+			want: []string{
+				"docker.io/library/nginx@" + testDigest,
+				"registry.example.com/mirror/library/nginx:1.29.4",
+				"registry.example.com/mirror/library/nginx@" + testDigest,
+			},
+		},
+		{
+			// system-default-registry set to the registry the image is already tagged
+			// for: every name we would generate is one the image already has.
+			name:       "registry matching image domain",
+			imageName:  "registry.example.com/library/nginx:1.29.4",
+			registries: []string{"registry.example.com"},
+			want: []string{
+				"registry.example.com/library/nginx@" + testDigest,
+			},
+		},
+		{
+			// As above, but with a path component the image name already carries;
+			// prepending it would repeat on every import. See rancher/rke2#10822.
+			name:       "registry with path component matching image",
+			imageName:  "registry.example.com/mirror/library/nginx:1.29.4",
+			registries: []string{"registry.example.com/mirror"},
+			want: []string{
+				"registry.example.com/mirror/library/nginx@" + testDigest,
+			},
+		},
+		{
+			// An image that already accumulated repeated components must not gain more.
+			name:       "registry with path component already repeated",
+			imageName:  "registry.example.com/mirror/mirror/library/nginx:1.29.4",
+			registries: []string{"registry.example.com/mirror"},
+			want: []string{
+				"registry.example.com/mirror/mirror/library/nginx@" + testDigest,
+			},
+		},
+		{
+			// A prefix of the image path, but not a path-segment prefix, so the image
+			// is not hosted by it and must still be retagged.
+			name:       "registry is a partial path segment",
+			imageName:  "registry.example.com/mirrored/library/nginx:1.29.4",
+			registries: []string{"registry.example.com/mirror"},
+			want: []string{
+				"registry.example.com/mirrored/library/nginx@" + testDigest,
+				"registry.example.com/mirror/mirrored/library/nginx:1.29.4",
+				"registry.example.com/mirror/mirrored/library/nginx@" + testDigest,
+			},
+		},
+		{
+			name:       "duplicate registries",
+			imageName:  "docker.io/library/nginx:1.29.4",
+			registries: []string{"registry.example.com", "registry.example.com"},
+			want: []string{
+				"docker.io/library/nginx@" + testDigest,
+				"registry.example.com/library/nginx:1.29.4",
+				"registry.example.com/library/nginx@" + testDigest,
+			},
+		},
+		{
+			// A trailing slash is trimmed, so it neither doubles the separator nor
+			// counts as distinct from the same registry written without one.
+			name:       "registry with trailing slash",
+			imageName:  "docker.io/library/nginx:1.29.4",
+			registries: []string{"registry.example.com/", "registry.example.com"},
+			want: []string{
+				"docker.io/library/nginx@" + testDigest,
+				"registry.example.com/library/nginx:1.29.4",
+				"registry.example.com/library/nginx@" + testDigest,
+			},
+		},
+		{
+			name:      "untagged image",
+			imageName: "docker.io/library/nginx@" + testDigest,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			image := images.Image{
+				Name:   tt.imageName,
+				Target: ocispec.Descriptor{Digest: testDigest},
+			}
+
+			got, err := imageTagNames(image, tt.registries)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, tt.imageName, "must not retag an image with its own name")
+		})
+	}
+}
+
+// fakeImageStore implements the subset of images.Store used by forceCreateTag, and
+// optionally simulates another writer mutating a record between calls.
+type fakeImageStore struct {
+	images.Store
+	records map[string]images.Image
+	creates int
+	updates int
+	deletes int
+	// onCall is invoked before each store operation with the operation name and the
+	// 1-based call count, and may mutate records to simulate a concurrent writer.
+	onCall func(f *fakeImageStore, op string, call int)
+	calls  int
+}
+
+func newFakeImageStore() *fakeImageStore {
+	return &fakeImageStore{records: map[string]images.Image{}}
+}
+
+func (f *fakeImageStore) hook(op string) {
+	f.calls++
+	if f.onCall != nil {
+		f.onCall(f, op, f.calls)
+	}
+}
+
+func (f *fakeImageStore) Create(ctx context.Context, image images.Image) (images.Image, error) {
+	f.hook("create")
+	f.creates++
+	if _, ok := f.records[image.Name]; ok {
+		return images.Image{}, errdefs.ErrAlreadyExists
+	}
+	f.records[image.Name] = image
+	return image, nil
+}
+
+func (f *fakeImageStore) Update(ctx context.Context, image images.Image, fieldpaths ...string) (images.Image, error) {
+	f.hook("update")
+	f.updates++
+	if _, ok := f.records[image.Name]; !ok {
+		return images.Image{}, errdefs.ErrNotFound
+	}
+	f.records[image.Name] = image
+	return image, nil
+}
+
+func (f *fakeImageStore) Delete(ctx context.Context, name string, opts ...images.DeleteOpt) error {
+	f.hook("delete")
+	f.deletes++
+	if _, ok := f.records[name]; !ok {
+		return errdefs.ErrNotFound
+	}
+	delete(f.records, name)
+	return nil
+}
+
+func Test_UnitForceCreateTag(t *testing.T) {
+	const targetRef = "registry.example.com/library/nginx@" + testDigest
+
+	newImage := func(content string) images.Image {
+		return images.Image{
+			Name:   "docker.io/library/nginx:1.29.4",
+			Target: ocispec.Descriptor{Digest: digest.FromString(content)},
+		}
+	}
+
+	t.Run("creates a new record", func(t *testing.T) {
+		store := newFakeImageStore()
+		image := newImage("a")
+
+		require.NoError(t, forceCreateTag(context.Background(), store, image, targetRef))
+		assert.Equal(t, image.Target, store.records[targetRef].Target)
+		assert.Equal(t, 1, store.creates)
+		assert.Equal(t, 0, store.updates)
+	})
+
+	t.Run("overwrites an existing record without deleting it", func(t *testing.T) {
+		store := newFakeImageStore()
+		store.records[targetRef] = newImage("stale")
+		image := newImage("fresh")
+
+		require.NoError(t, forceCreateTag(context.Background(), store, image, targetRef))
+		assert.Equal(t, image.Target, store.records[targetRef].Target)
+		assert.Equal(t, 1, store.updates)
+		assert.Equal(t, 0, store.deletes, "the existing record must be replaced, not deleted and recreated")
+	})
+
+	t.Run("tagging the same name twice is idempotent", func(t *testing.T) {
+		store := newFakeImageStore()
+		image := newImage("a")
+
+		require.NoError(t, forceCreateTag(context.Background(), store, image, targetRef))
+		require.NoError(t, forceCreateTag(context.Background(), store, image, targetRef))
+		assert.Equal(t, image.Target, store.records[targetRef].Target)
+	})
+
+	t.Run("recovers when another writer creates the record first", func(t *testing.T) {
+		store := newFakeImageStore()
+		// Another writer creates the record just before our Create.
+		store.onCall = func(f *fakeImageStore, op string, call int) {
+			if call == 1 {
+				f.records[targetRef] = newImage("other")
+			}
+		}
+		image := newImage("ours")
+
+		require.NoError(t, forceCreateTag(context.Background(), store, image, targetRef))
+		assert.Equal(t, image.Target, store.records[targetRef].Target)
+	})
+
+	t.Run("recovers when another writer deletes the record mid-flight", func(t *testing.T) {
+		store := newFakeImageStore()
+		store.records[targetRef] = newImage("stale")
+		// Another writer deletes the record after our Create fails but before our Update.
+		store.onCall = func(f *fakeImageStore, op string, call int) {
+			if call == 2 {
+				delete(f.records, targetRef)
+			}
+		}
+		image := newImage("ours")
+
+		require.NoError(t, forceCreateTag(context.Background(), store, image, targetRef))
+		assert.Equal(t, image.Target, store.records[targetRef].Target)
+	})
+
+	t.Run("gives up after repeated interference", func(t *testing.T) {
+		store := newFakeImageStore()
+		store.records[targetRef] = newImage("stale")
+		// Another writer defeats every attempt: the record is always present when we
+		// try to create it, and always gone by the time we try to update it.
+		store.onCall = func(f *fakeImageStore, op string, call int) {
+			if op == "create" {
+				f.records[targetRef] = newImage("other")
+			} else {
+				delete(f.records, targetRef)
+			}
+		}
+
+		err := forceCreateTag(context.Background(), store, newImage("ours"), targetRef)
+		assert.ErrorContains(t, err, "failed to tag image "+targetRef)
+	})
+}

--- a/pkg/agent/containerd/containerd_test.go
+++ b/pkg/agent/containerd/containerd_test.go
@@ -145,12 +145,14 @@ type fakeImageStore struct {
 	images.Store
 	records map[string]images.Image
 	creates int
-	updates int
 	deletes int
 	// onCall is invoked before each store operation with the operation name and the
 	// 1-based call count, and may mutate records to simulate a concurrent writer.
 	onCall func(f *fakeImageStore, op string, call int)
 	calls  int
+	// createErr is returned by the createErrOnCall'th Create.
+	createErr       error
+	createErrOnCall int
 }
 
 func newFakeImageStore() *fakeImageStore {
@@ -167,18 +169,11 @@ func (f *fakeImageStore) hook(op string) {
 func (f *fakeImageStore) Create(ctx context.Context, image images.Image) (images.Image, error) {
 	f.hook("create")
 	f.creates++
+	if f.createErr != nil && f.creates == f.createErrOnCall {
+		return images.Image{}, f.createErr
+	}
 	if _, ok := f.records[image.Name]; ok {
 		return images.Image{}, errdefs.ErrAlreadyExists
-	}
-	f.records[image.Name] = image
-	return image, nil
-}
-
-func (f *fakeImageStore) Update(ctx context.Context, image images.Image, fieldpaths ...string) (images.Image, error) {
-	f.hook("update")
-	f.updates++
-	if _, ok := f.records[image.Name]; !ok {
-		return images.Image{}, errdefs.ErrNotFound
 	}
 	f.records[image.Name] = image
 	return image, nil
@@ -211,18 +206,18 @@ func Test_UnitForceCreateTag(t *testing.T) {
 		require.NoError(t, forceCreateTag(context.Background(), store, image, targetRef))
 		assert.Equal(t, image.Target, store.records[targetRef].Target)
 		assert.Equal(t, 1, store.creates)
-		assert.Equal(t, 0, store.updates)
+		assert.Equal(t, 0, store.deletes)
 	})
 
-	t.Run("overwrites an existing record without deleting it", func(t *testing.T) {
+	t.Run("replaces an existing record", func(t *testing.T) {
 		store := newFakeImageStore()
 		store.records[targetRef] = newImage("stale")
 		image := newImage("fresh")
 
 		require.NoError(t, forceCreateTag(context.Background(), store, image, targetRef))
 		assert.Equal(t, image.Target, store.records[targetRef].Target)
-		assert.Equal(t, 1, store.updates)
-		assert.Equal(t, 0, store.deletes, "the existing record must be replaced, not deleted and recreated")
+		assert.Equal(t, 2, store.creates)
+		assert.Equal(t, 1, store.deletes)
 	})
 
 	t.Run("tagging the same name twice is idempotent", func(t *testing.T) {
@@ -234,49 +229,51 @@ func Test_UnitForceCreateTag(t *testing.T) {
 		assert.Equal(t, image.Target, store.records[targetRef].Target)
 	})
 
-	t.Run("recovers when another writer creates the record first", func(t *testing.T) {
+	t.Run("tolerates the record being recreated after we delete it", func(t *testing.T) {
 		store := newFakeImageStore()
-		// Another writer creates the record just before our Create.
+		store.records[targetRef] = newImage("stale")
+		// Another writer takes the name back between our delete and our second create.
+		// The import must not fail over a tag that we no longer own.
 		store.onCall = func(f *fakeImageStore, op string, call int) {
-			if call == 1 {
+			if op == "create" && call == 3 {
 				f.records[targetRef] = newImage("other")
 			}
 		}
-		image := newImage("ours")
 
-		require.NoError(t, forceCreateTag(context.Background(), store, image, targetRef))
-		assert.Equal(t, image.Target, store.records[targetRef].Target)
+		assert.NoError(t, forceCreateTag(context.Background(), store, newImage("ours"), targetRef))
+		assert.Equal(t, newImage("other").Target, store.records[targetRef].Target, "the other writer's record must be left alone")
 	})
 
-	t.Run("recovers when another writer deletes the record mid-flight", func(t *testing.T) {
+	t.Run("returns errors from the first create", func(t *testing.T) {
 		store := newFakeImageStore()
-		store.records[targetRef] = newImage("stale")
-		// Another writer deletes the record after our Create fails but before our Update.
-		store.onCall = func(f *fakeImageStore, op string, call int) {
-			if call == 2 {
-				delete(f.records, targetRef)
-			}
-		}
-		image := newImage("ours")
+		store.createErr = errdefs.ErrInvalidArgument
+		store.createErrOnCall = 1
 
-		require.NoError(t, forceCreateTag(context.Background(), store, image, targetRef))
-		assert.Equal(t, image.Target, store.records[targetRef].Target)
+		err := forceCreateTag(context.Background(), store, newImage("ours"), targetRef)
+		assert.ErrorContains(t, err, "failed to tag image "+targetRef)
 	})
 
-	t.Run("gives up after repeated interference", func(t *testing.T) {
+	t.Run("returns errors from the delete", func(t *testing.T) {
 		store := newFakeImageStore()
 		store.records[targetRef] = newImage("stale")
-		// Another writer defeats every attempt: the record is always present when we
-		// try to create it, and always gone by the time we try to update it.
+		// The record is already gone by the time we try to delete it.
 		store.onCall = func(f *fakeImageStore, op string, call int) {
-			if op == "create" {
-				f.records[targetRef] = newImage("other")
-			} else {
+			if op == "delete" {
 				delete(f.records, targetRef)
 			}
 		}
 
 		err := forceCreateTag(context.Background(), store, newImage("ours"), targetRef)
-		assert.ErrorContains(t, err, "failed to tag image "+targetRef)
+		assert.ErrorContains(t, err, "failed to delete existing image "+targetRef)
+	})
+
+	t.Run("returns non-AlreadyExists errors from the second create", func(t *testing.T) {
+		store := newFakeImageStore()
+		store.records[targetRef] = newImage("stale")
+		store.createErr = errdefs.ErrInvalidArgument
+		store.createErrOnCall = 2
+
+		err := forceCreateTag(context.Background(), store, newImage("ours"), targetRef)
+		assert.ErrorContains(t, err, "failed to tag after deleting existing image "+targetRef)
 	})
 }


### PR DESCRIPTION
#### Proposed Changes ####

`retagImages()` builds target names as `registry + "/" + docker.Path(name)`. `docker.Path()` returns everything after the *domain*, so this is only correct when the image is not already hosted by `registry`. When it is, the result is wrong in one of two ways:

**Bare domain** — `registry.example.com` + `library/nginx` reproduces the image's own name. `newNames` was not deduplicated, so `forceCreateTag()` ran twice for a byte-identical target. The second call necessarily got `AlreadyExists` and fell into delete-then-recreate, tearing down a record created microseconds earlier. `Delete` and `Create` are separate transactions; when another writer lands in the gap the retag fails, which fails the whole tarball import — skipping `labelContent()` and leaving the file uncached, so it re-imports on every restart.

**Registry with a path component** — `registry.example.com/mirror` + `mirror/library/nginx` repeats the path component. `prePullImages()` then iterates every `RepoTag` containerd reports for an already-pulled image and appends each as its own entry, so these names are fed back into `retagImages()` on the next run and gain another component each time. That is the unbounded growth reported in rancher/rke2#10822 — containerd is not inserting anything, k3s is re-consuming its own output.

Three changes:

1. **Skip registries the image is already hosted by.** New `isHostedBy()` does a path-segment-aware prefix check, so a registry with a path component is handled the same as a bare domain. This is the root-cause fix for both issues: no incorrect name is generated, so nothing is duplicated and nothing accumulates.

2. **Deduplicate the registry list and normalize trailing slashes.** Name generation moves into `imageTagNames()`, which skips a registry it has already emitted names for, and trims a trailing `/` before both the hosted-by check and name generation (previously `registry.example.com/` would have produced `registry.example.com//library/nginx`). Extracting the function makes the logic testable without a containerd client.

3. **Don't fail the import when the tag is already taken.** If the second `Create()` in `forceCreateTag()` returns `AlreadyExists`, log a warning and skip that tag rather than returning an error, which previously failed the whole tarball import. All other errors return early as before.

Change 3 is independent of 1 and 2. It is a safety net: with change 1 the duplicate name is no longer generated, so the `AlreadyExists` path should not be reachable in the reported scenario.

#### Types of Changes ####

Bugfix. No API, CLI, or config surface changes.

#### Verification ####

Reproducing before the change (1 node, airgapped):

1. `/etc/rancher/k3s/config.yaml`:

   ```yaml
   system-default-registry: registry.example.com
   ```

2. Place an image tarball in `/var/lib/rancher/k3s/agent/images/` whose images are already tagged for that same registry, e.g. `registry.example.com/library/nginx:1.29.4`.
3. Start K3s.

Before, the duplicate name is tagged, then deleted and re-created; when the re-create loses the race the import fails:

```log
level=info  msg="Imported registry.example.com/library/nginx:1.29.4"
level=info  msg="Tagged registry.example.com/library/nginx@sha256:72fe7346…"
level=error msg="Failed to process image event: failed to import /var/lib/rancher/k3s/agent/images/nginx.tar: failed to retag images: failed to tag after deleting existing image registry.example.com/library/nginx@sha256:72fe7346…: image \"registry.example.com/library/nginx@sha256:72fe7346…\": already exists"
```

After, the image is imported and tagged once, with no duplicate target and no delete.

For the rke2 variant, set `system-default-registry: harbor.example.com/mirror` with images already under that path and restart several times; `crictl image ls` should show no growth in the number of tags per digest.

I have not run these steps against a live cluster, so the reproduction and expected outcome above are derived from the code path and the logs in the linked issues, and need independent verification before merge.

#### Testing ####

New `pkg/agent/containerd/containerd_test.go` — the package had unit tests for `config.go` and `runtimes.go`, but none for `containerd.go`.

- `Test_UnitImageTagNames` — table-driven: no registries, distinct registry, registry with a path component, duplicate registries, trailing slash, untagged image, and the regression cases: registry matching the image's domain, registry with a path component matching the image, a name that has already accumulated repeated components, and a registry that is a partial (non-segment) prefix of the image path, which must still be retagged.
- `Test_UnitForceCreateTag` — a fake image store with hooks for simulating a concurrent writer and injecting store errors: create, replacing an existing record, idempotent re-tagging, tolerating the record being recreated after the delete, and error propagation from the first create, the delete, and the second create.

```bash
$ go test ./pkg/... -run Unit
ok      github.com/k3s-io/k3s/pkg/agent/containerd

$ go test -race ./pkg/agent/containerd/...
ok      github.com/k3s-io/k3s/pkg/agent/containerd
```

`go build ./pkg/... ./cmd/...`, `go vet`, `gofmt -s`, and `goimports` are clean.

The `AlreadyExists` path is a timing window against another containerd writer and is not reachable from an integration or E2E test, which is why it is covered by a fake store rather than a live cluster.

#### Linked Issues ####

- k3s-io/k3s#14482
- rancher/rke2#10822 — same root cause; fixed by change 1.

#### User-Facing Change ####

```release-note
Fixed an issue where airgap image imports could fail with an "already exists" error, or accumulate duplicate image tags on every restart, when system-default-registry matched the registry the images were already tagged for.
```

#### Further Comments ####

**AI disclosure:** Claude Code was used to help investigate the root cause, draft the change, and review it. I have reviewed and verified every change myself, and can explain each one.

One thing left out of scope, worth separate issue:

- `labelContent()` has the same registry-vs-domain confusion. At `containerd.go:408` the distribution source label key is built as `LabelDistributionSource + "." + registry`, so a registry with a path component produces a label key containing a slash and a value that repeats the path. That affects Spegel's content filtering rather than the import itself, so I have kept it out of this PR to keep the scope to one issue.
