### PR TITLE
Add advertise-address to SANs before generating apiserver cert

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -552,6 +552,14 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		}
 	}
 
+	// if we ended up with any advertise-ips, ensure they're added to the SAN list
+	// before PrepareServer generates the apiserver serving certificate;
+	// note that kube-apiserver does not support dual-stack advertise-ip as of 1.21.0:
+	// https://github.com/kubernetes/kubeadm/issues/1612#issuecomment-772583989
+	if serverConfig.ControlConfig.AdvertiseIP != "" {
+		serverConfig.ControlConfig.SANs = append(serverConfig.ControlConfig.SANs, serverConfig.ControlConfig.AdvertiseIP)
+	}
+
 	if err := server.PrepareServer(ctx, wg, &serverConfig, cfg); err != nil {
 		return err
 	}
@@ -626,13 +634,6 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		if err := agent.Run(ctx, wg, agentConfig); err != nil {
 			return err
 		}
-	}
-
-	// if we ended up with any advertise-ips, ensure they're added to the SAN list;
-	// note that kube-apiserver does not support dual-stack advertise-ip as of 1.21.0:
-	// https://github.com/kubernetes/kubeadm/issues/1612#issuecomment-772583989
-	if serverConfig.ControlConfig.AdvertiseIP != "" {
-		serverConfig.ControlConfig.SANs = append(serverConfig.ControlConfig.SANs, serverConfig.ControlConfig.AdvertiseIP)
 	}
 
 	go cmds.WriteCoverage(ctx)

--- a/tests/integration/startup/startup_int_test.go
+++ b/tests/integration/startup/startup_int_test.go
@@ -203,6 +203,11 @@ var _ = Describe("startup tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(apiInfo).To(ContainSubstring("11.11.22.22"))
 		})
+		It("has the advertise ip in the apiserver serving cert SANs", func() {
+			cert, err := testutil.RunCommand("openssl x509 -noout -text -in /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cert).To(ContainSubstring("IP Address:11.11.22.22"))
+		})
 		It("dies cleanly", func() {
 			Expect(testutil.K3sKillServer(startupServer)).To(Succeed())
 			Expect(testutil.K3sCleanup(-1, "")).To(Succeed())


### PR DESCRIPTION
#### Proposed Changes ####

Move the advertise-address SAN append so it runs before `PrepareServer`, which is what generates the apiserver serving certificate.

The block sat 79 lines after `PrepareServer`, so by the time the address was appended the certificate had already been issued without it. That is why `--advertise-address` stopped showing up in `serving-kube-apiserver.crt`.

On the concern raised in the issue about Tailscale: agent startup no longer changes `AdvertiseIP` after this point. Every assignment to it lives in `pkg/cli/server/server.go` (lines 179, 526, 537, 546, 551) and all of them complete before `PrepareServer` at line 555. The VPN block that sets it from Tailscale is at line 518, also before. Outside this file `AdvertiseIP` is only read, in `pkg/daemons/control/server.go:230-231`. `vpn.GetInfoFromExecutor()` reads from `executor.Get()`, which #14000 made an explicit setup step that runs before anything else, so it does not depend on `agent.Run` having started.

I also updated the comment, which described the old ordering constraint.

#### Types of Changes ####

Bugfix.

#### Verification ####

Start a server with an advertise address and check the cert:

```
k3s server --advertise-address=11.11.22.22
openssl x509 -in /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt -noout -text | grep 11.11.22.22
```

After this change the address is present in the Subject Alternative Name list. The reporter ran the same check on v1.36.3-rc1+k3s1 and the grep found nothing there.

#### Testing ####

Added a case to the existing `--advertise-address` startup integration test that checks the address landed in the apiserver serving cert SANs. It follows the same steps the issue reporter used.

Ran the startup suite locally against a binary built from this branch:

```
Ran 27 of 60 Specs in 382.652 seconds
```

The `when a server with different IPs is created` group passed, including the new spec. One unrelated spec (`when a server with different data-dir is created`) failed in my setup with a cert trust error, an artifact of running the suite in a container with a persistent `/var/lib/rancher` volume rather than on a clean runner.

#### Linked Issues ####

Issue: #14473
Related refactors: #14000, and commit fb658b45a09b19d5b02002bb595cf3838cdfaaf7

#### User-Facing Change ####
```release-note
Fixed the apiserver serving certificate not including the value of --advertise-address in its subject alternative names.
```

#### Further Comments ####

I used Claude Code while preparing this PR, for the source audit of `AdvertiseIP` assignments and for a first draft of the test case. I went through the change and ran the startup integration suite against a binary built from this branch before opening this.
