### PR TITLE
[release-1.32] fix: pre-apply feature gates before embedded API server starts

### DIFF
--- a/pkg/executor/embed/embed.go
+++ b/pkg/executor/embed/embed.go
@@ -31,6 +31,7 @@ import (
 	"github.com/k3s-io/k3s/pkg/vpn"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	cloudprovider "k8s.io/cloud-provider"
 	ccmapp "k8s.io/cloud-provider/app"
 	cloudcontrollerconfig "k8s.io/cloud-provider/app/config"
@@ -216,6 +217,13 @@ func (*Embedded) APIServerHandlers(ctx context.Context) (authenticator.Request, 
 }
 
 func (e *Embedded) APIServer(ctx context.Context, args []string) error {
+	// set feature-gates now, to avoid race conditions between components started in parallel
+	if featureGates := util.ArgValue("feature-gates", args); featureGates != "" {
+		if err := utilfeature.DefaultMutableFeatureGate.Set(featureGates); err != nil {
+			logrus.Warnf("Failed to set feature-gates %s: %v", featureGates, err)
+		}
+	}
+
 	command := apiapp.NewAPIServerCommand(ctx.Done())
 	command.SetArgs(args)
 


### PR DESCRIPTION
#### Proposed Changes ####

Backport of #14287 to `release-1.32`.

Pre-apply `--feature-gates` to `utilfeature.DefaultMutableFeatureGate` before the embedded API server starts, so REST storage registration does not race flag parsing.

This is the line that still needs the fix for alpha gates on Kubernetes v1.32 (e.g. `InPlacePodVerticalScaling` / `pods/resize`). The change is already present on `main` and on release branches 1.33–1.36 via the July backports.

#### Types of Changes ####

Bugfix (backport)

#### Verification ####

Same approach as #14287: minimal change in `pkg/executor/embed/embed.go` matching the merged main patch (import + early `DefaultMutableFeatureGate.Set`).

#### Testing ####

- Diff matches the final form of #14287 on `main`
- `util.ArgValue` already exists on this branch (`pkg/util/args.go`)
- Full CI on Linux runners

#### Linked Issues ####

* Ref #14286
* Backport of #14287
* Related: attune-io/attune#352 (nightly K8s v1.32 leg)

#### AI Disclosure ####

This PR was developed with AI assistance.