### PR TITLE
Support 1 server in the secrets encryption test

### DIFF
--- a/tests/docker/secretsencryption/secretsencryption_test.go
+++ b/tests/docker/secretsencryption/secretsencryption_test.go
@@ -88,7 +88,9 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 					cmd := "k3s secrets-encrypt status"
 					res, err := node.RunCmdOnNode(cmd)
 					g.Expect(err).NotTo(HaveOccurred(), res)
-					g.Expect(res).Should(ContainSubstring("Server Encryption Hashes: hash does not match"))
+					if *serverCount > 1 {
+						g.Expect(res).Should(ContainSubstring("Server Encryption Hashes: hash does not match"))
+					}
 					if i == 0 {
 						g.Expect(res).Should(ContainSubstring("Current Rotation Stage: reencrypt_finished"))
 					} else {
@@ -201,8 +203,12 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 		})
 		It("Restarts K3s servers", func() {
 			Expect(docker.RestartCluster(tc.Servers)).To(Succeed())
+			// Wait until we can access the cluster again.
+			cmd := "k3s secrets-encrypt status"
+			Eventually(func() (string, error) {
+				return tc.Servers[0].RunCmdOnNode(cmd)
+			}, "180s", "5s").Should(ContainSubstring("Encryption Status: Enabled"))
 		})
-
 		It("Rotates the Secrets-Encryption Keys, switching to new key type", func() {
 			cmd := "k3s secrets-encrypt rotate-keys"
 			res, err := tc.Servers[0].RunCmdOnNode(cmd)
@@ -212,7 +218,9 @@ var _ = Describe("Verify Secrets Encryption Rotation", Ordered, func() {
 					cmd := "k3s secrets-encrypt status"
 					res, err := node.RunCmdOnNode(cmd)
 					g.Expect(err).NotTo(HaveOccurred(), res)
-					g.Expect(res).Should(ContainSubstring("Server Encryption Hashes: hash does not match"))
+					if *serverCount > 1 {
+						g.Expect(res).Should(ContainSubstring("Server Encryption Hashes: hash does not match"))
+					}
 					if i == 0 {
 						g.Expect(res).Should(ContainSubstring("XSalsa20-POLY1305"))
 					} else {


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/main/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
The secrets encryption test now correctly passes when using only 1 server (SQLite DB)
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####
https://github.com/k3s-io/k3s/issues/14596
<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/main/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
