### PR TITLE
Servicelb multiple lbpools

### DIFF
--- a/pkg/cloudprovider/servicelb.go
+++ b/pkg/cloudprovider/servicelb.go
@@ -653,12 +653,14 @@ func (k *k3s) updateDaemonSets() error {
 	}
 
 	for _, ds := range daemonsets {
-		ds.Labels[nodeSelectorLabel] = fmt.Sprintf("%t", enableNodeSelector)
-		ds.Spec.Template.Spec.NodeSelector = map[string]string{}
+		// The cache returns pointers into the shared informer store, so copy before mutating.
+		updated := ds.DeepCopy()
+		updated.Labels[nodeSelectorLabel] = fmt.Sprintf("%t", enableNodeSelector)
+		updated.Spec.Template.Spec.NodeSelector = map[string]string{}
 		if enableNodeSelector {
-			ds.Spec.Template.Spec.NodeSelector[daemonsetNodeLabel] = "true"
+			updated.Spec.Template.Spec.NodeSelector[daemonsetNodeLabel] = "true"
 		}
-		if _, err := k.client.AppsV1().DaemonSets(ds.Namespace).Update(context.TODO(), ds, meta.UpdateOptions{}); err != nil {
+		if _, err := k.client.AppsV1().DaemonSets(updated.Namespace).Update(context.TODO(), updated, meta.UpdateOptions{}); err != nil {
 			return err
 		}
 	}

--- a/pkg/cloudprovider/servicelb.go
+++ b/pkg/cloudprovider/servicelb.go
@@ -36,15 +36,16 @@ import (
 )
 
 var (
-	finalizerName          = "svccontroller." + version.Program + ".cattle.io/daemonset"
-	svcNameLabel           = "svccontroller." + version.Program + ".cattle.io/svcname"
-	svcNamespaceLabel      = "svccontroller." + version.Program + ".cattle.io/svcnamespace"
-	daemonsetNodeLabel     = "svccontroller." + version.Program + ".cattle.io/enablelb"
-	daemonsetNodePoolLabel = "svccontroller." + version.Program + ".cattle.io/lbpool"
-	nodeSelectorLabel      = "svccontroller." + version.Program + ".cattle.io/nodeselector"
-	priorityAnnotation     = "svccontroller." + version.Program + ".cattle.io/priorityclassname"
-	tolerationsAnnotation  = "svccontroller." + version.Program + ".cattle.io/tolerations"
-	controllerName         = names.ServiceLBController
+	finalizerName           = "svccontroller." + version.Program + ".cattle.io/daemonset"
+	svcNameLabel            = "svccontroller." + version.Program + ".cattle.io/svcname"
+	svcNamespaceLabel       = "svccontroller." + version.Program + ".cattle.io/svcnamespace"
+	daemonsetNodeLabel      = "svccontroller." + version.Program + ".cattle.io/enablelb"
+	daemonsetNodePoolLabel  = "svccontroller." + version.Program + ".cattle.io/lbpool"
+	daemonsetNodePoolPrefix = "lbpool.svccontroller." + version.Program + ".cattle.io/"
+	nodeSelectorLabel       = "svccontroller." + version.Program + ".cattle.io/nodeselector"
+	priorityAnnotation      = "svccontroller." + version.Program + ".cattle.io/priorityclassname"
+	tolerationsAnnotation   = "svccontroller." + version.Program + ".cattle.io/tolerations"
+	controllerName          = names.ServiceLBController
 )
 
 const (
@@ -586,12 +587,11 @@ func (k *k3s) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 		ds.Spec.Template.Spec.NodeSelector = map[string]string{
 			daemonsetNodeLabel: "true",
 		}
-		// Add node selector for "svccontroller.k3s.cattle.io/lbpool=<pool>" if service has lbpool label
-		if svc.Labels[daemonsetNodePoolLabel] != "" {
-			ds.Spec.Template.Spec.NodeSelector[daemonsetNodePoolLabel] = svc.Labels[daemonsetNodePoolLabel]
-		}
 		ds.Labels[nodeSelectorLabel] = "true"
 	}
+
+	// Restrict the DaemonSet to nodes in the pool named by the service's lbpool label, if set.
+	ds.Spec.Template.Spec.Affinity = nodePoolAffinity(svc.Labels[daemonsetNodePoolLabel])
 
 	// Fetch tolerations from the "svccontroller.k3s.cattle.io/tolerations" annotation on the service
 	// and append them to the DaemonSet's pod tolerations.
@@ -602,6 +602,39 @@ func (k *k3s) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 	ds.Spec.Template.Spec.Tolerations = append(ds.Spec.Template.Spec.Tolerations, tolerations...)
 
 	return ds, nil
+}
+
+// nodePoolAffinity returns node affinity restricting pods to nodes belonging to the named pool,
+// or nil if no pool is named. A node is considered part of the pool if it is labeled with either
+// "svccontroller.k3s.cattle.io/lbpool=<pool>" or "lbpool.svccontroller.k3s.cattle.io/<pool>=true".
+// The two forms are listed as separate node selector terms, which are ORed by the scheduler, so
+// that nodes using the older single-pool label are still selected.
+func nodePoolAffinity(pool string) *core.Affinity {
+	if pool == "" {
+		return nil
+	}
+	return &core.Affinity{
+		NodeAffinity: &core.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+				NodeSelectorTerms: []core.NodeSelectorTerm{
+					{
+						MatchExpressions: []core.NodeSelectorRequirement{{
+							Key:      daemonsetNodePoolLabel,
+							Operator: core.NodeSelectorOpIn,
+							Values:   []string{pool},
+						}},
+					},
+					{
+						MatchExpressions: []core.NodeSelectorRequirement{{
+							Key:      daemonsetNodePoolPrefix + pool,
+							Operator: core.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						}},
+					},
+				},
+			},
+		},
+	}
 }
 
 // updateDaemonSets ensures that our DaemonSets have a NodeSelector present if one is enabled,

