### PR TITLE
Prevent systemd restart loop when no default route is present by waiting 60 seconds for default route to appear

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -453,7 +453,7 @@ func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.N
 		return nil, errors.WithMessage(err, "failed to retrieve configuration from server")
 	}
 
-	nodeName, nodeIPs, err := util.GetHostnameAndIPs(envInfo.NodeName, envInfo.NodeIP.Value())
+	nodeName, nodeIPs, err := util.GetHostnameAndIPs(ctx, envInfo.NodeName, envInfo.NodeIP.Value())
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to get node name and addresses")
 	}

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -328,7 +328,7 @@ func createProxyAndValidateToken(ctx context.Context, cfg *cmds.Agent) (proxy.Pr
 		return nil, err
 	}
 
-	_, nodeIPs, err := util.GetHostnameAndIPs(cfg.NodeName, cfg.NodeIP.Value())
+	_, nodeIPs, err := util.GetHostnameAndIPs(ctx, cfg.NodeName, cfg.NodeIP.Value())
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to get node name and addresses")
 	}

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -291,7 +291,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	// Ensure that we add the localhost name/ip and node name/ip to the SAN list. This list is shared by the
 	// certs for the supervisor, kube-apiserver cert, and etcd. DNS entries for the in-cluster kubernetes
 	// service endpoint are added later when the certificates are created.
