### PR TITLE
Bump docker version in CI to 29

### DIFF
--- a/.github/workflows/airgap.yaml
+++ b/.github/workflows/airgap.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-docker-action@6d7cfa65f60a9dda7b46e5513fa982536f3c9877 # v5.3.0
         with:
-          version: type=image,tag=28
+          version: type=image,tag=29
           daemon-config: '{"features":{"containerd-snapshotter":true}}'
           set-host: true
  

--- a/.github/workflows/build-k3s.yaml
+++ b/.github/workflows/build-k3s.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Docker
       uses: docker/setup-docker-action@6d7cfa65f60a9dda7b46e5513fa982536f3c9877 # v5.3.0
       with:
-        version: type=image,tag=28
+        version: type=image,tag=29
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-docker-action@6d7cfa65f60a9dda7b46e5513fa982536f3c9877 # v5.3.0
         with:
-          version: type=image,tag=28
+          version: type=image,tag=29
           daemon-config: '{"features":{"containerd-snapshotter":true}}'
           set-host: true
       - name: Set up vagrant and libvirt
@@ -255,7 +255,7 @@ jobs:
     - name: Set up Docker
       uses: docker/setup-docker-action@6d7cfa65f60a9dda7b46e5513fa982536f3c9877 # v5.3.0
       with:
-        version: type=image,tag=28
+        version: type=image,tag=29
         daemon-config: '{"features":{"containerd-snapshotter":true}}'
         set-host: true
     - name: Load and set K3s image
@@ -311,7 +311,7 @@ jobs:
     - name: Set up Docker
       uses: docker/setup-docker-action@6d7cfa65f60a9dda7b46e5513fa982536f3c9877 # v5.3.0
       with:
-        version: type=image,tag=28
+        version: type=image,tag=29
         set-host: true
     - name: "Download K3s image"
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/nightly-install.yaml
+++ b/.github/workflows/nightly-install.yaml
@@ -122,7 +122,7 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-docker-action@6d7cfa65f60a9dda7b46e5513fa982536f3c9877 # v5.3.0
         with:
-          version: type=image,tag=28
+          version: type=image,tag=29
           set-host: true
       - name: Install Go
         uses: ./.github/actions/setup-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-docker-action@6d7cfa65f60a9dda7b46e5513fa982536f3c9877 # v5.3.0
         with:
-          version: type=image,tag=28
+          version: type=image,tag=29
           daemon-config: '{"features":{"containerd-snapshotter":true}}'
           set-host: true
 


### PR DESCRIPTION
#### Proposed Changes ####

Bump docker version in CI to 29

Docker 28 has been EOL since 2026-05, no new releases have been published since 2025-11

#### Types of Changes ####

CI tooling version bump

#### Verification ####

Check CI

#### Testing ####

Yes

#### Linked Issues ####


#### User-Facing Change ####
```release-note
```

#### Further Comments ####