### PR TITLE
Etcd client locking

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -520,7 +520,7 @@ func (e *ETCD) pollJoin(ctx context.Context, wg *sync.WaitGroup, clientAccessInf
 }
 
 // startClient sets up the config's datastore endpoints, and starts an etcd client connected to the server endpoint.
-// The client is destroyed when the context is closed.
+// The client's connection is closed when the context is closed.
 func (e *ETCD) startClient(ctx context.Context) error {
 	if e.client != nil {
 		return errors.New("etcd datastore already started")
@@ -540,7 +540,6 @@ func (e *ETCD) startClient(ctx context.Context) error {
 
 	go func() {
 		<-ctx.Done()
-		e.client = nil
 		conn.Close()
 	}()
 

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -1519,6 +1519,12 @@ func (e *ETCD) Restore(ctx context.Context) error {
 	if _, err := os.Stat(e.config.ClusterResetRestorePath); err != nil {
 		return err
 	}
+	// Restore is an offline operation, so create a logger for it instead of borrowing one from
+	// the datastore client. Do it before anything is moved, so that we fail early.
+	logger, err := logutil.CreateDefaultZapLogger(zapcore.InfoLevel)
+	if err != nil {
+		return err
+	}
 
 	var restorePath string
 	if strings.HasSuffix(e.config.ClusterResetRestorePath, snapshot.CompressedExtension) {
@@ -1543,7 +1549,7 @@ func (e *ETCD) Restore(ctx context.Context) error {
 	}
 
 	logrus.Infof("Pre-restore etcd database moved to %s", oldDataDir)
-	return snapshotv3.NewV3(e.client.GetLogger()).Restore(snapshotv3.RestoreConfig{
+	return snapshotv3.NewV3(logger).Restore(snapshotv3.RestoreConfig{
 		SnapshotPath:   restorePath,
 		Name:           e.name,
 		OutputDataDir:  dbDir(e.config),


### PR DESCRIPTION
#### Proposed Changes ####

Add a lock to ETCD.client to guard it from concurrent cleanup clearing the pointer and then being dereferenced in another place

#### Types of Changes ####

Bugfix for the unit tests

#### Verification ####

- unit tests should now pass

#### Testing ####

- existing unit tests should be enough

#### Linked Issues ####

#14499 

#### User-Facing Change ####

None

#### Further Comments ####

Just saw that the unit tests were failing in the CI due to a race in the cleanup:
```
	goroutine 391 [running]:
	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x3a494f0, 0xcc02d0583c0}, {0x3186dc0, 0x5cc28a0})
		/home/runner/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apimachinery@v1.36.3-k3s1/pkg/util/runtime/runtime.go:134 +0xbc
	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x3a49528, 0xcc02cab9900}, {0x3186dc0, 0x5cc28a0}, {0x0, 0x0, 0xcc02cbb18b0?})
		/home/runner/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apimachinery@v1.36.3-k3s1/pkg/util/runtime/runtime.go:109 +0x116
	k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0x3a49528, 0xcc02cab9900}, {0x0, 0x0, 0x0})
		/home/runner/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apimachinery@v1.36.3-k3s1/pkg/util/runtime/runtime.go:80 +0x55
	panic({0x3186dc0?, 0x5cc28a0?})
		/opt/hostedtoolcache/go/1.26.5/x64/src/runtime/panic.go:860 +0x13a
	github.com/k3s-io/k3s/pkg/etcd.(*ETCD).getLearnerProgress(0xcc02cab98b0, {0x3a49598, 0xcc02c82a930})
		/home/runner/work/k3s/k3s/pkg/etcd/etcd.go:1388 +0x67
	github.com/k3s-io/k3s/pkg/etcd.(*ETCD).manageLearners.func1({0x3a49528?, 0xcc02cab9900?})
		/home/runner/work/k3s/k3s/pkg/etcd/etcd.go:1171 +0x1b1
	k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x3a49528?, 0xcc02cab9900?}, 0xcc02d7b2b40?)
		/home/runner/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apimachinery@v1.36.3-k3s1/pkg/util/wait/backoff.go:255 +0x51
	k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x3a49528, 0xcc02cab9900}, 0xcc02cbb1f78, {0x3a1af60, 0xcc02d7b2b40}, 0x1)
		/home/runner/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apimachinery@v1.36.3-k3s1/pkg/util/wait/backoff.go:256 +0xe5
	k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x3a49528, 0xcc02cab9900}, 0xcc02d27af78, 0x37e11d600, 0x0, 0x1)
		/home/runner/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apimachinery@v1.36.3-k3s1/pkg/util/wait/backoff.go:223 +0x8f
	k8s.io/apimachinery/pkg/util/wait.UntilWithContext(...)
		/home/runner/go/pkg/mod/github.com/k3s-io/kubernetes/staging/src/k8s.io/apimachinery@v1.36.3-k3s1/pkg/util/wait/backoff.go:172
	github.com/k3s-io/k3s/pkg/etcd.(*ETCD).manageLearners(0xcc02cab98b0?, {0x3a49528?, 0xcc02cab9900?})
		/home/runner/work/k3s/k3s/pkg/etcd/etcd.go:1151 +0x216
	created by github.com/k3s-io/k3s/pkg/etcd.(*ETCD).Start in goroutine 257
		/home/runner/work/k3s/k3s/pkg/etcd/etcd.go:450 +0x16d
 >
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
```