### PR TITLE
Bump k3s-io/api to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.9.2
 	github.com/joho/godotenv v1.5.1
 	github.com/json-iterator/go v1.1.12
-	github.com/k3s-io/api v0.1.4
+	github.com/k3s-io/api v0.2.0
 	github.com/k3s-io/helm-controller v0.17.7
 	github.com/k3s-io/kine v0.17.0
 	github.com/klauspost/compress v1.19.2

--- a/go.sum
+++ b/go.sum
@@ -1138,8 +1138,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k3s-io/api v0.1.4 h1:mnu1pgtEEwplvDHgjeyekbC96wykUWsq0E5ouJoRkM4=
-github.com/k3s-io/api v0.1.4/go.mod h1:9aQAaTKBFWO+BpGrMFJk9uZaUhZRrL9aahobcOQQm64=
+github.com/k3s-io/api v0.2.0 h1:1uURc+3rFZwpYcoyRvaLbtpikFEREQmvwlYrC4F9CsU=
+github.com/k3s-io/api v0.2.0/go.mod h1:Mq+hKDYVGRbUuYUo+TJX/GmS38ztCB0RcG4/JlktH0A=
 github.com/k3s-io/containerd/v2 v2.3.4-k3s1 h1:3w5iV0q9rhexGIQcBHl98R+vFN5AJqvgEophEE0qcPI=
 github.com/k3s-io/containerd/v2 v2.3.4-k3s1/go.mod h1:HWD6AVjqEzsxoI9hwhBiO4RKKkbwFzIETBzgDaZNjCI=
 github.com/k3s-io/cri-dockerd v0.3.19-k3s5 h1:LymM6LDgeqeEhxAdmVYuqucatFEOiWHqsp8hXAaJODc=


### PR DESCRIPTION
#### Proposed Changes ####

Bump k3s-io/api to v0.2.0:
* https://github.com/k3s-io/api/pull/7

No change other than using crds and generated clients from newer releases of kubernetes and wrangler.

#### Types of Changes ####

version bump

#### Verification ####

Check version in go.mod

#### Testing ####

#### Linked Issues ####
* 

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
