### PR TITLE
Bump gateway-api and traefik image versions for K3s 1.36

### DIFF
--- a/manifests/traefik.yaml
+++ b/manifests/traefik.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   forceConflicts: true
   failurePolicy: retry
-  chart: https://%{KUBERNETES_API}%/static/charts/traefik-crd-40.1.4+up40.1.0.tgz
+  chart: https://%{KUBERNETES_API}%/static/charts/traefik-crd-40.1.5+up40.1.0.tgz
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -17,7 +17,7 @@ metadata:
 spec:
   forceConflicts: true
   failurePolicy: retry
-  chart: https://%{KUBERNETES_API}%/static/charts/traefik-40.1.4+up40.1.0.tgz
+  chart: https://%{KUBERNETES_API}%/static/charts/traefik-40.1.5+up40.1.0.tgz
   set:
     global.systemDefaultRegistry: "%{SYSTEM_DEFAULT_REGISTRY_RAW}%"
   valuesContent: |-
@@ -32,7 +32,7 @@ spec:
     priorityClassName: "system-cluster-critical"
     image:
       repository: "rancher/mirrored-library-traefik"
-      tag: "3.7.8"
+      tag: "3.7.12"
     tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -3,6 +3,6 @@ docker.io/rancher/klipper-lb:v0.4.17
 docker.io/rancher/local-path-provisioner:v0.0.37
 docker.io/rancher/mirrored-coredns-coredns:1.14.6
 docker.io/rancher/mirrored-library-busybox:1.37.0
-docker.io/rancher/mirrored-library-traefik:3.7.8
+docker.io/rancher/mirrored-library-traefik:3.7.12
 docker.io/rancher/mirrored-metrics-server:v0.9.0
 docker.io/rancher/mirrored-pause:3.10.2


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Bump gateway-api to 1.6.1 and traefik image to 3.7.12

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Traefik is using image `rancher/mirrored-library-traefik:3.7.12`

Before upgrading to this PR:
1 - `kubectl get crd | grep gateway` returns 8 different crds 
2 - `kubectl get crd gateways.gateway.networking.k8s.io -o yaml | grep bundle-version` returns:
` gateway.networking.k8s.io/bundle-version: v1.5.1`
3 - `kubectl get crd -o yaml | grep "helm.sh/resource-policy: keep"` returns 8 lines

After upgrading:
1 - `kubectl get crd | grep gateway` returns 10 different crds
2 - `kubectl get crd gateways.gateway.networking.k8s.io -o yaml | grep bundle-version` returns:
` gateway.networking.k8s.io/bundle-version: v1.6.1`
3 - `kubectl get crd -o yaml | grep "helm.sh/resource-policy: keep"` returns 10 lines


#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->
https://github.com/k3s-io/k3s/issues/14566

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump Traefik image to 3.7.12 and gateway-api to 1.6.1
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
