### PR TITLE
Use ginkgo CLI to run tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -75,6 +75,8 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with: {fetch-depth: 1}
+      - name: Install Go
+        uses: ./.github/actions/setup-go
       - name: Set up Docker
         uses: docker/setup-docker-action@6d7cfa65f60a9dda7b46e5513fa982536f3c9877 # v5.3.0
         with:
@@ -120,8 +122,6 @@ jobs:
               vagrant plugin install "${plugin}"
             fi
           done
-      - name: Install Go
-        uses: ./.github/actions/setup-go
       - name: "Download k3s binary"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -129,16 +129,16 @@ jobs:
           path: ./dist/artifacts
       - name: Install kubectl from K3s artifacts
         run: |
+          chmod +x ./dist/artifacts/k3s
           sudo install -o root -g root -m 0755 ./dist/artifacts/bin-k3s /usr/local/bin/k3s
           sudo ln -sf /usr/local/bin/k3s /usr/local/bin/kubectl
       - name: Run ${{ matrix.etest }} Test
         env:
           E2E_GOCOVER: "true"
-        run: | 
-          chmod +x ./dist/artifacts/k3s
+        run: |
           mkdir -p /tmp/k3scov
-          cd tests/e2e/${{ matrix.etest }}
-          go test -timeout=45m ./${{ matrix.etest }}_test.go -test.v -ginkgo.v -ci -local
+          go install github.com/onsi/ginkgo/v2/ginkgo@$(. ./scripts/version.sh; get-module-version github.com/onsi/ginkgo/v2)
+          ginkgo run -v -timeout=45m ./tests/e2e/${{ matrix.etest }}/ -- -ci -local
       - name: On Failure, Upload Journald Logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ failure() }}
@@ -160,48 +160,8 @@ jobs:
           flags: e2etests # optional
           verbose: true # optional (default = false)
   
