### PR TITLE
Bump Traefik image/chart and add gateway-api for 1.37+

### DIFF
--- a/manifests/gateway-api-crd.yaml
+++ b/manifests/gateway-api-crd.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: gateway-api-crd
+  namespace: kube-system
+spec:
+  forceConflicts: true
+  failurePolicy: retry
+  takeOwnership: true
+  chart: https://%{KUBERNETES_API}%/static/charts/gateway-api-crd-1.6.102.tgz

--- a/manifests/traefik.yaml
+++ b/manifests/traefik.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   forceConflicts: true
   failurePolicy: retry
-  chart: https://%{KUBERNETES_API}%/static/charts/traefik-crd-40.1.4+up40.1.0.tgz
+  chart: https://%{KUBERNETES_API}%/static/charts/traefik-crd-41.4.2+up41.4.0.tgz
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -17,7 +17,7 @@ metadata:
 spec:
   forceConflicts: true
   failurePolicy: retry
-  chart: https://%{KUBERNETES_API}%/static/charts/traefik-40.1.4+up40.1.0.tgz
+  chart: https://%{KUBERNETES_API}%/static/charts/traefik-41.4.2+up41.4.0.tgz
   set:
     global.systemDefaultRegistry: "%{SYSTEM_DEFAULT_REGISTRY_RAW}%"
   valuesContent: |-
@@ -32,7 +32,7 @@ spec:
     priorityClassName: "system-cluster-critical"
     image:
       repository: "rancher/mirrored-library-traefik"
-      tag: "3.7.8"
+      tag: "3.7.12"
     tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -3,6 +3,6 @@ docker.io/rancher/klipper-lb:v0.4.17
 docker.io/rancher/local-path-provisioner:v0.0.37
 docker.io/rancher/mirrored-coredns-coredns:1.14.6
 docker.io/rancher/mirrored-library-busybox:1.37.0
-docker.io/rancher/mirrored-library-traefik:3.7.8
+docker.io/rancher/mirrored-library-traefik:3.7.12
 docker.io/rancher/mirrored-metrics-server:v0.9.0
 docker.io/rancher/mirrored-pause:3.10.2

--- a/tests/e2e/startup/startup_test.go
+++ b/tests/e2e/startup/startup_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Various Startup Configurations", Ordered, func() {
 				By("checking command results: " + res)
 				Expect(err).NotTo(HaveOccurred())
 			}
-			supervisorPortYAML := "supervisor-port: 9345\napiserver-port: 6443\napiserver-bind-address: 0.0.0.0\ndisable: traefik\nnode-taint: node-role.kubernetes.io/control-plane:NoExecute"
+			supervisorPortYAML := "supervisor-port: 9345\napiserver-port: 6443\napiserver-bind-address: 0.0.0.0\ndisable: [traefik, gateway-api-crd]\nnode-taint: node-role.kubernetes.io/control-plane:NoExecute"
 			err := StartK3sCluster(tc.AllNodes(), supervisorPortYAML, "")
 			Expect(err).NotTo(HaveOccurred(), e2e.GetVagrantLog(err))
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Bump Traefik chart and Traefik image

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Version bump

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Two verifications:

= TRAEFIK =
Deploy K3s and verify that the Traefik image is 3.7.12

= Gateway-api-crd =
New K3s cluster boots with rke2-gateway-api-crd chart that installs the gateway API CRDs:

* There is a helm-install-gateway-api-crd pod that completes correctly
* There is a /var/lib/rancher/k3s/server/manifests/gateway-api-crd.yaml and it includes `takeOwnership: true`
* The command `kubectl get crd | grep gateway` returns 10 crds:
backendtlspolicies.gateway.networking.k8s.io               2026-08-28T13:09:14Z
gatewayclasses.gateway.networking.k8s.io                   2026-08-28T13:09:14Z
gateways.gateway.networking.k8s.io                         2026-08-28T13:09:14Z
grpcroutes.gateway.networking.k8s.io                       2026-08-28T13:09:14Z
httproutes.gateway.networking.k8s.io                       2026-08-28T13:09:14Z
listenersets.gateway.networking.k8s.io                     2026-08-28T13:09:14Z
referencegrants.gateway.networking.k8s.io                  2026-08-28T13:09:14Z
tcproutes.gateway.networking.k8s.io                        2026-08-28T13:25:06Z
tlsroutes.gateway.networking.k8s.io                        2026-08-28T13:09:14Z
udproutes.gateway.networking.k8s.io                        2026-08-28T13:25:06Z

In upgrading clusters gateway-api-crd takes ownership of the gateway API CRDs from Traefik

Before upgrading from 1.36:

* `kubectl get crd | grep gateway` returns 8 crds (the ones above minus udproutes and tcproutes )
* `kubectl get crd gateways.gateway.networking.k8s.io -o yaml` has `meta.helm.sh/release-name: traefik-crd` and `gateway.networking.k8s.io/bundle-version: v1.5.1` and `helm.sh/resource-policy: keep`

After upgrading from 1.36:

* There is a helm-install-gateway-api-crd pod that completes correctly
* `kubectl get crd | grep gateway` returns 10 crds (the ones above)
* `kubectl get crd gateways.gateway.networking.k8s.io -o yaml` has `meta.helm.sh/release-name: gateway-api-crd` and `gateway.networking.k8s.io/bundle-version: v1.6.1` and `helm.sh/resource-policy: keep`

During an upgrade, if there are Gateway API objects created, these are not removed
In v1.36, create some gateway API objects and then run the upgrade

* There is a helm-install-rke2-gateway-api-crd pod that completes correctly
* `kubectl get crd | grep gateway` returns 10 crds (the ones above)
* The created gateway API objects are still present

disabling rke2-gateway-api-crd does not install the CRDs

Install v1.37 (like in the first verification) but using "disable: rke2-gateway-api-crd` in the config.yaml
* `kubectl get crd | grep gateway` should return nothing

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/14564

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump Traefik image to 3.7.12 and chart to 41.4.0. Bundle gateway-api crd
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
