### PR TITLE
Tidy dockerfile and build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,35 +7,36 @@ FROM --platform=$BUILDPLATFORM ${GOLANG} AS infra
 COPY --from=xx / /
 ARG TARGETOS
 ARG TARGETARCH
+ARG SELINUX=true
 ENV TARGETOS=$TARGETOS
 ENV TARGETARCH=$TARGETARCH
-
-RUN apk -U --no-cache add bash git docker vim less file curl wget ca-certificates jq \
-    tar zip squashfs-tools coreutils openssl-dev libffi-dev make libuv-static \
-    zstd pigz alpine-sdk yq clang lld \
-    && \
-    if [ "${TARGETARCH}" = "arm64" ]; then \
-    apk -U --no-cache add binutils-gold; \
-    fi \
-    && \
-    if [ "${TARGETOS}" = "windows" ] && [ "${TARGETARCH}" = "amd64" ]; then \
-    apk -U --no-cache add mingw-w64-gcc; \
-    fi
-
-RUN if [ "${TARGETOS}" = "linux" ]; then \
-      xx-apk add --no-cache gcc musl-dev linux-headers zlib-dev zlib-static libseccomp libseccomp-dev libseccomp-static sqlite-dev sqlite-static libselinux libselinux-dev btrfs-progs-dev btrfs-progs-static; \
-    fi
-
-# Install goimports
-RUN GOPROXY=direct go install golang.org/x/tools/cmd/goimports@gopls/v0.20.0
-RUN rm -rf /go/src /go/pkg
-
-ARG SELINUX=true
 ENV SELINUX=$SELINUX
 ENV STATIC_BUILD=true
 ENV SRC_DIR=/go/src/github.com/k3s-io/k3s
 WORKDIR ${SRC_DIR}/
 
+RUN apk -U add bash git docker vim less file curl wget ca-certificates jq \
+    tar zip squashfs-tools coreutils openssl-dev libffi-dev make libuv-static \
+    zstd pigz alpine-sdk yq clang lld \
+    && \
+    if [ "${TARGETARCH}" = "arm64" ]; then \
+    apk -U add binutils-gold; \
+    fi \
+    && \
+    if [ "${TARGETOS}" = "windows" ] && [ "${TARGETARCH}" = "amd64" ]; then \
+    apk -U add mingw-w64-gcc; \
+    fi \
+    && \
+    if [ "${TARGETOS}" = "linux" ]; then \
+      xx-apk add gcc musl-dev linux-headers zlib-dev zlib-static libseccomp libseccomp-dev libseccomp-static sqlite-dev sqlite-static libselinux libselinux-dev btrfs-progs-dev btrfs-progs-static; \
+    fi \
+    && \
+    git config --global advice.detachedHead false
+
+# Install goimports
+RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
+    --mount=type=cache,id=gobuild-${TARGETOS}-${TARGETARCH},target=/root/.cache/go-build \
+    GOPROXY=direct go install golang.org/x/tools/cmd/goimports@gopls/v0.20.0
 
 FROM infra AS manifests
 ARG GIT_TAG

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ tag-image-latest:
 
 .PHONY: validate
 validate:
-	DOCKER_BUILDKIT=1 docker build \
+	docker buildx build \
 		--build-arg="SKIP_VALIDATE=$(SKIP_VALIDATE)" \
 		--build-arg="DEBUG=$(DEBUG)" \
 		--progress=plain \
@@ -45,7 +45,7 @@ validate:
 binary:
 	@echo "INFO: Building K3s binaries and assets..."
 	. ./scripts/git_version.sh && \
-	DOCKER_BUILDKIT=1 docker build \
+	docker buildx build \
 		--build-arg "GIT_TAG=$$GIT_TAG" \
 		--build-arg "TREE_STATE=$$TREE_STATE" \
 		--build-arg "COMMIT=$$COMMIT" \
@@ -59,7 +59,7 @@ binary:
 multiarch-binary:
 	@echo "INFO: Building K3s binaries and assets for all release platforms..."
 	. ./scripts/git_version.sh && \
-	DOCKER_BUILDKIT=1 docker buildx build \
+	docker buildx build \
 		--platform linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64,windows/amd64 \
 		--build-arg "GIT_TAG=$$GIT_TAG" \
 		--build-arg "TREE_STATE=$$TREE_STATE" \

--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/dustin/go-humanize v1.0.1
-	github.com/erikdubbelboer/gspt v0.0.0-20190125194910-e68493906b83
+	github.com/erikdubbelboer/gspt v0.0.0-20210805194459-ce36a5128377
 	github.com/flannel-io/flannel v0.28.4
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -702,8 +702,8 @@ github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZ
 github.com/envoyproxy/protoc-gen-validate v1.1.0/go.mod h1:sXRDRVmzEbkM7CVcM06s9shE/m23dg3wzjl0UWqJ2q4=
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
-github.com/erikdubbelboer/gspt v0.0.0-20190125194910-e68493906b83 h1:ngHdSomn2MyugZYKHiycad2xERwIrmMlET7A0lC0UU4=
-github.com/erikdubbelboer/gspt v0.0.0-20190125194910-e68493906b83/go.mod h1:v6o7m/E9bfvm79dE1iFiF+3T7zLBnrjYjkWMa1J+Hv0=
+github.com/erikdubbelboer/gspt v0.0.0-20210805194459-ce36a5128377 h1:gT+RM6gdTIAzMT7HUvmT5mL8SyG8Wx7iS3+L0V34Km4=
+github.com/erikdubbelboer/gspt v0.0.0-20210805194459-ce36a5128377/go.mod h1:v6o7m/E9bfvm79dE1iFiF+3T7zLBnrjYjkWMa1J+Hv0=
 github.com/erofs/go-erofs v0.3.0 h1:o/W5ABAA3sHYl97WL93dacKEfeDpJhdFf3c2snAti7I=
 github.com/erofs/go-erofs v0.3.0/go.mod h1:XkSeN9MHszGd4+3gcEjadJLYHCQpWzJ7/8yznzMuzJs=
 github.com/esiqveland/notify v0.11.0/go.mod h1:63UbVSaeJwF0LVJARHFuPgUAoM7o1BEvCZyknsuonBc=

