### PR TITLE
updatecli: remove `release-1.33` branch

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -40,7 +40,6 @@ jobs:
           - release-1.36
           - release-1.35
           - release-1.34
-          - release-1.33
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/updatecli_k8s.yaml
+++ b/.github/workflows/updatecli_k8s.yaml
@@ -22,7 +22,6 @@ jobs:
           - release-1.36
           - release-1.35
           - release-1.34
-          - release-1.33
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
See also: 
* https://github.com/k3s-io/k3s/pull/14535#issuecomment-5360985137
* https://github.com/k3s-io/k3s/pull/14539#issuecomment-5362848121