### PR TITLE
Fix deploy controller not re-applying manifests when mtime is pinned to the epoch

### DIFF
--- a/pkg/deploy/controller.go
+++ b/pkg/deploy/controller.go
@@ -44,6 +44,11 @@ const (
 	gvkSep         = ";"
 )
 
+// epoch is the fixed mtime that some immutable filesystems (e.g. NixOS /nix/store)
+// pin all files to. Such files never register content changes via mtime, so they
+// must always be re-checked against the Addon checksum.
+var epoch = time.Unix(0, 0)
+
 // WatchFiles sets up an OnChange callback to start a periodic goroutine to watch files for changes once the controller has started up.
 func WatchFiles(ctx context.Context, client kubernetes.Interface, apply apply.Apply, addons controllersv1.AddonController, disables map[string]bool, bases ...string) error {
 	w := &watcher{
@@ -156,7 +161,7 @@ func (w *watcher) listFilesIn(base string, force bool) error {
 			continue
 		}
 		modTime := files[path].ModTime()
-		if !force && modTime.Equal(w.modTime[path]) {
+		if !force && !modTime.Equal(epoch) && modTime.Equal(w.modTime[path]) {
 			continue
 		}
 		if err := w.deploy(path, !force); err != nil {

--- a/pkg/deploy/controller_test.go
+++ b/pkg/deploy/controller_test.go
@@ -4,6 +4,15 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	apisv1 "github.com/k3s-io/api/k3s.cattle.io/v1"
+	clientsetfake "github.com/k3s-io/api/pkg/generated/clientset/versioned/fake"
+	applyfake "github.com/rancher/wrangler/v3/pkg/apply/fake"
+	genericfake "github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 )
 
 func Test_UnitWalkFilesSymlinkedDirectoryUsesLogicalPaths(t *testing.T) {
@@ -69,4 +78,123 @@ func fileKeys(files map[string]watchedFile) []string {
 		keys = append(keys, key)
 	}
 	return keys
+}
+
+// newTestWatcher returns a watcher whose Addon cache and client calls are wired
+// to a fake clientset. The fake clientset doesn't assign UIDs like the real API
+// server does, so the Addon is pre-created with one set; deploy() treats an
+// empty UID as a new Addon and attempts to create it.
+func newTestWatcher(t *testing.T, apply *applyfake.FakeApply) *watcher {
+	t.Helper()
+
+	clientset := clientsetfake.NewSimpleClientset(&apisv1.Addon{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "manifest", UID: "test-uid"}})
+	addons := clientset.K3sV1().Addons(metav1.NamespaceSystem)
+
+	ctrl := gomock.NewController(t)
+	addonCache := genericfake.NewMockCacheInterface[*apisv1.Addon](ctrl)
+	addonClient := genericfake.NewMockClientInterface[*apisv1.Addon, *apisv1.AddonList](ctrl)
+	addonCache.EXPECT().Get(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(_, name string) (*apisv1.Addon, error) {
+		return addons.Get(t.Context(), name, metav1.GetOptions{})
+	})
+	addonClient.EXPECT().Create(gomock.Any()).AnyTimes().DoAndReturn(func(a *apisv1.Addon) (*apisv1.Addon, error) {
+		return addons.Create(t.Context(), a, metav1.CreateOptions{})
+	})
+	addonClient.EXPECT().Update(gomock.Any()).AnyTimes().DoAndReturn(func(a *apisv1.Addon) (*apisv1.Addon, error) {
+		return addons.Update(t.Context(), a, metav1.UpdateOptions{})
+	})
+
+	return &watcher{
+		apply:      apply,
+		addonCache: addonCache,
+		addons:     addonClient,
+		modTime:    map[string]time.Time{},
+		recorder:   record.NewFakeRecorder(100),
+		discovery:  clientset.Discovery(),
+	}
+}
+
+func Test_UnitListFilesInAppliesOnContentChangeDespiteUnchangedModTime(t *testing.T) {
+	base := t.TempDir()
+	manifest := filepath.Join(base, "manifest.yaml")
+	contentA := "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: test\n"
+	contentB := "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: test\n  labels:\n    changed: \"true\"\n"
+
+	// Simulate filesystems (e.g. NixOS /nix/store) that pin all mtimes to the
+	// epoch, so mtime never changes even when file content does.
+	fixedMtime := time.Unix(0, 0)
+
+	writeManifest := func(content string) {
+		t.Helper()
+		if err := os.WriteFile(manifest, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(manifest, fixedMtime, fixedMtime); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	apply := &applyfake.FakeApply{}
+	w := newTestWatcher(t, apply)
+
+	// First pass is forced, so the manifest is applied and its checksum recorded.
+	writeManifest(contentA)
+	if err := w.listFilesIn(base, true); err != nil {
+		t.Fatal(err)
+	}
+	if apply.Count != 1 {
+		t.Fatalf("expected initial apply, got %d", apply.Count)
+	}
+
+	// Second (non-forced) pass must detect the content change via checksum even
+	// though mtime is unchanged, and apply it again.
+	writeManifest(contentB)
+	if err := w.listFilesIn(base, false); err != nil {
+		t.Fatal(err)
+	}
+	if apply.Count != 2 {
+		t.Fatalf("expected changed content to be applied despite unchanged mtime, got %d applies", apply.Count)
+	}
+}
+
+func Test_UnitListFilesInSkipsUnchangedNormalModTime(t *testing.T) {
+	base := t.TempDir()
+	manifest := filepath.Join(base, "manifest.yaml")
+	contentA := "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: test\n"
+	contentB := "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: test\n  labels:\n    changed: \"true\"\n"
+
+	// A normal (non-epoch) mtime: the modTime gate trusts it and skips the file
+	// when it is unchanged.
+	fixedMtime := time.Unix(1000000, 0)
+
+	writeManifest := func(content string) {
+		t.Helper()
+		if err := os.WriteFile(manifest, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(manifest, fixedMtime, fixedMtime); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	apply := &applyfake.FakeApply{}
+	w := newTestWatcher(t, apply)
+
+	// First pass is forced, so the manifest is applied and its checksum recorded.
+	writeManifest(contentA)
+	if err := w.listFilesIn(base, true); err != nil {
+		t.Fatal(err)
+	}
+	if apply.Count != 1 {
+		t.Fatalf("expected initial apply, got %d", apply.Count)
+	}
+
+	// Content changes but mtime does not: files with a normal mtime are skipped
+	// based on mtime alone, per the gate retained in listFilesIn.
+	writeManifest(contentB)
+	if err := w.listFilesIn(base, false); err != nil {
+		t.Fatal(err)
+	}
+	if apply.Count != 1 {
+		t.Fatalf("expected file with unchanged normal mtime to be skipped, got %d applies", apply.Count)
+	}
 }


### PR DESCRIPTION
#### Proposed Changes ####

The deploy controller's modTime gate in `listFilesIn()` skipped `deploy()`
entirely when a manifest's mtime was unchanged, so the checksum comparison
in `deploy()` — the authoritative content signal, already persisted on the
Addon CRD — was never consulted. On filesystems that pin all mtimes to a
fixed value, such as NixOS `/nix/store` (epoch), manifest updates were
silently ignored: additions were never created, and removals were never
pruned.

Files whose mtime is pinned to the epoch cannot register content changes
via mtime at all, so this PR exempts them from the modTime gate: they always
fall through to the checksum comparison, which alone decides whether to
re-apply. Files with normal mtimes keep the existing optimization.

#### Types of Changes ####

Bugfix

#### Verification ####

Verified end-to-end against a real k3s server, with two manifests: one with
its mtime pinned to the unix epoch (simulating NixOS `/nix/store`), and one
with a normal mtime as a control:

- With a binary built from this branch, changing the epoch-pinned manifest's
  content (keeping mtime fixed) is picked up and applied to the cluster
  within one watch loop (~15s). The control manifest updates as well.
- Running the same scenario against the v1.36.4+k3s1 release binary
  reproduces the reported behavior: the epoch-pinned manifest's change is
  silently ignored, while the control manifest updates normally.
- On a normal filesystem, behavior is unchanged: startup still force-applies
  all manifests, and subsequent loops skip unchanged files via the modTime
  gate as before.

#### Testing ####

- `Test_UnitListFilesInAppliesOnContentChangeDespiteUnchangedModTime`: writes
  a manifest with a fixed epoch mtime, applies it in a forced pass, then
  changes the content while keeping mtime fixed, and verifies that the second
  non-forced pass still detects the change via checksum and applies it. This
  test fails against the pre-fix gate.
- `Test_UnitListFilesInSkipsUnchangedNormalModTime`: verifies that files with
  a normal (non-epoch) mtime are still skipped by the gate when mtime is
  unchanged. This test fails if the gate is removed entirely, pinning the
  retained optimization.
- Tests use the generated fake clientset (`fake.NewSimpleClientset`) wired to
  the Addon cache/client mocks, wrangler's `FakeApply`, and
  `record.NewFakeRecorder`.

#### Linked Issues ####

Fixes #14556

#### User-Facing Change ####

```release-note
Fix deploy controller not re-applying auto-deployed manifests when file mtime does not reflect content changes (e.g. NixOS /nix/store)
```

#### Further Comments ####

- The epoch check is intentionally narrow: only files whose mtime is exactly
  the unix epoch — the value pinned by NixOS `/nix/store` and other
  reproducible-build stores — bypass the gate. All other files keep the
  existing modTime optimization.
- Unchanged epoch-mtime files cost one read + SHA256 per 15s loop; the deploy
  controller manages a handful of small manifests, so this is negligible.
  Unchanged files still return early from `deploy()` before any apply, API
  write, or event.

#### AI Use ####

Per the project's AI guidance: this PR was prepared with the assistance of
AI tools. All changes have been reviewed and verified by the author — unit
tests pass, and the fix was verified end-to-end against a real k3s server as
described in Verification. The author understands and can explain every
change.
