### PR TITLE
Restore Flatcar detection in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -613,8 +613,8 @@ setup_selinux() {
             rpm_site_infix=slemicro
         fi
 
-    # cover any atomic fedora flavors using rpm-ostree
-    elif  { [ "${ID:-}" = fedora ] || [ "${ID_LIKE:-}" = fedora ]; } && [ -n "${OSTREE_VERSION:-}" ]; then
+    # cover coreos derivatives like flatcar, plus any atomic fedora flavors using rpm-ostree
+    elif [ "${ID_LIKE:-}" = coreos ] || { { [ "${ID:-}" = fedora ] || [ "${ID_LIKE:-}" = fedora ]; } && [ -n "${OSTREE_VERSION:-}" ]; }; then
         rpm_target=coreos
         rpm_site_infix=coreos
         package_installer=rpm-ostree

--- a/install.sh.sha256sum
+++ b/install.sh.sha256sum
@@ -1,1 +1,1 @@
-ed01f89fd977bf20ac1516bbebf8370bf3ddbaa55dac8aba610956a4c78cc00b  install.sh
+e5cc3b3d9dfc1662c2d9be6da5abc9a4cd317d6abc3a5ffc02e3dd3248207fee  install.sh


### PR DESCRIPTION
#### Proposed Changes ####
Restore the `ID_LIKE=coreos` match in `setup_selinux` that #13712 removed.
On Flatcar (`ID_LIKE=coreos`, no `OSTREE_VERSION`, `VERSION_ID` ≥ 4xxx) the
current script falls through to the el8/yum branch; since Flatcar has no
RedHat-family release files, `install_selinux_rpm` is skipped, and the
missing-policy check then hits the fatal path because `rpm_target` is not
`coreos`. Restoring the match sends Flatcar back to the coreos branch, whose
missing-policy outcome is the "please reboot" warning — the pre-#13712
behavior.

Note: #13712 also removed `ID_LIKE=coreos` from the `policy_error=warn`
condition. This PR intentionally restores only the `rpm_target` selection; if
you'd like warn-not-fatal semantics for restorecon failures on Flatcar too,
I'm happy to add that condition back as well.

Disclosure: this patch was generated by an engineering system operated by me;
I reviewed and validated the change and am accountable for it.

#### Types of Changes ####
Bugfix (install script regression)

#### Verification ####
On a Flatcar node (e.g. 4593.2.0): run the patched install.sh; it should
complete instead of aborting with "Failed to find the k3s-selinux policy".
Pre-#13712 install.sh works on the same node (reporter-confirmed in #14018).

#### Testing ####
Not covered by unit tests (shell install script).

#### Linked Issues ####
Refs #14018 (regression introduced by #13712; prior attempt #14516 was closed unmerged)

#### User-Facing Change ####
```release-note
Fixed k3s installation failure on Flatcar Container Linux introduced by the setup_selinux changes in #13712.
```

#### Further Comments ####
None.
