### PR TITLE
make explicit where coredns customizations should be made

### DIFF
--- a/manifests/coredns.yaml
+++ b/manifests/coredns.yaml
@@ -53,8 +53,8 @@ metadata:
   namespace: kube-system
 data:
   Corefile: |
-    # THIS FILE IS RESET EVERY TIME THE K3S CONTROL-PLANE IS STARTED
-    # CUSTOMIZATIONS MUST BE MADE IN THE coredns-custom CONFIGMAP
+    # File managed by k3s. DO NOT EDIT.
+    # See: https://docs.k3s.io/advanced#coredns-custom-configuration-imports
     .:53 {
         errors
         health

--- a/manifests/coredns.yaml
+++ b/manifests/coredns.yaml
@@ -53,6 +53,8 @@ metadata:
   namespace: kube-system
 data:
   Corefile: |
+    # THIS FILE IS RESET EVERY TIME THE K3S CONTROL-PLANE IS STARTED
+    # CUSTOMIZATIONS MUST BE MADE IN THE coredns-custom CONFIGMAP
     .:53 {
         errors
         health


### PR DESCRIPTION
#### Proposed Changes ####

Last week, I added a couple CoreDNS server blocks to my k3s cluster in `kube-system/coredns`.  Today, someone restarted the control plane and the DNS behavior suddenly reverted.  This behavior is documented, but isn't immediately obvious unless you're looking for it.

This PR adds a comment to the top of the CoreDNS Corefile pointing sys-admins in the right direction so they can avoid my mistake.

#### Types of Changes ####

Extra comments in in-cluster configmaps to direct users away from an easy-to-make mistake

#### Verification ####

Spin up a cluster and verify that the comments are there.

#### Testing ####

This could presumably be tested as a Docker test that reads the configmap and confirms that the comment is still there.  I think that's overkill for a comment-only comment, but if you'd like that (or have a better way to test this), let me know and I'll amend the PR.

#### Linked Issues ####

#9223 - same issue, but the proposed solution on the ticket isn't ideal

#### User-Facing Change ####

```release-note
NONE
```

#### Further Comments ####

I won't be offended if this doesn't get merged - it just seemed like a nearly-free quality of life feature.