-	nodeName, nodeIPs, err := util.GetHostnameAndIPs(cmds.AgentConfig.NodeName, cmds.AgentConfig.NodeIP.Value())
+	nodeName, nodeIPs, err := util.GetHostnameAndIPs(ctx, cmds.AgentConfig.NodeName, cmds.AgentConfig.NodeIP.Value())
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -125,7 +125,7 @@ func (c *Cluster) startEtcdProxy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	_, nodeIPs, err := util.GetHostnameAndIPs(cmds.AgentConfig.NodeName, cmds.AgentConfig.NodeIP.Value())
+	_, nodeIPs, err := util.GetHostnameAndIPs(ctx, cmds.AgentConfig.NodeName, cmds.AgentConfig.NodeIP.Value())
 	if err != nil {
 		return errors.WithMessage(err, "failed to get node name and addresses")
 	}

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -84,7 +84,7 @@ func (c *Cluster) registerDBHandlers(handler http.Handler) (http.Handler, error)
 func (c *Cluster) assignManagedDriver(ctx context.Context) error {
 	// Check all managed drivers for an initialized database on disk; use one if found
 	for _, driver := range managed.Registered() {
-		if err := driver.SetControlConfig(c.config); err != nil {
+		if err := driver.SetControlConfig(ctx, c.config); err != nil {
 			return err
 		}
 		if ok, err := driver.IsInitialized(); err != nil {

--- a/pkg/cluster/managed/drivers.go
+++ b/pkg/cluster/managed/drivers.go
@@ -14,7 +14,7 @@ var (
 )
 
 type Driver interface {
-	SetControlConfig(config *config.Control) error
+	SetControlConfig(ctx context.Context, config *config.Control) error
 	IsInitialized() (bool, error)
 	Register(handler http.Handler) (http.Handler, error)
 	Reset(ctx context.Context, wg *sync.WaitGroup, reboostrap func() error) error

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -55,7 +55,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -880,11 +879,13 @@ func toTLSConfig(runtime *config.ControlRuntime) (*tls.Config, error) {
 	}, nil
 }
 
-// getAdvertiseAddress returns the IP address best suited for advertising to clients
+// getAdvertiseAddress returns the IP address best suited for advertising to clients.
+// When no advertise IP is configured, it uses ChooseHostInterfaceWithRetry to
+// wait for a default network route to become available during startup.
 func getAdvertiseAddress(advertiseIP string) (string, error) {
 	ip := advertiseIP
 	if ip == "" {
-		ipAddr, err := utilnet.ChooseHostInterface()
+		ipAddr, err := util.ChooseHostInterfaceWithRetry()
 		if err != nil {
 			return "", err
 		}

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -174,14 +174,14 @@ func (e *ETCD) EndpointName() string {
 
 // SetControlConfig passes the cluster config into the etcd datastore. This is necessary
 // because the config may not yet be fully built at the time the Driver instance is registered.
-func (e *ETCD) SetControlConfig(config *config.Control) error {
+func (e *ETCD) SetControlConfig(ctx context.Context, config *config.Control) error {
 	if e.config != nil {
 		return errors.New("control config already set")
 	}
 
 	e.config = config
 
-	address, err := getAdvertiseAddress(e.config.PrivateIP)
+	address, err := getAdvertiseAddress(ctx, e.config.PrivateIP)
 	if err != nil {
 		return err
 	}
@@ -880,12 +880,12 @@ func toTLSConfig(runtime *config.ControlRuntime) (*tls.Config, error) {
 }
 
 // getAdvertiseAddress returns the IP address best suited for advertising to clients.
-// When no advertise IP is configured, it uses ChooseHostInterfaceWithRetry to
+// When no advertise IP is configured, it uses ChooseHostInterfaceWithContext to
 // wait for a default network route to become available during startup.
-func getAdvertiseAddress(advertiseIP string) (string, error) {
+func getAdvertiseAddress(ctx context.Context, advertiseIP string) (string, error) {
 	ip := advertiseIP
 	if ip == "" {
-		ipAddr, err := util.ChooseHostInterfaceWithRetry()
+		ipAddr, err := util.ChooseHostInterfaceWithContext(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -1461,7 +1461,7 @@ func ClientURLs(ctx context.Context, clientAccessInfo *clientaccess.Info, selfIP
 	var memberList Members
 
 	// find the address advertised for our own client URL, so that we don't connect to ourselves
-	ip, err := getAdvertiseAddress(selfIP)
+	ip, err := getAdvertiseAddress(ctx, selfIP)
 	if err != nil {
 		return nil, memberList, err
 	}

--- a/pkg/etcd/etcd_linux_test.go
+++ b/pkg/etcd/etcd_linux_test.go
@@ -145,7 +145,7 @@ func Test_UnitETCD_IsInitialized(t *testing.T) {
 				t.Errorf("Prep for ETCD.IsInitialized() failed = %v", err)
 				return
 			}
-			if err := e.SetControlConfig(context.TODO(), tt.args.config); err != nil {
+			if err := e.SetControlConfig(t.Context(), tt.args.config); err != nil {
 				t.Errorf("ETCD.SetControlConfig() failed= %v", err)
 				return
 			}
@@ -226,7 +226,7 @@ func Test_UnitETCD_Register(t *testing.T) {
 				t.Errorf("Setup for ETCD.Register() failed = %v", err)
 				return
 			}
-			if err := e.SetControlConfig(context.TODO(), tt.args.config); err != nil {
+			if err := e.SetControlConfig(t.Context(), tt.args.config); err != nil {
 				t.Errorf("ETCD.SetControlConfig() failed = %v", err)
 				return
 			}

--- a/pkg/etcd/etcd_linux_test.go
+++ b/pkg/etcd/etcd_linux_test.go
@@ -145,7 +145,7 @@ func Test_UnitETCD_IsInitialized(t *testing.T) {
 				t.Errorf("Prep for ETCD.IsInitialized() failed = %v", err)
 				return
 			}
-			if err := e.SetControlConfig(tt.args.config); err != nil {
+			if err := e.SetControlConfig(context.TODO(), tt.args.config); err != nil {
 				t.Errorf("ETCD.SetControlConfig() failed= %v", err)
 				return
 			}
@@ -226,7 +226,7 @@ func Test_UnitETCD_Register(t *testing.T) {
 				t.Errorf("Setup for ETCD.Register() failed = %v", err)
 				return
 			}
-			if err := e.SetControlConfig(tt.args.config); err != nil {
+			if err := e.SetControlConfig(context.TODO(), tt.args.config); err != nil {
 				t.Errorf("ETCD.SetControlConfig() failed = %v", err)
 				return
 			}

--- a/pkg/executor/embed/embed.go
+++ b/pkg/executor/embed/embed.go
@@ -91,7 +91,7 @@ func New(ctx context.Context, cfg *cmds.Agent) (*Embedded, error) {
 		}
 
 		// Pass ipv4, ipv6 or both depending on nodeIPs mode
-		_, nodeIPs, err := util.GetHostnameAndIPs(cfg.NodeName, util.SplitStringSlice(cfg.NodeIP.Value()))
+		_, nodeIPs, err := util.GetHostnameAndIPs(ctx, cfg.NodeName, util.SplitStringSlice(cfg.NodeIP.Value()))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -133,20 +133,15 @@ func JoinIP6Nets(elems []*net.IPNet) string {
 	return strings.Join(strs, ",")
 }
 
-// ChooseHostInterfaceWithRetry wraps ChooseHostInterfaceWithContext with a default context.
-func ChooseHostInterfaceWithRetry() (net.IP, error) {
-	return ChooseHostInterfaceWithContext(context.TODO())
-}
-
 // ChooseHostInterfaceWithContext wraps apinet.ChooseHostInterface with a retry loop
 // that waits for a default network route to become available during startup.
 func ChooseHostInterfaceWithContext(ctx context.Context) (net.IP, error) {
 	var ip net.IP
+	var lastErr error
 	first := true
 	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
-		var err error
-		ip, err = apinet.ChooseHostInterface()
-		if err == nil {
+		ip, lastErr = apinet.ChooseHostInterface()
+		if lastErr == nil {
 			return true, nil
 		}
 		if first {
@@ -156,6 +151,9 @@ func ChooseHostInterfaceWithContext(ctx context.Context) (net.IP, error) {
 		return false, nil
 	})
 	if err != nil {
+		if lastErr != nil {
+			return nil, lastErr
+		}
 		return nil, err
 	}
 	return ip, nil
@@ -166,10 +164,10 @@ func ChooseHostInterfaceWithContext(ctx context.Context) (net.IP, error) {
 // the system hostname and primary interface addresses are returned instead.
 // When no node IPs are provided and the host has no default route yet,
 // the lookup is retried until a route becomes available or the timeout is reached.
-func GetHostnameAndIPs(name string, nodeIPs []string) (string, []net.IP, error) {
+func GetHostnameAndIPs(ctx context.Context, name string, nodeIPs []string) (string, []net.IP, error) {
 	ips := []net.IP{}
 	if len(nodeIPs) == 0 {
-		hostIP, err := ChooseHostInterfaceWithRetry()
+		hostIP, err := ChooseHostInterfaceWithContext(ctx)
 		if err != nil {
 			return "", nil, err
 		}

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -150,13 +150,7 @@ func ChooseHostInterfaceWithContext(ctx context.Context) (net.IP, error) {
 		}
 		return false, nil
 	})
-	if err != nil {
-		if lastErr != nil {
-			return nil, lastErr
-		}
-		return nil, err
-	}
-	return ip, nil
+	return ip, errors.Join(err, lastErr)
 }
 
 // GetHostnameAndIPs takes a node name and list of IPs, usually from CLI args.

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	apinet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
 	netutils "k8s.io/utils/net"
 )
 
@@ -132,13 +133,43 @@ func JoinIP6Nets(elems []*net.IPNet) string {
 	return strings.Join(strs, ",")
 }
 
+// ChooseHostInterfaceWithRetry wraps ChooseHostInterfaceWithContext with a default context.
+func ChooseHostInterfaceWithRetry() (net.IP, error) {
+	return ChooseHostInterfaceWithContext(context.TODO())
+}
+
+// ChooseHostInterfaceWithContext wraps apinet.ChooseHostInterface with a retry loop
+// that waits for a default network route to become available during startup.
+func ChooseHostInterfaceWithContext(ctx context.Context) (net.IP, error) {
+	var ip net.IP
+	first := true
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+		var err error
+		ip, err = apinet.ChooseHostInterface()
+		if err == nil {
+			return true, nil
+		}
+		if first {
+			logrus.Infof("Waiting for default network route to become available...")
+			first = false
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ip, nil
+}
+
 // GetHostnameAndIPs takes a node name and list of IPs, usually from CLI args.
 // If set, these are used to return the node's name and addresses. If not set,
 // the system hostname and primary interface addresses are returned instead.
+// When no node IPs are provided and the host has no default route yet,
+// the lookup is retried until a route becomes available or the timeout is reached.
 func GetHostnameAndIPs(name string, nodeIPs []string) (string, []net.IP, error) {
 	ips := []net.IP{}
 	if len(nodeIPs) == 0 {
-		hostIP, err := apinet.ChooseHostInterface()
+		hostIP, err := ChooseHostInterfaceWithRetry()
 		if err != nil {
 			return "", nil, err
 		}

--- a/tests/docker/network/network_test.go
+++ b/tests/docker/network/network_test.go
@@ -1,0 +1,87 @@
+package network
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/k3s-io/k3s/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var k3sImage = flag.String("k3sImage", "rancher/k3s:latest", "The image used to provision containers")
+
+func Test_DockerNetwork(t *testing.T) {
+	flag.Parse()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Network Docker Test Suite")
+}
+
+var _ = Describe("Network Tests", Ordered, func() {
+	Context("Verify startup with temporarily missing default route", func() {
+		var containerName string
+
+		It("Starts K3s with default route removed", func() {
+			containerName = "k3s-network-test"
+			
+			// Get path to locally compiled binary directory
+			pwd, _ := os.Getwd()
+			artifactDir := filepath.Join(pwd, "..", "..", "..", "dist", "artifacts")
+			
+			// Clean up any lingering container from past test runs
+			tests.RunCommand(fmt.Sprintf("docker rm -f %s", containerName))
+
+			// Boot K3s container, removing the default route before K3s starts.
+			dRun := strings.Join([]string{"docker run -d",
+				"--name", containerName,
+				"--hostname", containerName,
+				"--privileged",
+				"-e K3S_DEBUG=true",
+				fmt.Sprintf("--mount type=bind,source=%s,target=/opt/artifacts", artifactDir),
+				"--entrypoint sh",
+				*k3sImage,
+				"-c",
+				`"ip route del default && /opt/artifacts/k3s server"`}, " ")
+
+			out, err := tests.RunCommand(dRun)
+			Expect(err).NotTo(HaveOccurred(), "failed to run server container: %s", out)
+		})
+
+		It("Verifies the retry loop is active and waiting", func() {
+			// Instead of crashing instantly, it should hold in your retry loop
+			Eventually(func() (string, error) {
+				return tests.RunCommand(fmt.Sprintf("docker logs %s", containerName))
+			}, "20s", "2s").Should(ContainSubstring("Waiting for default network route to become available..."))
+		})
+
+		It("Restores the network dynamically", func() {
+			// Find the default gateway for this container from docker inspect
+			inspectCmd := fmt.Sprintf("docker inspect --format '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' %s", containerName)
+			gateway, err := tests.RunCommand(inspectCmd)
+			Expect(err).NotTo(HaveOccurred(), "failed to get gateway: %s", gateway)
+			gateway = strings.Trim(strings.TrimSpace(gateway), "'")
+
+			// Restore the default route dynamically while the container is running
+			addRouteCmd := fmt.Sprintf("docker exec %s ip route add default via %s dev eth0", containerName, gateway)
+			out, err := tests.RunCommand(addRouteCmd)
+			Expect(err).NotTo(HaveOccurred(), "failed to restore default route: %s", out)
+		})
+
+		It("Verifies K3s recovers and successfully starts up", func() {
+			// We query the nodes directly from within the container using our local binary
+			Eventually(func() (string, error) {
+				cmd := fmt.Sprintf("docker exec %s /opt/artifacts/k3s kubectl get nodes", containerName)
+				return tests.RunCommand(cmd)
+			}, "120s", "5s").Should(ContainSubstring("Ready"))
+		})
+
+		It("Cleans up the container", func() {
+			_, err := tests.RunCommand(fmt.Sprintf("docker rm -f %s", containerName))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
#### Proposed Changes

This PR addresses #13895, where K3s can fail during startup when a default network route is not yet available.

The change makes host interface detection wait for the network route to become available instead of immediately returning an error. The retry uses the existing Kubernetes `wait.PollUntilContextTimeout` mechanism and checks every 5 seconds for up to 60 seconds.

The retry behavior is centralized in `pkg/util/net.go` and reused by `getAdvertiseAddress` in `pkg/etcd/etcd.go`. The change to `pkg/daemons/config/types.go` from the previous implementation has been reverted because `BindAddressOrLoopback` already handles the missing route case through its existing loopback fallback.

#### Types of Changes

Bugfix

#### Verification

The behavior is tested with a Docker E2E test that:

1. Starts K3s without a default route.
2. Verifies that K3s waits for the route to become available.
3. Restores the default route inside the container.
4. Verifies that K3s continues startup and the node becomes Ready.

#### Testing

* Docker E2E test for the missing default-route scenario.
* Verified the retry behavior and recovery after the route is restored.
* Existing tests for the affected networking functionality continue to pass.

#### Linked Issues

#13895

Alternative to #14420

#### User-Facing Change

```release-note
K3s now waits for a default network route to become available during host interface detection instead of immediately failing when the route is temporarily unavailable.
```

#### AI Usage

I used AI tools during the development of this PR to help explore the codebase, discuss possible implementation approaches, and assist with parts of the implementation. I reviewed the changes, made the final implementation decisions, and tested the resulting changes myself.