--- a/pkg/cloudprovider/servicelb_test.go
+++ b/pkg/cloudprovider/servicelb_test.go
@@ -114,6 +114,53 @@ func Test_UnitFilterByIPFamily_Ordering(t *testing.T) {
 	}
 }
 
+func Test_UnitNodePoolAffinity(t *testing.T) {
+	tests := []struct {
+		name string
+		pool string
+		want *core.Affinity
+	}{
+		{
+			name: "No pool",
+			pool: "",
+			want: nil,
+		},
+		{
+			name: "Named pool",
+			pool: "pool-a",
+			want: &core.Affinity{
+				NodeAffinity: &core.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+						NodeSelectorTerms: []core.NodeSelectorTerm{
+							{
+								MatchExpressions: []core.NodeSelectorRequirement{{
+									Key:      "svccontroller.k3s.cattle.io/lbpool",
+									Operator: core.NodeSelectorOpIn,
+									Values:   []string{"pool-a"},
+								}},
+							},
+							{
+								MatchExpressions: []core.NodeSelectorRequirement{{
+									Key:      "lbpool.svccontroller.k3s.cattle.io/pool-a",
+									Operator: core.NodeSelectorOpIn,
+									Values:   []string{"true"},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nodePoolAffinity(tt.pool); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("nodePoolAffinity() = %+v\nWant = %+v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_UnitGenerateName(t *testing.T) {
 	uid := types.UID("35a5ccb3-4a82-40b7-8d83-cda9582e4251")
 	tests := []struct {


### PR DESCRIPTION
#### Proposed Changes ####

ServiceLB/KlipperLB lbpool feature works in a way where a node can only be part of one pool, because we store the pool name in label value and use same label key everywhere. I'd like it to be extended in a way that allows nodes to be part of multiple pools at once.

#### Types of Changes ####

Backward-compatible additions.

#### Verification ####

Verified on linux amd64 CI build with both old and new labels (without `enablelb`).

#### Testing ####

Added `Test_UnitNodePoolAffinity` test.

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/13894

#### User-Facing Change ####
```release-note
ServiceLB now supports using 'lbpool.svccontroller.k3s.cattle.io/<pool-name>' node label to specify node affinity thus making it possible for a node to be a part of multiple LB pools.
```

#### Further Comments ####

N/A