### PR TITLE
Enable seccomp in riscv64 builds

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -81,12 +81,6 @@ case ${OS} in
       TAGS="$TAGS selinux"
       RUNC_TAGS="$RUNC_TAGS selinux"
     fi
-
-    # runc's vendored libseccomp-golang can fail on riscv64 with duplicate
-    # C_ARCH_* switch cases when the seccomp build tag is enabled.
-    if [ "${ARCH}" = "riscv64" ]; then
-      RUNC_TAGS="${RUNC_TAGS/seccomp/}"
-    fi
     ;;
   windows)
     TAGS="$TAGS no_cri_dockerd"


### PR DESCRIPTION
#### Proposed Changes ####

For some reason, when building runc on `riscv64`, seccomp is disabled (perhaps this was necessary with some previous version of runc or RISC-V build container). Disabling seccomp produces errors when trying to run pods using the default configuration.

#### Types of Changes ####

I have just removed the lines that disable seccomp in `riscv64` builds. The change is only in the build script.

#### Verification ####

I have verified the change by building and running K3s in a RISC-V QEMU VM. (Running also requires changing some container images used to ones supporting the architecture; details [here](https://github.com/CARV-ICS-FORTH/kubernetes-riscv64), I have already opened relevant PRs in respective projects.)

#### Testing ####

N/A

#### Linked Issues ####

RISC-V support is discussed in #7151.

#### User-Facing Change ####
```release-note
NONE
```

#### Further Comments ####

N/A