### PR TITLE
Close minio.Object after read

### DIFF
--- a/pkg/etcd/s3/s3.go
+++ b/pkg/etcd/s3/s3.go
@@ -553,6 +553,7 @@ func (c *Client) ListSnapshots(ctx context.Context) (map[string]snapshot.File, e
 					sf.Metadata = base64.StdEncoding.EncodeToString(m)
 					snapshots[sfKey] = sf
 				}
+				obj.Close()
 			}
 		}
 	}


### PR DESCRIPTION
#### Proposed Changes ####

Close metadata file reader after we are done with it.

#### Types of Changes ####

bugfix

#### Verification ####

See linked issue

#### Testing ####


#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/14575

#### User-Facing Change ####
```release-note
```

#### Further Comments ####
