### PR TITLE
[Release 1.37] Bump gateway-api-crd version 3, which includes the keep annotation

### DIFF
--- a/manifests/gateway-api-crd.yaml
+++ b/manifests/gateway-api-crd.yaml
@@ -8,4 +8,4 @@ spec:
   forceConflicts: true
   failurePolicy: retry
   takeOwnership: true
-  chart: https://%{KUBERNETES_API}%/static/charts/gateway-api-crd-1.6.102.tgz
+  chart: https://%{KUBERNETES_API}%/static/charts/gateway-api-crd-1.6.103.tgz


### PR DESCRIPTION
Backport: https://github.com/k3s-io/k3s/pull/14581
Issue: https://github.com/k3s-io/k3s/issues/14564