### PR TITLE
Fix typo in spegel deferred store comment

### DIFF
--- a/pkg/spegel/store.go
+++ b/pkg/spegel/store.go
@@ -78,7 +78,7 @@ func (ds *deferredStore) Subscribe(ctx context.Context) (<-chan oci.OCIEvent, er
 	return ds.store.Subscribe(ctx)
 }
 
-// Close is not part of the Store interface, but probably should be. Containerd impliments it.
+// Close is not part of the Store interface, but probably should be. Containerd implements it.
 func (ds *deferredStore) Close() error {
 	if ds.store != nil {
 		store := ds.store


### PR DESCRIPTION
#### Proposed Changes ####

Fix a typo in the comment on `pkg/spegel/store.go`: `impliments` → `implements`.
Comment-only change, no behavioral impact.

#### Types of Changes ####

Cleanup (comment typo fix)

#### Verification ####

Inspect the single-line diff in `pkg/spegel/store.go` (Close method comment).

#### Testing ####

Not applicable — comment-only change with no code behavior change.

#### Linked Issues ####

None

#### User-Facing Change ####

```release-note
NONE
```