-  build-go-tests:
-    name: "Build Go Tests"
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
-    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
-    outputs:
-      channel: ${{ steps.channel_step.outputs.channel }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-    - name: Install Go
-      uses: ./.github/actions/setup-go
-    - name: Build Go Tests
-      run: |
-        mkdir -p ./dist/artifacts
-        go test -c -ldflags="-w -s" -o ./dist/artifacts ./tests/docker/...
-    - name: Upload Go Tests
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: docker-go-tests-${{ matrix.arch }}
-        path: ./dist/artifacts/*.test
-        compression-level: 9
-        retention-days: 1
-    # For upgrade and skew tests, we need to know the channel this run is based off.
-    # Since this is predetermined, we can run this step before the actual test job, saving time.
-    - name: Determine channel
-      id: channel_step
-      run: |
-        . ./scripts/version.sh
-        MINOR_VER=$(echo $VERSION_TAG | cut -d'.' -f1,2)
-        echo "CHANNEL=$MINOR_VER" >> $GITHUB_OUTPUT 
-    # channel name should be v1.XX or latest
-    - name: Fail if channel name does not match pattern
-      run: |
-        if [[ ! ${{ steps.channel_step.outputs.channel }} =~ ^v1\.[0-9]+$|latest$ ]]; then
-          echo "Channel name ${{ steps.channel_step.outputs.channel }} does not match pattern"
-          exit 1
-        fi
-  
   docker-go:
-    needs: [build, build-arm64, build-go-tests]
+    needs: [build, build-arm64]
     name: Docker
     timeout-minutes: 45
     strategy:
@@ -223,8 +183,6 @@ jobs:
           - dtest: svcpoliciesandfirewall
             arch: arm64
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
-    env:
-      CHANNEL: ${{ needs.build-go-tests.outputs.channel }}
     steps:
     - name: Remove Unnecessary Tools
       working-directory: /
@@ -247,6 +205,8 @@ jobs:
         df -khl
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Install Go
+      uses: ./.github/actions/setup-go
     - name: "Download K3s image"
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
@@ -277,30 +237,24 @@ jobs:
       run: |
         nix build github:pdtpartners/nix-snapshotter#image-hello
         cp result ./tests/docker/resources/nix-hello-image.tar
-    - name: Download Go Tests
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-      with:
-        name: docker-go-tests-${{ matrix.arch }}
-        path: ./dist/artifacts
-    - name: Run ${{ matrix.dtest }} Test
-      # Put the compiled test binary back in the same place as the test source
+    - name: Determine channel
       run: |
-        chmod +x ./dist/artifacts/${{ matrix.dtest }}.test
-        mv ./dist/artifacts/${{ matrix.dtest }}.test ./tests/docker/${{ matrix.dtest }}/
-        cd ./tests/docker/${{ matrix.dtest }}
-        
+        echo CHANNEL=$(. ./scripts/version.sh; echo $VERSION_K8S | cut -d'.' -f1,2) >> $GITHUB_ENV
+    - name: Run ${{ matrix.dtest }} Test
+      run: |
+        go install github.com/onsi/ginkgo/v2/ginkgo@$(. ./scripts/version.sh; get-module-version github.com/onsi/ginkgo/v2)
         # These tests use rancher/systemd-node and have different flags.
         CI_TESTS="autoimport dualstack hardened secretsencryption snapshotrestore svcpoliciesandfirewall token"
         if [ ${{ matrix.dtest }} = "upgrade" ] || [ ${{ matrix.dtest }} = "skew" ]; then
-          ./${{ matrix.dtest }}.test -test.timeout=0 -test.v -ginkgo.v -k3sImage=$K3S_IMAGE -channel=$CHANNEL
+          ginkgo run -v -timeout=0 ./tests/docker/${{ matrix.dtest }}/ -- -k3sImage=$K3S_IMAGE -channel=$CHANNEL
         elif [[ $CI_TESTS =~ ${{ matrix.dtest }} ]]; then
-          ./${{ matrix.dtest }}.test -test.timeout=0 -test.v -ginkgo.v -ci
+          ginkgo run -v -timeout=0 ./tests/docker/${{ matrix.dtest }}/ -- -ci
         else
-          ./${{ matrix.dtest }}.test -test.timeout=0 -test.v -ginkgo.v -k3sImage=$K3S_IMAGE
+          ginkgo run -v -timeout=0 ./tests/docker/${{ matrix.dtest }}/ -- -k3sImage=$K3S_IMAGE
         fi
 
   docker-large:
-    needs: [build, build-go-tests]
+    needs: build
     name: Docker Large
     timeout-minutes: 45
     runs-on: cncf-ubuntu-32-128-x86
@@ -308,6 +262,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Install Go
+      uses: ./.github/actions/setup-go
     - name: Set up Docker
       uses: docker/setup-docker-action@6d7cfa65f60a9dda7b46e5513fa982536f3c9877 # v5.3.0
       with:
@@ -324,14 +280,7 @@ jobs:
         docker image load -i ./dist/artifacts/k3s-image.tar
         IMAGE_TAG=$(docker image ls --format '{{.Repository}}:{{.Tag}}' | grep 'rancher/k3s')
         echo "K3S_IMAGE=$IMAGE_TAG" >> $GITHUB_ENV
-    - name: Download Go Tests
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-      with:
-        name: docker-go-tests-amd64
-        path: ./dist/artifacts
     - name: Run scale test
       run: |
-        chmod +x ./dist/artifacts/scale.test
-        mv ./dist/artifacts/scale.test ./tests/docker/scale/
-        cd ./tests/docker/scale
-        ./scale.test -test.timeout=40m -test.v -ginkgo.v -ci -k3sImage=$K3S_IMAGE
+        go install github.com/onsi/ginkgo/v2/ginkgo@$(. ./scripts/version.sh; get-module-version github.com/onsi/ginkgo/v2)
+        ginkgo run -v -timeout=40m ./tests/docker/scale/ -- -ci -k3sImage=$K3S_IMAGE

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -146,12 +146,6 @@ jobs:
           name: e2e-${{ matrix.etest }}-logs
           path: tests/e2e/${{ matrix.etest }}/*log.txt
           retention-days: 30
-      - name: On Failure, Launch Debug Session
-        uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 # v1
-        if: ${{ failure() }}
-        with:
-          ## If no one connects after 5 minutes, shut down server.
-          wait-timeout-minutes: 5
       - name: Upload Results To Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
         with:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -95,12 +95,6 @@ jobs:
         name: integration-${{ matrix.itest }}-logs
         path: tests/integration/${{ matrix.itest }}/*log.txt
         retention-days: 30
-    - name: On Failure, Launch Debug Session
-      uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 # v1
-      if: ${{ failure() }}
-      with:
-        ## If no one connects after 5 minutes, shut down server.
-        wait-timeout-minutes: 5
     - name: Generate coverage report
       run: sudo -E env "PATH=$PATH" go tool covdata textfmt -i $GOCOVERDIR -o ${{ matrix.itest }}.out
     - name: Upload Results To Codecov

--- a/.github/workflows/unitcoverage.yaml
+++ b/.github/workflows/unitcoverage.yaml
@@ -41,11 +41,6 @@ jobs:
       run: |
         go test -coverpkg ./pkg/... -coverprofile coverage.out ./pkg/... -run Unit
         go tool cover -func coverage.out
-    - name: On Failure, Launch Debug Session
-      if: ${{ failure() }}
-      uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 # v1
-      with:
-        wait-timeout-minutes: 5
     - name: Upload Results To Codecov
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
       with:

--- a/go.mod
+++ b/go.mod
@@ -119,8 +119,8 @@ require (
 	github.com/moby/sys/userns v0.1.0
 	github.com/mwitkow/go-http-dialer v0.0.0-20161116154839-378f744fb2b8
 	github.com/natefinch/lumberjack v2.0.0+incompatible
-	github.com/onsi/ginkgo/v2 v2.32.0
-	github.com/onsi/gomega v1.40.0
+	github.com/onsi/ginkgo/v2 v2.32.1
+	github.com/onsi/gomega v1.42.1
 	github.com/opencontainers/cgroups v0.0.7
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1475,11 +1475,11 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
-github.com/onsi/ginkgo/v2 v2.32.0 h1:Hw7s2pVrQo/8Yz5N77qdnpHaoc+c6cC9WIV1Jce+J6E=
-github.com/onsi/ginkgo/v2 v2.32.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
+github.com/onsi/ginkgo/v2 v2.32.1 h1:6tlvcDm/3sE8lGJbZ4+d4mO3RLy24/tQWOFzVSQNIfw=
+github.com/onsi/ginkgo/v2 v2.32.1/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
-github.com/onsi/gomega v1.40.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
+github.com/onsi/gomega v1.42.1 h1:iN1rCUX+44NZ1Dc97MPoeFYbFR0vh8zxoxMFwKdyZ6I=
+github.com/onsi/gomega v1.42.1/go.mod h1:REff/hsDsodHoKlWsP2mAPhu1+5/6hVYNf9rIEBpeSg=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/cgroups v0.0.7 h1:FqhggFhigAMgKKwy39jweWX3h7Ha6VBF/qNR6Sso3oc=
 github.com/opencontainers/cgroups v0.0.7/go.mod h1:hPBRvnBhLZueEN0eJyozMeM3HeFGYlZW9KnO//px6G4=


### PR DESCRIPTION
#### Proposed Changes ####

As per gingo docs it is NOT recommended to run these directly.

Ref: https://onsi.github.io/ginkgo/#ginkgo-cli-overview
> The Ginkgo CLI is the recommended and supported tool for running
> Ginkgo suites. While you can run Ginkgo suites with `go test` you must use
> the CLI to run suites in parallel and to aggregate profiles. There are
> also a (small) number of go test flags that Ginkgo does not support - an
> error will be emitted if you attempt to use these.


Also drops prebuilding the tests, as the time to build+upload+download a combined artifact is actually longer than just installing go and building the single test run by each step in the matrix.

#### Types of Changes ####

CI

#### Verification ####

Check CI logs

#### Testing ####

yes

#### Linked Issues ####


#### User-Facing Change ####
```release-note
```

#### Further Comments ####