--- a/pkg/agent/flannel/flannel.go
+++ b/pkg/agent/flannel/flannel.go
@@ -120,9 +120,8 @@ func flannel(ctx context.Context, wg *sync.WaitGroup, flannelIface *net.Interfac
 
 	if err := WriteSubnetFile(subnetFile, config.Network, config.IPv6Network, true, bn, nm); err != nil {
 		return errors.WithMessage(err, "failed to write flannel subnet file")
-	} else {
-		logrus.Infof("Wrote flannel subnet file to %s", subnetFile)
 	}
+	logrus.Infof("Wrote flannel subnet file to %s", subnetFile)
 
 	// Start "Running" the backend network. This will block until the context is done so run in another goroutine.
 	logrus.Info("Running flannel backend")

--- a/pkg/configfilearg/convert.go
+++ b/pkg/configfilearg/convert.go
@@ -1,0 +1,43 @@
+package configfilearg
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Cribbed from https://github.com/rancher/wrangler/blob/v3.7.0/pkg/data/convert/convert.go
+// We only need the string conversions, so this omits all the other type handling
+// including those that operate on metav1/unstructured. This saves us a bunch of
+// unnecessary imports in the self-extracting wrapper binary.
+
+func Singular(value any) any {
+	if slice, ok := value.([]string); ok {
+		if len(slice) == 0 {
+			return nil
+		}
+		return slice[0]
+	}
+	if slice, ok := value.([]any); ok {
+		if len(slice) == 0 {
+			return nil
+		}
+		return slice[0]
+	}
+	return value
+}
+
+func ToStringNoTrim(value any) string {
+	if t, ok := value.(time.Time); ok {
+		return t.Format(time.RFC3339)
+	}
+	single := Singular(value)
+	if single == nil {
+		return ""
+	}
+	return fmt.Sprint(single)
+}
+
+func ToString(value any) string {
+	return strings.TrimSpace(ToStringNoTrim(value))
+}

--- a/pkg/configfilearg/parser.go
+++ b/pkg/configfilearg/parser.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/k3s-io/k3s/pkg/agent/util"
-	"github.com/rancher/wrangler/v3/pkg/data/convert"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v2"
@@ -135,7 +134,7 @@ func (p *Parser) FindString(args []string, target string) (string, error) {
 			return "", err
 		}
 		for _, i := range data {
-			k, v := convert.ToString(i.Key), convert.ToString(i.Value)
+			k, v := ToString(i.Key), ToString(i.Value)
 			isAppend := strings.HasSuffix(k, "+")
 			k = strings.TrimSuffix(k, "+")
 			if k == target {
@@ -277,7 +276,7 @@ func readConfigFile(file string) (result []string, _ error) {
 		}
 
 		for _, i := range data {
-			k, v := convert.ToString(i.Key), i.Value
+			k, v := ToString(i.Key), i.Value
 			isAppend := strings.HasSuffix(k, "+")
 			k = strings.TrimSuffix(k, "+")
 
@@ -304,10 +303,10 @@ func readConfigFile(file string) (result []string, _ error) {
 
 		if slice, ok := v.([]any); ok {
 			for _, v := range slice {
-				result = append(result, prefix+k+"="+convert.ToString(v))
+				result = append(result, prefix+k+"="+ToString(v))
 			}
 		} else {
-			str := convert.ToString(v)
+			str := ToString(v)
 			result = append(result, prefix+k+"="+str)
 		}
 	}
@@ -322,7 +321,7 @@ func toSlice(v any) []any {
 	case []any:
 		return k
 	default:
-		str := strings.TrimSpace(convert.ToString(v))
+		str := strings.TrimSpace(ToString(v))
 		if str == "" {
 			return nil
 		}

--- a/pkg/proctitle/proctile.go
+++ b/pkg/proctitle/proctile.go
@@ -6,6 +6,4 @@ import (
 	"github.com/erikdubbelboer/gspt"
 )
 
-func SetProcTitle(cmd string) {
-	gspt.SetProcTitle(cmd)
-}
+var SetProcTitle = gspt.SetProcTitle


### PR DESCRIPTION
#### Proposed Changes ####

* Tidy dockerfile and build stages
  Explicitly call buildx build, and reduce build steps.
  Improves layer reuse when rebuilding
* Drop wrangler import from configfilearg parser
  Saves several MB out of the self-extracting binary by dropping import of wrangler and meta/v1
  ```
  # go build -o dist/artifacts/k3s ./cmd/k3s/
  -rwxrwxr-x 1 brandond brandond 17923360 Aug 13 19:26 dist/artifacts/k3s  # before
  -rwxrwxr-x 1 brandond brandond 13466720 Aug 13 19:25 dist/artifacts/k3s  # after
  ```

#### Types of Changes ####

dev/ci

#### Verification ####

* `make image` locally; note that initial build stages from cache are reused instead of being rebuilt every time.
* note k3s binary size is reduced

#### Testing ####


#### Linked Issues ####


#### User-Facing Change ####
```release-note
```

#### Further Comments ####
