### PR TITLE
[Release 1.34] Bump Traefik to v3.7.13

### DIFF
--- a/manifests/traefik.yaml
+++ b/manifests/traefik.yaml
@@ -32,7 +32,7 @@ spec:
     priorityClassName: "system-cluster-critical"
     image:
       repository: "rancher/mirrored-library-traefik"
-      tag: "3.7.12"
+      tag: "3.7.13"
     tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -3,6 +3,6 @@ docker.io/rancher/klipper-lb:v0.4.17
 docker.io/rancher/local-path-provisioner:v0.0.37
 docker.io/rancher/mirrored-coredns-coredns:1.14.7
 docker.io/rancher/mirrored-library-busybox:1.37.0
-docker.io/rancher/mirrored-library-traefik:3.7.12
+docker.io/rancher/mirrored-library-traefik:3.7.13
 docker.io/rancher/mirrored-metrics-server:v0.9.0
 docker.io/rancher/mirrored-pause:3.10.2


### PR DESCRIPTION
Issue: https://github.com/k3s-io/k3s/issues/14609
Backport: https://github.com/k3s-io/k3s/pull/14604