### PR TITLE
Use github.com/otiai10/copy for copy from tarfile

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -248,17 +248,24 @@ func stageAndRun(dataDir, cmd string, args []string, calledAsInternal bool) erro
 
 // getAssetAndDir returns the name of the bindata asset, along with a directory path
 // derived from the data-dir and bindata asset name.
-func getAssetAndDir(dataDir string) (string, string) {
-	asset := data.AssetNames()[0]
+func getAssetAndDir(dataDir string) (string, string, error) {
+	names := data.AssetNames()
+	if len(names) == 0 {
+		return "", "", errors.New("embedded data assets not found")
+	}
+	asset := names[0]
 	dir := filepath.Join(dataDir, "data", strings.SplitN(filepath.Base(asset), ".", 2)[0])
-	return asset, dir
+	return asset, dir, nil
 }
 
 // extract checks for and if necessary unpacks the bindata archive, returning the unique path
 // to the extracted bindata asset.
 func extract(dataDir string) (string, error) {
 	// check if content already exists in requested data-dir
-	asset, dir := getAssetAndDir(dataDir)
+	asset, dir, err := getAssetAndDir(dataDir)
+	if err != nil {
+		return "", err
+	}
 	if _, err := os.Stat(filepath.Join(dir, "bin", "k3s"+programPostfix)); err == nil {
 		return dir, nil
 	}
@@ -267,7 +274,10 @@ func extract(dataDir string) (string, error) {
 	// to extracting. This will prevent re-extracting into the user's home
 	// dir if the assets already exist in the default path.
 	if dataDir != datadir.DefaultDataDir {
-		_, defaultDir := getAssetAndDir(datadir.DefaultDataDir)
+		_, defaultDir, err := getAssetAndDir(datadir.DefaultDataDir)
+		if err != nil {
+			return "", err
+		}
 		if _, err := os.Stat(filepath.Join(defaultDir, "bin", "k3s"+programPostfix)); err == nil {
 			return defaultDir, nil
 		}

--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,7 @@ require (
 	github.com/moby/sys/userns v0.1.0
 	github.com/mwitkow/go-http-dialer v0.0.0-20161116154839-378f744fb2b8
 	github.com/natefinch/lumberjack v2.0.0+incompatible
+	github.com/nlepage/go-tarfs v1.2.1
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/opencontainers/cgroups v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -1482,6 +1482,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20200213170602-2833bce08e4c/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
+github.com/nlepage/go-tarfs v1.2.1 h1:o37+JPA+ajllGKSPfy5+YpsNHDjZnAoyfvf5GsUa+Ks=
+github.com/nlepage/go-tarfs v1.2.1/go.mod h1:rno18mpMy9aEH1IiJVftFsqPyIpwqSUiAOpJYjlV2NA=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=

--- a/pkg/untar/untar.go
+++ b/pkg/untar/untar.go
@@ -6,23 +6,15 @@
 package untar
 
 import (
-	"archive/tar"
-	"fmt"
 	"io"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
 
+	"github.com/k3s-io/k3s/pkg/util/errors"
 	"github.com/klauspost/compress/zstd"
-	"github.com/rancher/wharfie/pkg/tarfile"
-	"github.com/sirupsen/logrus"
+	"github.com/nlepage/go-tarfs"
+	"github.com/otiai10/copy"
 )
 
-// TODO(bradfitz): this was copied from x/build/cmd/buildlet/buildlet.go
-// but there were some buildlet-specific bits in there, so the code is
-// forked for now.  Unfork and add some opts arguments here, so the
-// buildlet can use this code somehow.
+const MaxDecoderMemory = uint64(1 << 25)
 
 // Untar reads the zstd-compressed tar file from r and writes it into dir.
 func Untar(r io.Reader, dir string) error {
@@ -30,105 +22,22 @@ func Untar(r io.Reader, dir string) error {
 }
 
 func untar(r io.Reader, dir string) (err error) {
-	t0 := time.Now()
-	nFiles := 0
-	madeDir := map[string]bool{}
-	defer func() {
-		td := time.Since(t0)
-		if err != nil {
-			logrus.Printf("error extracting tarball into %s after %d files, %d dirs, %v: %v", dir, nFiles, len(madeDir), td, err)
-		}
-	}()
-	zr, err := zstd.NewReader(r, zstd.WithDecoderMaxMemory(tarfile.MaxDecoderMemory))
+	zr, err := zstd.NewReader(r, zstd.WithDecoderMaxMemory(MaxDecoderMemory))
 	if err != nil {
-		return fmt.Errorf("error extracting zstd-compressed body: %v", err)
+		return errors.WithMessage(err, "failed to extract zstd-compressed body")
 	}
 	defer zr.Close()
-	tr := tar.NewReader(zr)
-	loggedChtimesError := false
-	for {
-		f, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			logrus.Printf("tar reading error: %v", err)
-			return fmt.Errorf("tar error: %v", err)
-		}
-		if !validRelPath(f.Name) {
-			return fmt.Errorf("tar contained invalid name error %q", f.Name)
-		}
-		rel := filepath.FromSlash(f.Name)
-		abs := filepath.Join(dir, rel)
-
-		fi := f.FileInfo()
-		mode := fi.Mode()
-		switch {
-		case mode.IsRegular():
-			// Make the directory. This is redundant because it should
-			// already be made by a directory entry in the tar
-			// beforehand. Thus, don't check for errors; the next
-			// write will fail with the same error.
-			dir := filepath.Dir(abs)
-			if !madeDir[dir] {
-				if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
-					return err
-				}
-				madeDir[dir] = true
-			}
-			wf, err := os.OpenFile(abs, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm())
-			if err != nil {
-				return err
-			}
-			n, err := io.Copy(wf, tr)
-			if closeErr := wf.Close(); closeErr != nil && err == nil {
-				err = closeErr
-			}
-			if err != nil {
-				return fmt.Errorf("error writing to %s: %v", abs, err)
-			}
-			if n != f.Size {
-				return fmt.Errorf("only wrote %d bytes to %s; expected %d", n, abs, f.Size)
-			}
-			modTime := f.ModTime
-			if modTime.After(t0) {
-				// Clamp modtimes at system time. See
-				// golang.org/issue/19062 when clock on
-				// buildlet was behind the gitmirror server
-				// doing the git-archive.
-				modTime = t0
-			}
-			if !modTime.IsZero() {
-				if err := os.Chtimes(abs, modTime, modTime); err != nil && !loggedChtimesError {
-					// benign error. Gerrit doesn't even set the
-					// modtime in these, and we don't end up relying
-					// on it anywhere (the gomote push command relies
-					// on digests only), so this is a little pointless
-					// for now.
-					logrus.Printf("error changing modtime: %v (further Chtimes errors suppressed)", err)
-					loggedChtimesError = true // once is enough
-				}
-			}
-			nFiles++
-		case mode.IsDir():
-			if err := os.MkdirAll(abs, 0755); err != nil {
-				return err
-			}
-			madeDir[abs] = true
-		case f.Linkname != "":
-			if err := os.Symlink(f.Linkname, abs); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("tar file entry %s contained unsupported file type %v", f.Name, mode)
-		}
+	tfs, err := tarfs.New(zr)
+	if err != nil {
+		return errors.WithMessage(err, "failed to open tar reader")
 	}
-	return nil
-}
-
-func validRelPath(p string) bool {
-	if p == "" || strings.Contains(p, `\`) || strings.HasPrefix(p, "/") || strings.Contains(p, "../") {
-		return false
-	}
-	return true
+	err = copy.Copy(".", dir, copy.Options{
+		PermissionControl: copy.AddPermission(0755),
+		PreserveOwner:     false,
+		PreserveTimes:     false,
+		NumOfWorkers:      0,
+		Sync:              true,
+		FS:                tfs,
+	})
+	return errors.WithMessage(err, "failed to copy files")
 }


### PR DESCRIPTION
#### Proposed Changes ####

Drop wharfie import in pkg/untar and use `otiai10/copy` instead of bespoke file copy
 
We are already using this library for file handling elsewhere (pkg/etcd/store), we should also use it here instead of maintaining our own tar extraction code that was originally cribbed from god knows where.

Blocked on:
* https://github.com/nlepage/go-tarfs/issues/23
* https://github.com/otiai10/copy/issues/177

#### Types of Changes ####

chore

#### Verification ####


#### Testing ####


#### Linked Issues ####


#### User-Facing Change ####
```release-note
```

#### Further Comments ####